### PR TITLE
Backport to branch(3) : Fix Action to assign reviewers for Dependabot PRs

### DIFF
--- a/.github/workflows/assign-dependabot-pr-reviewers.yaml
+++ b/.github/workflows/assign-dependabot-pr-reviewers.yaml
@@ -1,0 +1,20 @@
+name: Assign reviewer to dependabot PRs
+# This action assigns the ScalarDB team as reviewers when Dependabot opens a pull request.
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Assign ScalarDB team as reviewers for Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.ASSIGN_PR_REVIEWERS_PAT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: gh pr edit $PR_NUMBER --repo $REPOSITORY --add-reviewer scalar-labs/scalardb
+


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2958
- **Commit to backport:** cb1cbaaf2343b53804fe7e9f5543d0f3adf949be

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2958 &&
git cherry-pick --no-rerere-autoupdate -m1 cb1cbaaf2343b53804fe7e9f5543d0f3adf949be
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!