### PR TITLE
Fix Action to assign reviewers for Dependabot PRs

### DIFF
--- a/.github/workflows/assign-dependabot-pr-reviewers.yaml
+++ b/.github/workflows/assign-dependabot-pr-reviewers.yaml
@@ -10,13 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
 
-    permissions:
-      pull-requests: write
-
     steps:
       - name: Assign ScalarDB team as reviewers for Dependabot PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ASSIGN_PR_REVIEWERS_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: gh pr edit $PR_NUMBER --repo $REPOSITORY --add-reviewer scalar-labs/scalardb


### PR DESCRIPTION
## Description

This fixes the `assign-dependabot-pr-reviewers.yaml` action used to assign reviewers to the PR that Dependabot creates.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2694

## Changes made

The `secrets.GITHUB_TOKEN` provided by GitHub lacks the necessary permissions to execute the GitHub CLI command to assign PR reviewers. So we need to use a PAT instead.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
