### PR TITLE
Remove deprecated API usages (Part 1)

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -183,8 +183,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME2, "val2")
@@ -225,8 +225,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME2, "val2")
@@ -267,8 +267,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
 
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -310,10 +310,10 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 0);
-    Key clusteringKey2 = new Key(COL_NAME4, 1);
-    Key clusteringKey3 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 0);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey3 = Key.ofInt(COL_NAME4, 2);
 
     cassandra.mutate(
         Arrays.asList(
@@ -352,10 +352,10 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 0);
-    Key clusteringKey2 = new Key(COL_NAME4, 1);
-    Key clusteringKey3 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 0);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey3 = Key.ofInt(COL_NAME4, 2);
 
     jdbcDatabase.mutate(
         Arrays.asList(
@@ -394,10 +394,10 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 0);
-    Key clusteringKey2 = new Key(COL_NAME4, 1);
-    Key clusteringKey3 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 0);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey3 = Key.ofInt(COL_NAME4, 2);
 
     cassandra.mutate(
         Arrays.asList(
@@ -442,8 +442,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -479,8 +479,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -516,8 +516,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -552,9 +552,9 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 1);
-    Key clusteringKey2 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(COL_NAME3, 3)
@@ -607,9 +607,9 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 1);
-    Key clusteringKey2 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(COL_NAME3, 3)
@@ -662,9 +662,9 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 1);
-    Key clusteringKey2 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(COL_NAME3, 3)
@@ -718,8 +718,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME2, "val2")
@@ -760,10 +760,10 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 0);
-    Key clusteringKey2 = new Key(COL_NAME4, 1);
-    Key clusteringKey3 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 0);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey3 = Key.ofInt(COL_NAME4, 2);
 
     jdbcDatabase.mutate(
         Arrays.asList(
@@ -802,8 +802,8 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME4, 4);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -839,9 +839,9 @@ public class MultiStorageIntegrationTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME4, 1);
-    Key clusteringKey2 = new Key(COL_NAME4, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
+    Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(COL_NAME3, 3)

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
@@ -111,7 +111,7 @@ public class ConditionSetter implements MutationConditionVisitor {
   }
 
   private Clause createClauseWith(ConditionalExpression e) {
-    String name = quoteIfNecessary(e.getName());
+    String name = quoteIfNecessary(e.getColumn().getName());
     switch (e.getOperator()) {
       case EQ:
       case IS_NULL:

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -132,7 +132,7 @@ public class DynamoMutation extends DynamoOperation {
     if (mutation.getCondition().isPresent()) {
       int index = 0;
       for (ConditionalExpression expression : mutation.getCondition().get().getExpressions()) {
-        ret.put(CONDITION_COLUMN_NAME_ALIAS + index, expression.getName());
+        ret.put(CONDITION_COLUMN_NAME_ALIAS + index, expression.getColumn().getName());
         index++;
       }
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
@@ -192,7 +192,10 @@ public class SimpleSelectQuery implements SelectQuery {
             order = Scan.Ordering.Order.ASC;
           }
         }
-        orderingList.add(new Scan.Ordering(clusteringKeyName, order));
+        orderingList.add(
+            order == Scan.Ordering.Order.ASC
+                ? Scan.Ordering.asc(clusteringKeyName)
+                : Scan.Ordering.desc(clusteringKeyName));
       }
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
@@ -1,10 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.io.BigIntValue;
-import com.scalar.db.io.IntValue;
-import com.scalar.db.io.TextValue;
-
 public final class Attribute {
   public static final String ID = "tx_id";
   public static final String CHILD_IDS = "tx_child_ids";
@@ -19,52 +14,4 @@ public final class Attribute {
   public static final String BEFORE_VERSION = BEFORE_PREFIX + VERSION;
   public static final String BEFORE_PREPARED_AT = BEFORE_PREFIX + PREPARED_AT;
   public static final String BEFORE_COMMITTED_AT = BEFORE_PREFIX + COMMITTED_AT;
-
-  public static TextValue toIdValue(String transactionId) {
-    return new TextValue(Attribute.ID, transactionId);
-  }
-
-  public static TextValue toChildIdsValue(String childTransactionIds) {
-    return new TextValue(Attribute.CHILD_IDS, childTransactionIds);
-  }
-
-  public static IntValue toStateValue(TransactionState state) {
-    return new IntValue(Attribute.STATE, state.get());
-  }
-
-  public static IntValue toVersionValue(int version) {
-    return new IntValue(Attribute.VERSION, version);
-  }
-
-  public static BigIntValue toPreparedAtValue(long preparedAt) {
-    return new BigIntValue(Attribute.PREPARED_AT, preparedAt);
-  }
-
-  public static BigIntValue toCommittedAtValue(long committedAt) {
-    return new BigIntValue(Attribute.COMMITTED_AT, committedAt);
-  }
-
-  public static BigIntValue toCreatedAtValue(long createdAt) {
-    return new BigIntValue(Attribute.CREATED_AT, createdAt);
-  }
-
-  public static TextValue toBeforeIdValue(String transactionId) {
-    return new TextValue(Attribute.BEFORE_ID, transactionId);
-  }
-
-  public static IntValue toBeforeStateValue(TransactionState state) {
-    return new IntValue(Attribute.BEFORE_STATE, state.get());
-  }
-
-  public static IntValue toBeforeVersionValue(int version) {
-    return new IntValue(Attribute.BEFORE_VERSION, version);
-  }
-
-  public static BigIntValue toBeforePreparedAtValue(long preparedAt) {
-    return new BigIntValue(Attribute.BEFORE_PREPARED_AT, preparedAt);
-  }
-
-  public static BigIntValue toBeforeCommittedAtValue(long committedAt) {
-    return new BigIntValue(Attribute.BEFORE_COMMITTED_AT, committedAt);
-  }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.COMMITTED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
@@ -8,7 +7,6 @@ import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.get
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -123,8 +121,8 @@ public class CommitMutationComposer extends AbstractMutationComposer {
         .withConsistency(Consistency.LINEARIZABLE)
         .withCondition(
             new DeleteIf(
-                new ConditionalExpression(ID, id, Operator.EQ),
-                new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
+                ConditionBuilder.column(ID).isEqualToText(id),
+                ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
   }
 
   private Key getPartitionKey(Operation base, @Nullable TransactionResult result)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -4,8 +4,6 @@ import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.COMMITTED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -125,9 +123,8 @@ public class CommitMutationComposer extends AbstractMutationComposer {
         .withConsistency(Consistency.LINEARIZABLE)
         .withCondition(
             new DeleteIf(
-                new ConditionalExpression(ID, toIdValue(id), Operator.EQ),
-                new ConditionalExpression(
-                    STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
+                new ConditionalExpression(ID, id, Operator.EQ),
+                new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
   }
 
   private Key getPartitionKey(Operation base, @Nullable TransactionResult result)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -9,7 +9,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
@@ -120,9 +119,9 @@ public class CommitMutationComposer extends AbstractMutationComposer {
         .forTable(base.forTable().get())
         .withConsistency(Consistency.LINEARIZABLE)
         .withCondition(
-            new DeleteIf(
-                ConditionBuilder.column(ID).isEqualToText(id),
-                ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
+            ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(id))
+                .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+                .build());
   }
 
   private Key getPartitionKey(Operation base, @Nullable TransactionResult result)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -6,11 +6,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
@@ -335,7 +335,7 @@ public class Coordinator {
     return put.withIntValue(Attribute.STATE, state.getState().get())
         .withBigIntValue(Attribute.CREATED_AT, state.getCreatedAt())
         .withConsistency(Consistency.LINEARIZABLE)
-        .withCondition(new PutIfNotExists())
+        .withCondition(ConditionBuilder.putIfNotExists())
         .forNamespace(coordinatorNamespace)
         .forTable(TABLE);
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -286,7 +286,7 @@ public class Coordinator {
 
   @VisibleForTesting
   Get createGetWith(String id) {
-    return new Get(new Key(Attribute.toIdValue(id)))
+    return new Get(Key.ofText(Attribute.ID, id))
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(coordinatorNamespace)
         .forTable(TABLE);
@@ -327,13 +327,13 @@ public class Coordinator {
 
   @VisibleForTesting
   Put createPutWith(Coordinator.State state) {
-    Put put = new Put(new Key(Attribute.toIdValue(state.getId())));
+    Put put = new Put(Key.ofText(Attribute.ID, state.getId()));
     String childIds = state.getChildIdsAsString();
     if (!childIds.isEmpty()) {
-      put.withValue(Attribute.toChildIdsValue(childIds));
+      put.withTextValue(Attribute.CHILD_IDS, childIds);
     }
-    return put.withValue(Attribute.toStateValue(state.getState()))
-        .withValue(Attribute.toCreatedAtValue(state.getCreatedAt()))
+    return put.withIntValue(Attribute.STATE, state.getState().get())
+        .withBigIntValue(Attribute.CREATED_AT, state.getCreatedAt())
         .withConsistency(Consistency.LINEARIZABLE)
         .withCondition(new PutIfNotExists())
         .forNamespace(coordinatorNamespace)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -1,13 +1,11 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.createAfterImageColumnsFromBeforeImage;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -129,8 +127,8 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
         .forTable(base.forTable().get())
         .withCondition(
             new DeleteIf(
-                new ConditionalExpression(ID, id, Operator.EQ),
-                new ConditionalExpression(STATE, result.getState().get(), Operator.EQ)))
+                ConditionBuilder.column(ID).isEqualToText(id),
+                ConditionBuilder.column(STATE).isEqualToInt(result.getState().get())))
         .withConsistency(Consistency.LINEARIZABLE);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -8,7 +8,6 @@ import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.get
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
@@ -126,9 +125,9 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
         .forNamespace(base.forNamespace().get())
         .forTable(base.forTable().get())
         .withCondition(
-            new DeleteIf(
-                ConditionBuilder.column(ID).isEqualToText(id),
-                ConditionBuilder.column(STATE).isEqualToInt(result.getState().get())))
+            ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(id))
+                .and(ConditionBuilder.column(STATE).isEqualToInt(result.getState().get()))
+                .build())
         .withConsistency(Consistency.LINEARIZABLE);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -3,8 +3,6 @@ package com.scalar.db.transaction.consensuscommit;
 import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.createAfterImageColumnsFromBeforeImage;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
@@ -131,8 +129,8 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
         .forTable(base.forTable().get())
         .withCondition(
             new DeleteIf(
-                new ConditionalExpression(ID, toIdValue(id), Operator.EQ),
-                new ConditionalExpression(STATE, toStateValue(result.getState()), Operator.EQ)))
+                new ConditionalExpression(ID, id, Operator.EQ),
+                new ConditionalExpression(STATE, result.getState().get(), Operator.EQ)))
         .withConsistency(Consistency.LINEARIZABLE);
   }
 

--- a/core/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -86,7 +86,7 @@ public class DeleteTest {
     // Arrange
     Delete del =
         prepareDelete()
-            .withCondition(new DeleteIfExists())
+            .withCondition(ConditionBuilder.deleteIfExists())
             .withConsistency(Consistency.EVENTUAL)
             .forNamespace("n1")
             .forTable("t1");
@@ -128,8 +128,8 @@ public class DeleteTest {
   @Test
   public void equals_SameDeleteWithDeleteIfExistsGiven_ShouldReturnTrue() {
     // Arrange
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
-    Delete another = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete another = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act
     boolean ret = delete.equals(another);

--- a/core/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -16,16 +16,16 @@ public class DeleteTest {
   private static final String ANY_TEXT_2 = "text2";
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey);
   }
 
   @Test
   public void getPartitionKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Delete del = new Delete(expected, clusteringKey);
 
     // Act
@@ -38,8 +38,8 @@ public class DeleteTest {
   @Test
   public void getClusteringKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
     Delete del = new Delete(partitionKey, expected);
 
     // Act
@@ -52,7 +52,7 @@ public class DeleteTest {
   @Test
   public void getClusteringKey_ClusteringKeyNotGivenInConstructor_ShouldReturnNull() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Delete del = new Delete(partitionKey);
 
     // Act

--- a/core/src/test/java/com/scalar/db/api/GetTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetTest.java
@@ -20,28 +20,28 @@ public class GetTest {
   private static final String ANY_TEXT_3 = "text3";
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey);
   }
 
   private Get prepareAnotherGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     return new Get(partitionKey, clusteringKey);
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey);
   }
 
   @Test
   public void getPartitionKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Get get = new Get(expected, clusteringKey);
 
     // Act
@@ -54,8 +54,8 @@ public class GetTest {
   @Test
   public void getClusteringKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
     Get get = new Get(partitionKey, expected);
 
     // Act
@@ -68,7 +68,7 @@ public class GetTest {
   @Test
   public void getClusteringKey_ClusteringKeyNotGivenInConstructor_ShouldReturnNull() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Get get = new Get(partitionKey);
 
     // Act

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -474,7 +474,7 @@ public class PutTest {
     Put put =
         preparePut()
             .withValue("c1", 1)
-            .withCondition(new PutIfExists())
+            .withCondition(ConditionBuilder.putIfExists())
             .withConsistency(Consistency.EVENTUAL)
             .forNamespace("n1")
             .forTable("t1");
@@ -516,8 +516,8 @@ public class PutTest {
   @Test
   public void equals_SamePutWithPutIfExistsGiven_ShouldReturnTrue() {
     // Arrange
-    Put put = preparePut().withCondition(new PutIfExists());
-    Put another = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put another = preparePut().withCondition(ConditionBuilder.putIfExists());
 
     // Act
     boolean ret = put.equals(another);
@@ -530,8 +530,8 @@ public class PutTest {
   @Test
   public void equals_SamePutWithPutIfNotExistsGiven_ShouldReturnTrue() {
     // Arrange
-    Put put = preparePut().withCondition(new PutIfNotExists());
-    Put another = preparePut().withCondition(new PutIfNotExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Put another = preparePut().withCondition(ConditionBuilder.putIfNotExists());
 
     // Act
     boolean ret = put.equals(another);
@@ -561,9 +561,9 @@ public class PutTest {
   public void equals_PutWithDifferentConditionsGiven_ShouldReturnFalse() {
     // Arrange
     Put put = preparePut();
-    put.withCondition(new PutIfExists());
+    put.withCondition(ConditionBuilder.putIfExists());
     Put another = preparePut();
-    another.withCondition(new PutIfNotExists());
+    another.withCondition(ConditionBuilder.putIfNotExists());
 
     // Act
     boolean ret = put.equals(another);

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -48,16 +48,16 @@ public class PutTest {
   private static final String ANY_TEXT_4 = "text4";
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey);
   }
 
   @Test
   public void getPartitionKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Put put = new Put(expected, clusteringKey);
 
     // Act
@@ -70,8 +70,8 @@ public class PutTest {
   @Test
   public void getClusteringKey_ProperKeyGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key expected = new Key(ANY_NAME_1, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
     Put put = new Put(partitionKey, expected);
 
     // Act
@@ -84,7 +84,7 @@ public class PutTest {
   @Test
   public void getClusteringKey_ClusteringKeyNotGivenInConstructor_ShouldReturnNull() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Put put = new Put(partitionKey);
 
     // Act

--- a/core/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanTest.java
@@ -22,9 +22,9 @@ public class ScanTest {
   private static final String ANY_TEXT_4 = "text4";
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key startClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Key endClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     return new Scan(partitionKey)
@@ -36,9 +36,9 @@ public class ScanTest {
   }
 
   private Scan prepareAnotherScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key startClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Key endClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
     Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     return new Scan(partitionKey)
@@ -81,9 +81,9 @@ public class ScanTest {
   @Test
   public void constructorAndSetters_AllSet_ShouldGetWhatsSet() {
     // Arrange
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key startClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Key endClusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     // Act

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -772,9 +771,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition =
-        new PutIf(
-            new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
+    MutationCondition condition = new PutIf(ConditionBuilder.column(COL1).isEqualToText("1"));
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -1091,9 +1088,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition =
-        new DeleteIf(
-            new ConditionalExpression(COL1, new IntValue(1), ConditionalExpression.Operator.EQ));
+    MutationCondition condition = new DeleteIf(ConditionBuilder.column(COL1).isEqualToInt(1));
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1233,9 +1228,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition =
-        new DeleteIf(
-            new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
+    MutationCondition condition = new DeleteIf(ConditionBuilder.column(COL1).isEqualToText("1"));
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -10,16 +10,11 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIf;
-import com.scalar.db.api.PutIfExists;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.ScanAll;
@@ -603,7 +598,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIfNotExists();
+    MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -620,7 +615,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new PutIfNotExists();
+    MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL1, 1)
@@ -663,7 +658,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIfExists();
+    MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -685,7 +680,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIfExists();
+    MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -707,7 +702,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIfNotExists();
+    MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -728,7 +723,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
-    MutationCondition condition = new PutIfExists();
+    MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -749,7 +744,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIfNotExists();
+    MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -771,7 +766,8 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new PutIf(ConditionBuilder.column(COL1).isEqualToText("1"));
+    MutationCondition condition =
+        ConditionBuilder.putIf(ConditionBuilder.column(COL1).isEqualToText("1")).build();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -845,7 +841,7 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new DeleteIfExists();
+    MutationCondition condition = ConditionBuilder.deleteIfExists();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -866,7 +862,8 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = new DeleteIf();
+    MutationCondition condition =
+        ConditionBuilder.deleteIf(ConditionBuilder.column("dummy").isEqualToText("dummy")).build();
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValues(values)
@@ -1088,7 +1085,8 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new DeleteIf(ConditionBuilder.column(COL1).isEqualToInt(1));
+    MutationCondition condition =
+        ConditionBuilder.deleteIf(ConditionBuilder.column(COL1).isEqualToInt(1)).build();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1121,7 +1119,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, "p3", "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new DeleteIfExists();
+    MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1139,7 +1137,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, "c3", "val1");
-    MutationCondition condition = new DeleteIfExists();
+    MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1157,7 +1155,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
-    MutationCondition condition = new DeleteIfExists();
+    MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1174,7 +1172,8 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new PutIf();
+    MutationCondition condition =
+        ConditionBuilder.putIf(ConditionBuilder.column("dummy").isEqualToText("dummy")).build();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1192,7 +1191,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new PutIfExists();
+    MutationCondition condition = ConditionBuilder.putIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1210,7 +1209,7 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new PutIfNotExists();
+    MutationCondition condition = ConditionBuilder.putIfNotExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)
@@ -1228,7 +1227,8 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = new DeleteIf(ConditionBuilder.column(COL1).isEqualToText("1"));
+    MutationCondition condition =
+        ConditionBuilder.deleteIf(ConditionBuilder.column(COL1).isEqualToText("1")).build();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .withCondition(condition)

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -100,8 +100,8 @@ public class OperationCheckerTest {
   public void whenCheckingOperationWithWrongTable_shouldThrowIllegalArgumentException()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -120,8 +120,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingGetOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -136,8 +136,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingGetOperationWithInvalidProjections_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -154,8 +154,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, "p3", "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -172,8 +172,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidPartitionKeyType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, "1", PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, "1", PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -190,8 +190,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, "c3", "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, "c3", "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -208,8 +208,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidClusteringKeyType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, "2", CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, "2", CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -226,7 +226,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
@@ -243,9 +243,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -266,7 +266,7 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithoutAnyClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -289,9 +289,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithPartialClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 1);
-    Key endClusteringKey = new Key(CKEY1, 9);
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.ofInt(CKEY1, 1);
+    Key endClusteringKey = Key.ofInt(CKEY1, 9);
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -312,8 +312,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithoutAnyEndClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
@@ -335,9 +335,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithReverseOrderings_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -358,9 +358,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithPartialOrdering_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -380,9 +380,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithEmptyOrdering_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -402,9 +402,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidProjections_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     int limit = 10;
     Scan scan =
@@ -427,9 +427,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, "p3", "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -452,9 +452,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, "c3", "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, "c3", "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, "c3", "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, "c3", "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -477,9 +477,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidClusteringKeyRange_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2);
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.ofInt(CKEY1, 2);
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -527,9 +527,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithNegativeLimitNumber_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
     Scan scan =
@@ -551,9 +551,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithInvalidOrderings_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -576,9 +576,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidPartialOrdering_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -599,8 +599,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -619,8 +619,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithNullValue_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfNotExists();
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -638,8 +638,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithoutAnyCondition_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -659,8 +659,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, "c3", "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, "c3", "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -681,8 +681,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, "c3", "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -703,7 +703,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<Value<?>> values =
         Arrays.asList(
@@ -724,8 +724,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithInvalidValues_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
@@ -745,8 +745,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithInvalidValueType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -767,8 +767,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPutIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -791,8 +791,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPutIfConditionWithIsNull_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -817,8 +817,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPutIfConditionWithIsNotNull_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -843,8 +843,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithDeleteIfExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -864,8 +864,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithDeleteIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -887,7 +887,7 @@ public class OperationCheckerTest {
       whenCheckingPutOperationWithPartitionKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, null).build();
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -906,8 +906,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithPartitionKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -926,7 +926,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithClusteringKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, null).build();
     List<Value<?>> values =
         Arrays.asList(
@@ -946,8 +946,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithClusteringKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -979,8 +979,8 @@ public class OperationCheckerTest {
 
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
-    Key partitionKey = new Key(PKEY1, (byte[]) null);
-    Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
+    Key partitionKey = Key.ofBlob(PKEY1, (byte[]) null);
+    Key clusteringKey = Key.ofBlob(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -1010,8 +1010,8 @@ public class OperationCheckerTest {
 
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
-    Key partitionKey = new Key(PKEY1, new byte[0]);
-    Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
+    Key partitionKey = Key.ofBlob(PKEY1, new byte[0]);
+    Key clusteringKey = Key.ofBlob(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -1041,8 +1041,8 @@ public class OperationCheckerTest {
 
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
-    Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
-    Key clusteringKey = new Key(CKEY1, (byte[]) null);
+    Key partitionKey = Key.ofBlob(PKEY1, new byte[] {1, 1, 1});
+    Key clusteringKey = Key.ofBlob(CKEY1, (byte[]) null);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -1072,8 +1072,8 @@ public class OperationCheckerTest {
 
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
-    Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
-    Key clusteringKey = new Key(CKEY1, new byte[0]);
+    Key partitionKey = Key.ofBlob(PKEY1, new byte[] {1, 1, 1});
+    Key clusteringKey = Key.ofBlob(CKEY1, new byte[0]);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
         new Put(partitionKey, clusteringKey)
@@ -1089,8 +1089,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new IntValue(1), ConditionalExpression.Operator.EQ));
@@ -1107,8 +1107,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithoutAnyCondition_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = null;
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1124,8 +1124,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, "p3", "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new DeleteIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1142,8 +1142,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, "c3", "val1");
     MutationCondition condition = new DeleteIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1160,7 +1160,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     MutationCondition condition = new DeleteIfExists();
     Delete delete =
@@ -1177,8 +1177,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithPutIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIf();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1195,8 +1195,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithPutIfExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1213,8 +1213,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithPutIfNotExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfNotExists();
     Delete delete =
         new Delete(partitionKey, clusteringKey)
@@ -1231,8 +1231,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidDeleteIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
@@ -1251,8 +1251,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidDeleteIfConditionWithIsNull_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         ConditionBuilder.deleteIf(
                 ConditionBuilder.buildConditionalExpression(
@@ -1273,8 +1273,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidDeleteIfConditionWithIsNotNull_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         ConditionBuilder.deleteIf(
                 ConditionBuilder.buildConditionalExpression(
@@ -1297,8 +1297,8 @@ public class OperationCheckerTest {
     // Arrange
     when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL1, 1)
@@ -1328,9 +1328,9 @@ public class OperationCheckerTest {
     // Arrange
     when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
-    Key partitionKey1 = new Key(PKEY1, 1, PKEY2, "val1");
-    Key partitionKey2 = new Key(PKEY1, 2, PKEY2, "val2");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
+    Key partitionKey1 = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey2 = Key.of(PKEY1, 2, PKEY2, "val2");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val3");
     Put put =
         new Put(partitionKey1, clusteringKey)
             .withValue(COL1, 1)
@@ -1351,8 +1351,8 @@ public class OperationCheckerTest {
     // Arrange
     when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
-    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val3");
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL1, 1)
@@ -1439,7 +1439,7 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingGetOperationWithIndexedColumnAsPartitionKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(COL1, 1);
+    Key partitionKey = Key.ofInt(COL1, 1);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
@@ -1456,7 +1456,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithNonIndexedColumnAsPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL2, 0.1d);
+    Key partitionKey = Key.ofDouble(COL2, 0.1d);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
@@ -1474,7 +1474,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithIndexedColumnAsPartitionKeyButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL1, "1");
+    Key partitionKey = Key.ofText(COL1, "1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
@@ -1492,8 +1492,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithIndexedColumnAsPartitionKeyWithClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL1, 1);
-    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
+    Key partitionKey = Key.ofInt(COL1, 1);
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -1576,7 +1576,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithIndexedColumnAsPartitionKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = new Key(COL1, 1);
+    Key partitionKey = Key.ofInt(COL1, 1);
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -1598,7 +1598,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithNonIndexedColumnAsPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL2, 0.1d);
+    Key partitionKey = Key.ofDouble(COL2, 0.1d);
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -1621,7 +1621,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL1, "1");
+    Key partitionKey = Key.ofText(COL1, "1");
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -1644,9 +1644,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyWithClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL1, 1);
-    Key startClusteringKey = new Key(CKEY1, 2, "c3", "val1");
-    Key endClusteringKey = new Key(CKEY1, 2, "c3", "val9");
+    Key partitionKey = Key.ofInt(COL1, 1);
+    Key startClusteringKey = Key.of(CKEY1, 2, "c3", "val1");
+    Key endClusteringKey = Key.of(CKEY1, 2, "c3", "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -1667,7 +1667,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyWithOrderings_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = new Key(COL1, 1);
+    Key partitionKey = Key.ofInt(COL1, 1);
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -248,8 +248,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -271,8 +271,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -294,8 +294,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -317,8 +317,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -340,8 +340,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .withOrdering(Scan.Ordering.desc(CKEY1))
+            .withOrdering(Scan.Ordering.asc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -363,7 +363,7 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -407,8 +407,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -432,8 +432,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -457,8 +457,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -482,8 +482,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -532,8 +532,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -556,8 +556,8 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
+            .withOrdering(Scan.Ordering.desc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -581,7 +581,7 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .withOrdering(Scan.Ordering.asc(CKEY2))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 
@@ -1671,7 +1671,7 @@ public class OperationCheckerTest {
             .withStart(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .withOrdering(Scan.Ordering.asc(CKEY1))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -16,10 +16,9 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.WriteTimeoutException;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfExists;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Key;
@@ -97,7 +96,7 @@ public class BatchHandlerTest {
 
   private List<Mutation> prepareConditionalPuts() {
     List<Mutation> mutations = prepareNonConditionalPuts();
-    mutations.forEach(m -> m.withCondition(new PutIfNotExists()));
+    mutations.forEach(m -> m.withCondition(ConditionBuilder.putIfNotExists()));
     return mutations;
   }
 
@@ -146,7 +145,7 @@ public class BatchHandlerTest {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
-    mutations.get(1).withCondition(new PutIfExists());
+    mutations.get(1).withCondition(ConditionBuilder.putIfExists());
     when(session.execute(any(Statement.class))).thenReturn(results);
     when(results.wasApplied()).thenReturn(true);
 
@@ -165,7 +164,7 @@ public class BatchHandlerTest {
     // Arrange
     configureBehavior();
     mutations = prepareNonConditionalPuts();
-    mutations.get(1).withCondition(new PutIfNotExists());
+    mutations.get(1).withCondition(ConditionBuilder.putIfNotExists());
     when(session.execute(any(Statement.class))).thenReturn(results);
     when(results.wasApplied()).thenReturn(true);
     spy = prepareSpiedBatchHandler();

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -79,14 +79,14 @@ public class BatchHandlerTest {
   }
 
   private List<Mutation> prepareNonConditionalPuts() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey1 = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey1 = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Put put1 =
         new Put(partitionKey, clusteringKey1)
             .withValue(ANY_NAME_3, ANY_INT_1)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    Key clusteringKey2 = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key clusteringKey2 = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     Put put2 =
         new Put(partitionKey, clusteringKey2)
             .withValue(ANY_NAME_3, ANY_INT_1)

--- a/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
@@ -1,6 +1,5 @@
 package com.scalar.db.storage.cassandra;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -15,16 +14,14 @@ import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Joiner;
-import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -236,8 +233,8 @@ public class DeleteStatementHandlerTest {
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
+            ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)));
 
     // Act
     handler.prepare(del);
@@ -267,9 +264,7 @@ public class DeleteStatementHandlerTest {
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
     DeleteIf deleteIf =
-        spy(
-            new DeleteIf(
-                new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)));
+        spy(new DeleteIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)));
     del.withCondition(deleteIf);
 
     // Act
@@ -300,8 +295,8 @@ public class DeleteStatementHandlerTest {
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
+            ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)));
 
     // Act
     handler.bind(prepared, del);
@@ -378,8 +373,8 @@ public class DeleteStatementHandlerTest {
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
             new DeleteIf(
-                new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
-                new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)))
+                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
+                ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)))
         .withConsistency(Consistency.EVENTUAL);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
@@ -56,21 +56,21 @@ public class DeleteStatementHandlerTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
   private Delete prepareDeleteWithClusteringKey() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Delete prepareDeleteWithReservedKeywords() {
-    Key partitionKey = new Key("from", ANY_TEXT_1);
-    Key clusteringKey = new Key("to", ANY_TEXT_2);
+    Key partitionKey = Key.ofText("from", ANY_TEXT_1);
+    Key clusteringKey = Key.ofText("to", ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey).forNamespace("keyspace").forTable("table");
   }
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
@@ -200,7 +200,7 @@ public class DeleteStatementHandlerTest {
                 });
     configureBehavior(expected);
     del = prepareDeleteWithClusteringKey();
-    del.withCondition(new DeleteIfExists());
+    del.withCondition(ConditionBuilder.deleteIfExists());
 
     // Act
     handler.prepare(del);
@@ -232,9 +232,9 @@ public class DeleteStatementHandlerTest {
     configureBehavior(expected);
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
-            ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1))
+            .and(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3))
+            .build());
 
     // Act
     handler.prepare(del);
@@ -248,7 +248,7 @@ public class DeleteStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
-    DeleteIfExists deleteIfExists = spy(new DeleteIfExists());
+    DeleteIfExists deleteIfExists = spy(ConditionBuilder.deleteIfExists());
     del.withCondition(deleteIfExists);
 
     // Act
@@ -264,7 +264,9 @@ public class DeleteStatementHandlerTest {
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
     DeleteIf deleteIf =
-        spy(new DeleteIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)));
+        spy(
+            ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+                .build());
     del.withCondition(deleteIf);
 
     // Act
@@ -294,9 +296,9 @@ public class DeleteStatementHandlerTest {
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
-            ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1))
+            .and(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3))
+            .build());
 
     // Act
     handler.bind(prepared, del);
@@ -356,7 +358,7 @@ public class DeleteStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
-    del.withCondition(new DeleteIfExists()).withConsistency(Consistency.EVENTUAL);
+    del.withCondition(ConditionBuilder.deleteIfExists()).withConsistency(Consistency.EVENTUAL);
 
     // Act
     handler.setConsistency(bound, del);
@@ -372,9 +374,9 @@ public class DeleteStatementHandlerTest {
     configureBehavior(null);
     del = prepareDeleteWithClusteringKey();
     del.withCondition(
-            new DeleteIf(
-                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1),
-                ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3)))
+            ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_1))
+                .and(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_3))
+                .build())
         .withConsistency(Consistency.EVENTUAL);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
@@ -21,6 +21,7 @@ import com.datastax.driver.core.WriteType;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.WriteTimeoutException;
 import com.google.common.base.Joiner;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
@@ -215,7 +216,7 @@ public class InsertStatementHandlerTest {
                 });
     configureBehavior(expected);
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
 
     // Act
     handler.prepare(put);
@@ -229,7 +230,7 @@ public class InsertStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    PutIfNotExists putIfNotExists = spy(new PutIfNotExists());
+    PutIfNotExists putIfNotExists = spy(ConditionBuilder.putIfNotExists());
     put.withCondition(putIfNotExists);
 
     // Act
@@ -318,7 +319,7 @@ public class InsertStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists()).withConsistency(Consistency.EVENTUAL);
+    put.withCondition(ConditionBuilder.putIfNotExists()).withConsistency(Consistency.EVENTUAL);
 
     // Act
     handler.setConsistency(bound, put);
@@ -332,7 +333,7 @@ public class InsertStatementHandlerTest {
   public void handle_WTEWithCasThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
     spy = prepareSpiedInsertStatementHandler();
 
     WriteTimeoutException toThrow = mock(WriteTimeoutException.class);
@@ -349,7 +350,7 @@ public class InsertStatementHandlerTest {
   public void handle_PutWithConditionGivenAndWTEWithSimpleThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
     spy = prepareSpiedInsertStatementHandler();
 
     WriteTimeoutException toThrow = mock(WriteTimeoutException.class);
@@ -398,7 +399,7 @@ public class InsertStatementHandlerTest {
   public void handle_PutWithConditionButNoMutationApplied_ShouldThrowProperExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
     spy = prepareSpiedInsertStatementHandler();
 
     ResultSet results = mock(ResultSet.class);
@@ -415,7 +416,7 @@ public class InsertStatementHandlerTest {
   public void handle_PutWithoutConditionButNoMutationApplied_ShouldThrowProperExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
     spy = prepareSpiedInsertStatementHandler();
 
     ResultSet results = mock(ResultSet.class);

--- a/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
@@ -59,7 +59,7 @@ public class InsertStatementHandlerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Put(partitionKey)
         .withValue(ANY_NAME_2, ANY_INT_1)
         .withValue(ANY_NAME_3, ANY_INT_2)
@@ -68,8 +68,8 @@ public class InsertStatementHandlerTest {
   }
 
   private Put preparePutWithClusteringKey() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue(ANY_NAME_3, ANY_INT_1)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -77,8 +77,8 @@ public class InsertStatementHandlerTest {
   }
 
   private Put preparePutWithReservedKeywords() {
-    Key partitionKey = new Key("from", ANY_TEXT_1);
-    Key clusteringKey = new Key("to", ANY_TEXT_2);
+    Key partitionKey = Key.ofText("from", ANY_TEXT_1);
+    Key clusteringKey = Key.ofText("to", ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue("one", ANY_INT_1)
         .forNamespace("keyspace")

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -331,7 +331,7 @@ public class SelectStatementHandlerTest {
     configureBehavior(expected);
     scan = prepareScan();
     scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-        .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
+        .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
         .withLimit(ANY_LIMIT);
 
     // Act
@@ -365,8 +365,8 @@ public class SelectStatementHandlerTest {
     configureBehavior(expected);
     scan = prepareScan();
     scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-        .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
-        .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
+        .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
+        .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
         .withLimit(ANY_LIMIT);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -60,26 +60,26 @@ public class SelectStatementHandlerTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
   private Get prepareGetWithClusteringKey() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Get prepareGetWithReservedKeywords() {
-    Key partitionKey = new Key("from", ANY_TEXT_1);
-    Key clusteringKey = new Key("to", ANY_TEXT_2);
+    Key partitionKey = Key.ofText("from", ANY_TEXT_1);
+    Key clusteringKey = Key.ofText("to", ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey).forNamespace("keyspace").forTable("table");
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
@@ -239,7 +239,7 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2)).withEnd(new Key(ANY_NAME_2, ANY_TEXT_3));
+    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2)).withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3));
 
     // Act
     handler.prepare(scan);
@@ -269,8 +269,8 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-        .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+    scan.withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+        .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     // Act
     handler.prepare(scan);
@@ -298,8 +298,8 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-        .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), false);
+    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+        .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
 
     // Act
     handler.prepare(scan);
@@ -330,7 +330,7 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
         .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
         .withLimit(ANY_LIMIT);
 
@@ -364,7 +364,7 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
         .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
         .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
         .withLimit(ANY_LIMIT);
@@ -395,8 +395,8 @@ public class SelectStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     scan = prepareScan();
-    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-        .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+    scan.withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+        .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     // Act
     handler.bind(prepared, scan);

--- a/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
@@ -1,6 +1,5 @@
 package com.scalar.db.storage.cassandra;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -13,14 +12,12 @@ import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Joiner;
-import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -256,12 +253,12 @@ public class UpdateStatementHandlerTest {
     put = preparePutWithClusteringKey();
     put.withCondition(
         new PutIf(
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.NE),
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.GT),
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.GTE),
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.LT),
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.LTE)));
+            ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_4).isNotEqualToInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanOrEqualToInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_4).isLessThanInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_4).isLessThanOrEqualToInt(ANY_INT_2)));
 
     // Act
     handler.prepare(put);
@@ -291,8 +288,7 @@ public class UpdateStatementHandlerTest {
     configureBehavior(null);
     put = preparePutWithClusteringKey();
     PutIf putIf =
-        Mockito.spy(
-            new PutIf(new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)));
+        Mockito.spy(new PutIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)));
     put.withCondition(putIf);
 
     // Act
@@ -324,8 +320,8 @@ public class UpdateStatementHandlerTest {
     put = preparePutWithClusteringKey();
     put.withCondition(
         new PutIf(
-            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ),
-            new ConditionalExpression(ANY_NAME_5, new TextValue(ANY_TEXT_3), Operator.EQ)));
+            ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2),
+            ConditionBuilder.column(ANY_NAME_5).isEqualToText(ANY_TEXT_3)));
 
     // Act
     handler.bind(prepared, put);
@@ -417,8 +413,7 @@ public class UpdateStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    put.withCondition(
-            new PutIf(new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)))
+    put.withCondition(new PutIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)))
         .withConsistency(Consistency.EVENTUAL);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
@@ -54,7 +54,7 @@ public class UpdateStatementHandlerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Put(partitionKey)
         .withValue(ANY_NAME_2, ANY_INT_1)
         .withValue(ANY_NAME_3, ANY_INT_2)
@@ -63,8 +63,8 @@ public class UpdateStatementHandlerTest {
   }
 
   private Put preparePutWithClusteringKey() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue(ANY_NAME_3, ANY_INT_1)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -72,8 +72,8 @@ public class UpdateStatementHandlerTest {
   }
 
   private Put preparePutWithReservedKeywords() {
-    Key partitionKey = new Key("from", ANY_TEXT_1);
-    Key clusteringKey = new Key("to", ANY_TEXT_2);
+    Key partitionKey = Key.ofText("from", ANY_TEXT_1);
+    Key clusteringKey = Key.ofText("to", ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue("one", ANY_INT_1)
         .forNamespace("keyspace")

--- a/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
@@ -211,7 +211,7 @@ public class UpdateStatementHandlerTest {
                 });
     configureBehavior(expected);
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfExists());
+    put.withCondition(ConditionBuilder.putIfExists());
 
     // Act
     handler.prepare(put);
@@ -252,13 +252,13 @@ public class UpdateStatementHandlerTest {
     configureBehavior(expected);
     put = preparePutWithClusteringKey();
     put.withCondition(
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_4).isNotEqualToInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanOrEqualToInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_4).isLessThanInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_4).isLessThanOrEqualToInt(ANY_INT_2)));
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_4).isNotEqualToInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanOrEqualToInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_4).isLessThanInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_4).isLessThanOrEqualToInt(ANY_INT_2))
+            .build());
 
     // Act
     handler.prepare(put);
@@ -272,7 +272,7 @@ public class UpdateStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    PutIfExists putIfExists = Mockito.spy(new PutIfExists());
+    PutIfExists putIfExists = Mockito.spy(ConditionBuilder.putIfExists());
     put.withCondition(putIfExists);
 
     // Act
@@ -288,7 +288,9 @@ public class UpdateStatementHandlerTest {
     configureBehavior(null);
     put = preparePutWithClusteringKey();
     PutIf putIf =
-        Mockito.spy(new PutIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)));
+        Mockito.spy(
+            ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+                .build());
     put.withCondition(putIf);
 
     // Act
@@ -319,9 +321,9 @@ public class UpdateStatementHandlerTest {
     configureBehavior(null);
     put = preparePutWithClusteringKey();
     put.withCondition(
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2),
-            ConditionBuilder.column(ANY_NAME_5).isEqualToText(ANY_TEXT_3)));
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+            .and(ConditionBuilder.column(ANY_NAME_5).isEqualToText(ANY_TEXT_3))
+            .build());
 
     // Act
     handler.bind(prepared, put);
@@ -398,7 +400,7 @@ public class UpdateStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIfExists()).withConsistency(Consistency.EVENTUAL);
+    put.withCondition(ConditionBuilder.putIfExists()).withConsistency(Consistency.EVENTUAL);
 
     // Act
     handler.setConsistency(bound, put);
@@ -413,7 +415,9 @@ public class UpdateStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     put = preparePutWithClusteringKey();
-    put.withCondition(new PutIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2)))
+    put.withCondition(
+            ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+                .build())
         .withConsistency(Consistency.EVENTUAL);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
@@ -78,8 +78,8 @@ public class BatchHandlerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -88,8 +88,8 @@ public class BatchHandlerTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
@@ -19,11 +19,10 @@ import com.azure.cosmos.CosmosScripts;
 import com.azure.cosmos.CosmosStoredProcedure;
 import com.azure.cosmos.models.CosmosStoredProcedureRequestOptions;
 import com.azure.cosmos.models.CosmosStoredProcedureResponse;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -104,9 +103,9 @@ public class BatchHandlerTest {
         .thenReturn(spResponse);
 
     Put put1 = preparePut();
-    Put put2 = preparePut().withCondition(new PutIfNotExists());
+    Put put2 = preparePut().withCondition(ConditionBuilder.putIfNotExists());
     Delete delete1 = prepareDelete();
-    Delete delete2 = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete2 = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
     CosmosMutation cosmosMutation1 = new CosmosMutation(put1, metadata);
     CosmosMutation cosmosMutation2 = new CosmosMutation(put2, metadata);
     CosmosMutation cosmosMutation3 = new CosmosMutation(delete1, metadata);
@@ -156,8 +155,8 @@ public class BatchHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.PRECONDITION_FAILED.get());
 
-    Put put = preparePut().withCondition(new PutIfNotExists());
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(Arrays.asList(put, delete)))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
@@ -96,9 +96,10 @@ public class ConditionalQueryBuilderTest {
   public void visit_PutIfAcceptCalled_ShouldCallWhere() {
     // Arrange
     PutIf condition =
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.putIf(
+                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act
@@ -112,7 +113,7 @@ public class ConditionalQueryBuilderTest {
   @Test
   public void visit_PutIfExistsAcceptCalled_ShouldNotCallWhere() {
     // Arrange
-    PutIfExists condition = new PutIfExists();
+    PutIfExists condition = ConditionBuilder.putIfExists();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act
@@ -125,7 +126,7 @@ public class ConditionalQueryBuilderTest {
   @Test
   public void visit_PutIfNotExistsAcceptCalled_ShouldNotCallWhere() {
     // Arrange
-    PutIfNotExists condition = new PutIfNotExists();
+    PutIfNotExists condition = ConditionBuilder.putIfNotExists();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act
@@ -139,9 +140,10 @@ public class ConditionalQueryBuilderTest {
   public void visit_DeleteIfAcceptCalled_ShouldCallWhere() {
     // Arrange
     DeleteIf condition =
-        new DeleteIf(
-            ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.deleteIf(
+                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
-import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
@@ -99,8 +97,8 @@ public class ConditionalQueryBuilderTest {
     // Arrange
     PutIf condition =
         new PutIf(
-            new ConditionalExpression(ANY_NAME_1, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_2, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()));
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act
@@ -142,8 +140,8 @@ public class ConditionalQueryBuilderTest {
     // Arrange
     DeleteIf condition =
         new DeleteIf(
-            new ConditionalExpression(ANY_NAME_1, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_2, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()));
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -44,8 +44,8 @@ public class CosmosMutationTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -54,8 +54,8 @@ public class CosmosMutationTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
@@ -137,7 +137,7 @@ public class CosmosMutationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Delete delete =
         new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
 
@@ -161,8 +161,8 @@ public class CosmosMutationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_2, ANY_NAME_3)));
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Delete delete =
         new Delete(partitionKey, clusteringKey)
             .forNamespace(ANY_NAMESPACE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -190,9 +190,10 @@ public class CosmosMutationTest {
   public void makeConditionalQuery_MutationWithConditionsGiven_ShouldReturnQuery() {
     // Arrange
     PutIf conditions =
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.putIf(
+                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     Put put = preparePut().withCondition(conditions);
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     String id = cosmosMutation.getId();

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -3,8 +3,7 @@ package com.scalar.db.storage.cosmos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.scalar.db.api.ConditionalExpression;
-import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
@@ -192,8 +191,8 @@ public class CosmosMutationTest {
     // Arrange
     PutIf conditions =
         new PutIf(
-            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
     Put put = preparePut().withCondition(conditions);
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     String id = cosmosMutation.getId();

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -53,7 +53,7 @@ public class CosmosOperationTest {
     // Arrange
     when(metadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
+    Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -70,8 +70,8 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Get get =
         new Get(partitionKey, clusteringKey)
             .forNamespace(ANY_NAMESPACE_NAME)
@@ -91,7 +91,7 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
+    Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Delete delete =
         new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(delete, metadata);
@@ -110,7 +110,7 @@ public class CosmosOperationTest {
         .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3)));
 
     Key partitionKey =
-        new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
+        Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -128,7 +128,7 @@ public class CosmosOperationTest {
         .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3)));
 
     Key partitionKey =
-        new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
+        Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -147,8 +147,8 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Get get =
         new Get(partitionKey, clusteringKey)
             .forNamespace(ANY_NAMESPACE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -24,8 +24,8 @@ import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosStoredProcedureRequestOptions;
 import com.azure.cosmos.models.CosmosStoredProcedureResponse;
 import com.azure.cosmos.models.PartitionKey;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
@@ -174,7 +174,7 @@ public class DeleteStatementHandlerTest {
     when(storedProcedure.execute(anyList(), any(CosmosStoredProcedureRequestOptions.class)))
         .thenReturn(spResponse);
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
     CosmosMutation cosmosMutation = new CosmosMutation(delete, metadata);
     String query = cosmosMutation.makeConditionalQuery();
 
@@ -202,7 +202,7 @@ public class DeleteStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.PRECONDITION_FAILED.get());
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete)).isInstanceOf(NoMutationException.class);
@@ -218,7 +218,7 @@ public class DeleteStatementHandlerTest {
         .when(storedProcedure)
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -81,8 +81,8 @@ public class DeleteStatementHandlerTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     id = ANY_TEXT_1 + ":" + ANY_TEXT_2;
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
     return new Delete(partitionKey, clusteringKey)
@@ -145,7 +145,7 @@ public class DeleteStatementHandlerTest {
     when(storedProcedure.execute(anyList(), any(CosmosStoredProcedureRequestOptions.class)))
         .thenReturn(spResponse);
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
     Delete delete =
         new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -76,8 +76,8 @@ public class PutStatementHandlerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -121,7 +121,7 @@ public class PutStatementHandlerTest {
         .thenReturn(spResponse);
     when(spResponse.getResponseAsString()).thenReturn("true");
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Put put =
         new Put(partitionKey)
             .forNamespace(ANY_NAMESPACE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -19,10 +19,9 @@ import com.azure.cosmos.CosmosScripts;
 import com.azure.cosmos.CosmosStoredProcedure;
 import com.azure.cosmos.models.CosmosStoredProcedureRequestOptions;
 import com.azure.cosmos.models.CosmosStoredProcedureResponse;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfExists;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.NoMutationException;
@@ -171,7 +170,7 @@ public class PutStatementHandlerTest {
         .thenReturn(spResponse);
     when(spResponse.getResponseAsString()).thenReturn("true");
 
-    Put put = preparePut().withCondition(new PutIfNotExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     Record record = cosmosMutation.makeRecord();
     String query = cosmosMutation.makeConditionalQuery();
@@ -198,7 +197,7 @@ public class PutStatementHandlerTest {
     when(storedProcedure.execute(anyList(), any(CosmosStoredProcedureRequestOptions.class)))
         .thenReturn(spResponse);
 
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     Record record = cosmosMutation.makeRecord();
     String query = cosmosMutation.makeConditionalQuery();
@@ -227,7 +226,7 @@ public class PutStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.PRECONDITION_FAILED.get());
 
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put)).isInstanceOf(NoMutationException.class);
@@ -244,7 +243,7 @@ public class PutStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.RETRY_WITH.get());
 
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -90,8 +90,8 @@ public class SelectStatementHandlerTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     id = ANY_TEXT_1 + ":" + ANY_TEXT_2;
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
     return new Get(partitionKey, clusteringKey)
@@ -100,7 +100,7 @@ public class SelectStatementHandlerTest {
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
@@ -132,7 +132,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Get get = new Get(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     String query =
         "select * from Record r where r.values[\"" + ANY_NAME_3 + "\"]" + " = '" + ANY_TEXT_3 + "'";
@@ -221,7 +221,7 @@ public class SelectStatementHandlerTest {
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Scan scan = new Scan(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     String query =
         "select * from Record r where r.values[\"" + ANY_NAME_3 + "\"]" + " = '" + ANY_TEXT_3 + "'";
@@ -264,8 +264,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3));
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3));
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -310,8 +310,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -362,8 +362,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), false);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -404,7 +404,7 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
             .withLimit(ANY_LIMIT);
 
@@ -445,7 +445,7 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
             .withLimit(ANY_LIMIT);
 
@@ -490,7 +490,7 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
             .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.DESC))
             .withLimit(ANY_LIMIT);
@@ -538,7 +538,7 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
             .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.ASC))
             .withLimit(ANY_LIMIT);
@@ -694,7 +694,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Get get =
         new Get(indexKey)
             .forNamespace(ANY_NAMESPACE_NAME)
@@ -842,7 +842,7 @@ public class SelectStatementHandlerTest {
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Scan scan =
         new Scan(indexKey)
             .forNamespace(ANY_NAMESPACE_NAME)
@@ -882,7 +882,7 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
             .withLimit(ANY_LIMIT)
             .withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -405,7 +405,7 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -446,7 +446,7 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
+            .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -491,8 +491,8 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
-            .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.DESC))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
+            .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -539,8 +539,8 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
-            .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.ASC))
+            .withOrdering(Scan.Ordering.desc(ANY_NAME_2))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_3))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -883,7 +883,7 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
             .withLimit(ANY_LIMIT)
             .withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
@@ -8,11 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -110,8 +109,8 @@ public abstract class BatchHandlerTestBase {
             .build();
     doThrow(toThrow).when(client).transactWriteItems(any(TransactWriteItemsRequest.class));
 
-    Put put = preparePut().withCondition(new PutIfNotExists());
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(Arrays.asList(put, delete)))
@@ -129,8 +128,8 @@ public abstract class BatchHandlerTestBase {
             .build();
     doThrow(toThrow).when(client).transactWriteItems(any(TransactWriteItemsRequest.class));
 
-    Put put = preparePut().withCondition(new PutIfNotExists());
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(Arrays.asList(put, delete)))

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
@@ -72,8 +72,8 @@ public abstract class BatchHandlerTestBase {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -82,8 +82,8 @@ public abstract class BatchHandlerTestBase {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
@@ -68,7 +68,7 @@ public class ConditionExpressionBuilderTest {
   @Test
   public void visit_PutIfExistsAcceptCalled_ShouldReturnEmpty() {
     // Arrange
-    PutIfExists condition = new PutIfExists();
+    PutIfExists condition = ConditionBuilder.putIfExists();
     ConditionExpressionBuilder builder =
         new ConditionExpressionBuilder(
             DynamoOperation.CONDITION_COLUMN_NAME_ALIAS, DynamoOperation.CONDITION_VALUE_ALIAS);
@@ -84,7 +84,7 @@ public class ConditionExpressionBuilderTest {
   @Test
   public void visit_PutIfNotExistsAcceptCalled_ShouldReturnEmpty() {
     // Arrange
-    PutIfNotExists condition = new PutIfNotExists();
+    PutIfNotExists condition = ConditionBuilder.putIfNotExists();
     ConditionExpressionBuilder builder =
         new ConditionExpressionBuilder(
             DynamoOperation.CONDITION_COLUMN_NAME_ALIAS, DynamoOperation.CONDITION_VALUE_ALIAS);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
@@ -63,8 +63,8 @@ public abstract class DeleteStatementHandlerTestBase {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
@@ -111,7 +111,7 @@ public abstract class DeleteStatementHandlerTestBase {
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
     when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Delete delete =
         new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
@@ -136,7 +136,7 @@ public abstract class DeleteStatementHandlerTestBase {
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
     when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     DynamoMutation dynamoMutation = new DynamoMutation(delete, metadata);
 
@@ -162,7 +162,7 @@ public abstract class DeleteStatementHandlerTestBase {
     ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
     doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete)).isInstanceOf(NoMutationException.class);
@@ -177,7 +177,7 @@ public abstract class DeleteStatementHandlerTestBase {
     DynamoDbException toThrow = mock(DynamoDbException.class);
     doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
 
-    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete))

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -3,8 +3,7 @@ package com.scalar.db.storage.dynamo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.scalar.db.api.ConditionalExpression;
-import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
@@ -98,8 +97,8 @@ public class DynamoMutationTest {
     // Arrange
     PutIf conditions =
         new PutIf(
-            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
     Put put = preparePut().withCondition(conditions);
 
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
@@ -125,8 +124,8 @@ public class DynamoMutationTest {
     // Arrange
     PutIf conditions =
         new PutIf(
-            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
     Put put = preparePut().withCondition(conditions);
 
     Map<String, String> expected = new HashMap<>();
@@ -170,8 +169,8 @@ public class DynamoMutationTest {
     // Arrange
     PutIf conditions =
         new PutIf(
-            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
-            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
+            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
     Put put = preparePut().withCondition(conditions);
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -46,8 +46,8 @@ public class DynamoMutationTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
-import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
@@ -96,9 +95,10 @@ public class DynamoMutationTest {
   public void getCondition_PutGiven_ShouldReturnCondition() {
     // Arrange
     PutIf conditions =
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.putIf(
+                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     Put put = preparePut().withCondition(conditions);
 
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
@@ -123,9 +123,10 @@ public class DynamoMutationTest {
   public void getConditionColumnMap_PutGiven_ShouldReturnCondition() {
     // Arrange
     PutIf conditions =
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.putIf(
+                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     Put put = preparePut().withCondition(conditions);
 
     Map<String, String> expected = new HashMap<>();
@@ -144,7 +145,7 @@ public class DynamoMutationTest {
   @Test
   public void getUpdateExpression_PutWithIfExistsGiven_ShouldReturnExpression() {
     // Arrange
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
 
     // Act
@@ -168,9 +169,10 @@ public class DynamoMutationTest {
   public void getConditionBindMap_PutWithPutIfGiven_ShouldReturnBindMap() {
     // Arrange
     PutIf conditions =
-        new PutIf(
-            ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()),
-            ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()));
+        ConditionBuilder.putIf(
+                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+            .build();
     Put put = preparePut().withCondition(conditions);
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(
@@ -192,7 +194,7 @@ public class DynamoMutationTest {
   @Test
   public void getValueBindMap_PutWithPutIfExistsGiven_ShouldReturnBindMap() {
     // Arrange
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(
         DynamoOperation.VALUE_ALIAS + "0",

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -39,8 +39,8 @@ public class DynamoOperationTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
@@ -70,14 +70,14 @@ public class DynamoOperationTest {
         AttributeValue.builder()
             .b(
                 SdkBytes.fromByteBuffer(
-                    new KeyBytesEncoder().encode(new Key(ANY_NAME_1, ANY_TEXT_1))))
+                    new KeyBytesEncoder().encode(Key.ofText(ANY_NAME_1, ANY_TEXT_1))))
             .build());
     expected.put(
         DynamoOperation.CLUSTERING_KEY,
         AttributeValue.builder()
             .b(
                 SdkBytes.fromByteBuffer(
-                    new KeyBytesEncoder().encode(new Key(ANY_NAME_2, ANY_TEXT_2))))
+                    new KeyBytesEncoder().encode(Key.ofText(ANY_NAME_2, ANY_TEXT_2))))
             .build());
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
@@ -9,10 +9,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfExists;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -151,7 +150,7 @@ public abstract class PutStatementHandlerTestBase {
   public void handle_PutIfNotExistsGiven_ShouldCallUpdateItemWithCondition() {
     // Arrange
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
-    Put put = preparePut().withCondition(new PutIfNotExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
 
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
@@ -177,7 +176,7 @@ public abstract class PutStatementHandlerTestBase {
   public void handle_PutIfExistsGiven_ShouldCallUpdateItemWithCondition() {
     // Arrange
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
     String updateExpression = dynamoMutation.getUpdateExpression();
@@ -204,7 +203,7 @@ public abstract class PutStatementHandlerTestBase {
     ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
     doThrow(toThrow).when(client).updateItem(any(UpdateItemRequest.class));
 
-    Put put = preparePut().withCondition(new PutIfExists());
+    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put)).isInstanceOf(NoMutationException.class);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
@@ -70,8 +70,8 @@ public abstract class PutStatementHandlerTestBase {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -107,7 +107,7 @@ public abstract class PutStatementHandlerTestBase {
   public void handle_PutWithoutClusteringKeyGiven_ShouldCallUpdateItem() {
     // Arrange
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Put put =
         new Put(partitionKey)
             .forNamespace(ANY_NAMESPACE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
@@ -95,15 +95,15 @@ public abstract class SelectStatementHandlerTestBase {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
@@ -158,7 +158,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Get get = new Get(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     String expectedKeyCondition =
         DynamoOperation.COLUMN_NAME_ALIAS + "0 = " + DynamoOperation.VALUE_ALIAS + "0";
@@ -225,7 +225,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Scan scan = new Scan(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
     String expectedKeyCondition =
         DynamoOperation.COLUMN_NAME_ALIAS + "0 = " + DynamoOperation.VALUE_ALIAS + "0";
@@ -251,7 +251,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Scan scan =
         new Scan(indexKey)
             .withProjection(ANY_NAME_1)
@@ -308,8 +308,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -335,7 +335,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -343,7 +344,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_3), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_3), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -367,8 +369,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), false);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -396,7 +398,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -408,7 +410,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_3),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -432,7 +434,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+    Scan scan = prepareScan().withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -456,7 +458,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -478,7 +481,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+    Scan scan = prepareScan().withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -502,7 +505,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -524,7 +528,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+    Scan scan = prepareScan().withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -548,7 +552,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -570,7 +575,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+    Scan scan = prepareScan().withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -594,7 +599,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -626,8 +632,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
+            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
+            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -654,7 +660,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -664,7 +670,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -698,8 +704,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
+            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
+            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -726,7 +732,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -736,7 +742,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -769,8 +775,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
+            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
+            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -798,7 +804,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -810,7 +816,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -845,8 +851,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
+            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
+            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -874,7 +880,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -886,7 +892,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -920,8 +926,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -947,7 +953,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -957,7 +964,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_3),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -991,8 +998,8 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), false);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1020,7 +1027,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1030,7 +1037,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_3), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_3), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -1061,7 +1069,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
+        prepareScan().withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1088,7 +1096,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -1099,7 +1107,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1133,7 +1141,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
+        prepareScan().withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1159,7 +1167,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -1168,7 +1177,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -1200,7 +1209,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
+        prepareScan().withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1228,7 +1237,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1240,7 +1249,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1274,7 +1283,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
+        prepareScan().withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1300,7 +1309,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -1310,7 +1320,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1342,7 +1352,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+    Scan scan = prepareScan().withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1366,7 +1376,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -1396,7 +1407,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+    Scan scan = prepareScan().withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1422,7 +1433,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1454,8 +1465,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan =
-        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
+    Scan scan = prepareScan().withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1481,7 +1491,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -1490,7 +1501,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -1522,8 +1533,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan =
-        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
+    Scan scan = prepareScan().withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1550,7 +1560,7 @@ public abstract class SelectStatementHandlerTestBase {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                            Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -1561,7 +1571,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1594,7 +1604,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
+        prepareScan().withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1620,7 +1630,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
         DynamoOperation.END_CLUSTERING_KEY_ALIAS,
@@ -1630,7 +1641,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1664,7 +1675,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
+        prepareScan().withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1692,7 +1703,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
+                                    Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1704,7 +1715,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1736,7 +1747,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+    Scan scan = prepareScan().withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1762,7 +1773,7 @@ public abstract class SelectStatementHandlerTestBase {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    new Key(ANY_NAME_2, ANY_TEXT_2),
+                                    Key.ofText(ANY_NAME_2, ANY_TEXT_2),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1794,7 +1805,7 @@ public abstract class SelectStatementHandlerTestBase {
     when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
-    Scan scan = prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+    Scan scan = prepareScan().withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1818,7 +1829,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -1841,7 +1853,7 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
             .withLimit(ANY_LIMIT);
 
@@ -1865,7 +1877,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert
@@ -1890,7 +1903,7 @@ public abstract class SelectStatementHandlerTestBase {
 
     Scan scan =
         prepareScan()
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
             .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
             .withLimit(ANY_LIMIT);
@@ -1915,7 +1928,8 @@ public abstract class SelectStatementHandlerTestBase {
             .b(
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
-                        .encode(new Key(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
+                        .encode(
+                            Key.ofText(ANY_NAME_2, ANY_TEXT_2), metadata.getClusteringOrders())))
             .build());
 
     // Act Assert

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
@@ -59,8 +59,6 @@ public abstract class SelectStatementHandlerTestBase {
   private static final String ANY_TEXT_2 = "text2";
   private static final String ANY_TEXT_3 = "text3";
   private static final String ANY_TEXT_4 = "text4";
-  private static final Scan.Ordering.Order ASC_ORDER = Scan.Ordering.Order.ASC;
-  private static final Scan.Ordering.Order DESC_ORDER = Scan.Ordering.Order.DESC;
   private static final int ANY_LIMIT = 100;
 
   private SelectStatementHandler handler;
@@ -1854,7 +1852,7 @@ public abstract class SelectStatementHandlerTestBase {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
             .withLimit(ANY_LIMIT);
 
     String expectedCondition =
@@ -1904,8 +1902,8 @@ public abstract class SelectStatementHandlerTestBase {
     Scan scan =
         prepareScan()
             .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
-            .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
+            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
+            .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
             .withLimit(ANY_LIMIT);
 
     String expectedCondition =

--- a/core/src/test/java/com/scalar/db/storage/dynamo/bytes/KeyBytesEncoderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/bytes/KeyBytesEncoderTest.java
@@ -85,10 +85,10 @@ public class KeyBytesEncoderTest {
 
     // Add min and max values and random values
     List<Key> target = new ArrayList<>(KEY_ELEMENT_COUNT);
-    target.add(new Key(getMinValue(COL1, col1Type)));
-    target.add(new Key(getMaxValue(COL1, col1Type)));
+    target.add(Key.newBuilder().add(getMinValue(COL1, col1Type)).build());
+    target.add(Key.newBuilder().add(getMaxValue(COL1, col1Type)).build());
     for (int i = 0; i < KEY_ELEMENT_COUNT - 2; i++) {
-      target.add(new Key(getRandomValue(COL1, col1Type, col1Order)));
+      target.add(Key.newBuilder().add(getRandomValue(COL1, col1Type, col1Order)).build());
     }
 
     Map<String, Order> keyOrders = new HashMap<>();
@@ -131,13 +131,16 @@ public class KeyBytesEncoderTest {
 
     // Add min and max values and random values
     List<Key> target = new ArrayList<>(KEY_ELEMENT_COUNT);
-    target.add(new Key(getMinValue(COL1, col1Type), getMinValue(COL2, col2Type)));
-    target.add(new Key(getMaxValue(COL1, col1Type), getMaxValue(COL2, col2Type)));
+    target.add(
+        Key.newBuilder().add(getMinValue(COL1, col1Type)).add(getMinValue(COL2, col2Type)).build());
+    target.add(
+        Key.newBuilder().add(getMaxValue(COL1, col1Type)).add(getMaxValue(COL2, col2Type)).build());
     for (int i = 0; i < KEY_ELEMENT_COUNT - 2; i++) {
       target.add(
-          new Key(
-              getRandomValue(COL1, col1Type, col1Order),
-              getRandomValue(COL2, col2Type, col2Order)));
+          Key.newBuilder()
+              .add(getRandomValue(COL1, col1Type, col1Order))
+              .add(getRandomValue(COL2, col2Type, col2Order))
+              .build());
     }
 
     Map<String, Order> keyOrders = new HashMap<>();
@@ -195,17 +198,24 @@ public class KeyBytesEncoderTest {
     // Add min and max values and random values
     List<Key> target = new ArrayList<>(KEY_ELEMENT_COUNT);
     target.add(
-        new Key(
-            getMinValue(COL1, col1Type), getMinValue(COL2, col2Type), getMinValue(COL3, col3Type)));
+        Key.newBuilder()
+            .add(getMinValue(COL1, col1Type))
+            .add(getMinValue(COL2, col2Type))
+            .add(getMinValue(COL3, col3Type))
+            .build());
     target.add(
-        new Key(
-            getMaxValue(COL1, col1Type), getMaxValue(COL2, col2Type), getMaxValue(COL3, col3Type)));
+        Key.newBuilder()
+            .add(getMaxValue(COL1, col1Type))
+            .add(getMaxValue(COL2, col2Type))
+            .add(getMaxValue(COL3, col3Type))
+            .build());
     for (int i = 0; i < KEY_ELEMENT_COUNT - 2; i++) {
       target.add(
-          new Key(
-              getRandomValue(COL1, col1Type, col1Order),
-              getRandomValue(COL2, col2Type, col2Order),
-              getRandomValue(COL3, col3Type, col3Order)));
+          Key.newBuilder()
+              .add(getRandomValue(COL1, col1Type, col1Order))
+              .add(getRandomValue(COL2, col2Type, col2Order))
+              .add(getRandomValue(COL3, col3Type, col3Order))
+              .build());
     }
 
     Map<String, Order> keyOrders = new HashMap<>();

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -8,11 +8,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
@@ -214,7 +213,7 @@ public class JdbcDatabaseTest {
               Put put =
                   new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
-                      .withCondition(new PutIfNotExists())
+                      .withCondition(ConditionBuilder.putIfNotExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               jdbcDatabase.put(put);
@@ -271,7 +270,7 @@ public class JdbcDatabaseTest {
             () -> {
               Delete delete =
                   new Delete(Key.ofText("p1", "val1"))
-                      .withCondition(new DeleteIfExists())
+                      .withCondition(ConditionBuilder.deleteIfExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               jdbcDatabase.delete(delete);
@@ -333,12 +332,12 @@ public class JdbcDatabaseTest {
               Put put =
                   new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
-                      .withCondition(new PutIfNotExists())
+                      .withCondition(ConditionBuilder.putIfNotExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
                   new Delete(Key.ofText("p1", "val1"))
-                      .withCondition(new DeleteIfExists())
+                      .withCondition(ConditionBuilder.deleteIfExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -71,7 +71,7 @@ public class JdbcDatabaseTest {
     // Arrange
 
     // Act
-    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.get(get);
 
     // Assert
@@ -90,7 +90,7 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.get(get);
             })
         .isInstanceOf(ExecutionException.class)
@@ -107,7 +107,7 @@ public class JdbcDatabaseTest {
             new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet, true));
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     Scanner scanner = jdbcDatabase.scan(scan);
     scanner.close();
 
@@ -129,7 +129,7 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class)
@@ -152,7 +152,7 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(IllegalArgumentException.class);
@@ -170,7 +170,7 @@ public class JdbcDatabaseTest {
     doThrow(sqlException).when(connection).commit();
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     Scanner scanner = jdbcDatabase.scan(scan);
     assertThatThrownBy(scanner::close).isInstanceOf(IOException.class).hasCause(sqlException);
 
@@ -190,7 +190,7 @@ public class JdbcDatabaseTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
@@ -212,7 +212,7 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .withCondition(new PutIfNotExists())
                       .forNamespace(NAMESPACE)
@@ -234,7 +234,7 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -251,7 +251,7 @@ public class JdbcDatabaseTest {
     when(jdbcService.delete(any(), any())).thenReturn(true);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.delete(delete);
 
     // Assert
@@ -270,7 +270,7 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Delete delete =
-                  new Delete(new Key("p1", "val1"))
+                  new Delete(Key.ofText("p1", "val1"))
                       .withCondition(new DeleteIfExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -291,7 +291,7 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(ExecutionException.class)
@@ -306,11 +306,11 @@ public class JdbcDatabaseTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
-    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.mutate(Arrays.asList(put, delete));
 
     // Assert
@@ -331,13 +331,13 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .withCondition(new PutIfNotExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1"))
+                  new Delete(Key.ofText("p1", "val1"))
                       .withCondition(new DeleteIfExists())
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -361,12 +361,12 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(ExecutionException.class)
@@ -388,12 +388,12 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(RetriableExecutionException.class)
@@ -415,12 +415,12 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isEqualTo(exception);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -11,14 +11,9 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
-import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIf;
-import com.scalar.db.api.PutIfExists;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
@@ -328,7 +323,8 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIf(ConditionBuilder.column("v1").isEqualToText("val2")))
+            .withCondition(
+                ConditionBuilder.putIf(ConditionBuilder.column("v1").isEqualToText("val2")).build())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -354,7 +350,8 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIf(ConditionBuilder.column("v1").isEqualToText("val2")))
+            .withCondition(
+                ConditionBuilder.putIf(ConditionBuilder.column("v1").isEqualToText("val2")).build())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -380,7 +377,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIfExists())
+            .withCondition(ConditionBuilder.putIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -406,7 +403,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIfExists())
+            .withCondition(ConditionBuilder.putIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -431,7 +428,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIfNotExists())
+            .withCondition(ConditionBuilder.putIfNotExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -458,7 +455,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(new PutIfNotExists())
+            .withCondition(ConditionBuilder.putIfNotExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -500,7 +497,9 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(new DeleteIf(ConditionBuilder.column("v1").isEqualToText("val2")))
+            .withCondition(
+                ConditionBuilder.deleteIf(ConditionBuilder.column("v1").isEqualToText("val2"))
+                    .build())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);
@@ -524,7 +523,9 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(new DeleteIf(ConditionBuilder.column("v1").isEqualToText("val2")))
+            .withCondition(
+                ConditionBuilder.deleteIf(ConditionBuilder.column("v1").isEqualToText("val2"))
+                    .build())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);
@@ -549,7 +550,7 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(new DeleteIfExists())
+            .withCondition(ConditionBuilder.deleteIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);
@@ -574,7 +575,7 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(new DeleteIfExists())
+            .withCondition(ConditionBuilder.deleteIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
@@ -28,7 +27,6 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
 import com.scalar.db.storage.jdbc.query.DeleteQuery;
 import com.scalar.db.storage.jdbc.query.InsertQuery;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
@@ -330,10 +328,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(
-                new PutIf(
-                    new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .withCondition(new PutIf(ConditionBuilder.column("v1").isEqualToText("val2")))
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -359,10 +354,7 @@ public class JdbcServiceTest {
     Put put =
         new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
-            .withCondition(
-                new PutIf(
-                    new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .withCondition(new PutIf(ConditionBuilder.column("v1").isEqualToText("val2")))
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.put(put, connection);
@@ -508,10 +500,7 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(
-                new DeleteIf(
-                    new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .withCondition(new DeleteIf(ConditionBuilder.column("v1").isEqualToText("val2")))
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);
@@ -535,10 +524,7 @@ public class JdbcServiceTest {
     // Act
     Delete delete =
         new Delete(Key.ofText("p1", "val1"))
-            .withCondition(
-                new DeleteIf(
-                    new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .withCondition(new DeleteIf(ConditionBuilder.column("v1").isEqualToText("val2")))
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -107,7 +107,7 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcService.get(get, connection);
 
     // Assert
@@ -132,7 +132,7 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
@@ -228,7 +228,7 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcService.scan(scan, connection);
 
     // Assert
@@ -303,7 +303,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
@@ -328,7 +328,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(
                 new PutIf(
@@ -357,7 +357,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(
                 new PutIf(
@@ -386,7 +386,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(new PutIfExists())
             .forNamespace(NAMESPACE)
@@ -412,7 +412,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(new PutIfExists())
             .forNamespace(NAMESPACE)
@@ -437,7 +437,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(new PutIfNotExists())
             .forNamespace(NAMESPACE)
@@ -464,7 +464,7 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .withCondition(new PutIfNotExists())
             .forNamespace(NAMESPACE)
@@ -486,7 +486,7 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -507,7 +507,7 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(new Key("p1", "val1"))
+        new Delete(Key.ofText("p1", "val1"))
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
@@ -534,7 +534,7 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(new Key("p1", "val1"))
+        new Delete(Key.ofText("p1", "val1"))
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
@@ -562,7 +562,7 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(new Key("p1", "val1"))
+        new Delete(Key.ofText("p1", "val1"))
             .withCondition(new DeleteIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
@@ -587,7 +587,7 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(new Key("p1", "val1"))
+        new Delete(Key.ofText("p1", "val1"))
             .withCondition(new DeleteIfExists())
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
@@ -614,11 +614,11 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
-    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection);
 
     // Assert

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -79,7 +79,7 @@ public class QueryBuilderTest {
         queryBuilder
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
-            .where(new Key("p1", "p1Value"), Optional.empty(), Collections.emptySet())
+            .where(Key.ofText("p1", "p1Value"), Optional.empty(), Collections.emptySet())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE p1=?", rdbEngine));
     query.bind(preparedStatement);
@@ -91,7 +91,7 @@ public class QueryBuilderTest {
             .select(Collections.emptyList())
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value", "p2", "p2Value"), Optional.empty(), Collections.emptySet())
+                Key.of("p1", "p1Value", "p2", "p2Value"), Optional.empty(), Collections.emptySet())
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("SELECT * FROM n1.t1 WHERE p1=? AND p2=?", rdbEngine));
@@ -105,8 +105,8 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.emptySet())
             .build();
     assertThat(query.sql())
@@ -121,8 +121,8 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 Collections.emptySet())
             .build();
     assertThat(query.sql())
@@ -138,8 +138,8 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 ImmutableSet.of(
                     Conjunction.of(ConditionBuilder.column("v1").isEqualToText("value1")),
                     Conjunction.of(ConditionBuilder.column("v2").isEqualToText("value2"))))
@@ -162,10 +162,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .build();
@@ -185,10 +185,10 @@ public class QueryBuilderTest {
             .select(Collections.emptyList())
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 false,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 false,
                 ImmutableSet.of())
             .build();
@@ -208,10 +208,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1Value", "c2", "c2EndValue")),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2EndValue")),
                 false,
                 ImmutableSet.of())
             .build();
@@ -233,10 +233,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .orderBy(Collections.singletonList(new Scan.Ordering("c1", Scan.Ordering.Order.ASC)))
@@ -257,10 +257,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .orderBy(
@@ -284,10 +284,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .orderBy(Collections.singletonList(new Scan.Ordering("c1", Scan.Ordering.Order.DESC)))
@@ -308,10 +308,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .orderBy(
@@ -364,10 +364,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
             .limit(10)
@@ -384,10 +384,10 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1StartValue")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1StartValue")),
                 true,
-                Optional.of(new Key("c1", "c1EndValue")),
+                Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of(
                     Conjunction.of(ConditionBuilder.column("v1").isEqualToText("value1")),
@@ -766,7 +766,7 @@ public class QueryBuilderTest {
         queryBuilder
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
-            .where(new Key("v1", "v1Value"), Optional.empty(), Collections.emptySet())
+            .where(Key.ofText("v1", "v1Value"), Optional.empty(), Collections.emptySet())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v1=?", rdbEngine));
     query.bind(preparedStatement);
@@ -778,7 +778,7 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("v1", "v1Value"),
+                Key.ofText("v1", "v1Value"),
                 Optional.empty(),
                 false,
                 Optional.empty(),
@@ -794,7 +794,7 @@ public class QueryBuilderTest {
         queryBuilder
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
-            .where(new Key("v2", "v2Value"), Optional.empty(), Collections.emptySet())
+            .where(Key.ofText("v2", "v2Value"), Optional.empty(), Collections.emptySet())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v2=?", rdbEngine));
     query.bind(preparedStatement);
@@ -806,7 +806,7 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("v2", "v2Value"),
+                Key.ofText("v2", "v2Value"),
                 Optional.empty(),
                 ImmutableSet.of(
                     Conjunction.of(ConditionBuilder.column("v1").isEqualToText("value1")),
@@ -826,7 +826,7 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("v2", "v2Value"),
+                Key.ofText("v2", "v2Value"),
                 Optional.empty(),
                 false,
                 Optional.empty(),
@@ -843,7 +843,7 @@ public class QueryBuilderTest {
             .select(Arrays.asList("c1", "c2"))
             .from(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("v2", "v2Value"),
+                Key.ofText("v2", "v2Value"),
                 Optional.empty(),
                 false,
                 Optional.empty(),
@@ -934,7 +934,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .insertInto(NAMESPACE, TABLE, TABLE_METADATA)
-            .values(new Key("p1", "p1Value"), Optional.empty(), columns)
+            .values(Key.ofText("p1", "p1Value"), Optional.empty(), columns)
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("INSERT INTO n1.t1 (p1,v1,v2,v3) VALUES (?,?,?,?)", rdbEngine));
@@ -948,7 +948,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .insertInto(NAMESPACE, TABLE, TABLE_METADATA)
-            .values(new Key("p1", "p1Value"), Optional.of(new Key("c1", "c1Value")), columns)
+            .values(Key.ofText("p1", "p1Value"), Optional.of(Key.ofText("c1", "c1Value")), columns)
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("INSERT INTO n1.t1 (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?)", rdbEngine));
@@ -965,8 +965,8 @@ public class QueryBuilderTest {
         queryBuilder
             .insertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 columns)
             .build();
     assertThat(query.sql())
@@ -989,8 +989,8 @@ public class QueryBuilderTest {
         queryBuilder
             .insertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 columns)
             .build();
     assertThat(query.sql())
@@ -1029,7 +1029,7 @@ public class QueryBuilderTest {
         queryBuilder
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
-            .where(new Key("p1", "p1Value"), Optional.empty())
+            .where(Key.ofText("p1", "p1Value"), Optional.empty())
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("UPDATE n1.t1 SET v1=?,v2=?,v3=? WHERE p1=?", rdbEngine));
@@ -1044,7 +1044,7 @@ public class QueryBuilderTest {
         queryBuilder
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
-            .where(new Key("p1", "p1Value"), Optional.of(new Key("c1", "c1Value")))
+            .where(Key.ofText("p1", "p1Value"), Optional.of(Key.ofText("c1", "c1Value")))
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("UPDATE n1.t1 SET v1=?,v2=?,v3=? WHERE p1=? AND c1=?", rdbEngine));
@@ -1061,8 +1061,8 @@ public class QueryBuilderTest {
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
             .where(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")))
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -1084,8 +1084,8 @@ public class QueryBuilderTest {
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.singletonList(
                     new ConditionalExpression(
                         "v1", new TextValue("v1ConditionValue"), Operator.EQ)))
@@ -1107,8 +1107,8 @@ public class QueryBuilderTest {
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
                     new ConditionalExpression("v1", new TextValue("v1ConditionValue"), Operator.NE),
                     new ConditionalExpression("v2", new TextValue("v2ConditionValue"), Operator.GT),
@@ -1136,8 +1136,8 @@ public class QueryBuilderTest {
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
                     ConditionBuilder.column("v1").isNullText(),
                     ConditionBuilder.column("v2").isNotNullText()))
@@ -1160,7 +1160,7 @@ public class QueryBuilderTest {
         queryBuilder
             .update(NAMESPACE, TABLE, TABLE_METADATA)
             .set(columns)
-            .where(new Key("p1", "p1Value"), Optional.of(new Key("c1", "c1Value")))
+            .where(Key.ofText("p1", "p1Value"), Optional.of(Key.ofText("c1", "c1Value")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -1187,7 +1187,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
-            .where(new Key("p1", "p1Value"), Optional.empty())
+            .where(Key.ofText("p1", "p1Value"), Optional.empty())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql("DELETE FROM n1.t1 WHERE p1=?", rdbEngine));
     query.bind(preparedStatement);
@@ -1197,7 +1197,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
-            .where(new Key("p1", "p1Value"), Optional.of(new Key("c1", "c1Value")))
+            .where(Key.ofText("p1", "p1Value"), Optional.of(Key.ofText("c1", "c1Value")))
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("DELETE FROM n1.t1 WHERE p1=? AND c1=?", rdbEngine));
@@ -1210,8 +1210,8 @@ public class QueryBuilderTest {
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")))
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -1227,8 +1227,8 @@ public class QueryBuilderTest {
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.singletonList(
                     new ConditionalExpression(
                         "v1", new TextValue("v1ConditionValue"), Operator.EQ)))
@@ -1245,8 +1245,8 @@ public class QueryBuilderTest {
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
                     new ConditionalExpression("v1", new TextValue("v1ConditionValue"), Operator.NE),
                     new ConditionalExpression(
@@ -1270,8 +1270,8 @@ public class QueryBuilderTest {
         queryBuilder
             .deleteFrom(NAMESPACE, TABLE, TABLE_METADATA)
             .where(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
                     ConditionBuilder.column("v1").isNullText(),
                     ConditionBuilder.column("v2").isNotNullText()))
@@ -1344,7 +1344,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
-            .values(new Key("p1", "p1Value"), Optional.empty(), columns)
+            .values(Key.ofText("p1", "p1Value"), Optional.empty(), columns)
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
     query.bind(preparedStatement);
@@ -1424,7 +1424,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
-            .values(new Key("p1", "p1Value"), Optional.of(new Key("c1", "c1Value")), columns)
+            .values(Key.ofText("p1", "p1Value"), Optional.of(Key.ofText("c1", "c1Value")), columns)
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
     query.bind(preparedStatement);
@@ -1511,8 +1511,8 @@ public class QueryBuilderTest {
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 columns)
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
@@ -1611,8 +1611,8 @@ public class QueryBuilderTest {
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 columns)
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
@@ -1709,7 +1709,7 @@ public class QueryBuilderTest {
     query =
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
-            .values(new Key("p1", "p1Value"), Optional.empty(), Collections.emptyMap())
+            .values(Key.ofText("p1", "p1Value"), Optional.empty(), Collections.emptyMap())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
     query.bind(preparedStatement);
@@ -1769,8 +1769,8 @@ public class QueryBuilderTest {
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value"),
-                Optional.of(new Key("c1", "c1Value")),
+                Key.ofText("p1", "p1Value"),
+                Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.emptyMap())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));
@@ -1838,8 +1838,8 @@ public class QueryBuilderTest {
         queryBuilder
             .upsertInto(NAMESPACE, TABLE, TABLE_METADATA)
             .values(
-                new Key("p1", "p1Value", "p2", "p2Value"),
-                Optional.of(new Key("c1", "c1Value", "c2", "c2Value")),
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.of(Key.of("c1", "c1Value", "c2", "c2Value")),
                 Collections.emptyMap())
             .build();
     assertThat(query.sql()).isEqualTo(encloseSql(expectedQuery, rdbEngine));

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
-import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
@@ -15,7 +13,6 @@ import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.io.TextValue;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import java.sql.PreparedStatement;
@@ -1087,8 +1084,7 @@ public class QueryBuilderTest {
                 Key.ofText("p1", "p1Value"),
                 Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.singletonList(
-                    new ConditionalExpression(
-                        "v1", new TextValue("v1ConditionValue"), Operator.EQ)))
+                    ConditionBuilder.column("v1").isEqualToText("v1ConditionValue")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -1110,10 +1106,9 @@ public class QueryBuilderTest {
                 Key.ofText("p1", "p1Value"),
                 Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
-                    new ConditionalExpression("v1", new TextValue("v1ConditionValue"), Operator.NE),
-                    new ConditionalExpression("v2", new TextValue("v2ConditionValue"), Operator.GT),
-                    new ConditionalExpression(
-                        "v3", new TextValue("v3ConditionValue"), Operator.LTE)))
+                    ConditionBuilder.column("v1").isNotEqualToText("v1ConditionValue"),
+                    ConditionBuilder.column("v2").isGreaterThanText("v2ConditionValue"),
+                    ConditionBuilder.column("v3").isLessThanOrEqualToText("v3ConditionValue")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -1230,8 +1225,7 @@ public class QueryBuilderTest {
                 Key.ofText("p1", "p1Value"),
                 Optional.of(Key.ofText("c1", "c1Value")),
                 Collections.singletonList(
-                    new ConditionalExpression(
-                        "v1", new TextValue("v1ConditionValue"), Operator.EQ)))
+                    ConditionBuilder.column("v1").isEqualToText("v1ConditionValue")))
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("DELETE FROM n1.t1 WHERE p1=? AND c1=? AND v1=?", rdbEngine));
@@ -1248,11 +1242,9 @@ public class QueryBuilderTest {
                 Key.ofText("p1", "p1Value"),
                 Optional.of(Key.ofText("c1", "c1Value")),
                 Arrays.asList(
-                    new ConditionalExpression("v1", new TextValue("v1ConditionValue"), Operator.NE),
-                    new ConditionalExpression(
-                        "v2", new TextValue("v2ConditionValue"), Operator.GTE),
-                    new ConditionalExpression(
-                        "v3", new TextValue("v3ConditionValue"), Operator.LT)))
+                    ConditionBuilder.column("v1").isNotEqualToText("v1ConditionValue"),
+                    ConditionBuilder.column("v2").isGreaterThanOrEqualToText("v2ConditionValue"),
+                    ConditionBuilder.column("v3").isLessThanText("v3ConditionValue")))
             .build();
     assertThat(query.sql())
         .isEqualTo(

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -236,7 +236,7 @@ public class QueryBuilderTest {
                 Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
-            .orderBy(Collections.singletonList(new Scan.Ordering("c1", Scan.Ordering.Order.ASC)))
+            .orderBy(Collections.singletonList(Scan.Ordering.asc("c1")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -260,10 +260,7 @@ public class QueryBuilderTest {
                 Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
-            .orderBy(
-                Arrays.asList(
-                    new Scan.Ordering("c1", Scan.Ordering.Order.ASC),
-                    new Scan.Ordering("c2", Scan.Ordering.Order.DESC)))
+            .orderBy(Arrays.asList(Scan.Ordering.asc("c1"), Scan.Ordering.desc("c2")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -287,7 +284,7 @@ public class QueryBuilderTest {
                 Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
-            .orderBy(Collections.singletonList(new Scan.Ordering("c1", Scan.Ordering.Order.DESC)))
+            .orderBy(Collections.singletonList(Scan.Ordering.desc("c1")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -311,10 +308,7 @@ public class QueryBuilderTest {
                 Optional.of(Key.ofText("c1", "c1EndValue")),
                 true,
                 ImmutableSet.of())
-            .orderBy(
-                Arrays.asList(
-                    new Scan.Ordering("c1", Scan.Ordering.Order.DESC),
-                    new Scan.Ordering("c2", Scan.Ordering.Order.ASC)))
+            .orderBy(Arrays.asList(Scan.Ordering.desc("c1"), Scan.Ordering.asc("c2")))
             .build();
     assertThat(query.sql())
         .isEqualTo(
@@ -427,10 +421,7 @@ public class QueryBuilderTest {
             .select(Collections.emptyList())
             .from(NAMESPACE, TABLE, CROSS_PARTITION_TABLE_METADATA)
             .where(ImmutableSet.of())
-            .orderBy(
-                Arrays.asList(
-                    new Scan.Ordering("v1", Scan.Ordering.Order.ASC),
-                    new Scan.Ordering("v2", Scan.Ordering.Order.DESC)))
+            .orderBy(Arrays.asList(Scan.Ordering.asc("v1"), Scan.Ordering.desc("v2")))
             .build();
     assertThat(query.sql())
         .isEqualTo(encloseSql("SELECT * FROM n1.t1 ORDER BY v1 ASC,v2 DESC", rdbEngine));

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -59,8 +59,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -75,8 +75,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -92,8 +92,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -108,7 +108,7 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -122,7 +122,7 @@ public class MultiStorageTest {
   public void whenScanDataFromTable2_DataShouldBeScannedFromStorage2() throws ExecutionException {
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -138,7 +138,7 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -153,8 +153,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -173,8 +173,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -194,8 +194,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -214,8 +214,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -230,8 +230,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -247,8 +247,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -263,9 +263,9 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME2, 2);
-    Key clusteringKey2 = new Key(COL_NAME2, 3);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME2, 2);
+    Key clusteringKey2 = Key.ofInt(COL_NAME2, 3);
 
     // Act
     multiStorage.mutate(
@@ -285,9 +285,9 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE2;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME2, 2);
-    Key clusteringKey2 = new Key(COL_NAME2, 3);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME2, 2);
+    Key clusteringKey2 = Key.ofInt(COL_NAME2, 3);
 
     // Act
     multiStorage.mutate(
@@ -307,9 +307,9 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE1;
     String table = TABLE3;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME2, 2);
-    Key clusteringKey2 = new Key(COL_NAME2, 3);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME2, 2);
+    Key clusteringKey2 = Key.ofInt(COL_NAME2, 3);
 
     // Act
     multiStorage.mutate(
@@ -337,8 +337,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -354,7 +354,7 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -370,8 +370,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME3, 3)
@@ -391,8 +391,8 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey = new Key(COL_NAME2, 2);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     // Act
@@ -408,9 +408,9 @@ public class MultiStorageTest {
     // Arrange
     String namespace = NAMESPACE2;
     String table = TABLE1;
-    Key partitionKey = new Key(COL_NAME1, 1);
-    Key clusteringKey1 = new Key(COL_NAME2, 2);
-    Key clusteringKey2 = new Key(COL_NAME2, 3);
+    Key partitionKey = Key.ofInt(COL_NAME1, 1);
+    Key clusteringKey1 = Key.ofInt(COL_NAME2, 2);
+    Key clusteringKey2 = Key.ofInt(COL_NAME2, 3);
 
     // Act
     multiStorage.mutate(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -120,8 +120,8 @@ public class CommitHandlerTest {
   }
 
   private Put preparePut1() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -129,8 +129,8 @@ public class CommitHandlerTest {
   }
 
   private Put preparePut2() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_3);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_3);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -138,8 +138,8 @@ public class CommitHandlerTest {
   }
 
   private Put preparePut3() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -147,8 +147,8 @@ public class CommitHandlerTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     return Get.newBuilder()
         .namespace(ANY_NAMESPACE_NAME)
         .table(ANY_TABLE_NAME)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -12,8 +12,6 @@ import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.PREPARED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -163,7 +161,7 @@ public class CommitMutationComposerTest {
                 ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
                     .and(
                         ConditionBuilder.column(STATE)
-                            .isEqualToInt(toStateValue(TransactionState.PREPARED).getAsInt()))
+                            .isEqualToInt(TransactionState.PREPARED.get()))
                     .build())
             .bigIntValue(COMMITTED_AT, ANY_TIME_2)
             .intValue(STATE, TransactionState.COMMITTED.get())
@@ -205,11 +203,10 @@ public class CommitMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new PutIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID), Operator.EQ),
-            new ConditionalExpression(
-                STATE, toStateValue(TransactionState.PREPARED), Operator.EQ)));
-    expected.withValue(Attribute.toCommittedAtValue(ANY_TIME_2));
-    expected.withValue(Attribute.toStateValue(TransactionState.COMMITTED));
+            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
+            new ConditionalExpression(STATE, TransactionState.PREPARED.get(), Operator.EQ)));
+    expected.withBigIntValue(Attribute.COMMITTED_AT, ANY_TIME_2);
+    expected.withIntValue(Attribute.STATE, TransactionState.COMMITTED.get());
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -228,8 +225,8 @@ public class CommitMutationComposerTest {
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID), Operator.EQ),
-            new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
+            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
+            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -247,8 +244,8 @@ public class CommitMutationComposerTest {
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID), Operator.EQ),
-            new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
+            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
+            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -318,8 +315,8 @@ public class CommitMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID), Operator.EQ),
-            new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
+            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
+            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_COMMITTED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_PREFIX;
@@ -18,7 +17,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -203,8 +201,8 @@ public class CommitMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new PutIf(
-            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
-            new ConditionalExpression(STATE, TransactionState.PREPARED.get(), Operator.EQ)));
+            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
+            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get())));
     expected.withBigIntValue(Attribute.COMMITTED_AT, ANY_TIME_2);
     expected.withIntValue(Attribute.STATE, TransactionState.COMMITTED.get());
     assertThat(actual).isEqualTo(expected);
@@ -225,8 +223,8 @@ public class CommitMutationComposerTest {
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
-            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
+            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
+            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -244,8 +242,8 @@ public class CommitMutationComposerTest {
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
-            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
+            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
+            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -315,8 +313,8 @@ public class CommitMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, ANY_ID, Operator.EQ),
-            new ConditionalExpression(STATE, TransactionState.DELETED.get(), Operator.EQ)));
+            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
+            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -100,8 +100,8 @@ public class CommitMutationComposerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -109,16 +109,16 @@ public class CommitMutationComposerTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -19,10 +19,8 @@ import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIf;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
@@ -200,9 +198,9 @@ public class CommitMutationComposerTest {
             .forTable(put.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
-        new PutIf(
-            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
-            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get())));
+        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get()))
+            .build());
     expected.withBigIntValue(Attribute.COMMITTED_AT, ANY_TIME_2);
     expected.withIntValue(Attribute.STATE, TransactionState.COMMITTED.get());
     assertThat(actual).isEqualTo(expected);
@@ -222,9 +220,9 @@ public class CommitMutationComposerTest {
     Delete actual = (Delete) composer.get().get(0);
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
-            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+            .build());
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -241,9 +239,9 @@ public class CommitMutationComposerTest {
     Delete actual = (Delete) composer.get().get(0);
     delete.withConsistency(Consistency.LINEARIZABLE);
     delete.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
-            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+            .build());
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -312,9 +310,9 @@ public class CommitMutationComposerTest {
             .forTable(get.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ID).isEqualToText(ANY_ID),
-            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get())));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+            .build());
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -75,21 +75,21 @@ public class ConsensusCommitTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE).forTable(ANY_TABLE_NAME);
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue(ANY_NAME_3, ANY_TEXT_3)
         .forNamespace(ANY_NAMESPACE)
@@ -97,8 +97,8 @@ public class ConsensusCommitTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -26,12 +26,13 @@ import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
-import com.scalar.db.util.ScalarDbUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -198,9 +199,9 @@ public class CoordinatorTest {
     // Assert
     assertThat(put.getPartitionKey().get().get(0)).isEqualTo(new TextValue(Attribute.ID, ANY_ID_1));
     assertThat(put.getColumns().get(Attribute.STATE))
-        .isEqualTo(ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()));
     assertThat(put.getColumns().get(Attribute.CREATED_AT))
-        .isEqualTo(ScalarDbUtils.toColumn(Attribute.toCreatedAtValue(current)));
+        .isEqualTo(BigIntColumn.of(Attribute.CREATED_AT, current));
     assertThat(put.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
     assertThat(put.getCondition().get()).isExactlyInstanceOf(PutIfNotExists.class);
     assertThat(put.forNamespace().get()).isEqualTo(Coordinator.NAMESPACE);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -38,9 +38,9 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -168,15 +168,14 @@ public class CrudHandlerTest {
             .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, partitionKeyColumnValue))
             .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, clusteringKeyColumnValue))
             .put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-            .put(Attribute.STATE, ScalarDbUtils.toColumn(Attribute.toStateValue(state)))
-            .put(Attribute.VERSION, ScalarDbUtils.toColumn(Attribute.toVersionValue(2)))
-            .put(Attribute.BEFORE_ID, ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, state.get()))
+            .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, 2))
+            .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
             .put(
                 Attribute.BEFORE_STATE,
-                ScalarDbUtils.toColumn(Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
-            .put(
-                Attribute.BEFORE_VERSION, ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(1)))
+                IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
+            .put(Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, 1))
             .build();
     return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
   }
@@ -1403,17 +1402,14 @@ public class CrudHandlerTest {
         ImmutableMap.<String, Column<?>>builder()
             .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
             .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_3))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-            .put(
-                Attribute.STATE,
-                ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-            .put(Attribute.VERSION, ScalarDbUtils.toColumn(Attribute.toVersionValue(2)))
-            .put(Attribute.BEFORE_ID, ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+            .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, 2))
+            .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
             .put(
                 Attribute.BEFORE_STATE,
-                ScalarDbUtils.toColumn(Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
-            .put(
-                Attribute.BEFORE_VERSION, ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(1)))
+                IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
+            .put(Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, 1))
             .build();
     Result result2 = new ResultImpl(columns, TABLE_METADATA);
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -128,8 +128,8 @@ public class CrudHandlerTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
@@ -140,7 +140,7 @@ public class CrudHandlerTest {
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
@@ -1448,7 +1448,7 @@ public class CrudHandlerTest {
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     Delete delete =
-        new Delete(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_3))
+        new Delete(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_3))
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -8,10 +8,13 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
+import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.Arrays;
@@ -40,20 +43,22 @@ public class FilteredResultTest {
   private static final IntValue ACCOUNT_ID_VALUE = new IntValue(ACCOUNT_ID, 0);
   private static final IntValue ACCOUNT_TYPE_VALUE = new IntValue(ACCOUNT_TYPE, 1);
   private static final IntValue BALANCE_VALUE = new IntValue(BALANCE, 2);
-  private static final TextValue ID_VALUE = Attribute.toIdValue("aaa");
-  private static final IntValue STATE_VALUE = Attribute.toStateValue(TransactionState.COMMITTED);
-  private static final IntValue VERSION_VALUE = Attribute.toVersionValue(4);
-  private static final BigIntValue PREPARED_AT_VALUE = Attribute.toPreparedAtValue(5);
-  private static final BigIntValue COMMITTED_AT_VALUE = Attribute.toCommittedAtValue(6);
+  private static final TextColumn ID_VALUE = TextColumn.of(Attribute.ID, "aaa");
+  private static final IntColumn STATE_VALUE =
+      IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get());
+  private static final IntColumn VERSION_VALUE = IntColumn.of(Attribute.VERSION, 4);
+  private static final BigIntColumn PREPARED_AT_VALUE = BigIntColumn.of(Attribute.PREPARED_AT, 5);
+  private static final BigIntColumn COMMITTED_AT_VALUE = BigIntColumn.of(Attribute.COMMITTED_AT, 6);
   private static final IntValue BEFORE_BALANCE_VALUE =
       new IntValue(Attribute.BEFORE_PREFIX + BALANCE, 7);
-  private static final TextValue BEFORE_ID_VALUE = Attribute.toBeforeIdValue("bbb");
-  private static final IntValue BEFORE_STATE_VALUE =
-      Attribute.toBeforeStateValue(TransactionState.COMMITTED);
-  private static final IntValue BEFORE_VERSION_VALUE = Attribute.toBeforeVersionValue(8);
-  private static final BigIntValue BEFORE_PREPARED_AT_VALUE = Attribute.toBeforePreparedAtValue(9);
-  private static final BigIntValue BEFORE_COMMITTED_AT_VALUE =
-      Attribute.toBeforeCommittedAtValue(11);
+  private static final TextColumn BEFORE_ID_VALUE = TextColumn.of(Attribute.BEFORE_ID, "bbb");
+  private static final IntColumn BEFORE_STATE_VALUE =
+      IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
+  private static final IntColumn BEFORE_VERSION_VALUE = IntColumn.of(Attribute.BEFORE_VERSION, 8);
+  private static final BigIntColumn BEFORE_PREPARED_AT_VALUE =
+      BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, 9);
+  private static final BigIntColumn BEFORE_COMMITTED_AT_VALUE =
+      BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, 11);
 
   private Result result;
 
@@ -65,17 +70,17 @@ public class FilteredResultTest {
             .put(ACCOUNT_ID, ScalarDbUtils.toColumn(ACCOUNT_ID_VALUE))
             .put(ACCOUNT_TYPE, ScalarDbUtils.toColumn(ACCOUNT_TYPE_VALUE))
             .put(BALANCE, ScalarDbUtils.toColumn(BALANCE_VALUE))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(ID_VALUE))
-            .put(Attribute.STATE, ScalarDbUtils.toColumn(STATE_VALUE))
-            .put(Attribute.VERSION, ScalarDbUtils.toColumn(VERSION_VALUE))
-            .put(Attribute.PREPARED_AT, ScalarDbUtils.toColumn(PREPARED_AT_VALUE))
-            .put(Attribute.COMMITTED_AT, ScalarDbUtils.toColumn(COMMITTED_AT_VALUE))
+            .put(Attribute.ID, ID_VALUE)
+            .put(Attribute.STATE, STATE_VALUE)
+            .put(Attribute.VERSION, VERSION_VALUE)
+            .put(Attribute.PREPARED_AT, PREPARED_AT_VALUE)
+            .put(Attribute.COMMITTED_AT, COMMITTED_AT_VALUE)
             .put(Attribute.BEFORE_PREFIX + BALANCE, ScalarDbUtils.toColumn(BEFORE_BALANCE_VALUE))
-            .put(Attribute.BEFORE_ID, ScalarDbUtils.toColumn(BEFORE_ID_VALUE))
-            .put(Attribute.BEFORE_STATE, ScalarDbUtils.toColumn(BEFORE_STATE_VALUE))
-            .put(Attribute.BEFORE_VERSION, ScalarDbUtils.toColumn(BEFORE_VERSION_VALUE))
-            .put(Attribute.BEFORE_PREPARED_AT, ScalarDbUtils.toColumn(BEFORE_PREPARED_AT_VALUE))
-            .put(Attribute.BEFORE_COMMITTED_AT, ScalarDbUtils.toColumn(BEFORE_COMMITTED_AT_VALUE))
+            .put(Attribute.BEFORE_ID, BEFORE_ID_VALUE)
+            .put(Attribute.BEFORE_STATE, BEFORE_STATE_VALUE)
+            .put(Attribute.BEFORE_VERSION, BEFORE_VERSION_VALUE)
+            .put(Attribute.BEFORE_PREPARED_AT, BEFORE_PREPARED_AT_VALUE)
+            .put(Attribute.BEFORE_COMMITTED_AT, BEFORE_COMMITTED_AT_VALUE)
             .build();
 
     result = new ResultImpl(columns, TABLE_METADATA);
@@ -168,31 +173,38 @@ public class FilteredResultTest {
     assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
 
     assertThat(filteredResult.getValue(Attribute.ID)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.ID).get()).isEqualTo(ID_VALUE);
+    assertThat(filteredResult.getValue(Attribute.ID).get())
+        .isEqualTo(new TextValue(Attribute.ID, "aaa"));
     assertThat(filteredResult.getValue(Attribute.STATE)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.STATE).get()).isEqualTo(STATE_VALUE);
+    assertThat(filteredResult.getValue(Attribute.STATE).get())
+        .isEqualTo(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get()));
     assertThat(filteredResult.getValue(Attribute.VERSION)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.VERSION).get()).isEqualTo(VERSION_VALUE);
+    assertThat(filteredResult.getValue(Attribute.VERSION).get())
+        .isEqualTo(new IntValue(Attribute.VERSION, 4));
     assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.PREPARED_AT).get()).isEqualTo(PREPARED_AT_VALUE);
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT).get())
+        .isEqualTo(new BigIntValue(Attribute.PREPARED_AT, 5));
     assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT).get()).isEqualTo(COMMITTED_AT_VALUE);
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT).get())
+        .isEqualTo(new BigIntValue(Attribute.COMMITTED_AT, 6));
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE).get())
         .isEqualTo(BEFORE_BALANCE_VALUE);
     assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.BEFORE_ID).get()).isEqualTo(BEFORE_ID_VALUE);
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID).get())
+        .isEqualTo(new TextValue(Attribute.BEFORE_ID, "bbb"));
     assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE).get()).isEqualTo(BEFORE_STATE_VALUE);
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE).get())
+        .isEqualTo(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()));
     assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION).get())
-        .isEqualTo(BEFORE_VERSION_VALUE);
+        .isEqualTo(new IntValue(Attribute.BEFORE_VERSION, 8));
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT).get())
-        .isEqualTo(BEFORE_PREPARED_AT_VALUE);
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_PREPARED_AT, 9));
     assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT).get())
-        .isEqualTo(BEFORE_COMMITTED_AT_VALUE);
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, 11));
 
     assertThat(filteredResult.getContainedColumnNames())
         .containsOnly(
@@ -373,7 +385,8 @@ public class FilteredResultTest {
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.VERSION)).isPresent();
-    assertThat(filteredResult.getValue(Attribute.VERSION).get()).isEqualTo(VERSION_VALUE);
+    assertThat(filteredResult.getValue(Attribute.VERSION).get())
+        .isEqualTo(new IntValue(Attribute.VERSION, 4));
     assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isPresent();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
@@ -8,6 +8,8 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
@@ -16,7 +18,6 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.util.ScalarDbUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -71,41 +72,33 @@ public class MergedResultTest {
                     .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
                     .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
                     .put(ANY_NAME_4, TextColumn.of(ANY_NAME_4, ANY_TEXT_3))
-                    .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
+                    .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+                    .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
                     .put(
-                        Attribute.PREPARED_AT,
-                        ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-                    .put(
-                        Attribute.COMMITTED_AT,
-                        ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
+                        Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
                     .put(
                         Attribute.STATE,
-                        ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-                    .put(
-                        Attribute.VERSION,
-                        ScalarDbUtils.toColumn(Attribute.toVersionValue(ANY_VERSION_2)))
+                        IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+                    .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, ANY_VERSION_2))
                     .put(
                         Attribute.BEFORE_PREFIX + ANY_NAME_3,
                         IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
                     .put(
                         Attribute.BEFORE_PREFIX + ANY_NAME_4,
                         TextColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_4, ANY_TEXT_4))
-                    .put(
-                        Attribute.BEFORE_ID,
-                        ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+                    .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
                     .put(
                         Attribute.BEFORE_PREPARED_AT,
-                        ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                        BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
                     .put(
                         Attribute.BEFORE_COMMITTED_AT,
-                        ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                        BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
                     .put(
                         Attribute.BEFORE_STATE,
-                        ScalarDbUtils.toColumn(
-                            Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
+                        IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
                     .put(
                         Attribute.BEFORE_VERSION,
-                        ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(ANY_VERSION_1)))
+                        IntColumn.of(Attribute.BEFORE_VERSION, ANY_VERSION_1))
                     .build(),
                 TABLE_METADATA));
   }
@@ -193,27 +186,28 @@ public class MergedResultTest {
     assertThat(mergedResult.getValue(ANY_NAME_4))
         .isEqualTo(Optional.of(new TextValue(ANY_NAME_4, ANY_TEXT_3)));
     assertThat(mergedResult.getValue(Attribute.ID))
-        .isEqualTo(Optional.of(Attribute.toIdValue(ANY_ID_2)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.ID, ANY_ID_2)));
     assertThat(mergedResult.getValue(Attribute.PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toPreparedAtValue(ANY_TIME_3)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.PREPARED_AT, ANY_TIME_3)));
     assertThat(mergedResult.getValue(Attribute.COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toCommittedAtValue(ANY_TIME_4)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.COMMITTED_AT, ANY_TIME_4)));
     assertThat(mergedResult.getValue(Attribute.STATE))
-        .isEqualTo(Optional.of(Attribute.toStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
     assertThat(mergedResult.getValue(Attribute.VERSION))
-        .isEqualTo(Optional.of(Attribute.toVersionValue(ANY_VERSION_2)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.VERSION, ANY_VERSION_2)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_ID))
-        .isEqualTo(Optional.of(Attribute.toBeforeIdValue(ANY_ID_1)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.BEFORE_ID, ANY_ID_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforePreparedAtValue(ANY_TIME_1)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_STATE))
-        .isEqualTo(Optional.of(Attribute.toBeforeStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(
+            Optional.of(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())));
     assertThat(mergedResult.getValue(Attribute.BEFORE_VERSION))
-        .isEqualTo(Optional.of(Attribute.toBeforeVersionValue(ANY_VERSION_1)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_VERSION, ANY_VERSION_1)));
 
     assertThat(mergedResult.getContainedColumnNames())
         .isEqualTo(
@@ -340,27 +334,27 @@ public class MergedResultTest {
     assertThat(mergedResult.getValue(ANY_NAME_4))
         .isEqualTo(Optional.of(new TextValue(ANY_NAME_4, (String) null)));
     assertThat(mergedResult.getValue(Attribute.ID))
-        .isEqualTo(Optional.of(Attribute.toIdValue(null)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.ID, (String) null)));
     assertThat(mergedResult.getValue(Attribute.PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toPreparedAtValue(0L)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.PREPARED_AT, 0L)));
     assertThat(mergedResult.getValue(Attribute.COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toCommittedAtValue(0L)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.COMMITTED_AT, 0L)));
     assertThat(mergedResult.getValue(Attribute.STATE))
         .isEqualTo(Optional.of(new IntValue(Attribute.STATE, 0)));
     assertThat(mergedResult.getValue(Attribute.VERSION))
-        .isEqualTo(Optional.of(Attribute.toVersionValue(0)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.VERSION, 0)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, 0)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_ID))
-        .isEqualTo(Optional.of(Attribute.toBeforeIdValue(null)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.BEFORE_ID, (String) null)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforePreparedAtValue(0L)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_PREPARED_AT, 0L)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforeCommittedAtValue(0L)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, 0L)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_STATE))
         .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_STATE, 0)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_VERSION))
-        .isEqualTo(Optional.of(Attribute.toBeforeVersionValue(0)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_VERSION, 0)));
 
     assertThat(mergedResult.getContainedColumnNames())
         .isEqualTo(
@@ -484,27 +478,28 @@ public class MergedResultTest {
     assertThat(mergedResult.getValue(ANY_NAME_4))
         .isEqualTo(Optional.of(new TextValue(ANY_NAME_4, (String) null)));
     assertThat(mergedResult.getValue(Attribute.ID))
-        .isEqualTo(Optional.of(Attribute.toIdValue(ANY_ID_2)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.ID, ANY_ID_2)));
     assertThat(mergedResult.getValue(Attribute.PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toPreparedAtValue(ANY_TIME_3)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.PREPARED_AT, ANY_TIME_3)));
     assertThat(mergedResult.getValue(Attribute.COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toCommittedAtValue(ANY_TIME_4)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.COMMITTED_AT, ANY_TIME_4)));
     assertThat(mergedResult.getValue(Attribute.STATE))
-        .isEqualTo(Optional.of(Attribute.toStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
     assertThat(mergedResult.getValue(Attribute.VERSION))
-        .isEqualTo(Optional.of(Attribute.toVersionValue(ANY_VERSION_2)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.VERSION, ANY_VERSION_2)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_ID))
-        .isEqualTo(Optional.of(Attribute.toBeforeIdValue(ANY_ID_1)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.BEFORE_ID, ANY_ID_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforePreparedAtValue(ANY_TIME_1)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2)));
     assertThat(mergedResult.getValue(Attribute.BEFORE_STATE))
-        .isEqualTo(Optional.of(Attribute.toBeforeStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(
+            Optional.of(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())));
     assertThat(mergedResult.getValue(Attribute.BEFORE_VERSION))
-        .isEqualTo(Optional.of(Attribute.toBeforeVersionValue(ANY_VERSION_1)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_VERSION, ANY_VERSION_1)));
 
     assertThat(mergedResult.getContainedColumnNames())
         .isEqualTo(
@@ -629,25 +624,27 @@ public class MergedResultTest {
     assertThat(values.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
     assertThat(values.get(ANY_NAME_3)).isEqualTo(new IntValue(ANY_NAME_3, ANY_INT_3));
     assertThat(values.get(ANY_NAME_4)).isEqualTo(new TextValue(ANY_NAME_4, ANY_TEXT_3));
-    assertThat(values.get(Attribute.ID)).isEqualTo(Attribute.toIdValue(ANY_ID_2));
+    assertThat(values.get(Attribute.ID)).isEqualTo(new TextValue(Attribute.ID, ANY_ID_2));
     assertThat(values.get(Attribute.PREPARED_AT))
-        .isEqualTo(Attribute.toPreparedAtValue(ANY_TIME_3));
+        .isEqualTo(new BigIntValue(Attribute.PREPARED_AT, ANY_TIME_3));
     assertThat(values.get(Attribute.COMMITTED_AT))
-        .isEqualTo(Attribute.toCommittedAtValue(ANY_TIME_4));
+        .isEqualTo(new BigIntValue(Attribute.COMMITTED_AT, ANY_TIME_4));
     assertThat(values.get(Attribute.STATE))
-        .isEqualTo(Attribute.toStateValue(TransactionState.COMMITTED));
-    assertThat(values.get(Attribute.VERSION)).isEqualTo(Attribute.toVersionValue(ANY_VERSION_2));
+        .isEqualTo(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get()));
+    assertThat(values.get(Attribute.VERSION))
+        .isEqualTo(new IntValue(Attribute.VERSION, ANY_VERSION_2));
     assertThat(values.get(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1));
-    assertThat(values.get(Attribute.BEFORE_ID)).isEqualTo(Attribute.toBeforeIdValue(ANY_ID_1));
+    assertThat(values.get(Attribute.BEFORE_ID))
+        .isEqualTo(new TextValue(Attribute.BEFORE_ID, ANY_ID_1));
     assertThat(values.get(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Attribute.toBeforePreparedAtValue(ANY_TIME_1));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1));
     assertThat(values.get(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Attribute.toBeforeCommittedAtValue(ANY_TIME_2));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2));
     assertThat(values.get(Attribute.BEFORE_STATE))
-        .isEqualTo(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
+        .isEqualTo(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()));
     assertThat(values.get(Attribute.BEFORE_VERSION))
-        .isEqualTo(Attribute.toBeforeVersionValue(ANY_VERSION_1));
+        .isEqualTo(new IntValue(Attribute.BEFORE_VERSION, ANY_VERSION_1));
   }
 
   @Test
@@ -667,21 +664,25 @@ public class MergedResultTest {
     assertThat(values.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
     assertThat(values.get(ANY_NAME_3)).isEqualTo(new IntValue(ANY_NAME_3, ANY_INT_3));
     assertThat(values.get(ANY_NAME_4)).isEqualTo(new TextValue(ANY_NAME_4, (String) null));
-    assertThat(values.get(Attribute.ID)).isEqualTo(Attribute.toIdValue(null));
-    assertThat(values.get(Attribute.PREPARED_AT)).isEqualTo(Attribute.toPreparedAtValue(0L));
-    assertThat(values.get(Attribute.COMMITTED_AT)).isEqualTo(Attribute.toCommittedAtValue(0L));
+    assertThat(values.get(Attribute.ID)).isEqualTo(new TextValue(Attribute.ID, (String) null));
+    assertThat(values.get(Attribute.PREPARED_AT))
+        .isEqualTo(new BigIntValue(Attribute.PREPARED_AT, 0L));
+    assertThat(values.get(Attribute.COMMITTED_AT))
+        .isEqualTo(new BigIntValue(Attribute.COMMITTED_AT, 0L));
     assertThat(values.get(Attribute.STATE)).isEqualTo(new IntValue(Attribute.STATE, 0));
-    assertThat(values.get(Attribute.VERSION)).isEqualTo(Attribute.toVersionValue(0));
+    assertThat(values.get(Attribute.VERSION)).isEqualTo(new IntValue(Attribute.VERSION, 0));
     assertThat(values.get(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, 0));
-    assertThat(values.get(Attribute.BEFORE_ID)).isEqualTo(Attribute.toBeforeIdValue(null));
+    assertThat(values.get(Attribute.BEFORE_ID))
+        .isEqualTo(new TextValue(Attribute.BEFORE_ID, (String) null));
     assertThat(values.get(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Attribute.toBeforePreparedAtValue(0L));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_PREPARED_AT, 0L));
     assertThat(values.get(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Attribute.toBeforeCommittedAtValue(0L));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, 0L));
     assertThat(values.get(Attribute.BEFORE_STATE))
         .isEqualTo(new IntValue(Attribute.BEFORE_STATE, 0));
-    assertThat(values.get(Attribute.BEFORE_VERSION)).isEqualTo(Attribute.toBeforeVersionValue(0));
+    assertThat(values.get(Attribute.BEFORE_VERSION))
+        .isEqualTo(new IntValue(Attribute.BEFORE_VERSION, 0));
   }
 
   @Test
@@ -702,25 +703,27 @@ public class MergedResultTest {
     assertThat(values.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
     assertThat(values.get(ANY_NAME_3)).isEqualTo(new IntValue(ANY_NAME_3, ANY_INT_3));
     assertThat(values.get(ANY_NAME_4)).isEqualTo(new TextValue(ANY_NAME_4, (String) null));
-    assertThat(values.get(Attribute.ID)).isEqualTo(Attribute.toIdValue(ANY_ID_2));
+    assertThat(values.get(Attribute.ID)).isEqualTo(new TextValue(Attribute.ID, ANY_ID_2));
     assertThat(values.get(Attribute.PREPARED_AT))
-        .isEqualTo(Attribute.toPreparedAtValue(ANY_TIME_3));
+        .isEqualTo(new BigIntValue(Attribute.PREPARED_AT, ANY_TIME_3));
     assertThat(values.get(Attribute.COMMITTED_AT))
-        .isEqualTo(Attribute.toCommittedAtValue(ANY_TIME_4));
+        .isEqualTo(new BigIntValue(Attribute.COMMITTED_AT, ANY_TIME_4));
     assertThat(values.get(Attribute.STATE))
-        .isEqualTo(Attribute.toStateValue(TransactionState.COMMITTED));
-    assertThat(values.get(Attribute.VERSION)).isEqualTo(Attribute.toVersionValue(ANY_VERSION_2));
+        .isEqualTo(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get()));
+    assertThat(values.get(Attribute.VERSION))
+        .isEqualTo(new IntValue(Attribute.VERSION, ANY_VERSION_2));
     assertThat(values.get(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1));
-    assertThat(values.get(Attribute.BEFORE_ID)).isEqualTo(Attribute.toBeforeIdValue(ANY_ID_1));
+    assertThat(values.get(Attribute.BEFORE_ID))
+        .isEqualTo(new TextValue(Attribute.BEFORE_ID, ANY_ID_1));
     assertThat(values.get(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Attribute.toBeforePreparedAtValue(ANY_TIME_1));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1));
     assertThat(values.get(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Attribute.toBeforeCommittedAtValue(ANY_TIME_2));
+        .isEqualTo(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2));
     assertThat(values.get(Attribute.BEFORE_STATE))
-        .isEqualTo(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
+        .isEqualTo(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()));
     assertThat(values.get(Attribute.BEFORE_VERSION))
-        .isEqualTo(Attribute.toBeforeVersionValue(ANY_VERSION_1));
+        .isEqualTo(new IntValue(Attribute.BEFORE_VERSION, ANY_VERSION_1));
   }
 
   @Test
@@ -772,41 +775,31 @@ public class MergedResultTest {
                 .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
                 .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_3))
                 .put(ANY_NAME_4, TextColumn.of(ANY_NAME_4, ANY_TEXT_3))
-                .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-                .put(
-                    Attribute.PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-                .put(
-                    Attribute.COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
+                .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+                .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
+                .put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
                 .put(
                     Attribute.STATE,
-                    ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-                .put(
-                    Attribute.VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toVersionValue(ANY_VERSION_2)))
+                    IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+                .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, ANY_VERSION_2))
                 .put(
                     Attribute.BEFORE_PREFIX + ANY_NAME_3,
                     IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
                 .put(
                     Attribute.BEFORE_PREFIX + ANY_NAME_4,
                     TextColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_4, ANY_TEXT_4))
-                .put(
-                    Attribute.BEFORE_ID,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+                .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
                 .put(
                     Attribute.BEFORE_PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                    BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
                 .put(
                     Attribute.BEFORE_COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                    BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
                 .put(
                     Attribute.BEFORE_STATE,
-                    ScalarDbUtils.toColumn(
-                        Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
+                    IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
                 .put(
-                    Attribute.BEFORE_VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(ANY_VERSION_1)))
+                    Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, ANY_VERSION_1))
                 .build(),
             TABLE_METADATA);
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
@@ -107,7 +107,7 @@ public class MergedResultTest {
   public void getPartitionKey_ResultAndPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -116,14 +116,14 @@ public class MergedResultTest {
     Optional<Key> actual = mergedResult.getPartitionKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_1, ANY_TEXT_1)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
   }
 
   @Test
   public void getPartitionKey_OnlyPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
@@ -132,14 +132,14 @@ public class MergedResultTest {
     Optional<Key> actual = mergedResult.getPartitionKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_1, ANY_TEXT_1)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
   }
 
   @Test
   public void getClusteringKey_ResultAndPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -148,14 +148,14 @@ public class MergedResultTest {
     Optional<Key> actual = mergedResult.getClusteringKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_2, ANY_TEXT_2)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
   }
 
   @Test
   public void getClusteringKey_OnlyPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
@@ -164,14 +164,14 @@ public class MergedResultTest {
     Optional<Key> actual = mergedResult.getClusteringKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_2, ANY_TEXT_2)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
   }
 
   @Test
   public void getValue_ResultAndPutGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -319,7 +319,7 @@ public class MergedResultTest {
   public void getValue_OnlyPutGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
@@ -462,7 +462,7 @@ public class MergedResultTest {
   public void getValue_ResultAndPutWithNullValueGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3)
             .withTextValue(ANY_NAME_4, null);
 
@@ -611,7 +611,7 @@ public class MergedResultTest {
   public void getValues_ResultAndPutGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -651,7 +651,7 @@ public class MergedResultTest {
   public void getValues_OnlyPutGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
@@ -689,7 +689,7 @@ public class MergedResultTest {
   public void getValues_ResultAndPutWithNullValueGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3)
             .withTextValue(ANY_NAME_4, null);
 
@@ -730,7 +730,7 @@ public class MergedResultTest {
   public void equals_SamePutAndResultGiven_ShouldReturnTrue() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -747,7 +747,7 @@ public class MergedResultTest {
   public void equals_DifferentPutAndResultGiven_ShouldReturnFalse() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -764,7 +764,7 @@ public class MergedResultTest {
   public void equals_ResultImplWithSamePutAndResultGiven_ShouldReturnTrue() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -811,7 +811,7 @@ public class MergedResultTest {
   public void equals_ResultImplWithDifferentPutAndResultGiven_ShouldReturnFalse() {
     // Arrange
     Put put =
-        new Put(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .withValue(ANY_NAME_3, ANY_INT_3);
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -12,8 +12,6 @@ import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutIf;
-import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
@@ -169,7 +167,8 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(new PutIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
+    put.withCondition(
+        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build());
     put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     put.withValue(Attribute.ID, ANY_ID_3);
     put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
@@ -227,7 +226,7 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(new PutIfNotExists());
+    put.withCondition(ConditionBuilder.putIfNotExists());
     put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     put.withValue(Attribute.ID, ANY_ID_3);
     put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
@@ -301,7 +300,8 @@ public class PrepareMutationComposerTest {
             .forNamespace(delete.forNamespace().get())
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(new PutIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
+    expected.withCondition(
+        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build());
     expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     expected.withValue(Attribute.ID, ANY_ID_3);
     expected.withValue(Attribute.STATE, TransactionState.DELETED.get());
@@ -367,7 +367,7 @@ public class PrepareMutationComposerTest {
             .forNamespace(delete.forNamespace().get())
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(new PutIfNotExists());
+    expected.withCondition(ConditionBuilder.putIfNotExists());
     expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     expected.withValue(Attribute.ID, ANY_ID_3);
     expected.withValue(Attribute.STATE, TransactionState.DELETED.get());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -9,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Operation;
@@ -171,7 +169,7 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(new PutIf(new ConditionalExpression(ID, ANY_ID_2, Operator.EQ)));
+    put.withCondition(new PutIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
     put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     put.withValue(Attribute.ID, ANY_ID_3);
     put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
@@ -303,7 +301,7 @@ public class PrepareMutationComposerTest {
             .forNamespace(delete.forNamespace().get())
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(new PutIf(new ConditionalExpression(ID, ANY_ID_2, Operator.EQ)));
+    expected.withCondition(new PutIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
     expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
     expected.withValue(Attribute.ID, ANY_ID_3);
     expected.withValue(Attribute.STATE, TransactionState.DELETED.get());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -80,8 +80,8 @@ public class PrepareMutationComposerTest {
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
@@ -90,15 +90,15 @@ public class PrepareMutationComposerTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return Scan.newBuilder()
         .namespace(ANY_NAMESPACE_NAME)
         .table(ANY_TABLE_NAME)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +27,6 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.util.ScalarDbUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -115,35 +113,28 @@ public class PrepareMutationComposerTest {
             .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
             .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
             .put(ANY_NAME_WITH_BEFORE_PREFIX, IntColumn.of(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-            .put(
-                Attribute.PREPARED_AT,
-                ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-            .put(
-                Attribute.COMMITTED_AT,
-                ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
-            .put(
-                Attribute.STATE,
-                ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-            .put(Attribute.VERSION, ScalarDbUtils.toColumn(Attribute.toVersionValue(2)))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+            .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
+            .put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+            .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, 2))
             .put(
                 Attribute.BEFORE_PREFIX + ANY_NAME_3,
                 IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
             .put(
                 Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX,
                 IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_1))
-            .put(Attribute.BEFORE_ID, ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+            .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
             .put(
                 Attribute.BEFORE_PREPARED_AT,
-                ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
             .put(
                 Attribute.BEFORE_COMMITTED_AT,
-                ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
             .put(
                 Attribute.BEFORE_STATE,
-                ScalarDbUtils.toColumn(Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
-            .put(
-                Attribute.BEFORE_VERSION, ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(1)))
+                IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
+            .put(Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, 1))
             .build();
     return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
   }
@@ -180,16 +171,16 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(new PutIf(new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ)));
-    put.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
-    put.withValue(Attribute.toIdValue(ANY_ID_3));
-    put.withValue(Attribute.toStateValue(TransactionState.PREPARED));
-    put.withValue(Attribute.toVersionValue(3));
-    put.withValue(Attribute.toBeforePreparedAtValue(ANY_TIME_3));
-    put.withValue(Attribute.toBeforeCommittedAtValue(ANY_TIME_4));
-    put.withValue(Attribute.toBeforeIdValue(ANY_ID_2));
-    put.withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
-    put.withValue(Attribute.toBeforeVersionValue(2));
+    put.withCondition(new PutIf(new ConditionalExpression(ID, ANY_ID_2, Operator.EQ)));
+    put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
+    put.withValue(Attribute.ID, ANY_ID_3);
+    put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
+    put.withValue(Attribute.VERSION, 3);
+    put.withValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3);
+    put.withValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4);
+    put.withValue(Attribute.BEFORE_ID, ANY_ID_2);
+    put.withValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
+    put.withValue(Attribute.BEFORE_VERSION, 2);
     put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
     put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
     assertThat(actual).isEqualTo(put);
@@ -239,10 +230,10 @@ public class PrepareMutationComposerTest {
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
     put.withCondition(new PutIfNotExists());
-    put.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
-    put.withValue(Attribute.toIdValue(ANY_ID_3));
-    put.withValue(Attribute.toStateValue(TransactionState.PREPARED));
-    put.withValue(Attribute.toVersionValue(1));
+    put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
+    put.withValue(Attribute.ID, ANY_ID_3);
+    put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
+    put.withValue(Attribute.VERSION, 1);
     assertThat(actual).isEqualTo(put);
   }
 
@@ -312,17 +303,16 @@ public class PrepareMutationComposerTest {
             .forNamespace(delete.forNamespace().get())
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        new PutIf(new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ)));
-    expected.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
-    expected.withValue(Attribute.toIdValue(ANY_ID_3));
-    expected.withValue(Attribute.toStateValue(TransactionState.DELETED));
-    expected.withValue(Attribute.toVersionValue(3));
-    expected.withValue(Attribute.toBeforePreparedAtValue(ANY_TIME_3));
-    expected.withValue(Attribute.toBeforeCommittedAtValue(ANY_TIME_4));
-    expected.withValue(Attribute.toBeforeIdValue(ANY_ID_2));
-    expected.withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
-    expected.withValue(Attribute.toBeforeVersionValue(2));
+    expected.withCondition(new PutIf(new ConditionalExpression(ID, ANY_ID_2, Operator.EQ)));
+    expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
+    expected.withValue(Attribute.ID, ANY_ID_3);
+    expected.withValue(Attribute.STATE, TransactionState.DELETED.get());
+    expected.withValue(Attribute.VERSION, 3);
+    expected.withValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3);
+    expected.withValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4);
+    expected.withValue(Attribute.BEFORE_ID, ANY_ID_2);
+    expected.withValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
+    expected.withValue(Attribute.BEFORE_VERSION, 2);
     expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
     expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
     assertThat(actual).isEqualTo(expected);
@@ -380,10 +370,10 @@ public class PrepareMutationComposerTest {
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(new PutIfNotExists());
-    expected.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
-    expected.withValue(Attribute.toIdValue(ANY_ID_3));
-    expected.withValue(Attribute.toStateValue(TransactionState.DELETED));
-    expected.withValue(Attribute.toVersionValue(1));
+    expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
+    expected.withValue(Attribute.ID, ANY_ID_3);
+    expected.withValue(Attribute.STATE, TransactionState.DELETED.get());
+    expected.withValue(Attribute.VERSION, 1);
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -22,8 +22,11 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.Collections;
@@ -78,12 +81,10 @@ public class RecoveryHandlerTest {
     ImmutableMap<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
             .put(ANY_NAME_1, ScalarDbUtils.toColumn(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_1)))
-            .put(
-                Attribute.PREPARED_AT,
-                ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(preparedAt)))
-            .put(Attribute.STATE, ScalarDbUtils.toColumn(Attribute.toStateValue(transactionState)))
-            .put(Attribute.VERSION, ScalarDbUtils.toColumn(Attribute.toVersionValue(1)))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_1))
+            .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, preparedAt))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, transactionState.get()))
+            .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, 1))
             .build();
     return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
@@ -807,9 +806,9 @@ public class RollbackMutationComposerTest {
             .forTable(scan.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(ID).isEqualToText(ANY_ID_2),
-            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get())));
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2))
+            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get()))
+            .build());
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -12,8 +12,6 @@ import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.PREPARED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -812,9 +810,8 @@ public class RollbackMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ),
-            new ConditionalExpression(
-                STATE, toStateValue(TransactionState.PREPARED), Operator.EQ)));
+            new ConditionalExpression(ID, ANY_ID_2, Operator.EQ),
+            new ConditionalExpression(STATE, TransactionState.PREPARED.get(), Operator.EQ)));
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_COMMITTED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_PREFIX;
@@ -19,7 +18,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
-import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -810,8 +808,8 @@ public class RollbackMutationComposerTest {
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
         new DeleteIf(
-            new ConditionalExpression(ID, ANY_ID_2, Operator.EQ),
-            new ConditionalExpression(STATE, TransactionState.PREPARED.get(), Operator.EQ)));
+            ConditionBuilder.column(ID).isEqualToText(ANY_ID_2),
+            ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get())));
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -150,8 +150,8 @@ public class RollbackMutationComposerTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -159,7 +159,7 @@ public class RollbackMutationComposerTest {
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotKeyTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotKeyTest.java
@@ -17,21 +17,21 @@ public class SnapshotKeyTest {
   private static final String ANY_TEXT_4 = "text4";
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Get prepareGetWithoutClusteringKey() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
   }
 
   private Get prepareAnotherGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_3);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_3);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -175,8 +175,8 @@ public class SnapshotTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -184,8 +184,8 @@ public class SnapshotTest {
   }
 
   private Get prepareAnotherGet() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+    Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
+    Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
     return new Get(partitionKey, clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -193,7 +193,7 @@ public class SnapshotTest {
   }
 
   private Get prepareGetWithIndex() {
-    Key indexKey = new Key(ANY_NAME_4, ANY_TEXT_1);
+    Key indexKey = Key.ofText(ANY_NAME_4, ANY_TEXT_1);
     return Get.newBuilder()
         .namespace(ANY_NAMESPACE_NAME)
         .table(ANY_TABLE_NAME)
@@ -202,8 +202,8 @@ public class SnapshotTest {
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Scan(partitionKey)
         .withStart(clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
@@ -222,7 +222,7 @@ public class SnapshotTest {
   }
 
   private Scan prepareScanWithIndex() {
-    Key indexKey = new Key(ANY_NAME_4, ANY_TEXT_1);
+    Key indexKey = Key.ofText(ANY_NAME_4, ANY_TEXT_1);
     return Scan.newBuilder()
         .namespace(ANY_NAMESPACE_NAME)
         .table(ANY_TABLE_NAME)
@@ -260,8 +260,8 @@ public class SnapshotTest {
   }
 
   private Put prepareAnotherPut() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+    Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
+    Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
     return new Put(partitionKey, clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -269,7 +269,7 @@ public class SnapshotTest {
   }
 
   private Put preparePutWithPartitionKeyOnly() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Put(partitionKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -320,8 +320,8 @@ public class SnapshotTest {
   }
 
   private Delete prepareAnotherDelete() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+    Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
+    Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
     return new Delete(partitionKey, clusteringKey)
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(ANY_NAMESPACE_NAME)
@@ -1357,14 +1357,14 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE);
 
     Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .withStart(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
     Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_2))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .withStart(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
@@ -1408,8 +1408,8 @@ public class SnapshotTest {
     Scanner scanner1 = mock(Scanner.class);
     when(scanner1.one()).thenReturn(Optional.of(result1)).thenReturn(Optional.empty());
     Scan scan1WithProjections =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .withStart(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME)
@@ -1419,8 +1419,8 @@ public class SnapshotTest {
     Scanner scanner2 = mock(Scanner.class);
     when(scanner2.one()).thenReturn(Optional.of(result2)).thenReturn(Optional.empty());
     Scan scan2WithProjections =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_2))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .withStart(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME)
@@ -1824,7 +1824,7 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, infinite)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
@@ -1873,28 +1873,28 @@ public class SnapshotTest {
     Scan scan1 =
         prepareScan()
             // ["text1", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
     Scan scan2 =
         prepareScan()
             // ["text2", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
     Scan scan3 =
         prepareScan()
             // ["text1", "text2"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
     Scan scan4 =
         prepareScan()
             // ("text2", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
     Scan scan5 =
         prepareScan()
             // ["text1", "text2")
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
 
     // Act Assert
     Throwable thrown1 =
@@ -1926,23 +1926,23 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text3"]
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
     Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text2"]
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
     Scan scan3 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text2")
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false)
+            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
@@ -1971,23 +1971,23 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ["text1", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
     Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ["text2", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
     Scan scan3 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ("text2", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
+            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
@@ -2398,7 +2398,7 @@ public class SnapshotTest {
     {
       // The method returns an immutable value, so the following update shouldn't be included.
       Get delayedGet =
-          new Get(new Key(ANY_NAME_1, ANY_TEXT_2), new Key(ANY_NAME_2, ANY_TEXT_1))
+          new Get(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_1, ANY_TEXT_1))
               .withConsistency(Consistency.LINEARIZABLE)
               .forNamespace(ANY_NAMESPACE_NAME)
               .forTable(ANY_TABLE_NAME);
@@ -2406,7 +2406,7 @@ public class SnapshotTest {
       snapshot.putIntoReadSet(new Snapshot.Key(delayedGet), Optional.of(delayedResult));
 
       Put delayedPut =
-          new Put(new Key(ANY_NAME_1, ANY_TEXT_2), new Key(ANY_NAME_2, ANY_TEXT_1))
+          new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_1, ANY_TEXT_1))
               .withConsistency(Consistency.LINEARIZABLE)
               .forNamespace(ANY_NAMESPACE_NAME)
               .forTable(ANY_TABLE_NAME)
@@ -2465,7 +2465,7 @@ public class SnapshotTest {
     {
       // The method returns an immutable value, so the following update shouldn't be included.
       Get delayedGet =
-          new Get(new Key(ANY_NAME_1, ANY_TEXT_2), new Key(ANY_NAME_2, ANY_TEXT_1))
+          new Get(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_1, ANY_TEXT_1))
               .withConsistency(Consistency.LINEARIZABLE)
               .forNamespace(ANY_NAMESPACE_NAME)
               .forTable(ANY_TABLE_NAME);
@@ -2473,7 +2473,7 @@ public class SnapshotTest {
       snapshot.putIntoReadSet(new Snapshot.Key(delayedGet), Optional.of(delayedResult));
 
       Delete delayedDelete =
-          new Delete(new Key(ANY_NAME_1, ANY_TEXT_2), new Key(ANY_NAME_2, ANY_TEXT_1))
+          new Delete(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_1, ANY_TEXT_1))
               .withConsistency(Consistency.LINEARIZABLE)
               .forNamespace(ANY_NAMESPACE_NAME)
               .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -157,7 +157,7 @@ public class SnapshotTest {
                 ScalarDbUtils.toColumn(new TextValue(ANY_NAME_2, clusteringKeyColumnValue)))
             .put(ANY_NAME_3, ScalarDbUtils.toColumn(new TextValue(ANY_NAME_3, ANY_TEXT_3)))
             .put(ANY_NAME_4, ScalarDbUtils.toColumn(new TextValue(ANY_NAME_4, ANY_TEXT_4)))
-            .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(txId)))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, txId))
             .build();
     return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
   }
@@ -867,7 +867,7 @@ public class SnapshotTest {
                 .put(ANY_NAME_2, new TextValue(ANY_NAME_2, ANY_TEXT_2))
                 .put(ANY_NAME_3, new TextValue(ANY_NAME_3, ANY_TEXT_5))
                 .put(ANY_NAME_4, new TextValue(ANY_NAME_4, (String) null))
-                .put(Attribute.ID, Attribute.toIdValue(ANY_ID))
+                .put(Attribute.ID, new TextValue(Attribute.ID, ANY_ID))
                 .build());
     assertThat(result.getValue(ANY_NAME_1).isPresent()).isTrue();
     assertThat(result.getValue(ANY_NAME_1).get()).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
@@ -879,7 +879,7 @@ public class SnapshotTest {
     assertThat(result.getValue(ANY_NAME_4).get())
         .isEqualTo(new TextValue(ANY_NAME_4, (String) null));
     assertThat(result.getValue(Attribute.ID).isPresent()).isTrue();
-    assertThat(result.getValue(Attribute.ID).get()).isEqualTo(Attribute.toIdValue(ANY_ID));
+    assertThat(result.getValue(Attribute.ID).get()).isEqualTo(new TextValue(Attribute.ID, ANY_ID));
 
     assertThat(result.getContainedColumnNames())
         .isEqualTo(
@@ -1378,7 +1378,7 @@ public class SnapshotTest {
                     ANY_NAME_2,
                     TextColumn.of(ANY_NAME_2, ANY_TEXT_2),
                     Attribute.ID,
-                    ScalarDbUtils.toColumn(Attribute.toIdValue("id1"))),
+                    TextColumn.of(Attribute.ID, "id1")),
                 TABLE_METADATA));
 
     Result result2 =
@@ -1390,7 +1390,7 @@ public class SnapshotTest {
                     ANY_NAME_2,
                     TextColumn.of(ANY_NAME_2, ANY_TEXT_1),
                     Attribute.ID,
-                    ScalarDbUtils.toColumn(Attribute.toIdValue("id2"))),
+                    TextColumn.of(Attribute.ID, "id2")),
                 TABLE_METADATA));
 
     Snapshot.Key key1 = new Snapshot.Key(scan1, result1);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
@@ -121,7 +121,7 @@ public class TransactionResultTest {
     Optional<Key> actual = result.getPartitionKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_1, ANY_TEXT_1)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
   }
 
   @Test
@@ -133,7 +133,7 @@ public class TransactionResultTest {
     Optional<Key> actual = result.getClusteringKey();
 
     // Assert
-    assertThat(actual).isEqualTo(Optional.of(new Key(ANY_NAME_2, ANY_TEXT_2)));
+    assertThat(actual).isEqualTo(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
@@ -9,6 +9,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
@@ -17,7 +18,6 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.util.ScalarDbUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -59,38 +59,28 @@ public class TransactionResultTest {
                 .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
                 .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
                 .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
-                .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-                .put(
-                    Attribute.PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-                .put(
-                    Attribute.COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
+                .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+                .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
+                .put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
                 .put(
                     Attribute.STATE,
-                    ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-                .put(
-                    Attribute.VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toVersionValue(ANY_VERSION_2)))
+                    IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+                .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, ANY_VERSION_2))
                 .put(
                     Attribute.BEFORE_PREFIX + ANY_NAME_3,
                     IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
-                .put(
-                    Attribute.BEFORE_ID,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+                .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
                 .put(
                     Attribute.BEFORE_PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                    BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
                 .put(
                     Attribute.BEFORE_COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                    BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
                 .put(
                     Attribute.BEFORE_STATE,
-                    ScalarDbUtils.toColumn(
-                        Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
+                    IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
                 .put(
-                    Attribute.BEFORE_VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(ANY_VERSION_1)))
+                    Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, ANY_VERSION_1))
                 .build(),
             TABLE_METADATA));
   }
@@ -158,27 +148,29 @@ public class TransactionResultTest {
         .isEqualTo(Optional.of(new TextValue(ANY_NAME_2, ANY_TEXT_2)));
     assertThat(result.getValue(ANY_NAME_3))
         .isEqualTo(Optional.of(new IntValue(ANY_NAME_3, ANY_INT_2)));
-    assertThat(result.getValue(Attribute.ID)).isEqualTo(Optional.of(Attribute.toIdValue(ANY_ID_2)));
+    assertThat(result.getValue(Attribute.ID))
+        .isEqualTo(Optional.of(new TextValue(Attribute.ID, ANY_ID_2)));
     assertThat(result.getValue(Attribute.PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toPreparedAtValue(ANY_TIME_3)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.PREPARED_AT, ANY_TIME_3)));
     assertThat(result.getValue(Attribute.COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toCommittedAtValue(ANY_TIME_4)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.COMMITTED_AT, ANY_TIME_4)));
     assertThat(result.getValue(Attribute.STATE))
-        .isEqualTo(Optional.of(Attribute.toStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
     assertThat(result.getValue(Attribute.VERSION))
-        .isEqualTo(Optional.of(Attribute.toVersionValue(ANY_VERSION_2)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.VERSION, ANY_VERSION_2)));
     assertThat(result.getValue(Attribute.BEFORE_PREFIX + ANY_NAME_3))
         .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1)));
     assertThat(result.getValue(Attribute.BEFORE_ID))
-        .isEqualTo(Optional.of(Attribute.toBeforeIdValue(ANY_ID_1)));
+        .isEqualTo(Optional.of(new TextValue(Attribute.BEFORE_ID, ANY_ID_1)));
     assertThat(result.getValue(Attribute.BEFORE_PREPARED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforePreparedAtValue(ANY_TIME_1)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1)));
     assertThat(result.getValue(Attribute.BEFORE_COMMITTED_AT))
-        .isEqualTo(Optional.of(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)));
+        .isEqualTo(Optional.of(new BigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2)));
     assertThat(result.getValue(Attribute.BEFORE_STATE))
-        .isEqualTo(Optional.of(Attribute.toBeforeStateValue(TransactionState.COMMITTED)));
+        .isEqualTo(
+            Optional.of(new IntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())));
     assertThat(result.getValue(Attribute.BEFORE_VERSION))
-        .isEqualTo(Optional.of(Attribute.toBeforeVersionValue(ANY_VERSION_1)));
+        .isEqualTo(Optional.of(new IntValue(Attribute.BEFORE_VERSION, ANY_VERSION_1)));
 
     assertThat(result.getContainedColumnNames())
         .isEqualTo(
@@ -380,38 +372,28 @@ public class TransactionResultTest {
                 .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
                 .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
                 .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
-                .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-                .put(
-                    Attribute.PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-                .put(
-                    Attribute.COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
+                .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+                .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
+                .put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
                 .put(
                     Attribute.STATE,
-                    ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-                .put(
-                    Attribute.VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toVersionValue(ANY_VERSION_2)))
+                    IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+                .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, ANY_VERSION_2))
                 .put(
                     Attribute.BEFORE_PREFIX + ANY_NAME_3,
                     IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
-                .put(
-                    Attribute.BEFORE_ID,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+                .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
                 .put(
                     Attribute.BEFORE_PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                    BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
                 .put(
                     Attribute.BEFORE_COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                    BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
                 .put(
                     Attribute.BEFORE_STATE,
-                    ScalarDbUtils.toColumn(
-                        Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
+                    IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
                 .put(
-                    Attribute.BEFORE_VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(ANY_VERSION_1)))
+                    Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, ANY_VERSION_1))
                 .build(),
             TABLE_METADATA);
     Result r2 = new TransactionResult(r1);
@@ -429,38 +411,28 @@ public class TransactionResultTest {
                 .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
                 .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
                 .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
-                .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
-                .put(
-                    Attribute.PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toPreparedAtValue(ANY_TIME_3)))
-                .put(
-                    Attribute.COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toCommittedAtValue(ANY_TIME_4)))
+                .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_2))
+                .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, ANY_TIME_3))
+                .put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, ANY_TIME_4))
                 .put(
                     Attribute.STATE,
-                    ScalarDbUtils.toColumn(Attribute.toStateValue(TransactionState.COMMITTED)))
-                .put(
-                    Attribute.VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toVersionValue(ANY_VERSION_2)))
+                    IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()))
+                .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, ANY_VERSION_2))
                 .put(
                     Attribute.BEFORE_PREFIX + ANY_NAME_3,
                     IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
-                .put(
-                    Attribute.BEFORE_ID,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
+                .put(Attribute.BEFORE_ID, TextColumn.of(Attribute.BEFORE_ID, ANY_ID_1))
                 .put(
                     Attribute.BEFORE_PREPARED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforePreparedAtValue(ANY_TIME_1)))
+                    BigIntColumn.of(Attribute.BEFORE_PREPARED_AT, ANY_TIME_1))
                 .put(
                     Attribute.BEFORE_COMMITTED_AT,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeCommittedAtValue(ANY_TIME_2)))
+                    BigIntColumn.of(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_2))
                 .put(
                     Attribute.BEFORE_STATE,
-                    ScalarDbUtils.toColumn(
-                        Attribute.toBeforeStateValue(TransactionState.COMMITTED)))
+                    IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get()))
                 .put(
-                    Attribute.BEFORE_VERSION,
-                    ScalarDbUtils.toColumn(Attribute.toBeforeVersionValue(ANY_VERSION_1)))
+                    Attribute.BEFORE_VERSION, IntColumn.of(Attribute.BEFORE_VERSION, ANY_VERSION_1))
                 .build(),
             TABLE_METADATA);
     Map<String, Column<?>> emptyValues = Collections.emptyMap();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
@@ -74,7 +74,7 @@ public class TransactionTableMetadataManagerTest {
     // Act
     TransactionTableMetadata actual =
         tableMetadataManager.getTransactionTableMetadata(
-            new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl"));
+            new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl"));
 
     // Assert
     verify(admin).getTableMetadata(anyString(), anyString());
@@ -88,7 +88,7 @@ public class TransactionTableMetadataManagerTest {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
 
-    Get get = new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl");
+    Get get = new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl");
 
     // Act
     tableMetadataManager.getTransactionTableMetadata(get);
@@ -107,7 +107,7 @@ public class TransactionTableMetadataManagerTest {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, 1); // one second
 
-    Get get = new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl");
+    Get get = new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl");
 
     // Act
     tableMetadataManager.getTransactionTableMetadata(get);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -73,21 +73,21 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE)
         .forTable(ANY_TABLE_NAME);
   }
 
   private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE).forTable(ANY_TABLE_NAME);
   }
 
   private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Put(partitionKey, clusteringKey)
         .withValue(ANY_NAME_3, ANY_TEXT_3)
         .forNamespace(ANY_NAMESPACE)
@@ -95,8 +95,8 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE)
         .forTable(ANY_TABLE_NAME);

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -92,17 +92,17 @@ public class JdbcTransactionManagerTest {
 
     // Act
     DistributedTransaction transaction = manager.begin();
-    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     transaction.get(get);
-    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     transaction.scan(scan);
     Put put =
-        new Put(new Key("p1", "val1"))
+        new Put(Key.ofText("p1", "val1"))
             .withValue("v1", "val2")
             .forNamespace(NAMESPACE)
             .forTable(TABLE);
     transaction.put(put);
-    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     transaction.delete(delete);
     transaction.mutate(Arrays.asList(put, delete));
     transaction.commit();
@@ -126,7 +126,7 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
             })
         .isInstanceOf(CrudException.class);
@@ -214,7 +214,7 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -230,7 +230,7 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.scan(scan);
             })
         .isInstanceOf(CrudException.class);
@@ -247,7 +247,7 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.scan(scan);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -627,7 +627,7 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -648,7 +648,7 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -669,7 +669,7 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.delete(delete);
             })
         .isInstanceOf(CrudException.class);
@@ -687,7 +687,7 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.delete(delete);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -705,12 +705,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(CrudException.class);
@@ -728,12 +728,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(CrudConflictException.class);
@@ -749,10 +749,10 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -774,10 +774,10 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -798,10 +798,10 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);
@@ -824,10 +824,10 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
-                  new Put(new Key("p1", "val1"))
+                  new Put(Key.ofText("p1", "val1"))
                       .withValue("v1", "val2")
                       .forNamespace(NAMESPACE)
                       .forTable(TABLE);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -518,8 +518,8 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     DistributedStorage storage = null;
     try {
       // Arrange
-      Key partitionKey = new Key(getColumnName2(), "aaa", getColumnName1(), 1);
-      Key clusteringKey = new Key(getColumnName4(), 2, getColumnName3(), "bbb");
+      Key partitionKey = Key.of(getColumnName2(), "aaa", getColumnName1(), 1);
+      Key clusteringKey = Key.of(getColumnName4(), 2, getColumnName3(), "bbb");
       storage = storageFactory.getStorage();
       storage.put(
           new Put(partitionKey, clusteringKey)

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -890,7 +890,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     int pKey = 0;
     int cKey = 0;
     List<Put> puts = preparePuts();
-    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfNotExists());
     Key partitionKey = Key.ofInt(getColumnName1(), pKey);
     Key clusteringKey = Key.ofInt(getColumnName4(), cKey);
     Get get =
@@ -964,9 +964,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     int pKey = 0;
     int cKey = 0;
     List<Put> puts = preparePuts();
-    puts.get(0).withCondition(new PutIfNotExists());
-    puts.get(1).withCondition(new PutIfNotExists());
-    puts.get(2).withCondition(new PutIfNotExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfNotExists());
+    puts.get(1).withCondition(ConditionBuilder.putIfNotExists());
+    puts.get(2).withCondition(ConditionBuilder.putIfNotExists());
     Scan scan =
         Scan.newBuilder()
             .namespace(namespace)
@@ -1075,9 +1075,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     int cKey = 0;
     List<Put> puts = preparePuts();
     assertThatCode(() -> storage.put(puts.get(0))).doesNotThrowAnyException();
-    puts.get(0).withCondition(new PutIfNotExists());
-    puts.get(1).withCondition(new PutIfNotExists());
-    puts.get(2).withCondition(new PutIfNotExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfNotExists());
+    puts.get(1).withCondition(ConditionBuilder.putIfNotExists());
+    puts.get(2).withCondition(ConditionBuilder.putIfNotExists());
     Scan scan =
         Scan.newBuilder()
             .namespace(namespace)
@@ -1102,9 +1102,11 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Arrange
     List<Put> puts = preparePuts();
     storage.put(puts.get(1));
-    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfNotExists());
     puts.get(1)
-        .withCondition(new PutIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1")));
+        .withCondition(
+            ConditionBuilder.putIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1"))
+                .build());
 
     // Act
     assertThatCode(() -> storage.put(Arrays.asList(puts.get(0), puts.get(1))))
@@ -1136,7 +1138,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     int pKey = 0;
     int cKey = 0;
     List<Put> puts = preparePuts();
-    puts.get(0).withCondition(new PutIfExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfExists());
     Get get = prepareGet(pKey, cKey);
 
     // Act Assert
@@ -1158,7 +1160,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Act Assert
     storage.put(puts.get(0));
-    puts.get(0).withCondition(new PutIfExists());
+    puts.get(0).withCondition(ConditionBuilder.putIfExists());
     puts.get(0).withValue(getColumnName3(), Integer.MAX_VALUE);
     assertThatCode(() -> storage.put(puts.get(0))).doesNotThrowAnyException();
 
@@ -1187,7 +1189,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     storage.put(puts.get(0));
     puts.get(0)
         .withCondition(
-            new PutIf(ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey)));
+            ConditionBuilder.putIf(
+                    ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey))
+                .build());
     puts.get(0).withValue(getColumnName3(), Integer.MAX_VALUE);
     assertThatCode(() -> storage.put(puts.get(0))).doesNotThrowAnyException();
 
@@ -1216,7 +1220,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     storage.put(puts.get(0));
     puts.get(0)
         .withCondition(
-            new PutIf(ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey + 1)));
+            ConditionBuilder.putIf(
+                    ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey + 1))
+                .build());
     puts.get(0).withValue(getColumnName3(), Integer.MAX_VALUE);
     assertThatThrownBy(() -> storage.put(puts.get(0))).isInstanceOf(NoMutationException.class);
 
@@ -1361,7 +1367,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Act Assert
     Delete delete = prepareDelete(pKey, Integer.MAX_VALUE);
-    delete.withCondition(new DeleteIfExists());
+    delete.withCondition(ConditionBuilder.deleteIfExists());
     assertThatThrownBy(() -> storage.delete(delete)).isInstanceOf(NoMutationException.class);
   }
 
@@ -1377,7 +1383,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Act
     Delete delete = prepareDelete(pKey, cKey);
-    delete.withCondition(new DeleteIfExists());
+    delete.withCondition(ConditionBuilder.deleteIfExists());
     assertThatCode(() -> storage.delete(delete)).doesNotThrowAnyException();
 
     // Assert
@@ -1405,9 +1411,10 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Act
     Delete delete = prepareDelete(pKey, cKey);
     delete.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(getColumnName2())
-                .isEqualToText(Integer.toString(Integer.MAX_VALUE))));
+        ConditionBuilder.deleteIf(
+                ConditionBuilder.column(getColumnName2())
+                    .isEqualToText(Integer.toString(Integer.MAX_VALUE)))
+            .build());
     assertThatThrownBy(() -> storage.delete(delete)).isInstanceOf(NoMutationException.class);
 
     // Assert
@@ -1435,8 +1442,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Act
     Delete delete = prepareDelete(pKey, cKey);
     delete.withCondition(
-        new DeleteIf(
-            ConditionBuilder.column(getColumnName2()).isEqualToText(Integer.toString(pKey))));
+        ConditionBuilder.deleteIf(
+                ConditionBuilder.column(getColumnName2()).isEqualToText(Integer.toString(pKey)))
+            .build());
     assertThatCode(() -> storage.delete(delete)).doesNotThrowAnyException();
 
     // Assert
@@ -1458,10 +1466,12 @@ public abstract class DistributedStorageIntegrationTestBase {
     List<Put> puts = preparePuts();
     List<Delete> deletes = prepareDeletes();
     storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
-    deletes.get(0).withCondition(new DeleteIfExists());
+    deletes.get(0).withCondition(ConditionBuilder.deleteIfExists());
     deletes
         .get(1)
-        .withCondition(new DeleteIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1")));
+        .withCondition(
+            ConditionBuilder.deleteIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1"))
+                .build());
 
     // Act
     assertThatCode(

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1104,10 +1104,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     storage.put(puts.get(1));
     puts.get(0).withCondition(new PutIfNotExists());
     puts.get(1)
-        .withCondition(
-            new PutIf(
-                new ConditionalExpression(
-                    getColumnName2(), new TextValue("1"), ConditionalExpression.Operator.EQ)));
+        .withCondition(new PutIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1")));
 
     // Act
     assertThatCode(() -> storage.put(Arrays.asList(puts.get(0), puts.get(1))))
@@ -1190,11 +1187,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     storage.put(puts.get(0));
     puts.get(0)
         .withCondition(
-            new PutIf(
-                new ConditionalExpression(
-                    getColumnName3(),
-                    new IntValue(pKey + cKey),
-                    ConditionalExpression.Operator.EQ)));
+            new PutIf(ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey)));
     puts.get(0).withValue(getColumnName3(), Integer.MAX_VALUE);
     assertThatCode(() -> storage.put(puts.get(0))).doesNotThrowAnyException();
 
@@ -1223,11 +1216,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     storage.put(puts.get(0));
     puts.get(0)
         .withCondition(
-            new PutIf(
-                new ConditionalExpression(
-                    getColumnName3(),
-                    new IntValue(pKey + cKey + 1),
-                    ConditionalExpression.Operator.EQ)));
+            new PutIf(ConditionBuilder.column(getColumnName3()).isEqualToInt(pKey + cKey + 1)));
     puts.get(0).withValue(getColumnName3(), Integer.MAX_VALUE);
     assertThatThrownBy(() -> storage.put(puts.get(0))).isInstanceOf(NoMutationException.class);
 
@@ -1417,10 +1406,8 @@ public abstract class DistributedStorageIntegrationTestBase {
     Delete delete = prepareDelete(pKey, cKey);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(
-                getColumnName2(),
-                new TextValue(Integer.toString(Integer.MAX_VALUE)),
-                ConditionalExpression.Operator.EQ)));
+            ConditionBuilder.column(getColumnName2())
+                .isEqualToText(Integer.toString(Integer.MAX_VALUE))));
     assertThatThrownBy(() -> storage.delete(delete)).isInstanceOf(NoMutationException.class);
 
     // Assert
@@ -1449,10 +1436,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     Delete delete = prepareDelete(pKey, cKey);
     delete.withCondition(
         new DeleteIf(
-            new ConditionalExpression(
-                getColumnName2(),
-                new TextValue(Integer.toString(pKey)),
-                ConditionalExpression.Operator.EQ)));
+            ConditionBuilder.column(getColumnName2()).isEqualToText(Integer.toString(pKey))));
     assertThatCode(() -> storage.delete(delete)).doesNotThrowAnyException();
 
     // Assert
@@ -1477,10 +1461,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     deletes.get(0).withCondition(new DeleteIfExists());
     deletes
         .get(1)
-        .withCondition(
-            new DeleteIf(
-                new ConditionalExpression(
-                    getColumnName2(), new TextValue("1"), ConditionalExpression.Operator.EQ)));
+        .withCondition(new DeleteIf(ConditionBuilder.column(getColumnName2()).isEqualToText("1")));
 
     // Act
     assertThatCode(

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -630,8 +630,6 @@ public abstract class DistributedStorageIntegrationTestBase {
             .end(Key.ofInt(getColumnName4(), 2))
             .ordering(Scan.Ordering.desc(getColumnName4()))
             .build();
-    new Scan(Key.ofInt(getColumnName1(), 0))
-        .withOrdering(new Scan.Ordering(getColumnName4(), Scan.Ordering.Order.DESC));
 
     // Act
     List<Result> actual = scanAll(scan);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
-import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.AdminTestUtils;
@@ -203,14 +202,13 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Put put = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
     storageForNormalUser.put(put);
-    ConditionalExpression conditionalExpression =
-        ConditionBuilder.buildConditionalExpression(
-            IntColumn.of(COL_NAME3, INT_COLUMN_VALUE1), ConditionalExpression.Operator.EQ);
     Put putWithPutIf =
         createPut(
             CLUSTERING_KEY_VALUE1,
             INT_COLUMN_VALUE2,
-            ConditionBuilder.putIf(conditionalExpression).build());
+            ConditionBuilder.putIf(
+                    ConditionBuilder.column(COL_NAME3).isEqualToInt(INT_COLUMN_VALUE1))
+                .build());
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(putWithPutIf)).doesNotThrowAnyException();
   }
@@ -250,12 +248,12 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Put put = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
     storageForNormalUser.put(put);
-    ConditionalExpression conditionalExpression =
-        ConditionBuilder.buildConditionalExpression(
-            IntColumn.of(COL_NAME3, INT_COLUMN_VALUE1), ConditionalExpression.Operator.EQ);
     Delete delete =
         createDelete(
-            CLUSTERING_KEY_VALUE1, ConditionBuilder.deleteIf(conditionalExpression).build());
+            CLUSTERING_KEY_VALUE1,
+            ConditionBuilder.deleteIf(
+                    ConditionBuilder.column(COL_NAME3).isEqualToInt(INT_COLUMN_VALUE1))
+                .build());
     // Act Assert
     assertThatCode(() -> storageForNormalUser.delete(delete)).doesNotThrowAnyException();
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -424,8 +424,8 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     DistributedTransactionManager manager = null;
     try {
       // Arrange
-      Key partitionKey = new Key(COL_NAME2, "aaa", COL_NAME1, 1);
-      Key clusteringKey = new Key(COL_NAME4, 2, COL_NAME3, "bbb");
+      Key partitionKey = Key.of(COL_NAME2, "aaa", COL_NAME1, 1);
+      Key clusteringKey = Key.of(COL_NAME4, 2, COL_NAME3, "bbb");
       manager = transactionFactory.getTransactionManager();
       manager.put(
           new Put(partitionKey, clusteringKey)

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -2685,8 +2685,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   protected Get prepareGet(int id, int type) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(TABLE)
@@ -2701,13 +2701,13 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   protected Scan prepareScan(int id, int fromType, int toType) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespace)
         .forTable(TABLE)
         .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(new Key(ACCOUNT_TYPE, fromType))
-        .withEnd(new Key(ACCOUNT_TYPE, toType));
+        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
   }
 
   protected ScanAll prepareScanAll() {
@@ -2718,8 +2718,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   protected Put preparePut(int id, int type) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(TABLE)
@@ -2749,8 +2749,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   protected Delete prepareDelete(int id, int type) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(TABLE)

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -2962,8 +2962,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   protected Get prepareGet(int id, int type, String namespaceName, String tableName) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(namespaceName)
         .forTable(tableName)
@@ -2982,13 +2982,13 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
   protected Scan prepareScan(
       int id, int fromType, int toType, String namespaceName, String tableName) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespaceName)
         .forTable(tableName)
         .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(new Key(ACCOUNT_TYPE, fromType))
-        .withEnd(new Key(ACCOUNT_TYPE, toType));
+        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
   }
 
   protected ScanAll prepareScanAll(String namespaceName, String tableName) {
@@ -2999,8 +2999,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   protected Put preparePut(int id, int type, String namespaceName, String tableName) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(namespaceName)
         .forTable(tableName)
@@ -3033,8 +3033,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   protected Delete prepareDelete(int id, int type, String namespaceName, String tableName) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(namespaceName)
         .forTable(tableName)

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -8241,8 +8241,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       TransactionState coordinatorState,
       CommitType commitType)
       throws ExecutionException, CoordinatorException {
-    Key partitionKey = new Key(ACCOUNT_ID, 0);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, 0);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
 
     String ongoingTxId;
     CoordinatorGroupCommitKeyManipulator keyManipulator =
@@ -8296,8 +8296,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Get prepareGet(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -8315,17 +8315,17 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Scan prepareScan(int id, int fromType, int toType, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespace)
         .forTable(table)
         .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(new Key(ACCOUNT_TYPE, fromType))
-        .withEnd(new Key(ACCOUNT_TYPE, toType));
+        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
   }
 
   private Scan prepareScan(int id, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -8333,7 +8333,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Scan prepareScanWithIndex(String namespace, String table, int balance) {
-    Key indexKey = new Key(BALANCE, balance);
+    Key indexKey = Key.ofInt(BALANCE, balance);
     return Scan.newBuilder()
         .namespace(namespace)
         .table(table)
@@ -8350,8 +8350,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Put preparePut(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -8369,8 +8369,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Delete prepareDelete(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -8258,16 +8258,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .forNamespace(namespace)
             .forTable(table)
             .withValue(BALANCE, NEW_BALANCE)
-            .withValue(Attribute.toIdValue(ongoingTxId))
-            .withValue(Attribute.toStateValue(recordState))
-            .withValue(Attribute.toVersionValue(2))
-            .withValue(Attribute.toPreparedAtValue(preparedAt))
+            .withTextValue(Attribute.ID, ongoingTxId)
+            .withIntValue(Attribute.STATE, recordState.get())
+            .withIntValue(Attribute.VERSION, 2)
+            .withBigIntValue(Attribute.PREPARED_AT, preparedAt)
             .withValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
-            .withValue(Attribute.toBeforeIdValue(ANY_ID_1))
-            .withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED))
-            .withValue(Attribute.toBeforeVersionValue(1))
-            .withValue(Attribute.toBeforePreparedAtValue(1))
-            .withValue(Attribute.toBeforeCommittedAtValue(1));
+            .withTextValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .withIntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .withIntValue(Attribute.BEFORE_VERSION, 1)
+            .withBigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .withBigIntValue(Attribute.BEFORE_COMMITTED_AT, 1);
     storage.put(put);
 
     if (coordinatorState == null) {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -2373,15 +2373,15 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
             .forNamespace(namespace1)
             .forTable(TABLE_1)
             .withValue(new IntValue(BALANCE, INITIAL_BALANCE))
-            .withValue(Attribute.toIdValue(ANY_ID_2))
-            .withValue(Attribute.toStateValue(recordState))
-            .withValue(Attribute.toVersionValue(2))
-            .withValue(Attribute.toPreparedAtValue(preparedAt))
-            .withValue(Attribute.toBeforeIdValue(ANY_ID_1))
-            .withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED))
-            .withValue(Attribute.toBeforeVersionValue(1))
-            .withValue(Attribute.toBeforePreparedAtValue(1))
-            .withValue(Attribute.toBeforeCommittedAtValue(1));
+            .withTextValue(Attribute.ID, ANY_ID_2)
+            .withIntValue(Attribute.STATE, recordState.get())
+            .withIntValue(Attribute.VERSION, 2)
+            .withBigIntValue(Attribute.PREPARED_AT, preparedAt)
+            .withTextValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .withIntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .withIntValue(Attribute.BEFORE_VERSION, 1)
+            .withBigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .withBigIntValue(Attribute.BEFORE_COMMITTED_AT, 1);
     storage1.put(put);
 
     if (coordinatorState == null) {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -2366,8 +2366,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   private void populatePreparedRecordAndCoordinatorStateRecordForStorage1(
       TransactionState recordState, long preparedAt, TransactionState coordinatorState)
       throws ExecutionException, CoordinatorException {
-    Key partitionKey = new Key(new IntValue(ACCOUNT_ID, 0));
-    Key clusteringKey = new Key(new IntValue(ACCOUNT_TYPE, 0));
+    Key partitionKey = Key.newBuilder().add(new IntValue(ACCOUNT_ID, 0)).build();
+    Key clusteringKey = Key.newBuilder().add(new IntValue(ACCOUNT_TYPE, 0)).build();
     Put put =
         new Put(partitionKey, clusteringKey)
             .forNamespace(namespace1)
@@ -2442,8 +2442,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Get prepareGet(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Get(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -2451,17 +2451,17 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Scan prepareScan(int id, int fromType, int toType, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespace)
         .forTable(table)
         .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(new Key(ACCOUNT_TYPE, fromType))
-        .withEnd(new Key(ACCOUNT_TYPE, toType));
+        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
   }
 
   private Scan prepareScan(int id, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return new Scan(partitionKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -2469,8 +2469,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Put preparePut(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)
@@ -2478,8 +2478,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private Delete prepareDelete(int id, int type, String namespace, String table) {
-    Key partitionKey = new Key(ACCOUNT_ID, id);
-    Key clusteringKey = new Key(ACCOUNT_TYPE, type);
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
         .forNamespace(namespace)
         .forTable(table)


### PR DESCRIPTION
## Description

This PR removes deprecated API usages. The changes were primarily made using Claude Code.

## Related issues and/or PRs

N/A

## Changes made

- Removed deprecated API usages from `Attribute`.
- Removed deprecated `Key` constructors usages.
- Removed deprecated `ConditionalExpression` constructors usages.
- Removed deprecated condition constructors usages.
- Removed deprecated `Scan.Ordering` constructor usages.
- Removed deprecated methods usages of `ConditionalExpression`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
