### PR TITLE
Remove deprecated API usages (Part 2)

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -186,18 +186,27 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME2, "val2")
-            .withValue(COL_NAME3, 3)
-            .withValue(COL_NAME5, true)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(COL_NAME2, "val2")
+            .intValue(COL_NAME3, 3)
+            .booleanValue(COL_NAME5, true)
+            .build();
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -228,18 +237,27 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME2, "val2")
-            .withValue(COL_NAME3, 3)
-            .withValue(COL_NAME5, true)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(COL_NAME2, "val2")
+            .intValue(COL_NAME3, 3)
+            .booleanValue(COL_NAME5, true)
+            .build();
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -271,18 +289,27 @@ public class MultiStorageIntegrationTest {
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
 
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME2, "val2")
-            .withValue(COL_NAME3, 3)
-            .withValue(COL_NAME5, true)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(COL_NAME2, "val2")
+            .intValue(COL_NAME3, 3)
+            .booleanValue(COL_NAME5, true)
+            .build();
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -317,21 +344,32 @@ public class MultiStorageIntegrationTest {
 
     cassandra.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey1)
-                .withValue(COL_NAME3, 2)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 1)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey3)
-                .withValue(COL_NAME3, 0)
-                .forNamespace(namespace)
-                .forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .intValue(COL_NAME3, 2)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 1)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey3)
+                .intValue(COL_NAME3, 0)
+                .build()));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
+    List<Result> results =
+        scanAll(
+            Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build());
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -359,21 +397,32 @@ public class MultiStorageIntegrationTest {
 
     jdbcDatabase.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey1)
-                .withValue(COL_NAME3, 2)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 1)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey3)
-                .withValue(COL_NAME3, 0)
-                .forNamespace(namespace)
-                .forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .intValue(COL_NAME3, 2)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 1)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey3)
+                .intValue(COL_NAME3, 0)
+                .build()));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
+    List<Result> results =
+        scanAll(
+            Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build());
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -401,21 +450,32 @@ public class MultiStorageIntegrationTest {
 
     cassandra.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey1)
-                .withValue(COL_NAME3, 2)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 1)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey3)
-                .withValue(COL_NAME3, 0)
-                .forNamespace(namespace)
-                .forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .intValue(COL_NAME3, 2)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 1)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey3)
+                .intValue(COL_NAME3, 0)
+                .build()));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
+    List<Result> results =
+        scanAll(
+            Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build());
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -445,20 +505,34 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -482,20 +556,34 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -519,20 +607,34 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -556,10 +658,13 @@ public class MultiStorageIntegrationTest {
     Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
     Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
-        new Put(partitionKey, clusteringKey1)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
@@ -567,15 +672,35 @@ public class MultiStorageIntegrationTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
+    Get get1 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .build();
+    Get get2 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey2)
+            .build();
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -611,10 +736,13 @@ public class MultiStorageIntegrationTest {
     Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
     Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
-        new Put(partitionKey, clusteringKey1)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
@@ -622,15 +750,35 @@ public class MultiStorageIntegrationTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
+    Get get1 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .build();
+    Get get2 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey2)
+            .build();
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -666,10 +814,13 @@ public class MultiStorageIntegrationTest {
     Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
     Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
-        new Put(partitionKey, clusteringKey1)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
@@ -677,15 +828,35 @@ public class MultiStorageIntegrationTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
+    Get get1 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .build();
+    Get get2 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey2)
+            .build();
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -721,18 +892,27 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME2, "val2")
-            .withValue(COL_NAME3, 3)
-            .withValue(COL_NAME5, true)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(COL_NAME2, "val2")
+            .intValue(COL_NAME3, 3)
+            .booleanValue(COL_NAME5, true)
+            .build();
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -767,21 +947,32 @@ public class MultiStorageIntegrationTest {
 
     jdbcDatabase.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey1)
-                .withValue(COL_NAME3, 2)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 1)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Put(partitionKey, clusteringKey3)
-                .withValue(COL_NAME3, 0)
-                .forNamespace(namespace)
-                .forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .intValue(COL_NAME3, 2)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 1)
+                .build(),
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey3)
+                .intValue(COL_NAME3, 0)
+                .build()));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
+    List<Result> results =
+        scanAll(
+            Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build());
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -805,20 +996,34 @@ public class MultiStorageIntegrationTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME4, 4);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -843,10 +1048,13 @@ public class MultiStorageIntegrationTest {
     Key clusteringKey1 = Key.ofInt(COL_NAME4, 1);
     Key clusteringKey2 = Key.ofInt(COL_NAME4, 2);
     Put put =
-        new Put(partitionKey, clusteringKey1)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     cassandra.put(put);
     jdbcDatabase.put(put);
@@ -854,15 +1062,35 @@ public class MultiStorageIntegrationTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
+    Get get1 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .build();
+    Get get2 =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey2)
+            .build();
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();

--- a/core/src/main/java/com/scalar/db/api/Mutation.java
+++ b/core/src/main/java/com/scalar/db/api/Mutation.java
@@ -54,16 +54,6 @@ public abstract class Mutation extends Operation {
     condition = mutation.condition;
   }
 
-  Mutation(
-      @Nullable String namespace,
-      String tableName,
-      Key partitionKey,
-      @Nullable Key clusteringKey,
-      @Nullable MutationCondition condition) {
-    super(namespace, tableName, partitionKey, clusteringKey);
-    this.condition = condition;
-  }
-
   /**
    * Returns the {@link MutationCondition}
    *

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedStorage.java
@@ -76,12 +76,4 @@ public abstract class AbstractDistributedStorage implements DistributedStorage {
   protected Delete copyAndSetTargetToIfNot(Delete delete) {
     return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
   }
-
-  protected Get copyAndPrepareForDynamicFiltering(Get get) {
-    return ScalarDbUtils.copyAndPrepareForDynamicFiltering(get);
-  }
-
-  protected Scan copyAndPrepareForDynamicFiltering(Scan scan) {
-    return ScalarDbUtils.copyAndPrepareForDynamicFiltering(scan);
-  }
 }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -21,6 +21,7 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -100,7 +101,9 @@ public class Cassandra extends AbstractDistributedStorage {
       if (get.getConjunctions().isEmpty()) {
         scanner = getInternal(get);
       } else {
-        scanner = new FilterableScanner(get, getInternal(copyAndPrepareForDynamicFiltering(get)));
+        scanner =
+            new FilterableScanner(
+                get, getInternal(ScalarDbUtils.copyAndPrepareForDynamicFiltering(get)));
       }
       Optional<Result> ret = scanner.one();
       if (scanner.one().isPresent()) {
@@ -134,7 +137,8 @@ public class Cassandra extends AbstractDistributedStorage {
     if (scan.getConjunctions().isEmpty()) {
       return scanInternal(scan);
     } else {
-      return new FilterableScanner(scan, scanInternal(copyAndPrepareForDynamicFiltering(scan)));
+      return new FilterableScanner(
+          scan, scanInternal(ScalarDbUtils.copyAndPrepareForDynamicFiltering(scan)));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -21,6 +21,7 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -105,7 +106,9 @@ public class Cosmos extends AbstractDistributedStorage {
       } else {
         scanner =
             new FilterableScanner(
-                get, selectStatementHandler.handle(copyAndPrepareForDynamicFiltering(get)));
+                get,
+                selectStatementHandler.handle(
+                    ScalarDbUtils.copyAndPrepareForDynamicFiltering(get)));
       }
       Optional<Result> ret = scanner.one();
       if (scanner.one().isPresent()) {
@@ -133,7 +136,8 @@ public class Cosmos extends AbstractDistributedStorage {
       return selectStatementHandler.handle(scan);
     } else {
       return new FilterableScanner(
-          scan, selectStatementHandler.handle(copyAndPrepareForDynamicFiltering(scan)));
+          scan,
+          selectStatementHandler.handle(ScalarDbUtils.copyAndPrepareForDynamicFiltering(scan)));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -20,6 +20,7 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -125,7 +126,9 @@ public class Dynamo extends AbstractDistributedStorage {
       } else {
         scanner =
             new FilterableScanner(
-                get, selectStatementHandler.handle(copyAndPrepareForDynamicFiltering(get)));
+                get,
+                selectStatementHandler.handle(
+                    ScalarDbUtils.copyAndPrepareForDynamicFiltering(get)));
       }
       Optional<Result> ret = scanner.one();
       if (scanner.one().isPresent()) {
@@ -153,7 +156,8 @@ public class Dynamo extends AbstractDistributedStorage {
       return selectStatementHandler.handle(scan);
     } else {
       return new FilterableScanner(
-          scan, selectStatementHandler.handle(copyAndPrepareForDynamicFiltering(scan)));
+          scan,
+          selectStatementHandler.handle(ScalarDbUtils.copyAndPrepareForDynamicFiltering(scan)));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -114,14 +114,17 @@ public class CommitMutationComposer extends AbstractMutationComposer {
 
   private Delete composeDelete(Operation base, @Nullable TransactionResult result)
       throws ExecutionException {
-    return new Delete(getPartitionKey(base, result), getClusteringKey(base, result).orElse(null))
-        .forNamespace(base.forNamespace().get())
-        .forTable(base.forTable().get())
-        .withConsistency(Consistency.LINEARIZABLE)
-        .withCondition(
+    return Delete.newBuilder()
+        .namespace(base.forNamespace().get())
+        .table(base.forTable().get())
+        .partitionKey(getPartitionKey(base, result))
+        .clusteringKey(getClusteringKey(base, result).orElse(null))
+        .consistency(Consistency.LINEARIZABLE)
+        .condition(
             ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(id))
                 .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
-                .build());
+                .build())
+        .build();
   }
 
   private Key getPartitionKey(Operation base, @Nullable TransactionResult result)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -342,7 +342,7 @@ public class Coordinator {
             .condition(ConditionBuilder.putIfNotExists());
 
     if (!childIds.isEmpty()) {
-      builder.textValue(Attribute.CHILD_IDS, childIds);
+      builder = builder.textValue(Attribute.CHILD_IDS, childIds);
     }
     return builder.build();
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -713,9 +713,19 @@ public class CrudHandler {
   }
 
   private Selection prepareStorageSelection(Selection selection) {
-    selection.clearProjections();
-    selection.withConsistency(Consistency.LINEARIZABLE);
-    return selection;
+    if (selection instanceof Get) {
+      return Get.newBuilder((Get) selection)
+          .clearProjections()
+          .consistency(Consistency.LINEARIZABLE)
+          .build();
+    } else {
+      assert selection instanceof Scan;
+
+      return Scan.newBuilder((Scan) selection)
+          .clearProjections()
+          .consistency(Consistency.LINEARIZABLE)
+          .build();
+    }
   }
 
   private TransactionTableMetadata getTransactionTableMetadata(Operation operation)

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -160,7 +160,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     get = copyAndSetTargetToIfNot(get);
 
     try {
-      return storage.get(get.withConsistency(Consistency.LINEARIZABLE));
+      return storage.get(Get.newBuilder(get).consistency(Consistency.LINEARIZABLE).build());
     } catch (ExecutionException e) {
       throw new CrudException(e.getMessage(), e, null);
     }
@@ -171,7 +171,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     scan = copyAndSetTargetToIfNot(scan);
 
     try (com.scalar.db.api.Scanner scanner =
-        storage.scan(scan.withConsistency(Consistency.LINEARIZABLE))) {
+        storage.scan(Scan.newBuilder(scan).consistency(Consistency.LINEARIZABLE).build())) {
       return scanner.all();
     } catch (ExecutionException | IOException e) {
       throw new CrudException(e.getMessage(), e, null);
@@ -226,7 +226,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     put = copyAndSetTargetToIfNot(put);
 
     try {
-      storage.put(put.withConsistency(Consistency.LINEARIZABLE));
+      storage.put(Put.newBuilder(put).consistency(Consistency.LINEARIZABLE).build());
     } catch (NoMutationException e) {
       throwUnsatisfiedConditionException(put);
     } catch (ExecutionException e) {
@@ -331,7 +331,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     delete = copyAndSetTargetToIfNot(delete);
 
     try {
-      storage.delete(delete.withConsistency(Consistency.LINEARIZABLE));
+      storage.delete(Delete.newBuilder(delete).consistency(Consistency.LINEARIZABLE).build());
     } catch (NoMutationException e) {
       throwUnsatisfiedConditionException(delete);
     } catch (ExecutionException e) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -1,27 +1,33 @@
 package com.scalar.db.util;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Streams;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
 import com.scalar.db.api.GetWithIndex;
 import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
 import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
 import com.scalar.db.api.UpdateIf;
 import com.scalar.db.api.UpdateIfExists;
 import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
@@ -66,15 +72,29 @@ public final class ScalarDbUtils {
 
   public static Get copyAndSetTargetToIfNot(
       Get get, Optional<String> namespace, Optional<String> tableName) {
-    Get ret = Get.newBuilder(get).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get); // copy
+    if (!get.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!get.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Get ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
   public static Scan copyAndSetTargetToIfNot(
       Scan scan, Optional<String> namespace, Optional<String> tableName) {
-    Scan ret = Scan.newBuilder(scan).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan); // copy
+    if (!scan.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!scan.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Scan ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
@@ -96,47 +116,75 @@ public final class ScalarDbUtils {
 
   public static Put copyAndSetTargetToIfNot(
       Put put, Optional<String> namespace, Optional<String> tableName) {
-    Put ret = Put.newBuilder(put).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    PutBuilder.BuildableFromExisting builder = Put.newBuilder(put); // copy
+    if (!put.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!put.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Put ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
   public static Delete copyAndSetTargetToIfNot(
       Delete delete, Optional<String> namespace, Optional<String> tableName) {
-    Delete ret = Delete.newBuilder(delete).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete); // copy
+    if (!delete.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!delete.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Delete ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
   public static Insert copyAndSetTargetToIfNot(
       Insert insert, Optional<String> namespace, Optional<String> tableName) {
-    Insert ret = Insert.newBuilder(insert).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert); // copy
+    if (!insert.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!insert.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Insert ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
   public static Upsert copyAndSetTargetToIfNot(
       Upsert upsert, Optional<String> namespace, Optional<String> tableName) {
-    Upsert ret = Upsert.newBuilder(upsert).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert); // copy
+    if (!upsert.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!upsert.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Upsert ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
   public static Update copyAndSetTargetToIfNot(
       Update update, Optional<String> namespace, Optional<String> tableName) {
-    Update ret = Update.newBuilder(update).build(); // copy
-    setTargetToIfNot(ret, namespace, tableName);
+    UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update); // copy
+    if (!update.forNamespace().isPresent() && namespace.isPresent()) {
+      builder.namespace(namespace.get());
+    }
+    if (!update.forTable().isPresent() && tableName.isPresent()) {
+      builder.table(tableName.get());
+    }
+    Update ret = builder.build();
+    checkIfTargetIsSet(ret);
     return ret;
   }
 
-  private static void setTargetToIfNot(
-      Operation operation, Optional<String> namespace, Optional<String> tableName) {
-    if (!operation.forNamespace().isPresent()) {
-      operation.forNamespace(namespace.orElse(null));
-    }
-    if (!operation.forTable().isPresent()) {
-      operation.forTable(tableName.orElse(null));
-    }
+  private static void checkIfTargetIsSet(Operation operation) {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException(
           CoreError.OPERATION_DOES_NOT_HAVE_TARGET_NAMESPACE_OR_TABLE_NAME.buildMessage(operation));
@@ -156,17 +204,6 @@ public final class ScalarDbUtils {
     }
 
     return false;
-  }
-
-  public static void addProjectionsForKeys(Selection selection, TableMetadata metadata) {
-    List<String> projections = selection.getProjections();
-    if (projections.isEmpty()) { // meaning projecting all
-      return;
-    }
-    Streams.concat(
-            metadata.getPartitionKeyNames().stream(), metadata.getClusteringKeyNames().stream())
-        .filter(n -> !projections.contains(n))
-        .forEach(selection::withProjection);
   }
 
   public static <T> Future<T> takeUninterruptibly(CompletionService<T> completionService) {
@@ -275,28 +312,28 @@ public final class ScalarDbUtils {
   }
 
   public static Get copyAndPrepareForDynamicFiltering(Get get) {
-    Get ret = Get.newBuilder(get).build(); // copy
-    List<String> projections = ret.getProjections();
+    GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get); // copy
+    List<String> projections = get.getProjections();
     if (!projections.isEmpty()) {
       // Add columns in conditions into projections to use them in dynamic filtering
-      ScalarDbUtils.getColumnNamesUsedIn(ret.getConjunctions()).stream()
+      ScalarDbUtils.getColumnNamesUsedIn(get.getConjunctions()).stream()
           .filter(columnName -> !projections.contains(columnName))
-          .forEach(ret::withProjection);
+          .forEach(builder::projection);
     }
-    return ret;
+    return builder.build();
   }
 
   public static Scan copyAndPrepareForDynamicFiltering(Scan scan) {
     // Ignore limit to control it during dynamic filtering
-    Scan ret = Scan.newBuilder(scan).limit(0).build(); // copy
-    List<String> projections = ret.getProjections();
+    ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan).limit(0); // copy
+    List<String> projections = scan.getProjections();
     if (!projections.isEmpty()) {
       // Add columns in conditions into projections to use them in dynamic filtering
-      ScalarDbUtils.getColumnNamesUsedIn(ret.getConjunctions()).stream()
+      ScalarDbUtils.getColumnNamesUsedIn(scan.getConjunctions()).stream()
           .filter(columnName -> !projections.contains(columnName))
-          .forEach(ret::withProjection);
+          .forEach(builder::projection);
     }
-    return ret;
+    return builder.build();
   }
 
   public static Set<String> getColumnNamesUsedIn(Set<Conjunction> conjunctions) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -74,10 +74,10 @@ public final class ScalarDbUtils {
       Get get, Optional<String> namespace, Optional<String> tableName) {
     GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get); // copy
     if (!get.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!get.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Get ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -88,10 +88,10 @@ public final class ScalarDbUtils {
       Scan scan, Optional<String> namespace, Optional<String> tableName) {
     ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan); // copy
     if (!scan.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!scan.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Scan ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -118,10 +118,10 @@ public final class ScalarDbUtils {
       Put put, Optional<String> namespace, Optional<String> tableName) {
     PutBuilder.BuildableFromExisting builder = Put.newBuilder(put); // copy
     if (!put.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!put.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Put ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -132,10 +132,10 @@ public final class ScalarDbUtils {
       Delete delete, Optional<String> namespace, Optional<String> tableName) {
     DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete); // copy
     if (!delete.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!delete.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Delete ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -146,10 +146,10 @@ public final class ScalarDbUtils {
       Insert insert, Optional<String> namespace, Optional<String> tableName) {
     InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert); // copy
     if (!insert.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!insert.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Insert ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -160,10 +160,10 @@ public final class ScalarDbUtils {
       Upsert upsert, Optional<String> namespace, Optional<String> tableName) {
     UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert); // copy
     if (!upsert.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!upsert.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Upsert ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -174,10 +174,10 @@ public final class ScalarDbUtils {
       Update update, Optional<String> namespace, Optional<String> tableName) {
     UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update); // copy
     if (!update.forNamespace().isPresent() && namespace.isPresent()) {
-      builder.namespace(namespace.get());
+      builder = builder.namespace(namespace.get());
     }
     if (!update.forTable().isPresent() && tableName.isPresent()) {
-      builder.table(tableName.get());
+      builder = builder.table(tableName.get());
     }
     Update ret = builder.build();
     checkIfTargetIsSet(ret);
@@ -316,9 +316,11 @@ public final class ScalarDbUtils {
     List<String> projections = get.getProjections();
     if (!projections.isEmpty()) {
       // Add columns in conditions into projections to use them in dynamic filtering
-      ScalarDbUtils.getColumnNamesUsedIn(get.getConjunctions()).stream()
-          .filter(columnName -> !projections.contains(columnName))
-          .forEach(builder::projection);
+      for (String columnName : getColumnNamesUsedIn(get.getConjunctions())) {
+        if (!projections.contains(columnName)) {
+          builder = builder.projection(columnName);
+        }
+      }
     }
     return builder.build();
   }
@@ -329,14 +331,16 @@ public final class ScalarDbUtils {
     List<String> projections = scan.getProjections();
     if (!projections.isEmpty()) {
       // Add columns in conditions into projections to use them in dynamic filtering
-      ScalarDbUtils.getColumnNamesUsedIn(scan.getConjunctions()).stream()
-          .filter(columnName -> !projections.contains(columnName))
-          .forEach(builder::projection);
+      for (String columnName : getColumnNamesUsedIn(scan.getConjunctions())) {
+        if (!projections.contains(columnName)) {
+          builder = builder.projection(columnName);
+        }
+      }
     }
     return builder.build();
   }
 
-  public static Set<String> getColumnNamesUsedIn(Set<Conjunction> conjunctions) {
+  private static Set<String> getColumnNamesUsedIn(Set<Conjunction> conjunctions) {
     Set<String> columns = new HashSet<>();
     conjunctions.forEach(
         conjunction ->

--- a/core/src/test/java/com/scalar/db/api/DeleteBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteBuilderTest.java
@@ -33,7 +33,8 @@ public class DeleteBuilderTest {
     Delete actual = Delete.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new Delete(partitionKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(new Delete(null, TABLE_1, partitionKey1, null, null, ImmutableMap.of(), null));
   }
 
   @Test
@@ -50,7 +51,14 @@ public class DeleteBuilderTest {
     // Assert
     assertThat(delete)
         .isEqualTo(
-            new Delete(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+            new Delete(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                clusteringKey1,
+                null,
+                ImmutableMap.of(),
+                null));
   }
 
   @Test
@@ -97,11 +105,14 @@ public class DeleteBuilderTest {
   public void build_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Delete existingDelete =
-        new Delete(partitionKey1, clusteringKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withCondition(condition1)
-            .withConsistency(Consistency.LINEARIZABLE);
+        new Delete(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            Consistency.LINEARIZABLE,
+            ImmutableMap.of(),
+            condition1);
 
     // Act
     Delete newDelete = Delete.newBuilder(existingDelete).build();
@@ -195,43 +206,47 @@ public class DeleteBuilderTest {
   public void build_FromExistingAndClearCondition_ShouldBuildDeleteWithoutCondition() {
     // Arrange
     Delete existingDelete =
-        new Delete(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withCondition(condition1);
+        new Delete(NAMESPACE_1, TABLE_1, partitionKey1, null, null, ImmutableMap.of(), condition1);
 
     // Act
     Delete newDelete = Delete.newBuilder(existingDelete).clearCondition().build();
 
     // Assert
     assertThat(newDelete)
-        .isEqualTo(new Delete(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Delete(NAMESPACE_1, TABLE_1, partitionKey1, null, null, ImmutableMap.of(), null));
   }
 
   @Test
   public void build_FromExistingAndClearClusteringKey_ShouldBuildDeleteWithoutClusteringKey() {
     // Arrange
     Delete existingDelete =
-        new Delete(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Delete(
+            NAMESPACE_1, TABLE_1, partitionKey1, clusteringKey1, null, ImmutableMap.of(), null);
 
     // Act
     Delete newDelete = Delete.newBuilder(existingDelete).clearClusteringKey().build();
 
     // Assert
     assertThat(newDelete)
-        .isEqualTo(new Delete(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Delete(NAMESPACE_1, TABLE_1, partitionKey1, null, null, ImmutableMap.of(), null));
   }
 
   @Test
   public void build_FromExistingAndClearNamespace_ShouldBuildDeleteWithoutNamespace() {
     // Arrange
     Delete existingDelete =
-        new Delete(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Delete(
+            NAMESPACE_1, TABLE_1, partitionKey1, clusteringKey1, null, ImmutableMap.of(), null);
 
     // Act
     Delete newDelete = Delete.newBuilder(existingDelete).clearNamespace().build();
 
     // Assert
-    assertThat(newDelete).isEqualTo(new Delete(partitionKey1, clusteringKey1).forTable(TABLE_1));
+    assertThat(newDelete)
+        .isEqualTo(
+            new Delete(
+                null, TABLE_1, partitionKey1, clusteringKey1, null, ImmutableMap.of(), null));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
@@ -40,7 +40,17 @@ public class GetBuilderTest {
     Get actual = Get.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new Get(partitionKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new Get(
+                null,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -57,7 +67,15 @@ public class GetBuilderTest {
     // Assert
     assertThat(get)
         .isEqualTo(
-            new Get(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                clusteringKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -567,7 +585,17 @@ public class GetBuilderTest {
             .build();
 
     // Assert
-    assertThat(get).isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(get)
+        .isEqualTo(
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -583,7 +611,17 @@ public class GetBuilderTest {
             .build();
 
     // Assert
-    assertThat(get).isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(get)
+        .isEqualTo(
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -598,7 +636,17 @@ public class GetBuilderTest {
             .build();
 
     // Assert
-    assertThat(get).isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(get)
+        .isEqualTo(
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -613,18 +661,32 @@ public class GetBuilderTest {
             .build();
 
     // Assert
-    assertThat(get).isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(get)
+        .isEqualTo(
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
   public void buildGet_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Get existingGet =
-        new Get(partitionKey1, clusteringKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withProjections(Arrays.asList("c1", "c2"))
-            .withConsistency(Consistency.LINEARIZABLE);
+        new Get(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            Consistency.LINEARIZABLE,
+            ImmutableMap.of(),
+            Arrays.asList("c1", "c2"),
+            ImmutableSet.of());
 
     // Act
     Get newGet = Get.newBuilder(existingGet).build();
@@ -1207,14 +1269,31 @@ public class GetBuilderTest {
   public void buildGet_FromExistingAndClearClusteringKey_ShouldBuildGetWithoutClusteringKey() {
     // Arrange
     Get existingGet =
-        new Get(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Get(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of());
 
     // Act
     Get newGet = Get.newBuilder(existingGet).clearClusteringKey().build();
 
     // Assert
     assertThat(newGet)
-        .isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Get(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -1222,7 +1301,15 @@ public class GetBuilderTest {
       buildGet_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
     Get existingGet =
-        new Get(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Get(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of());
 
     // Act Assert
     assertThatThrownBy(() -> Get.newBuilder(existingGet).indexKey(indexKey1))
@@ -1252,7 +1339,16 @@ public class GetBuilderTest {
     Get actual = Get.newBuilder().table(TABLE_1).indexKey(indexKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new GetWithIndex(indexKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new GetWithIndex(
+                null,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -1680,7 +1776,15 @@ public class GetBuilderTest {
 
     // Assert
     assertThat(get)
-        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new GetWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -1698,7 +1802,15 @@ public class GetBuilderTest {
 
     // Assert
     assertThat(get)
-        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new GetWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -1715,7 +1827,15 @@ public class GetBuilderTest {
 
     // Assert
     assertThat(get)
-        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new GetWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
@@ -1732,18 +1852,29 @@ public class GetBuilderTest {
 
     // Assert
     assertThat(get)
-        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new GetWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of()));
   }
 
   @Test
   public void buildGetWithIndex_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     GetWithIndex existingGet =
-        new GetWithIndex(indexKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withProjections(Arrays.asList("c1", "c2"))
-            .withConsistency(Consistency.LINEARIZABLE);
+        new GetWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            Consistency.LINEARIZABLE,
+            ImmutableMap.of(),
+            Arrays.asList("c1", "c2"),
+            ImmutableSet.of());
 
     // Act
     Get newGet = Get.newBuilder(existingGet).build();
@@ -1942,7 +2073,14 @@ public class GetBuilderTest {
       buildGetWithIndex_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
     GetWithIndex existingGet =
-        new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new GetWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of());
 
     // Act Assert
     assertThatThrownBy(() -> Get.newBuilder(existingGet).partitionKey(partitionKey1))
@@ -1957,11 +2095,15 @@ public class GetBuilderTest {
   public void buildGet_FromExistingAndClearNamespace_ShouldBuildGetWithoutNamespace() {
     // Arrange
     Get existingGet =
-        new Get(indexKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withProjections(Arrays.asList("c1", "c2"))
-            .withConsistency(Consistency.LINEARIZABLE);
+        new Get(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            null,
+            Consistency.LINEARIZABLE,
+            ImmutableMap.of(),
+            Arrays.asList("c1", "c2"),
+            ImmutableSet.of());
 
     // Act
     Get newGet = Get.newBuilder(existingGet).clearNamespace().build();
@@ -1969,21 +2111,29 @@ public class GetBuilderTest {
     // Assert
     assertThat(newGet)
         .isEqualTo(
-            new Get(indexKey1)
-                .forTable(TABLE_1)
-                .withProjections(Arrays.asList("c1", "c2"))
-                .withConsistency(Consistency.LINEARIZABLE));
+            new Get(
+                null,
+                TABLE_1,
+                indexKey1,
+                null,
+                Consistency.LINEARIZABLE,
+                ImmutableMap.of(),
+                Arrays.asList("c1", "c2"),
+                ImmutableSet.of()));
   }
 
   @Test
   public void buildGetWithIndex_FromExistingAndClearNamespace_ShouldBuildGetWithoutNamespace() {
     // Arrange
     GetWithIndex existingGet =
-        new GetWithIndex(indexKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withProjections(Arrays.asList("c1", "c2"))
-            .withConsistency(Consistency.LINEARIZABLE);
+        new GetWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            Consistency.LINEARIZABLE,
+            ImmutableMap.of(),
+            Arrays.asList("c1", "c2"),
+            ImmutableSet.of());
 
     // Act
     Get newGet = Get.newBuilder(existingGet).clearNamespace().build();
@@ -1991,9 +2141,13 @@ public class GetBuilderTest {
     // Assert
     assertThat(newGet)
         .isEqualTo(
-            new GetWithIndex(indexKey1)
-                .forTable(TABLE_1)
-                .withProjections(Arrays.asList("c1", "c2"))
-                .withConsistency(Consistency.LINEARIZABLE));
+            new GetWithIndex(
+                null,
+                TABLE_1,
+                indexKey1,
+                Consistency.LINEARIZABLE,
+                ImmutableMap.of(),
+                Arrays.asList("c1", "c2"),
+                ImmutableSet.of()));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -58,7 +59,17 @@ public class PutBuilderTest {
     Put actual = Put.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new Put(partitionKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new Put(
+                null,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                null,
+                new LinkedHashMap<>()));
   }
 
   @Test
@@ -75,7 +86,15 @@ public class PutBuilderTest {
     // Assert
     assertThat(put)
         .isEqualTo(
-            new Put(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+            new Put(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                clusteringKey1,
+                null,
+                ImmutableMap.of(),
+                null,
+                new LinkedHashMap<>()));
   }
 
   @Test
@@ -220,10 +239,15 @@ public class PutBuilderTest {
     // Assert
     assertThat(put)
         .isEqualTo(
-            new Put(partitionKey1)
-                .forNamespace(NAMESPACE_1)
-                .forTable(TABLE_1)
-                .withTextValue("bigint", "a_value"));
+            new Put(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                null,
+                ImmutableMap.of("bigint", TextColumn.of("bigint", "a_value"))));
   }
 
   @Test
@@ -386,11 +410,18 @@ public class PutBuilderTest {
   public void build_FromExistingAndClearValue_ShouldBuildPutWithoutClearedValues() {
     // Arrange
     Put existingPut =
-        new Put(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withBooleanValue("bool", Boolean.TRUE)
-            .withDoubleValue("double", Double.MIN_VALUE);
+        new Put(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            null,
+            ImmutableMap.of(),
+            null,
+            ImmutableMap.<String, Column<?>>builder()
+                .put("bool", BooleanColumn.of("bool", true))
+                .put("double", DoubleColumn.of("double", Double.MIN_VALUE))
+                .build());
 
     // Act
     Put newPut =
@@ -399,53 +430,107 @@ public class PutBuilderTest {
     // Assert
     assertThat(newPut)
         .isEqualTo(
-            new Put(partitionKey1)
-                .forNamespace(NAMESPACE_1)
-                .forTable(TABLE_1)
-                .withBooleanValue("bool", Boolean.TRUE));
+            new Put(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                null,
+                ImmutableMap.of("bool", BooleanColumn.of("bool", true))));
   }
 
   @Test
   public void build_FromExistingAndClearCondition_ShouldBuildPutWithoutCondition() {
     // Arrange
     Put existingPut =
-        new Put(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withCondition(condition1);
+        new Put(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            null,
+            ImmutableMap.of(),
+            condition1,
+            new LinkedHashMap<>());
 
     // Act
     Put newPut = Put.newBuilder(existingPut).clearCondition().build();
 
     // Assert
     assertThat(newPut)
-        .isEqualTo(new Put(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Put(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                null,
+                new LinkedHashMap<>()));
   }
 
   @Test
   public void build_FromExistingAndClearClusteringKey_ShouldBuildPutWithoutClusteringKey() {
     // Arrange
     Put existingPut =
-        new Put(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Put(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            null,
+            ImmutableMap.of(),
+            null,
+            new LinkedHashMap<>());
 
     // Act
     Put newPut = Put.newBuilder(existingPut).clearClusteringKey().build();
 
     // Assert
     assertThat(newPut)
-        .isEqualTo(new Put(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Put(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                null,
+                ImmutableMap.of(),
+                null,
+                new LinkedHashMap<>()));
   }
 
   @Test
   public void build_FromExistingAndClearNamespace_ShouldBuildPutWithoutNamespace() {
     // Arrange
     Put existingPut =
-        new Put(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new Put(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            clusteringKey1,
+            null,
+            ImmutableMap.of(),
+            null,
+            new LinkedHashMap<>());
 
     // Act
     Put newPut = Put.newBuilder(existingPut).clearNamespace().build();
 
     // Assert
-    assertThat(newPut).isEqualTo(new Put(partitionKey1, clusteringKey1).forTable(TABLE_1));
+    assertThat(newPut)
+        .isEqualTo(
+            new Put(
+                null,
+                TABLE_1,
+                partitionKey1,
+                clusteringKey1,
+                null,
+                ImmutableMap.of(),
+                null,
+                new LinkedHashMap<>()));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -80,7 +80,22 @@ public class ScanBuilderTest {
     Scan actual = Scan.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new Scan(partitionKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new Scan(
+                null,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -155,11 +170,20 @@ public class ScanBuilderTest {
 
     // Assert
     Scan expectedScan =
-        new Scan(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withStart(startClusteringKey1, true)
-            .withEnd(endClusteringKey1, true);
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            startClusteringKey1,
+            true,
+            endClusteringKey1,
+            true,
+            Collections.emptyList(),
+            0);
     assertThat(scan1).isEqualTo(expectedScan);
     assertThat(scan2).isEqualTo(expectedScan);
   }
@@ -178,11 +202,20 @@ public class ScanBuilderTest {
 
     // Assert
     Scan expectedScan =
-        new Scan(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withStart(startClusteringKey1, false)
-            .withEnd(endClusteringKey1, false);
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            startClusteringKey1,
+            false,
+            endClusteringKey1,
+            false,
+            Collections.emptyList(),
+            0);
     assertThat(scan).isEqualTo(expectedScan);
   }
 
@@ -190,16 +223,20 @@ public class ScanBuilderTest {
   public void buildScan_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Scan existingScan =
-        new Scan(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withConsistency(Consistency.EVENTUAL)
-            .withStart(startClusteringKey1)
-            .withEnd(endClusteringKey1)
-            .withOrdering(ordering1)
-            .withOrdering(ordering2)
-            .withLimit(10)
-            .withProjections(Arrays.asList("pk1", "ck1"));
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            Consistency.EVENTUAL,
+            ImmutableMap.of(),
+            Arrays.asList("pk1", "ck1"),
+            ImmutableSet.of(),
+            startClusteringKey1,
+            true,
+            endClusteringKey1,
+            true,
+            Arrays.asList(ordering1, ordering2),
+            10);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).build();
@@ -315,37 +352,103 @@ public class ScanBuilderTest {
   public void buildScan_FromExistingAndClearBoundaries_ShouldBuildScanWithoutBoundaries() {
     // Arrange
     Scan existingScan =
-        new Scan(partitionKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withStart(startClusteringKey1)
-            .withEnd(endClusteringKey1);
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            startClusteringKey1,
+            true,
+            endClusteringKey1,
+            true,
+            Collections.emptyList(),
+            0);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).clearStart().clearEnd().build();
 
     // Assert
     assertThat(newScan)
-        .isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new Scan(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
   public void buildScan_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
     // Arrange
-    Scan existingScan = new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan =
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            null,
+            false,
+            null,
+            false,
+            Collections.emptyList(),
+            0);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
 
     // Assert
-    assertThat(newScan).isEqualTo(new Scan(partitionKey1).forTable(TABLE_1));
+    assertThat(newScan)
+        .isEqualTo(
+            new Scan(
+                null,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
   public void
       buildScan_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    Scan existingScan = new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan =
+        new Scan(
+            NAMESPACE_1,
+            TABLE_1,
+            partitionKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            null,
+            false,
+            null,
+            false,
+            Collections.emptyList(),
+            0);
 
     // Act Assert
     assertThatThrownBy(() -> Scan.newBuilder(existingScan).indexKey(indexKey1))
@@ -358,7 +461,17 @@ public class ScanBuilderTest {
     Scan actual = Scan.newBuilder().table(TABLE_1).all().build();
 
     // Assert
-    assertThat(actual).isEqualTo(new ScanAll().forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new ScanAll(
+                null,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -410,12 +523,15 @@ public class ScanBuilderTest {
   public void buildScanAll_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Scan existingScan =
-        new ScanAll()
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withConsistency(Consistency.EVENTUAL)
-            .withLimit(10)
-            .withProjections(Arrays.asList("pk1", "ck1"));
+        new ScanAll(
+            NAMESPACE_1,
+            TABLE_1,
+            Consistency.EVENTUAL,
+            ImmutableMap.of(),
+            Arrays.asList("pk1", "ck1"),
+            ImmutableSet.of(),
+            Collections.emptyList(),
+            10);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).build();
@@ -509,7 +625,16 @@ public class ScanBuilderTest {
   public void
       buildScanAll_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    Scan existingScan = new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan =
+        new ScanAll(
+            NAMESPACE_1,
+            TABLE_1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            Collections.emptyList(),
+            0);
 
     // Act Assert
     assertThatThrownBy(() -> Scan.newBuilder(existingScan).partitionKey(partitionKey1))
@@ -533,13 +658,32 @@ public class ScanBuilderTest {
   @Test
   public void buildScanAll_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
     // Arrange
-    ScanAll existingScan = new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    ScanAll existingScan =
+        new ScanAll(
+            NAMESPACE_1,
+            TABLE_1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            Collections.emptyList(),
+            0);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
 
     // Assert
-    assertThat(newScan).isEqualTo(new ScanAll().forTable(TABLE_1));
+    assertThat(newScan)
+        .isEqualTo(
+            new ScanAll(
+                null,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -548,7 +692,17 @@ public class ScanBuilderTest {
     Scan actual = Scan.newBuilder().table(TABLE_1).indexKey(indexKey1).build();
 
     // Assert
-    assertThat(actual).isEqualTo(new ScanWithIndex(indexKey1).forTable(TABLE_1));
+    assertThat(actual)
+        .isEqualTo(
+            new ScanWithIndex(
+                null,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -595,12 +749,15 @@ public class ScanBuilderTest {
   public void buildScanWithIndex_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Scan existingScan =
-        new ScanWithIndex(indexKey1)
-            .forNamespace(NAMESPACE_1)
-            .forTable(TABLE_1)
-            .withConsistency(Consistency.EVENTUAL)
-            .withLimit(10)
-            .withProjections(Arrays.asList("pk1", "ck1"));
+        new ScanWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            Consistency.EVENTUAL,
+            ImmutableMap.of(),
+            Arrays.asList("pk1", "ck1"),
+            ImmutableSet.of(),
+            10);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).build();
@@ -691,7 +848,16 @@ public class ScanBuilderTest {
   public void
       buildScanWithIndex_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    Scan existingScan = new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan =
+        new ScanWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            0);
 
     // Act Assert
     assertThatThrownBy(() -> Scan.newBuilder(existingScan).partitionKey(partitionKey1))
@@ -718,13 +884,31 @@ public class ScanBuilderTest {
   public void buildScanWithIndex_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
     // Arrange
     ScanWithIndex existingScan =
-        new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+        new ScanWithIndex(
+            NAMESPACE_1,
+            TABLE_1,
+            indexKey1,
+            null,
+            ImmutableMap.of(),
+            Collections.emptyList(),
+            ImmutableSet.of(),
+            0);
 
     // Act
     Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
 
     // Assert
-    assertThat(newScan).isEqualTo(new ScanWithIndex(indexKey1).forTable(TABLE_1));
+    assertThat(newScan)
+        .isEqualTo(
+            new ScanWithIndex(
+                null,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -1269,7 +1453,22 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new Scan(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -1286,7 +1485,22 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new Scan(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -1302,7 +1516,22 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new Scan(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -1318,7 +1547,22 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new Scan(
+                NAMESPACE_1,
+                TABLE_1,
+                partitionKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                null,
+                false,
+                null,
+                false,
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -1758,7 +2002,16 @@ public class ScanBuilderTest {
 
     // Assert
     assertThat(scan)
-        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new ScanWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -1776,7 +2029,16 @@ public class ScanBuilderTest {
 
     // Assert
     assertThat(scan)
-        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new ScanWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -1793,7 +2055,16 @@ public class ScanBuilderTest {
 
     // Assert
     assertThat(scan)
-        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new ScanWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -1810,7 +2081,16 @@ public class ScanBuilderTest {
 
     // Assert
     assertThat(scan)
-        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(
+            new ScanWithIndex(
+                NAMESPACE_1,
+                TABLE_1,
+                indexKey1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                0));
   }
 
   @Test
@@ -2871,7 +3151,17 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new ScanAll(
+                NAMESPACE_1,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -2888,7 +3178,17 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new ScanAll(
+                NAMESPACE_1,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -2904,7 +3204,17 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new ScanAll(
+                NAMESPACE_1,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test
@@ -2920,7 +3230,17 @@ public class ScanBuilderTest {
             .build();
 
     // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(scan)
+        .isEqualTo(
+            new ScanAll(
+                NAMESPACE_1,
+                TABLE_1,
+                null,
+                ImmutableMap.of(),
+                Collections.emptyList(),
+                ImmutableSet.of(),
+                Collections.emptyList(),
+                0));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -17,7 +17,6 @@ import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.Update;
@@ -27,14 +26,9 @@ import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.BooleanValue;
 import com.scalar.db.io.DataType;
-import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
-import com.scalar.db.io.Value;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -98,10 +92,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Returning null means table not found
     when(metadataManager.getTableMetadata(any())).thenReturn(null);
@@ -118,10 +115,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -134,10 +134,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -152,10 +155,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -170,10 +176,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -188,10 +197,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, "c3", "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -206,10 +218,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, "2", CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -221,13 +236,14 @@ public class OperationCheckerTest {
       whenCheckingGetOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -243,15 +259,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -261,20 +279,18 @@ public class OperationCheckerTest {
   public void whenCheckingScanOperationWithoutAnyClusteringKey_shouldNotThrowAnyException() {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
-    Key startClusteringKey = null;
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -289,15 +305,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -308,19 +326,19 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key startClusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -335,15 +353,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.desc(CKEY1))
-            .withOrdering(Scan.Ordering.asc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.desc(CKEY1))
+            .ordering(Scan.Ordering.asc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -358,14 +378,16 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -380,13 +402,15 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -402,15 +426,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -427,15 +453,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -452,15 +480,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -477,15 +507,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -502,15 +534,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -527,15 +561,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -551,15 +587,17 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.desc(CKEY1))
-            .withOrdering(Scan.Ordering.desc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.desc(CKEY1))
+            .ordering(Scan.Ordering.desc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -576,14 +614,16 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withEnd(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY2))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY2))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -595,16 +635,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -617,13 +659,16 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL1, 1)
-            .withValue(COL2, 0.1D)
-            .withBooleanValue(COL3, null)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1D)
+            .booleanValue(COL3, null)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -634,16 +679,16 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    MutationCondition condition = null;
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -655,16 +700,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, "c3", "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -677,16 +724,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, "c3", "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -698,17 +747,17 @@ public class OperationCheckerTest {
       whenCheckingPutOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = null;
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -720,16 +769,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
     MutationCondition condition = ConditionBuilder.putIfExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue("v4", true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -741,16 +792,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.putIfNotExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(COL1, "1")
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -763,17 +816,19 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition =
         ConditionBuilder.putIf(ConditionBuilder.column(COL1).isEqualToText("1")).build();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -786,20 +841,22 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition =
         ConditionBuilder.putIf(
                 ConditionBuilder.buildConditionalExpression(
                     IntColumn.of(COL1, 1), Operator.IS_NULL))
             .build();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -812,20 +869,22 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition =
         ConditionBuilder.putIf(
                 ConditionBuilder.buildConditionalExpression(
                     IntColumn.of(COL1, 1), Operator.IS_NOT_NULL))
             .build();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -838,16 +897,18 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = ConditionBuilder.deleteIfExists();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -859,17 +920,19 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition =
         ConditionBuilder.deleteIf(ConditionBuilder.column("dummy").isEqualToText("dummy")).build();
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -882,14 +945,16 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, null).build();
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -902,14 +967,16 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -922,14 +989,16 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, null).build();
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -942,14 +1011,16 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "");
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .doubleValue(COL2, 0.1)
+            .booleanValue(COL3, true)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -975,12 +1046,14 @@ public class OperationCheckerTest {
 
     Key partitionKey = Key.ofBlob(PKEY1, (byte[]) null);
     Key clusteringKey = Key.ofBlob(CKEY1, new byte[] {1, 1, 1});
-    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -1006,12 +1079,14 @@ public class OperationCheckerTest {
 
     Key partitionKey = Key.ofBlob(PKEY1, new byte[0]);
     Key clusteringKey = Key.ofBlob(CKEY1, new byte[] {1, 1, 1});
-    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -1037,12 +1112,14 @@ public class OperationCheckerTest {
 
     Key partitionKey = Key.ofBlob(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = Key.ofBlob(CKEY1, (byte[]) null);
-    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -1068,12 +1145,14 @@ public class OperationCheckerTest {
 
     Key partitionKey = Key.ofBlob(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = Key.ofBlob(CKEY1, new byte[0]);
-    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValues(values)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -1088,10 +1167,13 @@ public class OperationCheckerTest {
     MutationCondition condition =
         ConditionBuilder.deleteIf(ConditionBuilder.column(COL1).isEqualToInt(1)).build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -1102,12 +1184,13 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
-    MutationCondition condition = null;
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -1121,10 +1204,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1139,10 +1225,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, "c3", "val1");
     MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1154,13 +1243,14 @@ public class OperationCheckerTest {
       whenCheckingDeleteOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = null;
     MutationCondition condition = ConditionBuilder.deleteIfExists();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1175,10 +1265,13 @@ public class OperationCheckerTest {
     MutationCondition condition =
         ConditionBuilder.putIf(ConditionBuilder.column("dummy").isEqualToText("dummy")).build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1193,10 +1286,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = ConditionBuilder.putIfExists();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1211,10 +1307,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = ConditionBuilder.putIfNotExists();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1230,10 +1329,13 @@ public class OperationCheckerTest {
     MutationCondition condition =
         ConditionBuilder.deleteIf(ConditionBuilder.column(COL1).isEqualToText("1")).build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1252,10 +1354,13 @@ public class OperationCheckerTest {
                     IntColumn.of(COL1, 1), Operator.IS_NULL))
             .build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1274,10 +1379,13 @@ public class OperationCheckerTest {
                     IntColumn.of(COL1, 1), Operator.IS_NOT_NULL))
             .build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .withCondition(condition)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .condition(condition)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1293,12 +1401,20 @@ public class OperationCheckerTest {
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val1");
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL1, 1)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
     Delete delete =
-        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1325,12 +1441,20 @@ public class OperationCheckerTest {
     Key partitionKey2 = Key.of(PKEY1, 2, PKEY2, "val2");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val3");
     Put put =
-        new Put(partitionKey1, clusteringKey)
-            .withValue(COL1, 1)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
     Delete delete =
-        new Delete(partitionKey2, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey2)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1347,11 +1471,20 @@ public class OperationCheckerTest {
     Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val3");
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL1, 1)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
-    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace("n2").forTable(TABLE_NAME);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace("n2")
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1433,13 +1566,14 @@ public class OperationCheckerTest {
   public void whenCheckingGetOperationWithIndexedColumnAsPartitionKey_shouldNotThrowAnyException() {
     // Arrange
     Key partitionKey = Key.ofInt(COL1, 1);
-    Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -1450,13 +1584,14 @@ public class OperationCheckerTest {
       whenCheckingGetOperationWithNonIndexedColumnAsPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.ofDouble(COL2, 0.1d);
-    Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1468,13 +1603,14 @@ public class OperationCheckerTest {
       whenCheckingGetOperationWithIndexedColumnAsPartitionKeyButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.ofText(COL1, "1");
-    Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1489,10 +1625,13 @@ public class OperationCheckerTest {
     Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(projections)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(projections)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1570,18 +1709,16 @@ public class OperationCheckerTest {
       whenCheckingScanOperationWithIndexedColumnAsPartitionKey_shouldNotThrowAnyException() {
     // Arrange
     Key partitionKey = Key.ofInt(COL1, 1);
-    Key startClusteringKey = null;
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withStart(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .limit(limit)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -1592,18 +1729,16 @@ public class OperationCheckerTest {
       whenCheckingScanOperationWithNonIndexedColumnAsPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.ofDouble(COL2, 0.1d);
-    Key startClusteringKey = null;
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withStart(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .limit(limit)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1615,18 +1750,16 @@ public class OperationCheckerTest {
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.ofText(COL1, "1");
-    Key startClusteringKey = null;
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withStart(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .limit(limit)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1643,13 +1776,15 @@ public class OperationCheckerTest {
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withStart(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .start(startClusteringKey)
+            .end(endClusteringKey)
+            .projections(projections)
+            .limit(limit)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1661,19 +1796,17 @@ public class OperationCheckerTest {
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyWithOrderings_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.ofInt(COL1, 1);
-    Key startClusteringKey = null;
-    Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
-        new Scan(partitionKey)
-            .withStart(startClusteringKey)
-            .withStart(endClusteringKey)
-            .withProjections(projections)
-            .withLimit(limit)
-            .withOrdering(Scan.Ordering.asc(CKEY1))
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(projections)
+            .limit(limit)
+            .ordering(Scan.Ordering.asc(CKEY1))
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1755,12 +1888,14 @@ public class OperationCheckerTest {
     // Arrange
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
-    ScanAll scanAll =
-        new ScanAll()
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .projections(projections)
+            .limit(limit)
+            .build();
     when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
@@ -1774,12 +1909,14 @@ public class OperationCheckerTest {
     // Arrange
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
-    ScanAll scanAll =
-        new ScanAll()
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .projections(projections)
+            .limit(limit)
+            .build();
     when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 
@@ -1794,12 +1931,14 @@ public class OperationCheckerTest {
     // Arrange
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     int limit = 10;
-    ScanAll scanAll =
-        new ScanAll()
-            .withProjections(projections)
-            .withLimit(limit)
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE_NAME);
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .projections(projections)
+            .limit(limit)
+            .build();
     when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
     operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -22,6 +22,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Key;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,23 +82,37 @@ public class BatchHandlerTest {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey1 = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Put put1 =
-        new Put(partitionKey, clusteringKey1)
-            .withValue(ANY_NAME_3, ANY_INT_1)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey1)
+            .intValue(ANY_NAME_3, ANY_INT_1)
+            .build();
     Key clusteringKey2 = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
     Put put2 =
-        new Put(partitionKey, clusteringKey2)
-            .withValue(ANY_NAME_3, ANY_INT_1)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey2)
+            .intValue(ANY_NAME_3, ANY_INT_1)
+            .build();
     return Arrays.asList(put1, put2);
   }
 
   private List<Mutation> prepareConditionalPuts() {
     List<Mutation> mutations = prepareNonConditionalPuts();
-    mutations.forEach(m -> m.withCondition(ConditionBuilder.putIfNotExists()));
-    return mutations;
+    List<Mutation> conditionalMutations = new ArrayList<>();
+    for (Mutation m : mutations) {
+      if (m instanceof Put) {
+        conditionalMutations.add(
+            Put.newBuilder((Put) m).condition(ConditionBuilder.putIfNotExists()).build());
+      } else {
+        conditionalMutations.add(m);
+      }
+    }
+    return conditionalMutations;
   }
 
   private BatchHandler prepareSpiedBatchHandler() {
@@ -145,7 +160,9 @@ public class BatchHandlerTest {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
-    mutations.get(1).withCondition(ConditionBuilder.putIfExists());
+    mutations.set(
+        1,
+        Put.newBuilder((Put) mutations.get(1)).condition(ConditionBuilder.putIfExists()).build());
     when(session.execute(any(Statement.class))).thenReturn(results);
     when(results.wasApplied()).thenReturn(true);
 
@@ -164,7 +181,11 @@ public class BatchHandlerTest {
     // Arrange
     configureBehavior();
     mutations = prepareNonConditionalPuts();
-    mutations.get(1).withCondition(ConditionBuilder.putIfNotExists());
+    mutations.set(
+        1,
+        Put.newBuilder((Put) mutations.get(1))
+            .condition(ConditionBuilder.putIfNotExists())
+            .build());
     when(session.execute(any(Statement.class))).thenReturn(results);
     when(results.wasApplied()).thenReturn(true);
     spy = prepareSpiedBatchHandler();

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -22,9 +22,9 @@ import com.scalar.db.api.Put;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Key;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -102,17 +102,15 @@ public class BatchHandlerTest {
   }
 
   private List<Mutation> prepareConditionalPuts() {
-    List<Mutation> mutations = prepareNonConditionalPuts();
-    List<Mutation> conditionalMutations = new ArrayList<>();
-    for (Mutation m : mutations) {
-      if (m instanceof Put) {
-        conditionalMutations.add(
-            Put.newBuilder((Put) m).condition(ConditionBuilder.putIfNotExists()).build());
-      } else {
-        conditionalMutations.add(m);
-      }
-    }
-    return conditionalMutations;
+    return prepareNonConditionalPuts().stream()
+        .map(
+            m -> {
+              if (m instanceof Put) {
+                return Put.newBuilder((Put) m).condition(ConditionBuilder.putIfNotExists()).build();
+              }
+              return m;
+            })
+        .collect(Collectors.toList());
   }
 
   private BatchHandler prepareSpiedBatchHandler() {

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -21,10 +21,8 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Key;
-import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -61,30 +59,46 @@ public class SelectStatementHandlerTest {
 
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
   private Get prepareGetWithClusteringKey() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Get prepareGetWithReservedKeywords() {
     Key partitionKey = Key.ofText("from", ANY_TEXT_1);
     Key clusteringKey = Key.ofText("to", ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey).forNamespace("keyspace").forTable("table");
+    return Get.newBuilder()
+        .namespace("keyspace")
+        .table("table")
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Scan prepareScan() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
-  private ScanAll prepareScanAll() {
-    return new ScanAll().forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+  private Scan prepareScanAll() {
+    return Scan.newBuilder().namespace(ANY_NAMESPACE_NAME).table(ANY_TABLE_NAME).all().build();
   }
 
   private void configureBehavior(String expected) {
@@ -210,8 +224,7 @@ public class SelectStatementHandlerTest {
                   ANY_NAME_2 + "=?;",
                 });
     configureBehavior(expected);
-    get = prepareGetWithClusteringKey();
-    get.withProjection(ANY_NAME_1);
+    get = Get.newBuilder(prepareGetWithClusteringKey()).projection(ANY_NAME_1).build();
 
     // Act
     handler.prepare(get);
@@ -238,8 +251,11 @@ public class SelectStatementHandlerTest {
                   ANY_NAME_2 + "<=?;",
                 });
     configureBehavior(expected);
-    scan = prepareScan();
-    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2)).withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3));
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3))
+            .build();
 
     // Act
     handler.prepare(scan);
@@ -268,9 +284,11 @@ public class SelectStatementHandlerTest {
                   ANY_NAME_3 + "<=?;",
                 });
     configureBehavior(expected);
-    scan = prepareScan();
-    scan.withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-        .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+            .end(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4))
+            .build();
 
     // Act
     handler.prepare(scan);
@@ -297,9 +315,11 @@ public class SelectStatementHandlerTest {
                   ANY_NAME_2 + "<?;",
                 });
     configureBehavior(expected);
-    scan = prepareScan();
-    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
-        .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false)
+            .build();
 
     // Act
     handler.prepare(scan);
@@ -329,10 +349,12 @@ public class SelectStatementHandlerTest {
                   ANY_LIMIT + ";",
                 });
     configureBehavior(expected);
-    scan = prepareScan();
-    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-        .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
-        .withLimit(ANY_LIMIT);
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_2))
+            .limit(ANY_LIMIT)
+            .build();
 
     // Act
     handler.prepare(scan);
@@ -363,11 +385,13 @@ public class SelectStatementHandlerTest {
                   ANY_LIMIT + ";",
                 });
     configureBehavior(expected);
-    scan = prepareScan();
-    scan.withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-        .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
-        .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
-        .withLimit(ANY_LIMIT);
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_2))
+            .ordering(Scan.Ordering.desc(ANY_NAME_3))
+            .limit(ANY_LIMIT)
+            .build();
 
     // Act
     handler.prepare(scan);
@@ -394,9 +418,11 @@ public class SelectStatementHandlerTest {
   public void bind_ScanOperationWithMultipleClusteringKeysGiven_ShouldBindProperly() {
     // Arrange
     configureBehavior(null);
-    scan = prepareScan();
-    scan.withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-        .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+    scan =
+        Scan.newBuilder(prepareScan())
+            .start(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+            .end(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4))
+            .build();
 
     // Act
     handler.bind(prepared, scan);
@@ -412,8 +438,7 @@ public class SelectStatementHandlerTest {
   public void setConsistency_GetOperationWithStrongConsistencyGiven_ShouldPrepareWithQuorum() {
     // Arrange
     configureBehavior(null);
-    get = prepareGetWithClusteringKey();
-    get.withConsistency(Consistency.SEQUENTIAL);
+    get = Get.newBuilder(prepareGetWithClusteringKey()).consistency(Consistency.SEQUENTIAL).build();
 
     // Act
     handler.setConsistency(bound, get);
@@ -426,8 +451,7 @@ public class SelectStatementHandlerTest {
   public void setConsistency_GetOperationWithEventualConsistencyGiven_ShouldPrepareWithOne() {
     // Arrange
     configureBehavior(null);
-    get = prepareGetWithClusteringKey();
-    get.withConsistency(Consistency.EVENTUAL);
+    get = Get.newBuilder(prepareGetWithClusteringKey()).consistency(Consistency.EVENTUAL).build();
 
     // Act
     handler.setConsistency(bound, get);
@@ -441,8 +465,8 @@ public class SelectStatementHandlerTest {
       setConsistency_GetOperationWithLinearizableConsistencyGiven_ShouldPrepareWithSerial() {
     // Arrange
     configureBehavior(null);
-    get = prepareGetWithClusteringKey();
-    get.withConsistency(Consistency.LINEARIZABLE);
+    get =
+        Get.newBuilder(prepareGetWithClusteringKey()).consistency(Consistency.LINEARIZABLE).build();
 
     // Act
     handler.setConsistency(bound, get);
@@ -455,8 +479,7 @@ public class SelectStatementHandlerTest {
   public void setConsistency_ScanOperationWithStrongConsistencyGiven_ShouldPrepareWithQuorum() {
     // Arrange
     configureBehavior(null);
-    scan = prepareScan();
-    scan.withConsistency(Consistency.SEQUENTIAL);
+    scan = Scan.newBuilder(prepareScan()).consistency(Consistency.SEQUENTIAL).build();
 
     // Act
     handler.setConsistency(bound, scan);
@@ -469,8 +492,7 @@ public class SelectStatementHandlerTest {
   public void setConsistency_ScanOperationWithEventualConsistencyGiven_ShouldPrepareWithOne() {
     // Arrange
     configureBehavior(null);
-    scan = prepareScan();
-    scan.withConsistency(Consistency.EVENTUAL);
+    scan = Scan.newBuilder(prepareScan()).consistency(Consistency.EVENTUAL).build();
 
     // Act
     handler.setConsistency(bound, scan);
@@ -484,8 +506,7 @@ public class SelectStatementHandlerTest {
       setConsistency_ScanOperationWithLinearizableConsistencyGiven_ShouldPrepareWithSerial() {
     // Arrange
     configureBehavior(null);
-    scan = prepareScan();
-    scan.withConsistency(Consistency.LINEARIZABLE);
+    scan = Scan.newBuilder(prepareScan()).consistency(Consistency.LINEARIZABLE).build();
 
     // Act
     handler.setConsistency(bound, scan);
@@ -544,8 +565,7 @@ public class SelectStatementHandlerTest {
                   ANY_LIMIT + ";",
                 });
     configureBehavior(expected);
-    ScanAll scanAll = prepareScanAll();
-    scanAll.withLimit(ANY_LIMIT);
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).limit(ANY_LIMIT).build();
 
     // Act
     handler.prepare(scanAll);
@@ -565,7 +585,7 @@ public class SelectStatementHandlerTest {
                   "SELECT * FROM", ANY_NAMESPACE_NAME + "." + ANY_TABLE_NAME + ";",
                 });
     configureBehavior(expected);
-    ScanAll scanAll = prepareScanAll();
+    Scan scanAll = prepareScanAll();
 
     // Act
     handler.prepare(scanAll);
@@ -588,7 +608,7 @@ public class SelectStatementHandlerTest {
                   ANY_NAMESPACE_NAME + "." + ANY_TABLE_NAME + ";",
                 });
     configureBehavior(expected);
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(ANY_NAME_1, ANY_NAME_2).build();
 
     // Act
     handler.prepare(scanAll);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -45,19 +45,25 @@ public class CosmosMutationTest {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1)
-        .withValue(ANY_NAME_4, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .intValue(ANY_NAME_4, ANY_INT_2)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test
@@ -84,7 +90,7 @@ public class CosmosMutationTest {
   public void makeRecord_PutWithNullValueGiven_ShouldReturnWithValues() {
     // Arrange
     Put put = preparePut();
-    put.withIntValue(ANY_NAME_3, null);
+    put = Put.newBuilder(put).intValue(ANY_NAME_3, null).build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     String id = cosmosMutation.getId();
     String concatenatedPartitionKey = cosmosMutation.getConcatenatedPartitionKey();
@@ -138,7 +144,11 @@ public class CosmosMutationTest {
 
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Delete delete =
-        new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
 
     CosmosMutation cosmosMutation = new CosmosMutation(delete, metadata);
     String concatenatedPartitionKey = cosmosMutation.getConcatenatedPartitionKey();
@@ -163,9 +173,12 @@ public class CosmosMutationTest {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Delete delete =
-        new Delete(partitionKey, clusteringKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     CosmosMutation cosmosMutation = new CosmosMutation(delete, metadata);
     String concatenatedPartitionKey = cosmosMutation.getConcatenatedPartitionKey();
@@ -194,7 +207,7 @@ public class CosmosMutationTest {
                 ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
             .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
             .build();
-    Put put = preparePut().withCondition(conditions);
+    Put put = Put.newBuilder(preparePut()).condition(conditions).build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     String id = cosmosMutation.getId();
 

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -54,7 +54,12 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
 
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
-    Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
     // Act
@@ -73,9 +78,12 @@ public class CosmosOperationTest {
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
     // Act
@@ -93,7 +101,11 @@ public class CosmosOperationTest {
 
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Delete delete =
-        new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(delete, metadata);
 
     // Act
@@ -111,7 +123,12 @@ public class CosmosOperationTest {
 
     Key partitionKey =
         Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
-    Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
     // Act
@@ -129,7 +146,12 @@ public class CosmosOperationTest {
 
     Key partitionKey =
         Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
-    Get get = new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
     // Act
@@ -150,9 +172,12 @@ public class CosmosOperationTest {
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
     // Act

--- a/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -85,9 +85,12 @@ public class DeleteStatementHandlerTest {
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     id = ANY_TEXT_1 + ":" + ANY_TEXT_2;
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test
@@ -148,7 +151,11 @@ public class DeleteStatementHandlerTest {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
     Delete delete =
-        new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
 
     CosmosMutation cosmosMutation = new CosmosMutation(delete, metadata);
     String query = cosmosMutation.makeConditionalQuery();
@@ -174,7 +181,8 @@ public class DeleteStatementHandlerTest {
     when(storedProcedure.execute(anyList(), any(CosmosStoredProcedureRequestOptions.class)))
         .thenReturn(spResponse);
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
     CosmosMutation cosmosMutation = new CosmosMutation(delete, metadata);
     String query = cosmosMutation.makeConditionalQuery();
 
@@ -202,7 +210,8 @@ public class DeleteStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.PRECONDITION_FAILED.get());
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete)).isInstanceOf(NoMutationException.class);
@@ -218,7 +227,8 @@ public class DeleteStatementHandlerTest {
         .when(storedProcedure)
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -77,11 +77,14 @@ public class PutStatementHandlerTest {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1)
-        .withValue(ANY_NAME_4, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .intValue(ANY_NAME_4, ANY_INT_2)
+        .build();
   }
 
   @Test
@@ -122,11 +125,13 @@ public class PutStatementHandlerTest {
 
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Put put =
-        new Put(partitionKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withValue(ANY_NAME_3, ANY_INT_1)
-            .withValue(ANY_NAME_4, ANY_INT_2);
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .intValue(ANY_NAME_3, ANY_INT_1)
+            .intValue(ANY_NAME_4, ANY_INT_2)
+            .build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     Record record = cosmosMutation.makeRecord();
     String query = cosmosMutation.makeConditionalQuery();
@@ -170,7 +175,7 @@ public class PutStatementHandlerTest {
         .thenReturn(spResponse);
     when(spResponse.getResponseAsString()).thenReturn("true");
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfNotExists()).build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     Record record = cosmosMutation.makeRecord();
     String query = cosmosMutation.makeConditionalQuery();
@@ -197,7 +202,7 @@ public class PutStatementHandlerTest {
     when(storedProcedure.execute(anyList(), any(CosmosStoredProcedureRequestOptions.class)))
         .thenReturn(spResponse);
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);
     Record record = cosmosMutation.makeRecord();
     String query = cosmosMutation.makeConditionalQuery();
@@ -226,7 +231,7 @@ public class PutStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.PRECONDITION_FAILED.get());
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put)).isInstanceOf(NoMutationException.class);
@@ -243,7 +248,7 @@ public class PutStatementHandlerTest {
         .execute(anyList(), any(CosmosStoredProcedureRequestOptions.class));
     when(toThrow.getSubStatusCode()).thenReturn(CosmosErrorCode.RETRY_WITH.get());
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -25,7 +25,6 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering.Order;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
@@ -94,19 +93,26 @@ public class SelectStatementHandlerTest {
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     id = ANY_TEXT_1 + ":" + ANY_TEXT_2;
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Scan prepareScan() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1);
-    return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
-  private ScanAll prepareScanAll() {
-    return new ScanAll().forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+  private Scan prepareScanAll() {
+    return Scan.newBuilder().namespace(ANY_NAMESPACE_NAME).table(ANY_TABLE_NAME).all().build();
   }
 
   @Test
@@ -133,7 +139,12 @@ public class SelectStatementHandlerTest {
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
     Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
-    Get get = new Get(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(indexKey)
+            .build();
     String query =
         "select * from Record r where r.values[\"" + ANY_NAME_3 + "\"]" + " = '" + ANY_TEXT_3 + "'";
 
@@ -222,7 +233,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
-    Scan scan = new Scan(indexKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(indexKey)
+            .build();
     String query =
         "select * from Record r where r.values[\"" + ANY_NAME_3 + "\"]" + " = '" + ANY_TEXT_3 + "'";
 
@@ -263,9 +279,10 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3));
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3))
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -309,9 +326,10 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
-            .withEnd(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
+        Scan.newBuilder(prepareScan())
+            .start(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+            .end(Key.of(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4))
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -361,9 +379,10 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false);
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), false)
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -403,10 +422,11 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
-            .withLimit(ANY_LIMIT);
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_2))
+            .limit(ANY_LIMIT)
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -444,10 +464,11 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(Scan.Ordering.desc(ANY_NAME_2))
-            .withLimit(ANY_LIMIT);
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.desc(ANY_NAME_2))
+            .limit(ANY_LIMIT)
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -489,11 +510,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
-            .withOrdering(Scan.Ordering.desc(ANY_NAME_3))
-            .withLimit(ANY_LIMIT);
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_2))
+            .ordering(Scan.Ordering.desc(ANY_NAME_3))
+            .limit(ANY_LIMIT)
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -537,11 +559,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(Scan.Ordering.desc(ANY_NAME_2))
-            .withOrdering(Scan.Ordering.asc(ANY_NAME_3))
-            .withLimit(ANY_LIMIT);
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.desc(ANY_NAME_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_3))
+            .limit(ANY_LIMIT)
+            .build();
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"
@@ -578,7 +601,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll().withLimit(ANY_LIMIT);
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).limit(ANY_LIMIT).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -600,7 +623,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll();
+    Scan scanAll = prepareScanAll();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -622,7 +645,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    Get get = prepareGet().withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
+    Get get = Get.newBuilder(prepareGet()).projections(ANY_NAME_3, ANY_NAME_4).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(get)).doesNotThrowAnyException();
@@ -658,7 +681,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    Get get = prepareGet().withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+    Get get = Get.newBuilder(prepareGet()).projections(ANY_NAME_1, ANY_NAME_2).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(get)).doesNotThrowAnyException();
@@ -696,10 +719,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
     Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Get get =
-        new Get(indexKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(indexKey)
+            .projections(ANY_NAME_3, ANY_NAME_4)
+            .build();
     String query =
         "select r.id, "
             + "r.concatenatedPartitionKey, "
@@ -731,7 +756,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(ANY_NAME_3, ANY_NAME_4).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -758,7 +783,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(ANY_NAME_1, ANY_NAME_2).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -786,7 +811,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_4));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(ANY_NAME_1, ANY_NAME_4).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -814,7 +839,7 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(ANY_NAME_2, ANY_NAME_4));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(ANY_NAME_2, ANY_NAME_4).build();
 
     // Act Assert
     assertThatCode(() -> handler.handle(scanAll)).doesNotThrowAnyException();
@@ -844,10 +869,12 @@ public class SelectStatementHandlerTest {
 
     Key indexKey = Key.ofText(ANY_NAME_3, ANY_TEXT_3);
     Scan scan =
-        new Scan(indexKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(indexKey)
+            .projections(ANY_NAME_3, ANY_NAME_4)
+            .build();
     String query =
         "select r.id, "
             + "r.concatenatedPartitionKey, "
@@ -881,11 +908,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
 
     Scan scan =
-        prepareScan()
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(Scan.Ordering.asc(ANY_NAME_2))
-            .withLimit(ANY_LIMIT)
-            .withProjections(Arrays.asList(ANY_NAME_3, ANY_NAME_4));
+        Scan.newBuilder(prepareScan())
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .ordering(Scan.Ordering.asc(ANY_NAME_2))
+            .limit(ANY_LIMIT)
+            .projections(ANY_NAME_3, ANY_NAME_4)
+            .build();
 
     String query =
         "select r.id, "
@@ -933,10 +961,12 @@ public class SelectStatementHandlerTest {
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
     Scan scan =
-        new Scan(partitionKey)
-            .withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4))
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .projections(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4))
+            .build();
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1 + ":" + ANY_TEXT_2);
 
     String query =
@@ -977,11 +1007,13 @@ public class SelectStatementHandlerTest {
         .thenReturn(responseIterable);
     when(responseIterable.iterableByPage(anyInt())).thenReturn(pagesIterable);
     when(pagesIterable.iterator()).thenReturn(pagesIterator);
-    ScanAll scanAll =
-        new ScanAll()
-            .withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4))
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .projections(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4)
+            .build();
 
     String query =
         "select r.id, "
@@ -1020,10 +1052,13 @@ public class SelectStatementHandlerTest {
     Key partitionKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
     Key clusteringKey = Key.of(ANY_NAME_3, ANY_TEXT_3, ANY_NAME_4, ANY_TEXT_4);
     Get get =
-        new Get(partitionKey, clusteringKey)
-            .withProjections(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4))
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .projections(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3, ANY_NAME_4))
+            .build();
     cosmosPartitionKey = new PartitionKey(ANY_TEXT_1 + ":" + ANY_TEXT_2);
 
     String query =

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
@@ -73,19 +73,25 @@ public abstract class BatchHandlerTestBase {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1)
-        .withValue(ANY_NAME_4, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .intValue(ANY_NAME_4, ANY_INT_2)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test
@@ -109,8 +115,9 @@ public abstract class BatchHandlerTestBase {
             .build();
     doThrow(toThrow).when(client).transactWriteItems(any(TransactWriteItemsRequest.class));
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfNotExists()).build();
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(Arrays.asList(put, delete)))
@@ -128,8 +135,9 @@ public abstract class BatchHandlerTestBase {
             .build();
     doThrow(toThrow).when(client).transactWriteItems(any(TransactWriteItemsRequest.class));
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfNotExists()).build();
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(Arrays.asList(put, delete)))

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTestBase.java
@@ -65,9 +65,12 @@ public abstract class DeleteStatementHandlerTestBase {
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test
@@ -113,7 +116,11 @@ public abstract class DeleteStatementHandlerTestBase {
 
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Delete delete =
-        new Delete(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .build();
 
     DynamoMutation dynamoMutation = new DynamoMutation(delete, metadata);
 
@@ -136,7 +143,8 @@ public abstract class DeleteStatementHandlerTestBase {
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
     when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     DynamoMutation dynamoMutation = new DynamoMutation(delete, metadata);
 
@@ -162,7 +170,8 @@ public abstract class DeleteStatementHandlerTestBase {
     ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
     doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete)).isInstanceOf(NoMutationException.class);
@@ -177,7 +186,8 @@ public abstract class DeleteStatementHandlerTestBase {
     DynamoDbException toThrow = mock(DynamoDbException.class);
     doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(delete))

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -46,11 +46,14 @@ public class DynamoMutationTest {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1)
-        .withValue(ANY_NAME_4, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .intValue(ANY_NAME_4, ANY_INT_2)
+        .build();
   }
 
   @Test
@@ -99,7 +102,7 @@ public class DynamoMutationTest {
                 ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
             .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
             .build();
-    Put put = preparePut().withCondition(conditions);
+    Put put = Put.newBuilder(preparePut()).condition(conditions).build();
 
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
 
@@ -127,7 +130,7 @@ public class DynamoMutationTest {
                 ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
             .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
             .build();
-    Put put = preparePut().withCondition(conditions);
+    Put put = Put.newBuilder(preparePut()).condition(conditions).build();
 
     Map<String, String> expected = new HashMap<>();
     expected.put(DynamoOperation.CONDITION_COLUMN_NAME_ALIAS + "0", ANY_NAME_3);
@@ -145,7 +148,7 @@ public class DynamoMutationTest {
   @Test
   public void getUpdateExpression_PutWithIfExistsGiven_ShouldReturnExpression() {
     // Arrange
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
 
     // Act
@@ -173,7 +176,7 @@ public class DynamoMutationTest {
                 ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
             .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
             .build();
-    Put put = preparePut().withCondition(conditions);
+    Put put = Put.newBuilder(preparePut()).condition(conditions).build();
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(
         DynamoOperation.CONDITION_VALUE_ALIAS + "0",
@@ -194,7 +197,7 @@ public class DynamoMutationTest {
   @Test
   public void getValueBindMap_PutWithPutIfExistsGiven_ShouldReturnBindMap() {
     // Arrange
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(
         DynamoOperation.VALUE_ALIAS + "0",
@@ -215,7 +218,7 @@ public class DynamoMutationTest {
   @Test
   public void getValueBindMap_PutWithNullValueGiven_ShouldReturnBindMap() {
     // Arrange
-    Put put = preparePut().withIntValue(ANY_NAME_3, null);
+    Put put = Put.newBuilder(preparePut()).intValue(ANY_NAME_3, null).build();
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(DynamoOperation.VALUE_ALIAS + "0", AttributeValue.builder().nul(true).build());
     expected.put(

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationCheckerTest.java
@@ -72,7 +72,13 @@ public class DynamoOperationCheckerTest {
   @Test
   public void check_ForPutWithNullIndex_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Put put = new Put(Key.ofInt(PKEY1, 0), Key.ofInt(CKEY1, 0)).withIntValue(COL1, null);
+    Put put =
+        Put.newBuilder()
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofInt(PKEY1, 0))
+            .clusteringKey(Key.ofInt(CKEY1, 0))
+            .intValue(COL1, null)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -82,7 +88,13 @@ public class DynamoOperationCheckerTest {
   @Test
   public void check_ForPutWithNonNullIndex_ShouldDoNothing() {
     // Arrange
-    Put put = new Put(Key.ofInt(PKEY1, 0), Key.ofInt(CKEY1, 0)).withIntValue(COL1, 1);
+    Put put =
+        Put.newBuilder()
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofInt(PKEY1, 0))
+            .clusteringKey(Key.ofInt(CKEY1, 0))
+            .intValue(COL1, 1)
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -91,7 +103,12 @@ public class DynamoOperationCheckerTest {
   @Test
   public void check_ForPutWithoutSettingIndex_ShouldDoNothing() {
     // Arrange
-    Put put = new Put(Key.ofInt(PKEY1, 0), Key.ofInt(CKEY1, 0));
+    Put put =
+        Put.newBuilder()
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofInt(PKEY1, 0))
+            .clusteringKey(Key.ofInt(CKEY1, 0))
+            .build();
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -41,9 +41,12 @@ public class DynamoOperationTest {
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
@@ -71,11 +71,14 @@ public abstract class PutStatementHandlerTestBase {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1)
-        .withValue(ANY_NAME_4, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .intValue(ANY_NAME_4, ANY_INT_2)
+        .build();
   }
 
   @Test
@@ -108,11 +111,13 @@ public abstract class PutStatementHandlerTestBase {
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Put put =
-        new Put(partitionKey)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withValue(ANY_NAME_3, ANY_INT_1)
-            .withValue(ANY_NAME_4, ANY_INT_2);
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .intValue(ANY_NAME_3, ANY_INT_1)
+            .intValue(ANY_NAME_4, ANY_INT_2)
+            .build();
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
     String updateExpression = dynamoMutation.getUpdateExpressionWithKey();
@@ -150,7 +155,7 @@ public abstract class PutStatementHandlerTestBase {
   public void handle_PutIfNotExistsGiven_ShouldCallUpdateItemWithCondition() {
     // Arrange
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
-    Put put = preparePut().withCondition(ConditionBuilder.putIfNotExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfNotExists()).build();
 
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
@@ -176,7 +181,7 @@ public abstract class PutStatementHandlerTestBase {
   public void handle_PutIfExistsGiven_ShouldCallUpdateItemWithCondition() {
     // Arrange
     when(client.updateItem(any(UpdateItemRequest.class))).thenReturn(updateResponse);
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadata);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
     String updateExpression = dynamoMutation.getUpdateExpression();
@@ -203,7 +208,7 @@ public abstract class PutStatementHandlerTestBase {
     ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
     doThrow(toThrow).when(client).updateItem(any(UpdateItemRequest.class));
 
-    Put put = preparePut().withCondition(ConditionBuilder.putIfExists());
+    Put put = Put.newBuilder(preparePut()).condition(ConditionBuilder.putIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(put)).isInstanceOf(NoMutationException.class);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -70,7 +70,12 @@ public class JdbcDatabaseTest {
     // Arrange
 
     // Act
-    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     jdbcDatabase.get(get);
 
     // Assert
@@ -89,7 +94,12 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               jdbcDatabase.get(get);
             })
         .isInstanceOf(ExecutionException.class)
@@ -106,7 +116,12 @@ public class JdbcDatabaseTest {
             new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet, true));
 
     // Act
-    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     Scanner scanner = jdbcDatabase.scan(scan);
     scanner.close();
 
@@ -128,7 +143,12 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan =
+                  Scan.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class)
@@ -151,7 +171,12 @@ public class JdbcDatabaseTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan =
+                  Scan.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(IllegalArgumentException.class);
@@ -169,7 +194,12 @@ public class JdbcDatabaseTest {
     doThrow(sqlException).when(connection).commit();
 
     // Act
-    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     Scanner scanner = jdbcDatabase.scan(scan);
     assertThatThrownBy(scanner::close).isInstanceOf(IOException.class).hasCause(sqlException);
 
@@ -189,10 +219,12 @@ public class JdbcDatabaseTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .build();
     jdbcDatabase.put(put);
 
     // Assert
@@ -211,11 +243,13 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .withCondition(ConditionBuilder.putIfNotExists())
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .condition(ConditionBuilder.putIfNotExists())
+                      .build();
               jdbcDatabase.put(put);
             })
         .isInstanceOf(NoMutationException.class);
@@ -233,10 +267,12 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               jdbcDatabase.put(put);
             })
         .isInstanceOf(ExecutionException.class)
@@ -250,7 +286,12 @@ public class JdbcDatabaseTest {
     when(jdbcService.delete(any(), any())).thenReturn(true);
 
     // Act
-    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .build();
     jdbcDatabase.delete(delete);
 
     // Assert
@@ -269,10 +310,12 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1"))
-                      .withCondition(ConditionBuilder.deleteIfExists())
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .condition(ConditionBuilder.deleteIfExists())
+                      .build();
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(NoMutationException.class);
@@ -290,7 +333,11 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(ExecutionException.class)
@@ -305,11 +352,18 @@ public class JdbcDatabaseTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
-    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .build();
     jdbcDatabase.mutate(Arrays.asList(put, delete));
 
     // Assert
@@ -330,16 +384,20 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .withCondition(ConditionBuilder.putIfNotExists())
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .condition(ConditionBuilder.putIfNotExists())
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1"))
-                      .withCondition(ConditionBuilder.deleteIfExists())
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .condition(ConditionBuilder.deleteIfExists())
+                      .build();
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(NoMutationException.class);
@@ -360,12 +418,18 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(ExecutionException.class)
@@ -387,12 +451,18 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(RetriableExecutionException.class)
@@ -414,12 +484,18 @@ public class JdbcDatabaseTest {
     assertThatThrownBy(
             () -> {
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isEqualTo(exception);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -100,7 +100,12 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     jdbcService.get(get, connection);
 
     // Assert
@@ -125,7 +130,12 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
@@ -153,7 +163,7 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new ScanAll().forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan = Scan.newBuilder().namespace(NAMESPACE).table(TABLE).all().build();
     Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
@@ -221,7 +231,12 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     jdbcService.scan(scan, connection);
 
     // Assert
@@ -245,7 +260,7 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    ScanAll scanAll = new ScanAll().forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scanAll = Scan.newBuilder().namespace(NAMESPACE).table(TABLE).all().build();
     jdbcService.scan(scanAll, connection);
 
     // Assert
@@ -296,10 +311,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -321,12 +338,14 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(
                 ConditionBuilder.putIf(ConditionBuilder.column("v1").isEqualToText("val2")).build())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -348,12 +367,14 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(
                 ConditionBuilder.putIf(ConditionBuilder.column("v1").isEqualToText("val2")).build())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -375,11 +396,13 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(ConditionBuilder.putIfExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(ConditionBuilder.putIfExists())
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -401,11 +424,13 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(ConditionBuilder.putIfExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(ConditionBuilder.putIfExists())
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -426,11 +451,13 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(ConditionBuilder.putIfNotExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -453,11 +480,13 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .withCondition(ConditionBuilder.putIfNotExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
     boolean ret = jdbcService.put(put, connection);
 
     // Assert
@@ -475,7 +504,12 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .build();
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -496,12 +530,14 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(Key.ofText("p1", "val1"))
-            .withCondition(
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .condition(
                 ConditionBuilder.deleteIf(ConditionBuilder.column("v1").isEqualToText("val2"))
                     .build())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+            .build();
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -522,12 +558,14 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(Key.ofText("p1", "val1"))
-            .withCondition(
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .condition(
                 ConditionBuilder.deleteIf(ConditionBuilder.column("v1").isEqualToText("val2"))
                     .build())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+            .build();
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -549,10 +587,12 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(Key.ofText("p1", "val1"))
-            .withCondition(ConditionBuilder.deleteIfExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .condition(ConditionBuilder.deleteIfExists())
+            .build();
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -574,10 +614,12 @@ public class JdbcServiceTest {
 
     // Act
     Delete delete =
-        new Delete(Key.ofText("p1", "val1"))
-            .withCondition(ConditionBuilder.deleteIfExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .condition(ConditionBuilder.deleteIfExists())
+            .build();
     boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
@@ -601,11 +643,18 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
-    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .build();
     boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection);
 
     // Assert

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -61,7 +61,13 @@ public class MultiStorageTest {
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.get(get);
@@ -77,7 +83,13 @@ public class MultiStorageTest {
     String table = TABLE2;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.get(get);
@@ -94,7 +106,13 @@ public class MultiStorageTest {
     String table = TABLE3;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.get(get);
@@ -109,7 +127,8 @@ public class MultiStorageTest {
     String namespace = NAMESPACE1;
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
-    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+    Scan scan =
+        Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build();
 
     // Act
     multiStorage.scan(scan);
@@ -123,7 +142,8 @@ public class MultiStorageTest {
     String namespace = NAMESPACE1;
     String table = TABLE2;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
-    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+    Scan scan =
+        Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build();
 
     // Act
     multiStorage.scan(scan);
@@ -139,7 +159,8 @@ public class MultiStorageTest {
     String namespace = NAMESPACE1;
     String table = TABLE3;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
-    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+    Scan scan =
+        Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build();
 
     // Act
     multiStorage.scan(scan);
@@ -156,10 +177,13 @@ public class MultiStorageTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     // Act
     multiStorage.put(put);
@@ -176,10 +200,13 @@ public class MultiStorageTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     // Act
     multiStorage.put(put);
@@ -197,10 +224,13 @@ public class MultiStorageTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     // Act
     multiStorage.put(put);
@@ -216,7 +246,13 @@ public class MultiStorageTest {
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.delete(delete);
@@ -232,7 +268,13 @@ public class MultiStorageTest {
     String table = TABLE2;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.delete(delete);
@@ -249,7 +291,13 @@ public class MultiStorageTest {
     String table = TABLE3;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.delete(delete);
@@ -270,11 +318,19 @@ public class MultiStorageTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
     verify(storage1).mutate(anyList());
@@ -292,11 +348,19 @@ public class MultiStorageTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
     verify(storage2).mutate(anyList());
@@ -314,11 +378,19 @@ public class MultiStorageTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
     verify(storage3).mutate(anyList());
@@ -339,7 +411,13 @@ public class MultiStorageTest {
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.get(get);
@@ -355,7 +433,8 @@ public class MultiStorageTest {
     String namespace = NAMESPACE2;
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
-    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+    Scan scan =
+        Scan.newBuilder().namespace(namespace).table(table).partitionKey(partitionKey).build();
 
     // Act
     multiStorage.scan(scan);
@@ -373,10 +452,13 @@ public class MultiStorageTest {
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .withValue(COL_NAME3, 3)
-            .forNamespace(namespace)
-            .forTable(table);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL_NAME3, 3)
+            .build();
 
     // Act
     multiStorage.put(put);
@@ -393,7 +475,13 @@ public class MultiStorageTest {
     String table = TABLE1;
     Key partitionKey = Key.ofInt(COL_NAME1, 1);
     Key clusteringKey = Key.ofInt(COL_NAME2, 2);
-    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build();
 
     // Act
     multiStorage.delete(delete);
@@ -415,11 +503,19 @@ public class MultiStorageTest {
     // Act
     multiStorage.mutate(
         Arrays.asList(
-            new Put(partitionKey, clusteringKey2)
-                .withValue(COL_NAME3, 3)
-                .forNamespace(namespace)
-                .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+            Put.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey2)
+                .intValue(COL_NAME3, 3)
+                .build(),
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(table)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey1)
+                .build()));
 
     // Assert
     verify(storage2).mutate(anyList());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -122,28 +122,37 @@ public class CommitHandlerTest {
   private Put preparePut1() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .build();
   }
 
   private Put preparePut2() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_3);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_2)
+        .build();
   }
 
   private Put preparePut3() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_2);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_2)
+        .build();
   }
 
   private Get prepareGet() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -98,26 +98,35 @@ public class CommitMutationComposerTest {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private TransactionResult prepareResult(TransactionState state) {
@@ -193,16 +202,21 @@ public class CommitMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     Put expected =
-        new Put(put.getPartitionKey(), put.getClusteringKey().orElse(null))
-            .forNamespace(put.forNamespace().get())
-            .forTable(put.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
-            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.PREPARED.get()))
-            .build());
-    expected.withBigIntValue(Attribute.COMMITTED_AT, ANY_TIME_2);
-    expected.withIntValue(Attribute.STATE, TransactionState.COMMITTED.get());
+        Put.newBuilder()
+            .namespace(put.forNamespace().get())
+            .table(put.forTable().get())
+            .partitionKey(put.getPartitionKey())
+            .clusteringKey(put.getClusteringKey().orElse(null))
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+                    .and(
+                        ConditionBuilder.column(STATE)
+                            .isEqualToInt(TransactionState.PREPARED.get()))
+                    .build())
+            .bigIntValue(Attribute.COMMITTED_AT, ANY_TIME_2)
+            .intValue(Attribute.STATE, TransactionState.COMMITTED.get())
+            .build();
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -218,11 +232,15 @@ public class CommitMutationComposerTest {
 
     // Assert
     Delete actual = (Delete) composer.get().get(0);
-    delete.withConsistency(Consistency.LINEARIZABLE);
-    delete.withCondition(
-        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
-            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
-            .build());
+    delete =
+        Delete.newBuilder(delete)
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+                    .and(
+                        ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+                    .build())
+            .build();
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -237,11 +255,15 @@ public class CommitMutationComposerTest {
 
     // Assert
     Delete actual = (Delete) composer.get().get(0);
-    delete.withConsistency(Consistency.LINEARIZABLE);
-    delete.withCondition(
-        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
-            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
-            .build());
+    delete =
+        Delete.newBuilder(delete)
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+                    .and(
+                        ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+                    .build())
+            .build();
     assertThat(actual).isEqualTo(delete);
   }
 
@@ -305,14 +327,18 @@ public class CommitMutationComposerTest {
     // Assert
     Delete actual = (Delete) composer.get().get(0);
     Delete expected =
-        new Delete(get.getPartitionKey(), get.getClusteringKey().orElse(null))
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
-            .and(ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
-            .build());
+        Delete.newBuilder()
+            .namespace(get.forNamespace().get())
+            .table(get.forTable().get())
+            .partitionKey(get.getPartitionKey())
+            .clusteringKey(get.getClusteringKey().orElse(null))
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID))
+                    .and(
+                        ConditionBuilder.column(STATE).isEqualToInt(TransactionState.DELETED.get()))
+                    .build())
+            .build();
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -77,31 +77,44 @@ public class ConsensusCommitTest {
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Scan prepareScan() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Scan(partitionKey).forNamespace(ANY_NAMESPACE).forTable(ANY_TABLE_NAME);
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .withValue(ANY_NAME_3, ANY_TEXT_3)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .textValue(ANY_NAME_3, ANY_TEXT_3)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
@@ -107,8 +107,12 @@ public class MergedResultTest {
   public void getPartitionKey_ResultAndPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -123,8 +127,12 @@ public class MergedResultTest {
   public void getPartitionKey_OnlyPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
 
@@ -139,8 +147,12 @@ public class MergedResultTest {
   public void getClusteringKey_ResultAndPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -155,8 +167,12 @@ public class MergedResultTest {
   public void getClusteringKey_OnlyPutGiven_ShouldReturnCorrectKey() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
 
@@ -171,8 +187,12 @@ public class MergedResultTest {
   public void getValue_ResultAndPutGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -319,8 +339,12 @@ public class MergedResultTest {
   public void getValue_OnlyPutGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
 
@@ -462,9 +486,13 @@ public class MergedResultTest {
   public void getValue_ResultAndPutWithNullValueGiven_ShouldReturnMergedValue() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3)
-            .withTextValue(ANY_NAME_4, null);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .textValue(ANY_NAME_4, null)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -611,8 +639,12 @@ public class MergedResultTest {
   public void getValues_ResultAndPutGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -651,8 +683,12 @@ public class MergedResultTest {
   public void getValues_OnlyPutGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
 
@@ -689,9 +725,13 @@ public class MergedResultTest {
   public void getValues_ResultAndPutWithNullValueGiven_ShouldReturnMergedValues() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3)
-            .withTextValue(ANY_NAME_4, null);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .textValue(ANY_NAME_4, null)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
 
@@ -730,8 +770,12 @@ public class MergedResultTest {
   public void equals_SamePutAndResultGiven_ShouldReturnTrue() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
     MergedResult anotherMergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
@@ -747,8 +791,12 @@ public class MergedResultTest {
   public void equals_DifferentPutAndResultGiven_ShouldReturnFalse() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
     MergedResult anotherMergedResult = new MergedResult(Optional.empty(), put, TABLE_METADATA);
@@ -764,8 +812,12 @@ public class MergedResultTest {
   public void equals_ResultImplWithSamePutAndResultGiven_ShouldReturnTrue() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
     Result another =
@@ -811,8 +863,12 @@ public class MergedResultTest {
   public void equals_ResultImplWithDifferentPutAndResultGiven_ShouldReturnFalse() {
     // Arrange
     Put put =
-        new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withValue(ANY_NAME_3, ANY_INT_3);
+        Put.newBuilder()
+            .table("test")
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .intValue(ANY_NAME_3, ANY_INT_3)
+            .build();
 
     MergedResult mergedResult = new MergedResult(Optional.of(result), put, TABLE_METADATA);
     Result another = new ResultImpl(Collections.emptyMap(), TABLE_METADATA);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -78,19 +78,25 @@ public class PrepareMutationComposerTest {
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_3)
-        .withValue(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_3);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .intValue(ANY_NAME_3, ANY_INT_3)
+        .intValue(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_3)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Scan prepareScan() {
@@ -166,20 +172,23 @@ public class PrepareMutationComposerTest {
 
     // Assert
     Put actual = (Put) composer.get().get(0);
-    put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(
-        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build());
-    put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
-    put.withValue(Attribute.ID, ANY_ID_3);
-    put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
-    put.withValue(Attribute.VERSION, 3);
-    put.withValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3);
-    put.withValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4);
-    put.withValue(Attribute.BEFORE_ID, ANY_ID_2);
-    put.withValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
-    put.withValue(Attribute.BEFORE_VERSION, 2);
-    put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
-    put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
+    put =
+        Put.newBuilder(put)
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build())
+            .bigIntValue(Attribute.PREPARED_AT, ANY_TIME_5)
+            .textValue(Attribute.ID, ANY_ID_3)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 3)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_2)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 2)
+            .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2)
+            .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2)
+            .build();
     assertThat(actual).isEqualTo(put);
   }
 
@@ -225,12 +234,15 @@ public class PrepareMutationComposerTest {
 
     // Assert
     Put actual = (Put) composer.get().get(0);
-    put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(ConditionBuilder.putIfNotExists());
-    put.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
-    put.withValue(Attribute.ID, ANY_ID_3);
-    put.withValue(Attribute.STATE, TransactionState.PREPARED.get());
-    put.withValue(Attribute.VERSION, 1);
+    put =
+        Put.newBuilder(put)
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(ConditionBuilder.putIfNotExists())
+            .bigIntValue(Attribute.PREPARED_AT, ANY_TIME_5)
+            .textValue(Attribute.ID, ANY_ID_3)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 1)
+            .build();
     assertThat(actual).isEqualTo(put);
   }
 
@@ -296,23 +308,26 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     Put expected =
-        new Put(delete.getPartitionKey(), delete.getClusteringKey().orElse(null))
-            .forNamespace(delete.forNamespace().get())
-            .forTable(delete.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build());
-    expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
-    expected.withValue(Attribute.ID, ANY_ID_3);
-    expected.withValue(Attribute.STATE, TransactionState.DELETED.get());
-    expected.withValue(Attribute.VERSION, 3);
-    expected.withValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3);
-    expected.withValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4);
-    expected.withValue(Attribute.BEFORE_ID, ANY_ID_2);
-    expected.withValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
-    expected.withValue(Attribute.BEFORE_VERSION, 2);
-    expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
-    expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
+        Put.newBuilder()
+            .namespace(delete.forNamespace().get())
+            .table(delete.forTable().get())
+            .partitionKey(delete.getPartitionKey())
+            .clusteringKey(delete.getClusteringKey().orElse(null))
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(
+                ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)).build())
+            .bigIntValue(Attribute.PREPARED_AT, ANY_TIME_5)
+            .textValue(Attribute.ID, ANY_ID_3)
+            .intValue(Attribute.STATE, TransactionState.DELETED.get())
+            .intValue(Attribute.VERSION, 3)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, ANY_TIME_3)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, ANY_TIME_4)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_2)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 2)
+            .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2)
+            .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2)
+            .build();
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -363,15 +378,18 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     Put expected =
-        new Put(delete.getPartitionKey(), delete.getClusteringKey().orElse(null))
-            .forNamespace(delete.forNamespace().get())
-            .forTable(delete.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(ConditionBuilder.putIfNotExists());
-    expected.withValue(Attribute.PREPARED_AT, ANY_TIME_5);
-    expected.withValue(Attribute.ID, ANY_ID_3);
-    expected.withValue(Attribute.STATE, TransactionState.DELETED.get());
-    expected.withValue(Attribute.VERSION, 1);
+        Put.newBuilder()
+            .namespace(delete.forNamespace().get())
+            .table(delete.forTable().get())
+            .partitionKey(delete.getPartitionKey())
+            .clusteringKey(delete.getClusteringKey().orElse(null))
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(ConditionBuilder.putIfNotExists())
+            .bigIntValue(Attribute.PREPARED_AT, ANY_TIME_5)
+            .textValue(Attribute.ID, ANY_ID_3)
+            .intValue(Attribute.STATE, TransactionState.DELETED.get())
+            .intValue(Attribute.VERSION, 1)
+            .build();
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotKeyTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotKeyTest.java
@@ -19,22 +19,32 @@ public class SnapshotKeyTest {
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Get prepareGetWithoutClusteringKey() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Get(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
   private Get prepareAnotherGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_3);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -30,7 +30,6 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
@@ -177,19 +176,25 @@ public class SnapshotTest {
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Get prepareAnotherGet() {
     Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
     Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
-    return new Get(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Get prepareGetWithIndex() {
@@ -204,11 +209,13 @@ public class SnapshotTest {
   private Scan prepareScan() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Scan(partitionKey)
-        .withStart(clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .start(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Scan prepareScanWithLimit(int limit) {
@@ -262,20 +269,25 @@ public class SnapshotTest {
   private Put prepareAnotherPut() {
     Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
     Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
-    return new Put(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Put preparePutWithPartitionKeyOnly() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Put(partitionKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_TEXT_3)
-        .withValue(ANY_NAME_4, ANY_TEXT_4);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .textValue(ANY_NAME_3, ANY_TEXT_3)
+        .textValue(ANY_NAME_4, ANY_TEXT_4)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Put preparePutWithIntColumns() {
@@ -322,10 +334,13 @@ public class SnapshotTest {
   private Delete prepareAnotherDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_5, ANY_TEXT_5);
     Key clusteringKey = Key.ofText(ANY_NAME_6, ANY_TEXT_6);
-    return new Delete(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private void configureBehavior() throws ExecutionException {
@@ -807,7 +822,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void getResults_ScanNotContainedInScanSetGiven_ShouldReturnEmpty() throws CrudException {
+  public void getResults_ScanNotContainedInScanSetGiven_ShouldReturnEmpty() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Scan scan = prepareScan();
@@ -820,8 +835,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void getResults_ScanContainedInScanSetGiven_ShouldReturnProperResults()
-      throws CrudException {
+  public void getResults_ScanContainedInScanSetGiven_ShouldReturnProperResults() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Scan scan = prepareScan();
@@ -914,7 +928,7 @@ public class SnapshotTest {
 
   @Test
   public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
-      throws PreparationConflictException, ExecutionException {
+      throws ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -936,7 +950,7 @@ public class SnapshotTest {
 
   @Test
   public void to_CommitMutationComposerGiven_ShouldCallComposerProperly()
-      throws PreparationConflictException, ExecutionException {
+      throws ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -957,7 +971,7 @@ public class SnapshotTest {
 
   @Test
   public void to_RollbackMutationComposerGiven_ShouldCallComposerProperly()
-      throws PreparationConflictException, ExecutionException {
+      throws ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -989,7 +1003,7 @@ public class SnapshotTest {
     snapshot.putIntoGetSet(get, Optional.of(txResult));
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
-    Get getWithProjections = prepareAnotherGet().withProjection(Attribute.ID);
+    Get getWithProjections = Get.newBuilder(prepareAnotherGet()).projection(Attribute.ID).build();
     when(storage.get(getWithProjections)).thenReturn(Optional.of(txResult));
 
     // Act Assert
@@ -1011,7 +1025,7 @@ public class SnapshotTest {
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult changedTxResult = prepareResult(ANY_ID + "x");
-    Get getWithProjections = prepareAnotherGet().withProjection(Attribute.ID);
+    Get getWithProjections = Get.newBuilder(prepareAnotherGet()).projection(Attribute.ID).build();
     when(storage.get(getWithProjections)).thenReturn(Optional.of(changedTxResult));
 
     // Act Assert
@@ -1033,7 +1047,7 @@ public class SnapshotTest {
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult txResult = prepareResult(ANY_ID);
-    Get getWithProjections = prepareAnotherGet().withProjection(Attribute.ID);
+    Get getWithProjections = Get.newBuilder(prepareAnotherGet()).projection(Attribute.ID).build();
     when(storage.get(getWithProjections)).thenReturn(Optional.of(txResult));
 
     // Act Assert
@@ -1054,7 +1068,9 @@ public class SnapshotTest {
     snapshot.putIntoGetSet(getWithIndex, Optional.of(txResult));
     DistributedStorage storage = mock(DistributedStorage.class);
     Scan scanWithIndex =
-        prepareScanWithIndex().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScanWithIndex())
+            .projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2)
+            .build();
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
     when(storage.scan(scanWithIndex)).thenReturn(scanner);
@@ -1078,7 +1094,9 @@ public class SnapshotTest {
     snapshot.putIntoGetSet(getWithIndex, Optional.of(result1));
     DistributedStorage storage = mock(DistributedStorage.class);
     Scan scanWithIndex =
-        prepareScanWithIndex().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScanWithIndex())
+            .projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2)
+            .build();
     Scanner scanner = mock(Scanner.class);
     when(scanner.one())
         .thenReturn(Optional.of(result1))
@@ -1106,7 +1124,9 @@ public class SnapshotTest {
     snapshot.putIntoGetSet(getWithIndex, Optional.of(result1));
     DistributedStorage storage = mock(DistributedStorage.class);
     Scan scanWithIndex =
-        prepareScanWithIndex().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScanWithIndex())
+            .projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2)
+            .build();
     Scanner scanner = mock(Scanner.class);
     when(scanner.one())
         .thenReturn(Optional.of(result1))
@@ -1134,7 +1154,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1158,7 +1178,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(changedTxResult)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1183,7 +1203,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(changedTxResult)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1206,7 +1226,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1235,7 +1255,7 @@ public class SnapshotTest {
         .thenReturn(Optional.of(result2))
         .thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1259,7 +1279,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1287,7 +1307,7 @@ public class SnapshotTest {
         .thenReturn(Optional.of(result2))
         .thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1310,7 +1330,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1339,7 +1359,7 @@ public class SnapshotTest {
     Scanner scanner = mock(Scanner.class);
     when(scanner.one()).thenReturn(Optional.of(result2)).thenReturn(Optional.empty());
     Scan scanWithProjections =
-        prepareScan().withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder(prepareScan()).projections(Attribute.ID, ANY_NAME_1, ANY_NAME_2).build();
     when(storage.scan(scanWithProjections)).thenReturn(scanner);
 
     // Act Assert
@@ -1357,17 +1377,21 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE);
 
     Scan scan1 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     Scan scan2 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_2))
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_2))
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     Result result1 =
         new TransactionResult(
@@ -1408,23 +1432,27 @@ public class SnapshotTest {
     Scanner scanner1 = mock(Scanner.class);
     when(scanner1.one()).thenReturn(Optional.of(result1)).thenReturn(Optional.empty());
     Scan scan1WithProjections =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .consistency(Consistency.LINEARIZABLE)
+            .projections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2))
+            .build();
     when(storage.scan(scan1WithProjections)).thenReturn(scanner1);
 
     Scanner scanner2 = mock(Scanner.class);
     when(scanner2.one()).thenReturn(Optional.of(result2)).thenReturn(Optional.empty());
     Scan scan2WithProjections =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_2))
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withProjections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2));
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_2))
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
+            .consistency(Consistency.LINEARIZABLE)
+            .projections(Arrays.asList(Attribute.ID, ANY_NAME_1, ANY_NAME_2))
+            .build();
     when(storage.scan(scan2WithProjections)).thenReturn(scanner2);
 
     // Act Assert
@@ -1824,11 +1852,13 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, infinite)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
@@ -1871,30 +1901,35 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
-        prepareScan()
+        Scan.newBuilder(prepareScan())
             // ["text1", "text3"]
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
+            .build();
     Scan scan2 =
-        prepareScan()
+        Scan.newBuilder(prepareScan())
             // ["text2", "text3"]
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
+            .build();
     Scan scan3 =
-        prepareScan()
+        Scan.newBuilder(prepareScan())
             // ["text1", "text2"]
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .build();
     Scan scan4 =
-        prepareScan()
+        Scan.newBuilder(prepareScan())
             // ("text2", "text3"]
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
+            .build();
     Scan scan5 =
-        prepareScan()
+        Scan.newBuilder(prepareScan())
             // ["text1", "text2")
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .build();
 
     // Act Assert
     Throwable thrown1 =
@@ -1926,26 +1961,32 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text3"]
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_3), true)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     Scan scan2 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text2"]
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     Scan scan3 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text2")
-            .withEnd(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .end(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     // Act Assert
     Throwable thrown1 =
@@ -1971,26 +2012,32 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ["text1", infinite)
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_1), true)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     Scan scan2 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ["text2", infinite)
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), true)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     Scan scan3 =
-        new Scan(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
             // ("text2", infinite)
-            .withStart(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+            .start(Key.ofText(ANY_NAME_2, ANY_TEXT_2), false)
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     // Act Assert
     Throwable thrown1 =
@@ -2154,11 +2201,13 @@ public class SnapshotTest {
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
-    ScanAll scanAll =
-        new ScanAll()
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
+    Scan scanAll =
+        ScanAll.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scanAll, result);
 
@@ -2180,11 +2229,13 @@ public class SnapshotTest {
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.putIntoWriteSet(putKey, put);
-    ScanAll scanAll =
-        new ScanAll()
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME_2)
-            .forTable(ANY_TABLE_NAME_2);
+    Scan scanAll =
+        ScanAll.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME_2)
+            .table(ANY_TABLE_NAME_2)
+            .all()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scanAll, result);
 
@@ -2398,19 +2449,25 @@ public class SnapshotTest {
     {
       // The method returns an immutable value, so the following update shouldn't be included.
       Get delayedGet =
-          new Get(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_1))
-              .withConsistency(Consistency.LINEARIZABLE)
-              .forNamespace(ANY_NAMESPACE_NAME)
-              .forTable(ANY_TABLE_NAME);
+          Get.newBuilder()
+              .namespace(ANY_NAMESPACE_NAME)
+              .table(ANY_TABLE_NAME)
+              .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+              .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
+              .consistency(Consistency.LINEARIZABLE)
+              .build();
       TransactionResult delayedResult = prepareResult("t3");
       snapshot.putIntoReadSet(new Snapshot.Key(delayedGet), Optional.of(delayedResult));
 
       Put delayedPut =
-          new Put(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-              .withConsistency(Consistency.LINEARIZABLE)
-              .forNamespace(ANY_NAMESPACE_NAME)
-              .forTable(ANY_TABLE_NAME)
-              .withValue(ANY_NAME_3, ANY_TEXT_3);
+          Put.newBuilder()
+              .namespace(ANY_NAMESPACE_NAME)
+              .table(ANY_TABLE_NAME)
+              .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+              .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+              .textValue(ANY_NAME_3, ANY_TEXT_3)
+              .consistency(Consistency.LINEARIZABLE)
+              .build();
       snapshot.putIntoWriteSet(new Snapshot.Key(delayedPut), delayedPut);
     }
 
@@ -2465,18 +2522,24 @@ public class SnapshotTest {
     {
       // The method returns an immutable value, so the following update shouldn't be included.
       Get delayedGet =
-          new Get(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_1))
-              .withConsistency(Consistency.LINEARIZABLE)
-              .forNamespace(ANY_NAMESPACE_NAME)
-              .forTable(ANY_TABLE_NAME);
+          Get.newBuilder()
+              .namespace(ANY_NAMESPACE_NAME)
+              .table(ANY_TABLE_NAME)
+              .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+              .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
+              .consistency(Consistency.LINEARIZABLE)
+              .build();
       TransactionResult delayedResult = prepareResult("t3");
       snapshot.putIntoReadSet(new Snapshot.Key(delayedGet), Optional.of(delayedResult));
 
       Delete delayedDelete =
-          new Delete(Key.ofText(ANY_NAME_1, ANY_TEXT_1), Key.ofText(ANY_NAME_2, ANY_TEXT_1))
-              .withConsistency(Consistency.LINEARIZABLE)
-              .forNamespace(ANY_NAMESPACE_NAME)
-              .forTable(ANY_TABLE_NAME);
+          Delete.newBuilder()
+              .namespace(ANY_NAMESPACE_NAME)
+              .table(ANY_TABLE_NAME)
+              .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+              .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_1))
+              .consistency(Consistency.LINEARIZABLE)
+              .build();
       snapshot.putIntoDeleteSet(new Snapshot.Key(delayedDelete), delayedDelete);
     }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
@@ -74,7 +74,11 @@ public class TransactionTableMetadataManagerTest {
     // Act
     TransactionTableMetadata actual =
         tableMetadataManager.getTransactionTableMetadata(
-            new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl"));
+            Get.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .partitionKey(Key.ofText("c1", "aaa"))
+                .build());
 
     // Assert
     verify(admin).getTableMetadata(anyString(), anyString());
@@ -88,7 +92,8 @@ public class TransactionTableMetadataManagerTest {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
 
-    Get get = new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl");
+    Get get =
+        Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofText("c1", "aaa")).build();
 
     // Act
     tableMetadataManager.getTransactionTableMetadata(get);
@@ -107,7 +112,8 @@ public class TransactionTableMetadataManagerTest {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, 1); // one second
 
-    Get get = new Get(Key.ofText("c1", "aaa")).forNamespace("ns").forTable("tbl");
+    Get get =
+        Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofText("c1", "aaa")).build();
 
     // Act
     tableMetadataManager.getTransactionTableMetadata(get);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -75,31 +75,44 @@ public class TwoPhaseConsensusCommitTest {
   private Get prepareGet() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   private Scan prepareScan() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    return new Scan(partitionKey).forNamespace(ANY_NAMESPACE).forTable(ANY_TABLE_NAME);
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .build();
   }
 
   private Put preparePut() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .withValue(ANY_NAME_3, ANY_TEXT_3)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .textValue(ANY_NAME_3, ANY_TEXT_3)
+        .build();
   }
 
   private Delete prepareDelete() {
     Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE)
-        .forTable(ANY_TABLE_NAME);
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .build();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -92,17 +92,34 @@ public class JdbcTransactionManagerTest {
 
     // Act
     DistributedTransaction transaction = manager.begin();
-    Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     transaction.get(get);
-    Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
     transaction.scan(scan);
     Put put =
-        new Put(Key.ofText("p1", "val1"))
-            .withValue("v1", "val2")
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
+        Put.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .textValue("v1", "val2")
+            .build();
     transaction.put(put);
-    Delete delete = new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val1"))
+            .build();
     transaction.delete(delete);
     transaction.mutate(Arrays.asList(put, delete));
     transaction.commit();
@@ -126,7 +143,12 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
             })
         .isInstanceOf(CrudException.class);
@@ -214,7 +236,12 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -230,7 +257,12 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan =
+                  Scan.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.scan(scan);
             })
         .isInstanceOf(CrudException.class);
@@ -247,7 +279,12 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Scan scan = new Scan(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Scan scan =
+                  Scan.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.scan(scan);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -627,10 +664,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
             })
         .isInstanceOf(CrudException.class);
@@ -648,10 +687,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -669,7 +710,11 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               transaction.delete(delete);
             })
         .isInstanceOf(CrudException.class);
@@ -687,7 +732,11 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               transaction.delete(delete);
             })
         .isInstanceOf(CrudConflictException.class);
@@ -705,12 +754,18 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.start();
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               transaction.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(CrudException.class);
@@ -728,12 +783,18 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               Delete delete =
-                  new Delete(Key.ofText("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
               transaction.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(CrudConflictException.class);
@@ -749,13 +810,20 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
               transaction.commit();
             })
@@ -774,13 +842,20 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
               transaction.abort();
             })
@@ -798,13 +873,20 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.begin();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
               transaction.rollback();
             })
@@ -824,13 +906,20 @@ public class JdbcTransactionManagerTest {
     assertThatThrownBy(
             () -> {
               DistributedTransaction transaction = manager.start();
-              Get get = new Get(Key.ofText("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              Get get =
+                  Get.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val"))
+                      .build();
               transaction.get(get);
               Put put =
-                  new Put(Key.ofText("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
               transaction.put(put);
               transaction.commit();
             })

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -522,23 +522,31 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       Key clusteringKey = Key.of(getColumnName4(), 2, getColumnName3(), "bbb");
       storage = storageFactory.getStorage();
       storage.put(
-          new Put(partitionKey, clusteringKey)
-              .withValue(getColumnName5(), 3)
-              .withValue(getColumnName6(), "ccc")
-              .withValue(getColumnName7(), 4L)
-              .withValue(getColumnName8(), 1.0f)
-              .withValue(getColumnName9(), 1.0d)
-              .withValue(getColumnName10(), true)
-              .withValue(getColumnName11(), "ddd".getBytes(StandardCharsets.UTF_8))
-              .forNamespace(namespace1)
-              .forTable(getTable1()));
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(getTable1())
+              .partitionKey(partitionKey)
+              .clusteringKey(clusteringKey)
+              .intValue(getColumnName5(), 3)
+              .textValue(getColumnName6(), "ccc")
+              .bigIntValue(getColumnName7(), 4L)
+              .floatValue(getColumnName8(), 1.0f)
+              .doubleValue(getColumnName9(), 1.0d)
+              .booleanValue(getColumnName10(), true)
+              .blobValue(getColumnName11(), "ddd".getBytes(StandardCharsets.UTF_8))
+              .build());
 
       // Act
       admin.truncateTable(namespace1, getTable1());
 
       // Assert
       Scanner scanner =
-          storage.scan(new Scan(partitionKey).forNamespace(namespace1).forTable(getTable1()));
+          storage.scan(
+              Scan.newBuilder()
+                  .namespace(namespace1)
+                  .table(getTable1())
+                  .partitionKey(partitionKey)
+                  .build());
       assertThat(scanner.all()).isEmpty();
       scanner.close();
     } finally {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -215,7 +215,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.putIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Put put = preparePutWithRandomValues(operator, dataType).withCondition(condition);
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -239,7 +240,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
       MutationCondition condition =
           ConditionBuilder.putIf(buildConditionalExpression(columnToCompare, operator)).build();
-      Put put = preparePutWithRandomValues(operator, dataType).withCondition(condition);
+      Put put =
+          Put.newBuilder(preparePutWithRandomValues(operator, dataType))
+              .condition(condition)
+              .build();
 
       boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -263,7 +267,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.putIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Put put = preparePutWithRandomValues(operator, dataType).withCondition(condition);
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -286,7 +291,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.putIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Put put = preparePutWithRandomValues(operator, dataType).withCondition(condition);
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -337,8 +343,11 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
             .and(buildConditionalExpression(secondColumnToCompare, secondOperator))
             .build();
     Put put =
-        preparePutWithRandomValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Put.newBuilder(
+                preparePutWithRandomValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     boolean shouldMutate =
         shouldMutate(initialData.get(firstColumnName), firstColumnToCompare, firstOperator)
@@ -385,8 +394,11 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
               .and(buildConditionalExpression(secondColumnToCompare, secondOperator))
               .build();
       Put put =
-          preparePutWithRandomValues(firstOperator, firstDataType, secondOperator, secondDataType)
-              .withCondition(condition);
+          Put.newBuilder(
+                  preparePutWithRandomValues(
+                      firstOperator, firstDataType, secondOperator, secondDataType))
+              .condition(condition)
+              .build();
 
       boolean shouldMutate =
           shouldMutate(initialData.get(firstColumnName), firstColumnToCompare, firstOperator)
@@ -432,8 +444,11 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
             .and(buildConditionalExpression(secondColumnToCompare, secondOperator))
             .build();
     Put put =
-        preparePutWithRandomValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Put.newBuilder(
+                preparePutWithRandomValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     boolean shouldMutate =
         shouldMutate(initialData.get(firstColumnName), firstColumnToCompare, firstOperator)
@@ -478,8 +493,11 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
             .and(buildConditionalExpression(secondColumnToCompare, secondOperator))
             .build();
     Put put =
-        preparePutWithRandomValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Put.newBuilder(
+                preparePutWithRandomValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     boolean shouldMutate =
         shouldMutate(initialData.get(firstColumnName), firstColumnToCompare, firstOperator)
@@ -597,7 +615,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     // Arrange
     putInitialDataWithRandomValues();
 
-    Put put = preparePutWithRandomValues().withCondition(ConditionBuilder.putIfExists());
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues())
+            .condition(ConditionBuilder.putIfExists())
+            .build();
 
     // Act
     storage.put(put);
@@ -645,7 +666,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     random.get().setSeed(seed);
 
     // Arrange
-    Put put = preparePutWithRandomValues().withCondition(ConditionBuilder.putIfExists());
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues())
+            .condition(ConditionBuilder.putIfExists())
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> storage.put(put)).isInstanceOf(NoMutationException.class);
@@ -660,7 +684,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     random.get().setSeed(seed);
 
     // Arrange
-    Put put = preparePutWithRandomValues().withCondition(ConditionBuilder.putIfNotExists());
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues())
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
 
     // Act
     storage.put(put);
@@ -710,7 +737,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     // Arrange
     Map<String, Column<?>> initialData = putInitialDataWithRandomValues();
 
-    Put put = preparePutWithRandomValues().withCondition(ConditionBuilder.putIfNotExists());
+    Put put =
+        Put.newBuilder(preparePutWithRandomValues())
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> storage.put(put)).isInstanceOf(NoMutationException.class);
@@ -783,7 +813,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.deleteIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Delete delete = prepareDelete(operator, dataType).withCondition(condition);
+    Delete delete =
+        Delete.newBuilder(prepareDelete(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -807,7 +838,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
       MutationCondition condition =
           ConditionBuilder.deleteIf(buildConditionalExpression(columnToCompare, operator)).build();
-      Delete delete = prepareDelete(operator, dataType).withCondition(condition);
+      Delete delete =
+          Delete.newBuilder(prepareDelete(operator, dataType)).condition(condition).build();
 
       boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -832,7 +864,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.deleteIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Delete delete = prepareDelete(operator, dataType).withCondition(condition);
+    Delete delete =
+        Delete.newBuilder(prepareDelete(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -855,7 +888,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
     MutationCondition condition =
         ConditionBuilder.deleteIf(buildConditionalExpression(columnToCompare, operator)).build();
-    Delete delete = prepareDelete(operator, dataType).withCondition(condition);
+    Delete delete =
+        Delete.newBuilder(prepareDelete(operator, dataType)).condition(condition).build();
 
     boolean shouldMutate = shouldMutate(initialData.get(columnName), columnToCompare, operator);
 
@@ -912,8 +946,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
                 initialData.get(secondColumnName), secondColumnToCompare, secondOperator);
 
     Delete delete =
-        prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Delete.newBuilder(
+                prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     // Act Assert
     delete_withDeleteIf_shouldPutProperly(
@@ -961,8 +997,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
                   initialData.get(secondColumnName), secondColumnToCompare, secondOperator);
 
       Delete delete =
-          prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-              .withCondition(condition);
+          Delete.newBuilder(
+                  prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+              .condition(condition)
+              .build();
 
       // Act Assert
       delete_withDeleteIf_shouldPutProperly(
@@ -1010,8 +1048,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
                 initialData.get(secondColumnName), secondColumnToCompare, secondOperator);
 
     Delete delete =
-        prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Delete.newBuilder(
+                prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     // Act Assert
     delete_withDeleteIf_shouldPutProperly(
@@ -1058,8 +1098,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
                 initialData.get(secondColumnName), secondColumnToCompare, secondOperator);
 
     Delete delete =
-        prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(condition);
+        Delete.newBuilder(
+                prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(condition)
+            .build();
 
     // Act Assert
     delete_withDeleteIf_shouldPutProperly(
@@ -1175,7 +1217,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     // Arrange
     putInitialDataWithRandomValues();
 
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act
     storage.delete(delete);
@@ -1191,7 +1234,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     random.get().setSeed(seed);
 
     // Arrange
-    Delete delete = prepareDelete().withCondition(ConditionBuilder.deleteIfExists());
+    Delete delete =
+        Delete.newBuilder(prepareDelete()).condition(ConditionBuilder.deleteIfExists()).build();
 
     // Act Assert
     assertThatThrownBy(() -> storage.delete(delete)).isInstanceOf(NoMutationException.class);
@@ -1213,13 +1257,15 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       DataType firstDataType,
       @Nullable Operator secondOperator,
       @Nullable DataType secondDataType) {
-    return new Get(
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(
             Key.ofText(
                 PARTITION_KEY,
                 getPartitionKeyValue(firstOperator, firstDataType, secondOperator, secondDataType)))
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(namespace)
-        .forTable(TABLE);
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Put preparePutWithRandomValues() {
@@ -1275,13 +1321,15 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       DataType firstDataType,
       @Nullable Operator secondOperator,
       @Nullable DataType secondDataType) {
-    return new Delete(
+    return Delete.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(
             Key.ofText(
                 PARTITION_KEY,
                 getPartitionKeyValue(firstOperator, firstDataType, secondOperator, secondDataType)))
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(namespace)
-        .forTable(TABLE);
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Map<String, Column<?>> putInitialDataWithRandomValues() throws ExecutionException {
@@ -1301,15 +1349,20 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       throws ExecutionException {
     try {
       storage.delete(
-          prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-              .withCondition(ConditionBuilder.deleteIfExists()));
+          Delete.newBuilder(
+                  prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+              .condition(ConditionBuilder.deleteIfExists())
+              .build());
     } catch (NoMutationException ignored) {
       // ignored
     }
 
     Put initialPut =
-        preparePutWithRandomValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(ConditionBuilder.putIfNotExists());
+        Put.newBuilder(
+                preparePutWithRandomValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
     storage.put(initialPut);
     return initialPut.getColumns();
   }
@@ -1327,15 +1380,20 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       throws ExecutionException {
     try {
       storage.delete(
-          prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-              .withCondition(ConditionBuilder.deleteIfExists()));
+          Delete.newBuilder(
+                  prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+              .condition(ConditionBuilder.deleteIfExists())
+              .build());
     } catch (NoMutationException ignored) {
       // ignored
     }
 
     Put initialPut =
-        preparePutWithNullValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(ConditionBuilder.putIfNotExists());
+        Put.newBuilder(
+                preparePutWithNullValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
     storage.put(initialPut);
     return initialPut.getColumns();
   }
@@ -1386,15 +1444,20 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       throws ExecutionException {
     try {
       storage.delete(
-          prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType)
-              .withCondition(ConditionBuilder.deleteIfExists()));
+          Delete.newBuilder(
+                  prepareDelete(firstOperator, firstDataType, secondOperator, secondDataType))
+              .condition(ConditionBuilder.deleteIfExists())
+              .build());
     } catch (NoMutationException ignored) {
       // ignored
     }
 
     Put initialPut =
-        preparePutWithoutValues(firstOperator, firstDataType, secondOperator, secondDataType)
-            .withCondition(ConditionBuilder.putIfNotExists());
+        Put.newBuilder(
+                preparePutWithoutValues(
+                    firstOperator, firstDataType, secondOperator, secondDataType))
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
     storage.put(initialPut);
     ImmutableMap.Builder<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
@@ -1426,13 +1489,15 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
       DataType firstDataType,
       @Nullable Operator secondOperator,
       @Nullable DataType secondDataType) {
-    return new Put(
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(
             Key.ofText(
                 PARTITION_KEY,
                 getPartitionKeyValue(firstOperator, firstDataType, secondOperator, secondDataType)))
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(namespace)
-        .forTable(TABLE);
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private String getPartitionKeyValue(

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -428,23 +428,31 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       Key clusteringKey = Key.of(COL_NAME4, 2, COL_NAME3, "bbb");
       manager = transactionFactory.getTransactionManager();
       manager.put(
-          new Put(partitionKey, clusteringKey)
-              .withValue(COL_NAME5, 3)
-              .withValue(COL_NAME6, "ccc")
-              .withValue(COL_NAME7, 4L)
-              .withValue(COL_NAME8, 1.0f)
-              .withValue(COL_NAME9, 1.0d)
-              .withValue(COL_NAME10, true)
-              .withValue(COL_NAME11, "ddd".getBytes(StandardCharsets.UTF_8))
-              .forNamespace(namespace1)
-              .forTable(TABLE1));
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE1)
+              .partitionKey(partitionKey)
+              .clusteringKey(clusteringKey)
+              .intValue(COL_NAME5, 3)
+              .textValue(COL_NAME6, "ccc")
+              .bigIntValue(COL_NAME7, 4L)
+              .floatValue(COL_NAME8, 1.0f)
+              .doubleValue(COL_NAME9, 1.0d)
+              .booleanValue(COL_NAME10, true)
+              .blobValue(COL_NAME11, "ddd".getBytes(StandardCharsets.UTF_8))
+              .build());
 
       // Act
       admin.truncateTable(namespace1, TABLE1);
 
       // Assert
       List<Result> results =
-          manager.scan(new Scan(partitionKey).forNamespace(namespace1).forTable(TABLE1));
+          manager.scan(
+              Scan.newBuilder()
+                  .namespace(namespace1)
+                  .table(TABLE1)
+                  .partitionKey(partitionKey)
+                  .build());
       assertThat(results).isEmpty();
     } finally {
       if (manager != null) {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
@@ -18,7 +18,6 @@ import com.scalar.db.util.TestUtils;
 import com.scalar.db.util.TestUtils.ExpectedResult;
 import com.scalar.db.util.TestUtils.ExpectedResult.ExpectedResultBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -262,7 +261,7 @@ public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBas
     populateSingleRecord();
     Scan scan =
         Scan.newBuilder(prepareCrossPartitionScan(0, 0, 0))
-            .projections(Arrays.asList(BALANCE, SOME_COLUMN))
+            .projections(BALANCE, SOME_COLUMN)
             .build();
 
     // Act

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -220,10 +220,11 @@ public abstract class DistributedTransactionIntegrationTestBase {
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Get get =
-        prepareGet(0, 0)
-            .withProjection(ACCOUNT_ID)
-            .withProjection(ACCOUNT_TYPE)
-            .withProjection(BALANCE);
+        Get.newBuilder(prepareGet(0, 0))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
 
     // Act
     Optional<Result> result = transaction.get(get);
@@ -369,10 +370,11 @@ public abstract class DistributedTransactionIntegrationTestBase {
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan =
-        prepareScan(1, 0, 2)
-            .withProjection(ACCOUNT_ID)
-            .withProjection(ACCOUNT_TYPE)
-            .withProjection(BALANCE);
+        Scan.newBuilder(prepareScan(1, 0, 2))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -403,7 +405,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
-    Scan scan = prepareScan(1, 0, 2).withOrdering(Ordering.desc(ACCOUNT_TYPE));
+    Scan scan = Scan.newBuilder(prepareScan(1, 0, 2)).ordering(Ordering.desc(ACCOUNT_TYPE)).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -434,7 +436,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
-    Scan scan = prepareScan(1, 0, 2).withLimit(2);
+    Scan scan = Scan.newBuilder(prepareScan(1, 0, 2)).limit(2).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -502,10 +504,12 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
     transaction = manager.start();
     Get getBuiltByConstructor =
-        new Get(Key.ofInt(SOME_COLUMN, 2))
-            .forNamespace(namespace)
-            .forTable(TABLE)
-            .withConsistency(Consistency.LINEARIZABLE);
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     Get getBuiltByBuilder =
         Get.newBuilder()
@@ -538,10 +542,12 @@ public abstract class DistributedTransactionIntegrationTestBase {
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scanBuiltByConstructor =
-        new Scan(Key.ofInt(SOME_COLUMN, 2))
-            .forNamespace(namespace)
-            .forTable(TABLE)
-            .withConsistency(Consistency.LINEARIZABLE);
+        Scan.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     Scan scanBuiltByBuilder =
         Scan.newBuilder()
@@ -610,7 +616,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
-    ScanAll scanAll = prepareScanAll();
+    Scan scanAll = prepareScanAll();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -641,7 +647,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     insert(prepareInsert(1, 1), prepareInsert(1, 2), prepareInsert(2, 1), prepareInsert(3, 0));
 
     DistributedTransaction scanAllTransaction = manager.start();
-    ScanAll scanAll = prepareScanAll().withLimit(2);
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).limit(2).build();
 
     // Act
     List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
@@ -681,7 +687,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
-    ScanAll scanAll = prepareScanAll().withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
+    Scan scanAll =
+        Scan.newBuilder(prepareScanAll()).projection(ACCOUNT_TYPE).projection(BALANCE).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -709,7 +716,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.start();
-    ScanAll scanAll = prepareScanAll();
+    Scan scanAll = prepareScanAll();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -780,7 +787,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
   @Test
   public void putWithNullValueAndCommit_ShouldCreateRecordProperly() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0).withIntValue(BALANCE, null);
+    Put put = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, null).build();
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -839,7 +846,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
   @Test
   public void putAndAbort_ShouldNotCreateRecord() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0).withValue(BALANCE, INITIAL_BALANCE);
+    Put put = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, INITIAL_BALANCE).build();
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -857,7 +864,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
   @Test
   public void putAndRollback_ShouldNotCreateRecord() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0).withValue(BALANCE, INITIAL_BALANCE);
+    Put put = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, INITIAL_BALANCE).build();
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -955,7 +962,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     populateRecords();
     Get get1 = prepareGet(0, 0);
     Get get2 = prepareGet(1, 0);
-    Put put = preparePut(0, 0).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, INITIAL_BALANCE - 100).build();
     Delete delete = prepareDelete(1, 0);
 
     DistributedTransaction transaction = manager.begin();
@@ -1017,7 +1024,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.get(prepareGet(0, 0));
-    transaction.put(preparePut(0, 0).withValue(BALANCE, 1));
+    transaction.put(Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act
@@ -1032,11 +1039,11 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     DistributedTransaction transaction1 = manager.begin();
     transaction1.get(prepareGet(0, 0));
-    transaction1.put(preparePut(0, 0).withValue(BALANCE, 1));
+    transaction1.put(Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, 1).build());
 
     DistributedTransaction transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0));
-    transaction2.put(preparePut(0, 0).withValue(BALANCE, 1));
+    transaction2.put(Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, 1).build());
     transaction2.commit();
 
     assertThatCode(transaction1::commit).isInstanceOf(CommitConflictException.class);
@@ -1053,7 +1060,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.get(prepareGet(0, 0));
-    transaction.put(preparePut(0, 0).withValue(BALANCE, 1));
+    transaction.put(Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, 1).build());
 
     // Act
     manager.abort(transaction.getId());
@@ -1070,7 +1077,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.get(prepareGet(0, 0));
-    transaction.put(preparePut(0, 0).withValue(BALANCE, 1));
+    transaction.put(Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, 1).build());
 
     // Act
     manager.rollback(transaction.getId());
@@ -1089,7 +1096,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
-    Get get = prepareGet(0, 0).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+    Get get = Get.newBuilder(prepareGet(0, 0)).projections(BALANCE, SOME_COLUMN).build();
 
     // Act
     Optional<Result> result = transaction.get(get);
@@ -1110,7 +1117,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
-    Scan scan = prepareScan(0, 0, 0).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+    Scan scan = Scan.newBuilder(prepareScan(0, 0, 0)).projections(BALANCE, SOME_COLUMN).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -1133,7 +1140,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
-    ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+    Scan scanAll = Scan.newBuilder(prepareScanAll()).projections(BALANCE, SOME_COLUMN).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -2675,10 +2682,13 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   protected void populateSingleRecord() throws TransactionException {
     Put put =
-        new Put(Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0))
-            .forNamespace(namespace)
-            .forTable(TABLE)
-            .withIntValue(BALANCE, INITIAL_BALANCE);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
     DistributedTransaction transaction = manager.start();
     transaction.put(put);
     transaction.commit();
@@ -2687,10 +2697,13 @@ public abstract class DistributedTransactionIntegrationTestBase {
   protected Get prepareGet(int id, int type) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(TABLE)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected List<Get> prepareGets() {
@@ -2702,28 +2715,35 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   protected Scan prepareScan(int id, int fromType, int toType) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespace)
-        .forTable(TABLE)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
-        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .start(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .end(Key.ofInt(ACCOUNT_TYPE, toType))
+        .build();
   }
 
-  protected ScanAll prepareScanAll() {
-    return new ScanAll()
-        .forNamespace(namespace)
-        .forTable(TABLE)
-        .withConsistency(Consistency.LINEARIZABLE);
+  protected Scan prepareScanAll() {
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .all()
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected Put preparePut(int id, int type) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(TABLE)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected Insert prepareInsert(int id, int type) {
@@ -2751,10 +2771,13 @@ public abstract class DistributedTransactionIntegrationTestBase {
   protected Delete prepareDelete(int id, int type) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(TABLE)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Delete.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected int getBalance(Result result) {

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -239,10 +239,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Get get =
-        prepareGet(0, 0, namespace1, TABLE_1)
-            .withProjection(ACCOUNT_ID)
-            .withProjection(ACCOUNT_TYPE)
-            .withProjection(BALANCE);
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
 
     // Act
     Optional<Result> result = transaction.get(get);
@@ -376,10 +377,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan =
-        prepareScan(1, 0, 2, namespace1, TABLE_1)
-            .withProjection(ACCOUNT_ID)
-            .withProjection(ACCOUNT_TYPE)
-            .withProjection(BALANCE);
+        Scan.newBuilder(prepareScan(1, 0, 2, namespace1, TABLE_1))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -412,7 +414,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
-    Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withOrdering(Ordering.desc(ACCOUNT_TYPE));
+    Scan scan =
+        Scan.newBuilder(prepareScan(1, 0, 2, namespace1, TABLE_1))
+            .ordering(Ordering.desc(ACCOUNT_TYPE))
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -445,7 +450,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
-    Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withLimit(2);
+    Scan scan = Scan.newBuilder(prepareScan(1, 0, 2, namespace1, TABLE_1)).limit(2).build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -521,10 +526,12 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
     transaction = manager1.start();
     Get getBuiltByConstructor =
-        new Get(Key.ofInt(SOME_COLUMN, 2))
-            .forNamespace(namespace1)
-            .forTable(TABLE_1)
-            .withConsistency(Consistency.LINEARIZABLE);
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     Get getBuiltByBuilder =
         Get.newBuilder()
@@ -559,10 +566,12 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scanBuiltByConstructor =
-        new Scan(Key.ofInt(SOME_COLUMN, 2))
-            .forNamespace(namespace1)
-            .forTable(TABLE_1)
-            .withConsistency(Consistency.LINEARIZABLE);
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     Scan scanBuiltByBuilder =
         Scan.newBuilder()
@@ -666,7 +675,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void putWithNullValueAndCommit_ShouldCreateRecordProperly() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, null);
+    Put put = Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, null).build();
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
@@ -733,7 +742,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void putAndRollback_ShouldNotCreateRecord() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, INITIAL_BALANCE);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
@@ -753,7 +765,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void putAndAbort_ShouldNotCreateRecord() throws TransactionException {
     // Arrange
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, INITIAL_BALANCE);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
@@ -865,7 +880,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     Get get1 = prepareGet(0, 0, namespace1, TABLE_1);
     Get get2 = prepareGet(1, 0, namespace1, TABLE_1);
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE - 100)
+            .build();
     Delete delete = prepareDelete(1, 0, namespace1, TABLE_1);
 
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1054,7 +1072,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1071,11 +1090,13 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     transaction1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction2.prepare();
     transaction2.validate();
     transaction2.commit();
@@ -1095,7 +1116,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     manager1.rollback(transaction.getId());
@@ -1115,7 +1137,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     manager1.abort(transaction.getId());
@@ -1137,7 +1160,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -1178,7 +1201,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     putTransaction.commit();
 
     TwoPhaseCommitTransaction scanAllTransaction = manager1.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(2);
+    Scan scanAll = Scan.newBuilder(prepareScanAll(namespace1, TABLE_1)).limit(2).build();
 
     // Act
     List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
@@ -1220,8 +1243,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    ScanAll scanAll =
-        prepareScanAll(namespace1, TABLE_1).withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
+    Scan scanAll =
+        Scan.newBuilder(prepareScanAll(namespace1, TABLE_1))
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -1256,7 +1282,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -1276,7 +1302,9 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateSingleRecord(namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
     Get get =
-        prepareGet(0, 0, namespace1, TABLE_1).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .projections(BALANCE, SOME_COLUMN)
+            .build();
 
     // Act
     Optional<Result> result = transaction.get(get);
@@ -1300,8 +1328,9 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     TwoPhaseCommitTransaction transaction = manager1.begin();
     populateSingleRecord(namespace1, TABLE_1);
     Scan scan =
-        prepareScan(0, 0, 0, namespace1, TABLE_1)
-            .withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+        Scan.newBuilder(prepareScan(0, 0, 0, namespace1, TABLE_1))
+            .projections(BALANCE, SOME_COLUMN)
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scan, scanType);
@@ -1326,8 +1355,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateSingleRecord(namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    ScanAll scanAll =
-        prepareScanAll(namespace1, TABLE_1).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
+    Scan scanAll =
+        Scan.newBuilder(prepareScanAll(namespace1, TABLE_1))
+            .projections(BALANCE, SOME_COLUMN)
+            .build();
 
     // Act
     List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
@@ -2964,10 +2995,13 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   protected Get prepareGet(int id, int type, String namespaceName, String tableName) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(namespaceName)
-        .forTable(tableName)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Get.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected List<Get> prepareGets(String namespaceName, String tableName) {
@@ -2983,28 +3017,35 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   protected Scan prepareScan(
       int id, int fromType, int toType, String namespaceName, String tableName) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespaceName)
-        .forTable(tableName)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
-        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
+    return Scan.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .start(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .end(Key.ofInt(ACCOUNT_TYPE, toType))
+        .build();
   }
 
-  protected ScanAll prepareScanAll(String namespaceName, String tableName) {
-    return new ScanAll()
-        .forNamespace(namespaceName)
-        .forTable(tableName)
-        .withConsistency(Consistency.LINEARIZABLE);
+  protected Scan prepareScanAll(String namespaceName, String tableName) {
+    return Scan.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .all()
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected Put preparePut(int id, int type, String namespaceName, String tableName) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(namespaceName)
-        .forTable(tableName)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Put.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected Insert prepareInsert(int id, int type, String namespaceName, String tableName) {
@@ -3035,10 +3076,13 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   protected Delete prepareDelete(int id, int type, String namespaceName, String tableName) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(namespaceName)
-        .forTable(tableName)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Delete.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   protected int getBalance(Result result) {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -1101,7 +1101,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // Arrange
     populateRecordsWithNullMetadata(namespace1, TABLE_1);
     DistributedTransaction transaction = manager.begin();
-    Scan scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(1);
+    Scan scanAll = Scan.newBuilder(prepareScanAll(namespace1, TABLE_1)).limit(1).build();
 
     // Act
     List<Result> results = transaction.scan(scanAll);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -30,7 +30,6 @@ import com.scalar.db.api.Insert;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
@@ -1338,7 +1337,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1348,7 +1347,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void getScanner_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -1446,7 +1445,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws TransactionException, ExecutionException, CoordinatorException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1456,7 +1455,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void getScanner_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws TransactionException, ExecutionException, CoordinatorException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -1579,7 +1578,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1590,7 +1589,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -1692,7 +1691,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -1702,7 +1701,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1826,7 +1825,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1836,7 +1835,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void getScanner_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -1934,7 +1933,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -1944,7 +1943,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void getScanner_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -2067,7 +2066,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -2078,7 +2077,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -2178,7 +2177,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
   }
@@ -2189,7 +2188,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
           Isolation isolation, boolean readOnly, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
   }
@@ -2655,7 +2654,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     DistributedTransaction transaction1 = begin(manager, readOnly);
@@ -2663,7 +2663,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     DistributedTransaction transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction2.commit();
 
     // Act Assert
@@ -2711,7 +2712,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     int expected = INITIAL_BALANCE;
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, expected);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, expected).build();
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -2776,7 +2778,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Optional<Result> result = transaction.get(get);
     assertThat(result).isPresent();
     int expected = getBalance(result.get()) + 100;
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, expected);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, expected).build();
     transaction.put(put);
     transaction.commit();
 
@@ -3008,8 +3011,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     int to = NUM_TYPES;
     int anotherFrom = to;
     int anotherTo = NUM_TYPES * 2;
-    puts1.get(from).withValue(BALANCE, expected);
-    puts2.get(to).withValue(BALANCE, expected);
+    puts1.set(from, Put.newBuilder(puts1.get(from)).intValue(BALANCE, expected).build());
+    puts2.set(to, Put.newBuilder(puts2.get(to)).intValue(BALANCE, expected).build());
 
     DistributedTransaction transaction1 = manager.begin();
     transaction1.get(gets1.get(from));
@@ -3018,7 +3021,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction1.put(puts2.get(to));
 
     DistributedTransaction transaction2 = manager.begin();
-    puts1.get(anotherTo).withValue(BALANCE, expected);
+    puts1.set(anotherTo, Put.newBuilder(puts1.get(anotherTo)).intValue(BALANCE, expected).build());
 
     // Act Assert
     assertThatCode(
@@ -3300,16 +3303,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     int to = NUM_TYPES;
     int anotherFrom = from;
     int anotherTo = to;
-    puts1.get(from).withValue(BALANCE, expected);
-    puts1.get(to).withValue(BALANCE, expected);
+    puts1.set(from, Put.newBuilder(puts1.get(from)).intValue(BALANCE, expected).build());
+    puts1.set(to, Put.newBuilder(puts1.get(to)).intValue(BALANCE, expected).build());
 
     DistributedTransaction transaction1 = manager.begin();
     transaction1.put(puts1.get(from));
     transaction1.put(puts1.get(to));
 
     DistributedTransaction transaction2 = manager.begin();
-    puts2.get(from).withValue(BALANCE, expected);
-    puts2.get(to).withValue(BALANCE, expected);
+    puts2.set(from, Put.newBuilder(puts2.get(from)).intValue(BALANCE, expected).build());
+    puts2.set(to, Put.newBuilder(puts2.get(to)).intValue(BALANCE, expected).build());
 
     // Act Assert
     assertThatCode(
@@ -3462,8 +3465,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     List<Put> puts =
         Arrays.asList(
-            preparePut(0, 0, namespace1, table1).withValue(BALANCE, 1),
-            preparePut(0, 1, namespace2, table2).withValue(BALANCE, 1));
+            Put.newBuilder(preparePut(0, 0, namespace1, table1)).intValue(BALANCE, 1).build(),
+            Put.newBuilder(preparePut(0, 1, namespace2, table2)).intValue(BALANCE, 1).build());
     DistributedTransaction transaction = manager.begin();
     transaction.put(puts);
     transaction.commit();
@@ -3484,9 +3487,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     int current2 = getBalance(result2.get());
     Get get2_2 = prepareGet(0, 1, namespace2, table2);
     transaction2.get(get2_2);
-    Put put1 = preparePut(0, 0, namespace1, table1).withValue(BALANCE, current1 + 1);
+    Put put1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, table1))
+            .intValue(BALANCE, current1 + 1)
+            .build();
     transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace2, table2).withValue(BALANCE, current2 + 1);
+    Put put2 =
+        Put.newBuilder(preparePut(0, 1, namespace2, table2))
+            .intValue(BALANCE, current2 + 1)
+            .build();
     transaction2.put(put2);
     transaction1.commit();
 
@@ -3561,9 +3570,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Get get2_2 = prepareGet(0, 1, namespace2, table2);
     transaction2.get(get2_2);
     int current2 = 0;
-    Put put1 = preparePut(0, 0, namespace1, table1).withValue(BALANCE, current1 + 1);
+    Put put1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, table1))
+            .intValue(BALANCE, current1 + 1)
+            .build();
     transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace2, table2).withValue(BALANCE, current2 + 1);
+    Put put2 =
+        Put.newBuilder(preparePut(0, 1, namespace2, table2))
+            .intValue(BALANCE, current2 + 1)
+            .build();
     transaction2.put(put2);
     Throwable thrown1 = catchThrowable(transaction1::commit);
     Throwable thrown2 = catchThrowable(transaction2::commit);
@@ -3630,8 +3645,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     List<Put> puts =
         Arrays.asList(
-            preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1),
-            preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+            Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build(),
+            Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     DistributedTransaction transaction = manager.begin();
     transaction.put(puts);
     transaction.commit();
@@ -3643,9 +3658,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     int count1 = results1.size();
     List<Result> results2 = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     int count2 = results2.size();
-    Put put1 = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, count1 + 1);
+    Put put1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, count1 + 1).build();
     transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, count2 + 1);
+    Put put2 =
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, count2 + 1).build();
     transaction2.put(put2);
     Throwable thrown1 = catchThrowable(transaction1::commit);
     Throwable thrown2 = catchThrowable(transaction2::commit);
@@ -3702,9 +3719,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     int count1 = results1.size();
     List<Result> results2 = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     int count2 = results2.size();
-    Put put1 = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, count1 + 1);
+    Put put1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, count1 + 1).build();
     transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, count2 + 1);
+    Put put2 =
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, count2 + 1).build();
     transaction2.put(put2);
     Throwable thrown1 = catchThrowable(transaction1::commit);
     Throwable thrown2 = catchThrowable(transaction2::commit);
@@ -3807,7 +3826,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction.commit();
 
     // Act
@@ -3817,7 +3837,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     if (result1.isPresent()) {
       balance1 = getBalance(result1.get());
     }
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance1 + 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance1 + 1)
+            .build());
 
     DistributedTransaction transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -3831,7 +3854,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     if (result3.isPresent()) {
       balance3 = getBalance(result3.get());
     }
-    transaction3.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance3 + 1));
+    transaction3.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance3 + 1)
+            .build());
     transaction3.commit();
 
     Throwable thrown = catchThrowable(transaction1::commit);
@@ -3852,7 +3878,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction.commit();
 
     // Act
@@ -3872,7 +3899,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     if (result3.isPresent()) {
       balance3 = getBalance(result3.get());
     }
-    transaction3.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance3 + 1));
+    transaction3.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance3 + 1)
+            .build());
     transaction3.commit();
 
     Throwable thrown = catchThrowable(transaction1::commit);
@@ -3895,7 +3925,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     Optional<Result> result = transaction.get(get);
     assertThatCode(transaction::commit).doesNotThrowAnyException();
@@ -3914,7 +3945,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     Get get =
         Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
             .where(column(BALANCE).isEqualToInt(1))
@@ -3936,7 +3968,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     Get get =
         Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
             .where(column(BALANCE).isEqualToInt(0))
@@ -3956,7 +3989,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     populateRecord(manager, namespace1, TABLE_1);
     DistributedTransaction transaction = manager.begin();
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1);
+    Put put = Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build();
     Get get =
         Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
             .where(column(BALANCE).isLessThanOrEqualToInt(INITIAL_BALANCE))
@@ -3980,7 +4013,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     populateRecord(manager, namespace1, TABLE_1);
     DistributedTransaction transaction = manager.begin();
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1);
+    Put put = Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build();
     Get get =
         Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
             .where(column(BALANCE).isEqualToInt(0))
@@ -4002,7 +4035,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act
@@ -4024,14 +4058,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act
     DistributedTransaction transaction1 = manager.begin();
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     Optional<Result> resultBefore = transaction1.get(get);
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     assertThatCode(transaction1::commit).doesNotThrowAnyException();
 
@@ -4050,7 +4086,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act
@@ -4060,7 +4097,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     Throwable thrown =
         catchThrowable(
-            () -> transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2)));
+            () ->
+                transaction1.put(
+                    Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+                        .intValue(BALANCE, 2)
+                        .build()));
     transaction1.rollback();
 
     // Assert
@@ -4074,7 +4115,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
@@ -4092,7 +4134,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     Scan scan = prepareScan(0, 1, 1, namespace1, TABLE_1);
@@ -4110,7 +4153,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     Scan scan =
         Scan.newBuilder()
             .namespace(namespace1)
@@ -4136,7 +4180,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     populateRecords(manager, namespace1, TABLE_1);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 9999));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 9999).build());
     Scan scan =
         Scan.newBuilder(prepareScan(0, 1, 1, namespace1, TABLE_1))
             .where(column(BALANCE).isLessThanOrEqualToInt(INITIAL_BALANCE))
@@ -4158,9 +4203,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
     transaction.put(
-        preparePut(0, 0, namespace1, TABLE_1)
-            .withValue(BALANCE, 999)
-            .withValue(SOME_COLUMN, "aaa"));
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, 999)
+            .textValue(SOME_COLUMN, "aaa")
+            .build());
     Scan scan =
         Scan.newBuilder(prepareScan(0, namespace1, TABLE_1))
             .where(column(BALANCE).isLessThanInt(1000))
@@ -4273,9 +4319,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
     transaction.put(
-        preparePut(0, 0, namespace1, TABLE_1)
-            .withValue(BALANCE, 999)
-            .withValue(SOME_COLUMN, "aaa"));
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, 999)
+            .textValue(SOME_COLUMN, "aaa")
+            .build());
     Scan scan =
         Scan.newBuilder(prepareScanWithIndex(namespace1, TABLE_1, 999))
             .where(column(BALANCE).isLessThanInt(1000))
@@ -4297,8 +4344,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act Assert
@@ -4316,14 +4365,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act Assert
     DistributedTransaction transaction1 = manager.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     assertThatThrownBy(() -> transaction1.scan(scanAll))
         .isInstanceOf(IllegalArgumentException.class);
     transaction1.rollback();
@@ -4336,10 +4387,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
-    ScanAll scanAll = prepareScanAll(namespace2, TABLE_2);
+    Scan scanAll = prepareScanAll(namespace2, TABLE_2);
     Throwable thrown = catchThrowable(() -> transaction.scan(scanAll));
     transaction.commit();
 
@@ -4354,10 +4406,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     Throwable thrown = catchThrowable(() -> transaction.scan(scanAll));
     transaction.rollback();
 
@@ -4373,7 +4426,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     populateRecords(manager, namespace1, TABLE_1);
     DistributedTransaction transaction = begin(manager, readOnly);
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(1);
+    Scan scanAll = Scan.newBuilder(prepareScanAll(namespace1, TABLE_1)).limit(1).build();
 
     // Act
     List<Result> results = transaction.scan(scanAll);
@@ -4397,7 +4450,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     putTransaction.commit();
 
     DistributedTransaction transaction = begin(manager, readOnly);
-    ScanAll scanAll = prepareScanAll(namespace2, TABLE_2);
+    Scan scanAll = prepareScanAll(namespace2, TABLE_2);
 
     // Act
     List<Result> results = transaction.scan(scanAll);
@@ -4462,7 +4515,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     // Act Assert
@@ -4524,7 +4578,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.commit();
 
     DistributedTransaction transaction1 = begin(manager, readOnly);
@@ -8254,20 +8309,23 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .forNamespace(namespace)
-            .forTable(table)
-            .withValue(BALANCE, NEW_BALANCE)
-            .withTextValue(Attribute.ID, ongoingTxId)
-            .withIntValue(Attribute.STATE, recordState.get())
-            .withIntValue(Attribute.VERSION, 2)
-            .withBigIntValue(Attribute.PREPARED_AT, preparedAt)
-            .withValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
-            .withTextValue(Attribute.BEFORE_ID, ANY_ID_1)
-            .withIntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
-            .withIntValue(Attribute.BEFORE_VERSION, 1)
-            .withBigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
-            .withBigIntValue(Attribute.BEFORE_COMMITTED_AT, 1);
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ongoingTxId)
+            .intValue(Attribute.STATE, recordState.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, preparedAt)
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
     storage.put(put);
 
     if (coordinatorState == null) {
@@ -8298,10 +8356,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   private Get prepareGet(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private List<Get> prepareGets(String namespace, String table) {
@@ -8316,20 +8377,24 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   private Scan prepareScan(int id, int fromType, int toType, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
-        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .start(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .end(Key.ofInt(ACCOUNT_TYPE, toType))
+        .build();
   }
 
   private Scan prepareScan(int id, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Scan prepareScanWithIndex(String namespace, String table, int balance) {
@@ -8342,20 +8407,25 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .build();
   }
 
-  private ScanAll prepareScanAll(String namespace, String table) {
-    return new ScanAll()
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+  private Scan prepareScanAll(String namespace, String table) {
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .all()
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Put preparePut(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private List<Put> preparePuts(String namespace, String table) {
@@ -8371,10 +8441,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   private Delete prepareDelete(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Delete.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private List<Delete> prepareDeletes(String namespace, String table) {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -13,7 +13,6 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
@@ -25,7 +24,6 @@ import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.DataType;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.service.StorageFactory;
@@ -640,7 +638,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -649,7 +648,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction2.prepare();
     transaction2.commit();
 
@@ -673,7 +673,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, expected));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, expected).build());
     transaction.prepare();
     transaction.commit();
 
@@ -733,7 +734,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result.isPresent()).isTrue();
 
     int afterBalance = getBalance(result.get()) + 100;
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, afterBalance));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, afterBalance)
+            .build());
     transaction.prepare();
     transaction.commit();
 
@@ -963,8 +967,14 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     TwoPhaseCommitTransaction toTx = manager2.join(fromTx.getId());
     fromTx.get(prepareGet(fromId, fromType, namespace1, TABLE_1));
     toTx.get(prepareGet(toId, toType, namespace2, TABLE_2));
-    fromTx.put(preparePut(fromId, fromType, namespace1, TABLE_1).withValue(BALANCE, expected));
-    toTx.put(preparePut(toId, toType, namespace2, TABLE_2).withValue(BALANCE, expected));
+    fromTx.put(
+        Put.newBuilder(preparePut(fromId, fromType, namespace1, TABLE_1))
+            .intValue(BALANCE, expected)
+            .build());
+    toTx.put(
+        Put.newBuilder(preparePut(toId, toType, namespace2, TABLE_2))
+            .intValue(BALANCE, expected)
+            .build());
 
     // Act Assert
     assertThatCode(
@@ -972,11 +982,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
               TwoPhaseCommitTransaction anotherFromTx = manager2.begin();
               TwoPhaseCommitTransaction anotherToTx = manager1.join(anotherFromTx.getId());
               anotherFromTx.put(
-                  preparePut(anotherFromId, anotherFromType, namespace2, TABLE_2)
-                      .withValue(BALANCE, expected));
+                  Put.newBuilder(preparePut(anotherFromId, anotherFromType, namespace2, TABLE_2))
+                      .intValue(BALANCE, expected)
+                      .build());
               anotherToTx.put(
-                  preparePut(anotherToId, anotherToType, namespace1, TABLE_1)
-                      .withValue(BALANCE, expected));
+                  Put.newBuilder(preparePut(anotherToId, anotherToType, namespace1, TABLE_1))
+                      .intValue(BALANCE, expected)
+                      .build());
               anotherFromTx.prepare();
               anotherToTx.prepare();
               anotherFromTx.commit();
@@ -1292,8 +1304,14 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseCommitTransaction fromTx = manager1.begin();
     TwoPhaseCommitTransaction toTx = manager2.join(fromTx.getId());
-    fromTx.put(preparePut(fromId, fromType, namespace1, TABLE_1).withValue(BALANCE, expected));
-    toTx.put(preparePut(toId, toType, namespace2, TABLE_2).withValue(BALANCE, expected));
+    fromTx.put(
+        Put.newBuilder(preparePut(fromId, fromType, namespace1, TABLE_1))
+            .intValue(BALANCE, expected)
+            .build());
+    toTx.put(
+        Put.newBuilder(preparePut(toId, toType, namespace2, TABLE_2))
+            .intValue(BALANCE, expected)
+            .build());
 
     // Act Assert
     assertThatCode(
@@ -1301,11 +1319,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
               TwoPhaseCommitTransaction anotherFromTx = manager2.begin();
               TwoPhaseCommitTransaction anotherToTx = manager1.join(anotherFromTx.getId());
               anotherFromTx.put(
-                  preparePut(anotherFromId, anotherFromType, namespace2, TABLE_2)
-                      .withValue(BALANCE, expected));
+                  Put.newBuilder(preparePut(anotherFromId, anotherFromType, namespace2, TABLE_2))
+                      .intValue(BALANCE, expected)
+                      .build());
               anotherToTx.put(
-                  preparePut(anotherToId, anotherToType, namespace1, TABLE_1)
-                      .withValue(BALANCE, expected));
+                  Put.newBuilder(preparePut(anotherToId, anotherToType, namespace1, TABLE_1))
+                      .intValue(BALANCE, expected)
+                      .build());
 
               anotherFromTx.prepare();
               anotherToTx.prepare();
@@ -1579,8 +1599,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction2.put(preparePut(1, 0, namespace2, TABLE_2).withValue(BALANCE, 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction2.put(
+        Put.newBuilder(preparePut(1, 0, namespace2, TABLE_2)).intValue(BALANCE, 1).build());
     transaction1.prepare();
     transaction2.prepare();
     transaction1.commit();
@@ -1593,7 +1615,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isPresent();
     int current1 = getBalance(result.get());
     tx1Sub1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    tx1Sub1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, current1 + 1));
+    tx1Sub1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, current1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction tx2Sub1 = manager1.begin();
     TwoPhaseCommitTransaction tx2Sub2 = manager2.join(tx2Sub1.getId());
@@ -1601,7 +1626,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isPresent();
     int current2 = getBalance(result.get());
     tx2Sub2.get(prepareGet(1, 0, namespace2, TABLE_2));
-    tx2Sub2.put(preparePut(1, 0, namespace2, TABLE_2).withValue(BALANCE, current2 + 1));
+    tx2Sub2.put(
+        Put.newBuilder(preparePut(1, 0, namespace2, TABLE_2))
+            .intValue(BALANCE, current2 + 1)
+            .build());
 
     tx1Sub1.prepare();
     tx1Sub2.prepare();
@@ -1638,8 +1666,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction2.put(preparePut(1, 0, namespace2, TABLE_2).withValue(BALANCE, 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction2.put(
+        Put.newBuilder(preparePut(1, 0, namespace2, TABLE_2)).intValue(BALANCE, 1).build());
     transaction1.prepare();
     transaction2.prepare();
     transaction1.commit();
@@ -1652,7 +1682,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isPresent();
     int current1 = getBalance(result.get());
     tx1Sub1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    tx1Sub1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, current1 + 1));
+    tx1Sub1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, current1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction tx2Sub1 = manager1.begin(Isolation.SERIALIZABLE);
     TwoPhaseCommitTransaction tx2Sub2 = manager2.join(tx2Sub1.getId(), Isolation.SERIALIZABLE);
@@ -1660,7 +1693,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isPresent();
     int current2 = getBalance(result.get());
     tx2Sub2.get(prepareGet(1, 0, namespace2, TABLE_2));
-    tx2Sub2.put(preparePut(1, 0, namespace2, TABLE_2).withValue(BALANCE, current2 + 1));
+    tx2Sub2.put(
+        Put.newBuilder(preparePut(1, 0, namespace2, TABLE_2))
+            .intValue(BALANCE, current2 + 1)
+            .build());
 
     tx1Sub1.prepare();
     tx1Sub2.prepare();
@@ -1710,7 +1746,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isNotPresent();
     int current1 = 0;
     tx1Sub1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    tx1Sub1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, current1 + 1));
+    tx1Sub1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, current1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction tx2Sub1 = manager1.begin(Isolation.SERIALIZABLE);
     TwoPhaseCommitTransaction tx2Sub2 = manager2.join(tx2Sub1.getId(), Isolation.SERIALIZABLE);
@@ -1718,7 +1757,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     assertThat(result).isNotPresent();
     int current2 = 0;
     tx2Sub2.get(prepareGet(1, 0, namespace2, TABLE_2));
-    tx2Sub2.put(preparePut(1, 0, namespace2, TABLE_2).withValue(BALANCE, current2 + 1));
+    tx2Sub2.put(
+        Put.newBuilder(preparePut(1, 0, namespace2, TABLE_2))
+            .intValue(BALANCE, current2 + 1)
+            .build());
 
     tx1Sub1.prepare();
     tx1Sub2.prepare();
@@ -1765,13 +1807,19 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     List<Result> results = transaction1.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     assertThat(results).isEmpty();
     int count1 = 0;
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, count1 + 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, count1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin(Isolation.SERIALIZABLE);
     results = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     assertThat(results).isEmpty();
     int count2 = 0;
-    transaction2.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, count2 + 1));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1))
+            .intValue(BALANCE, count2 + 1)
+            .build());
 
     assertThatCode(
             () -> {
@@ -1803,8 +1851,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
           throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -1813,13 +1863,19 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     List<Result> results = transaction1.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     assertThat(results.size()).isEqualTo(2);
     int count1 = results.size();
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, count1 + 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, count1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin(Isolation.SERIALIZABLE);
     results = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     assertThat(results.size()).isEqualTo(2);
     int count2 = results.size();
-    transaction2.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, count2 + 1));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1))
+            .intValue(BALANCE, count2 + 1)
+            .build());
 
     assertThatCode(
             () -> {
@@ -1870,7 +1926,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction.prepare();
     transaction.commit();
 
@@ -1879,7 +1936,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     Optional<Result> result = transaction1.get(prepareGet(0, 0, namespace1, TABLE_1));
     assertThat(result).isPresent();
     int balance1 = getBalance(result.get());
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance1 + 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance1 + 1)
+            .build());
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -1892,7 +1952,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     result = transaction3.get(prepareGet(0, 0, namespace1, TABLE_1));
     assertThat(result).isNotPresent();
     int balance3 = 0;
-    transaction3.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance3 + 1));
+    transaction3.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance3 + 1)
+            .build());
     transaction3.prepare();
     transaction3.commit();
 
@@ -1914,7 +1977,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction.prepare();
     transaction.commit();
 
@@ -1933,7 +1997,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     Optional<Result> result = transaction3.get(prepareGet(0, 0, namespace1, TABLE_1));
     assertThat(result).isNotPresent();
     int balance3 = 0;
-    transaction3.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, balance3 + 1));
+    transaction3.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, balance3 + 1)
+            .build());
     transaction3.prepare();
     transaction3.commit();
 
@@ -1956,7 +2023,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     Optional<Result> result = transaction.get(get);
     assertThatCode(
@@ -1975,7 +2043,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void get_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -2001,14 +2070,16 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void delete_PutCalledBefore_ShouldDelete() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
     // Act Assert
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     Optional<Result> resultBefore = transaction1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 2).build());
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
 
     assertThatCode(
@@ -2034,7 +2105,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -2045,7 +2117,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     Throwable thrown =
         catchThrowable(
-            () -> transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2)));
+            () ->
+                transaction1.put(
+                    Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+                        .intValue(BALANCE, 2)
+                        .build()));
     transaction1.rollback();
 
     // Assert
@@ -2057,7 +2133,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act Assert
     assertThatThrownBy(() -> transaction.scan(prepareScan(0, 0, 0, namespace1, TABLE_1)))
@@ -2070,7 +2147,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void scan_NonOverlappingPutGivenBefore_ShouldScan() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act Assert
     assertThatCode(() -> transaction.scan(prepareScan(0, 1, 1, namespace1, TABLE_1)))
@@ -2085,8 +2163,10 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -2129,7 +2209,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
@@ -2145,11 +2226,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     transaction1.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     TwoPhaseCommitTransaction transaction2 = manager1.begin();
     transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction2.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction2.prepare();
     transaction2.commit();
 
@@ -2168,7 +2251,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     manager1.abort(transaction.getId());
@@ -2187,15 +2271,17 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
-    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
+    transaction.put(
+        Put.newBuilder(preparePut(0, 1, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
     transaction.prepare();
     transaction.commit();
 
     // Act Assert
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     assertThatThrownBy(() -> transaction1.scan(scanAll))
         .isInstanceOf(IllegalArgumentException.class);
     transaction1.rollback();
@@ -2207,7 +2293,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());
 
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction1.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     assertThatCode(() -> transaction2.scan(prepareScanAll(namespace2, TABLE_2)))
@@ -2222,7 +2309,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
+    transaction.put(
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).intValue(BALANCE, 1).build());
 
     // Act
     assertThatThrownBy(() -> transaction.scan(prepareScanAll(namespace1, TABLE_1)))
@@ -2237,7 +2325,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     populate(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(1);
+    Scan scanAll = Scan.newBuilder(prepareScanAll(namespace1, TABLE_1)).limit(1).build();
 
     // Act
     List<Result> results = transaction.scan(scanAll);
@@ -2290,11 +2378,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     putTransaction.commit();
 
     TwoPhaseCommitTransaction transaction = manager2.begin();
-    ScanAll scanAll =
-        new ScanAll()
-            .forNamespace(namespace2)
-            .forTable(TABLE_2)
-            .withConsistency(Consistency.LINEARIZABLE);
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(namespace2)
+            .table(TABLE_2)
+            .all()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
 
     // Act
     List<Result> results = transaction.scan(scanAll);
@@ -2356,11 +2446,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
   }
 
-  private ScanAll prepareScanAll(String namespace, String table) {
-    return new ScanAll()
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+  private Scan prepareScanAll(String namespace, String table) {
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .all()
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private void populatePreparedRecordAndCoordinatorStateRecordForStorage1(
@@ -2369,19 +2461,22 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
     Put put =
-        new Put(partitionKey, clusteringKey)
-            .forNamespace(namespace1)
-            .forTable(TABLE_1)
-            .withValue(new IntValue(BALANCE, INITIAL_BALANCE))
-            .withTextValue(Attribute.ID, ANY_ID_2)
-            .withIntValue(Attribute.STATE, recordState.get())
-            .withIntValue(Attribute.VERSION, 2)
-            .withBigIntValue(Attribute.PREPARED_AT, preparedAt)
-            .withTextValue(Attribute.BEFORE_ID, ANY_ID_1)
-            .withIntValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
-            .withIntValue(Attribute.BEFORE_VERSION, 1)
-            .withBigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
-            .withBigIntValue(Attribute.BEFORE_COMMITTED_AT, 1);
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, recordState.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, preparedAt)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
     storage1.put(put);
 
     if (coordinatorState == null) {
@@ -2418,9 +2513,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
             .get()
             .getAsInt();
     fromTx.put(
-        preparePut(fromId, fromType, fromNamespace, fromTable)
-            .withValue(BALANCE, fromBalance - amount));
-    toTx.put(preparePut(toId, toType, toNamespace, toTable).withValue(BALANCE, toBalance + amount));
+        Put.newBuilder(preparePut(fromId, fromType, fromNamespace, fromTable))
+            .intValue(BALANCE, fromBalance - amount)
+            .build());
+    toTx.put(
+        Put.newBuilder(preparePut(toId, toType, toNamespace, toTable))
+            .intValue(BALANCE, toBalance + amount)
+            .build());
   }
 
   private void deletes(
@@ -2444,46 +2543,59 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   private Get prepareGet(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Scan prepareScan(int id, int fromType, int toType, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .withStart(Key.ofInt(ACCOUNT_TYPE, fromType))
-        .withEnd(Key.ofInt(ACCOUNT_TYPE, toType));
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .start(Key.ofInt(ACCOUNT_TYPE, fromType))
+        .end(Key.ofInt(ACCOUNT_TYPE, toType))
+        .build();
   }
 
   private Scan prepareScan(int id, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
-    return new Scan(partitionKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Put preparePut(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private Delete prepareDelete(int id, int type, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(namespace)
-        .forTable(table)
-        .withConsistency(Consistency.LINEARIZABLE);
+    return Delete.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
   }
 
   private int getAccountId(Result result) {


### PR DESCRIPTION
## Description

This PR removes deprecated API usages. The changes were primarily made using Claude Code.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2947

## Changes made

- Removed deprecated operation constructors usages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
