### PR TITLE
Remove deprecated API usages (Part 3)

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
@@ -57,7 +57,7 @@ public class MultiStorageAdminIntegrationTest {
   private void initCassandraAdmin() throws ExecutionException {
     StorageFactory factory =
         StorageFactory.create(MultiStorageEnv.getPropertiesForCassandra(TEST_NAME));
-    cassandraAdmin = factory.getAdmin();
+    cassandraAdmin = factory.getStorageAdmin();
 
     // create tables
     cassandraAdmin.createNamespace(NAMESPACE1, true, getCreationOptions());
@@ -81,7 +81,7 @@ public class MultiStorageAdminIntegrationTest {
 
   private void initJdbcAdmin() throws ExecutionException {
     StorageFactory factory = StorageFactory.create(MultiStorageEnv.getPropertiesForJdbc(TEST_NAME));
-    jdbcAdmin = factory.getAdmin();
+    jdbcAdmin = factory.getStorageAdmin();
 
     // create tables
     jdbcAdmin.createNamespace(NAMESPACE1, true);

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -76,14 +76,14 @@ public class MultiStorageIntegrationTest {
   private void initCassandraAndCassandraAdmin() throws ExecutionException {
     StorageFactory factory =
         StorageFactory.create(MultiStorageEnv.getPropertiesForCassandra(TEST_NAME));
-    cassandraAdmin = factory.getAdmin();
+    cassandraAdmin = factory.getStorageAdmin();
     createTables(cassandraAdmin);
     cassandra = factory.getStorage();
   }
 
   private void initJdbcDatabaseAndJdbcAdmin() throws ExecutionException {
     StorageFactory factory = StorageFactory.create(MultiStorageEnv.getPropertiesForJdbc(TEST_NAME));
-    jdbcAdmin = factory.getAdmin();
+    jdbcAdmin = factory.getStorageAdmin();
     createTables(jdbcAdmin);
     jdbcDatabase = factory.getStorage();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -1189,28 +1189,32 @@ public class MultiStorageIntegrationTest {
   }
 
   private int getCol1Value(Result result) {
-    assertThat(result.getValue(COL_NAME1).isPresent()).isTrue();
-    return result.getValue(COL_NAME1).get().getAsInt();
+    assertThat(result.contains(COL_NAME1)).isTrue();
+    assertThat(result.isNull(COL_NAME1)).isFalse();
+    return result.getInt(COL_NAME1);
   }
 
   private String getCol2Value(Result result) {
-    assertThat(result.getValue(COL_NAME2).isPresent()).isTrue();
-    assertThat(result.getValue(COL_NAME2).get().getAsString().isPresent()).isTrue();
-    return result.getValue(COL_NAME2).get().getAsString().get();
+    assertThat(result.contains(COL_NAME2)).isTrue();
+    assertThat(result.isNull(COL_NAME2)).isFalse();
+    return result.getText(COL_NAME2);
   }
 
   private int getCol3Value(Result result) {
-    assertThat(result.getValue(COL_NAME3).isPresent()).isTrue();
-    return result.getValue(COL_NAME3).get().getAsInt();
+    assertThat(result.contains(COL_NAME3)).isTrue();
+    assertThat(result.isNull(COL_NAME3)).isFalse();
+    return result.getInt(COL_NAME3);
   }
 
   private int getCol4Value(Result result) {
-    assertThat(result.getValue(COL_NAME4).isPresent()).isTrue();
-    return result.getValue(COL_NAME4).get().getAsInt();
+    assertThat(result.contains(COL_NAME4)).isTrue();
+    assertThat(result.isNull(COL_NAME4)).isFalse();
+    return result.getInt(COL_NAME4);
   }
 
   private boolean getCol5Value(Result result) {
-    assertThat(result.getValue(COL_NAME5).isPresent()).isTrue();
-    return result.getValue(COL_NAME5).get().getAsBoolean();
+    assertThat(result.contains(COL_NAME5)).isTrue();
+    assertThat(result.isNull(COL_NAME5)).isFalse();
+    return result.getBoolean(COL_NAME5);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -18,7 +18,6 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -394,20 +393,15 @@ public class Coordinator {
 
     public State(Result result) throws CoordinatorException {
       checkNotMissingRequired(result);
-      id = result.getValue(Attribute.ID).get().getAsString().get();
-      state = TransactionState.getInstance(result.getValue(Attribute.STATE).get().getAsInt());
-      createdAt = result.getValue(Attribute.CREATED_AT).get().getAsLong();
-      Optional<Value<?>> childIdsOpt = result.getValue(Attribute.CHILD_IDS);
-      Optional<String> childIdsStrOpt;
-      if (childIdsOpt.isPresent()) {
-        childIdsStrOpt = childIdsOpt.get().getAsString();
+      id = result.getText(Attribute.ID);
+      state = TransactionState.getInstance(result.getInt(Attribute.STATE));
+      createdAt = result.getBigInt(Attribute.CREATED_AT);
+      String childIdsStr = result.getText(Attribute.CHILD_IDS);
+      if (childIdsStr != null) {
+        childIds = Splitter.on(CHILD_IDS_DELIMITER).omitEmptyStrings().splitToList(childIdsStr);
       } else {
-        childIdsStrOpt = Optional.empty();
+        childIds = EMPTY_CHILD_IDS;
       }
-      childIds =
-          childIdsStrOpt
-              .map(s -> Splitter.on(CHILD_IDS_DELIMITER).omitEmptyStrings().splitToList(s))
-              .orElse(EMPTY_CHILD_IDS);
     }
 
     public State(String id, TransactionState state) {
@@ -486,16 +480,13 @@ public class Coordinator {
     }
 
     private void checkNotMissingRequired(Result result) throws CoordinatorException {
-      if (!result.getValue(Attribute.ID).isPresent()
-          || !result.getValue(Attribute.ID).get().getAsString().isPresent()) {
+      if (result.isNull(Attribute.ID) || result.getText(Attribute.ID) == null) {
         throw new CoordinatorException("id is missing in the coordinator state");
       }
-      if (!result.getValue(Attribute.STATE).isPresent()
-          || result.getValue(Attribute.STATE).get().getAsInt() == 0) {
+      if (result.isNull(Attribute.STATE) || result.getInt(Attribute.STATE) == 0) {
         throw new CoordinatorException("state is missing in the coordinator state");
       }
-      if (!result.getValue(Attribute.CREATED_AT).isPresent()
-          || result.getValue(Attribute.CREATED_AT).get().getAsLong() == 0) {
+      if (result.isNull(Attribute.CREATED_AT) || result.getBigInt(Attribute.CREATED_AT) == 0) {
         throw new CoordinatorException("created_at is missing in the coordinator state");
       }
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -157,7 +157,8 @@ public class CrudHandler {
       if (key == null) {
         // Only for a Get with index, the argument `key` is null. In that case, create a key from
         // the result
-        key = new Snapshot.Key(get, result.get());
+        TableMetadata tableMetadata = getTableMetadata(get);
+        key = new Snapshot.Key(get, result.get(), tableMetadata);
       }
 
       result = executeRecovery(key, get, result.get());
@@ -186,7 +187,8 @@ public class CrudHandler {
         if (result.isPresent()) {
           // Only when we can get the record with the Get with index, we can put it into the read
           // set
-          key = new Snapshot.Key(get, result.get());
+          TableMetadata tableMetadata = getTableMetadata(get);
+          key = new Snapshot.Key(get, result.get(), tableMetadata);
           putIntoReadSetInSnapshot(key, result);
         }
       }
@@ -255,7 +257,8 @@ public class CrudHandler {
 
       for (Result r : scanner) {
         TransactionResult result = new TransactionResult(r);
-        Snapshot.Key key = new Snapshot.Key(scan, r);
+        TableMetadata tableMetadata = getTableMetadata(scan);
+        Snapshot.Key key = new Snapshot.Key(scan, r, tableMetadata);
         Optional<TransactionResult> processedScanResult = processScanResult(key, scan, result);
         processedScanResult.ifPresent(res -> results.put(key, res));
 
@@ -810,7 +813,8 @@ public class CrudHandler {
             return Optional.empty();
           }
 
-          Snapshot.Key key = new Snapshot.Key(scan, r.get());
+          TableMetadata tableMetadata = getTableMetadata(scan);
+          Snapshot.Key key = new Snapshot.Key(scan, r.get(), tableMetadata);
           TransactionResult result = new TransactionResult(r.get());
 
           Optional<TransactionResult> processedScanResult = processScanResult(key, scan, result);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -626,7 +626,7 @@ public class Snapshot {
       // Compare the records of the iterators
       while (latestResult.isPresent() && originalResultEntry != null) {
         TransactionResult latestTxResult = new TransactionResult(latestResult.get());
-        Key key = new Key(scan, latestTxResult);
+        Key key = new Key(scan, latestTxResult, tableMetadata);
 
         if (latestTxResult.getId() != null && latestTxResult.getId().equals(id)) {
           // The record is inserted/deleted/updated by this transaction
@@ -744,7 +744,9 @@ public class Snapshot {
             .build();
 
     LinkedHashMap<Key, TransactionResult> results = new LinkedHashMap<>(1);
-    originalResult.ifPresent(r -> results.put(new Snapshot.Key(scanWithIndex, r), r));
+    TableMetadata tableMetadata = getTableMetadata(scanWithIndex);
+    originalResult.ifPresent(
+        r -> results.put(new Snapshot.Key(scanWithIndex, r, tableMetadata), r));
 
     // Validate the result to check if there is no anti-dependency
     validateScanResults(storage, scanWithIndex, results, false);
@@ -812,11 +814,11 @@ public class Snapshot {
       this((Operation) get);
     }
 
-    public Key(Get get, Result result) {
+    public Key(Get get, Result result, TableMetadata tableMetadata) {
       this.namespace = get.forNamespace().get();
       this.table = get.forTable().get();
-      this.partitionKey = result.getPartitionKey().get();
-      this.clusteringKey = result.getClusteringKey();
+      this.partitionKey = ScalarDbUtils.getPartitionKey(result, tableMetadata);
+      this.clusteringKey = ScalarDbUtils.getClusteringKey(result, tableMetadata);
     }
 
     public Key(Put put) {
@@ -827,11 +829,11 @@ public class Snapshot {
       this((Operation) delete);
     }
 
-    public Key(Scan scan, Result result) {
+    public Key(Scan scan, Result result, TableMetadata tableMetadata) {
       this.namespace = scan.forNamespace().get();
       this.table = scan.forTable().get();
-      this.partitionKey = result.getPartitionKey().get();
-      this.clusteringKey = result.getClusteringKey();
+      this.partitionKey = ScalarDbUtils.getPartitionKey(result, tableMetadata);
+      this.clusteringKey = ScalarDbUtils.getClusteringKey(result, tableMetadata);
     }
 
     private Key(Operation operation) {

--- a/core/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DeleteTest {
@@ -32,7 +32,7 @@ public class DeleteTest {
     Key actual = del.getPartitionKey();
 
     // Assert
-    assertThat((Iterable<? extends Value<?>>) expected).isEqualTo(actual);
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/GetTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class GetTest {
@@ -48,7 +48,7 @@ public class GetTest {
     Key actual = get.getPartitionKey();
 
     // Assert
-    assertThat((Iterable<? extends Value<?>>) expected).isEqualTo(actual);
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -36,6 +36,7 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PutTest {
@@ -64,7 +65,7 @@ public class PutTest {
     Key actual = put.getPartitionKey();
 
     // Assert
-    assertThat((Iterable<? extends Value<?>>) expected).isEqualTo(actual);
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanTest.java
@@ -6,9 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import java.util.Collections;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ScanTest {
@@ -96,7 +96,7 @@ public class ScanTest {
             .withLimit(100);
 
     // Assert
-    assertThat((Iterable<? extends Value<?>>) scan.getPartitionKey()).isEqualTo(partitionKey);
+    Assertions.<Key>assertThat(scan.getPartitionKey()).isEqualTo(partitionKey);
     assertThat(scan.getStartClusteringKey()).isEqualTo(Optional.of(startClusteringKey));
     assertThat(scan.getEndClusteringKey()).isEqualTo(Optional.of(endClusteringKey));
     assertThat(scan.getProjections()).isEqualTo(Collections.singletonList(ANY_NAME_1));

--- a/core/src/test/java/com/scalar/db/common/ResultImplTest.java
+++ b/core/src/test/java/com/scalar/db/common/ResultImplTest.java
@@ -172,8 +172,8 @@ public class ResultImplTest {
 
     assertThat(result.contains(ANY_COLUMN_NAME_3)).isTrue();
     assertThat(result.isNull(ANY_COLUMN_NAME_3)).isFalse();
-    assertThat(result.getBigInt(ANY_COLUMN_NAME_3)).isEqualTo(BigIntValue.MAX_VALUE);
-    assertThat(result.getAsObject(ANY_COLUMN_NAME_3)).isEqualTo(BigIntValue.MAX_VALUE);
+    assertThat(result.getBigInt(ANY_COLUMN_NAME_3)).isEqualTo(BigIntColumn.MAX_VALUE);
+    assertThat(result.getAsObject(ANY_COLUMN_NAME_3)).isEqualTo(BigIntColumn.MAX_VALUE);
 
     assertThat(result.contains(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(result.isNull(ANY_COLUMN_NAME_4)).isFalse();
@@ -397,8 +397,8 @@ public class ResultImplTest {
 
     assertThat(result.contains(ANY_COLUMN_NAME_3)).isTrue();
     assertThat(result.isNull(ANY_COLUMN_NAME_3)).isFalse();
-    assertThat(result.getBigInt(ANY_COLUMN_NAME_3)).isEqualTo(BigIntValue.MAX_VALUE);
-    assertThat(result.getAsObject(ANY_COLUMN_NAME_3)).isEqualTo(BigIntValue.MAX_VALUE);
+    assertThat(result.getBigInt(ANY_COLUMN_NAME_3)).isEqualTo(BigIntColumn.MAX_VALUE);
+    assertThat(result.getAsObject(ANY_COLUMN_NAME_3)).isEqualTo(BigIntColumn.MAX_VALUE);
 
     assertThat(result.contains(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(result.isNull(ANY_COLUMN_NAME_4)).isFalse();
@@ -539,8 +539,8 @@ public class ResultImplTest {
 
     // Assert
     assertThat(key.isPresent()).isTrue();
-    assertThat(key.get().get().size()).isEqualTo(1);
-    assertThat(key.get().get().get(0)).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    assertThat(key.get().getColumns().size()).isEqualTo(1);
+    assertThat(key.get().getColumns().get(0)).isEqualTo(TextColumn.of(ANY_NAME_1, ANY_TEXT_1));
   }
 
   @Test
@@ -570,8 +570,8 @@ public class ResultImplTest {
 
     // Assert
     assertThat(key.isPresent()).isTrue();
-    assertThat(key.get().get().size()).isEqualTo(1);
-    assertThat(key.get().get().get(0)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(key.get().getColumns().size()).isEqualTo(1);
+    assertThat(key.get().getColumns().get(0)).isEqualTo(TextColumn.of(ANY_NAME_2, ANY_TEXT_2));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
@@ -8,7 +8,6 @@ import com.datastax.driver.core.Row;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.BigIntColumn;
-import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DateColumn;
@@ -81,7 +80,7 @@ public class ResultInterpreterTest {
     when(row.getString(ANY_NAME_2)).thenReturn(ANY_TEXT_2);
     when(row.getBool(ANY_COLUMN_NAME_1)).thenReturn(true);
     when(row.getInt(ANY_COLUMN_NAME_2)).thenReturn(Integer.MAX_VALUE);
-    when(row.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntValue.MAX_VALUE);
+    when(row.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntColumn.MAX_VALUE);
     when(row.getFloat(ANY_COLUMN_NAME_4)).thenReturn(Float.MAX_VALUE);
     when(row.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(row.getString(ANY_COLUMN_NAME_6)).thenReturn("string");

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
@@ -10,7 +10,6 @@ import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
-import com.scalar.db.io.IntValue;
 import org.jooq.Condition;
 import org.jooq.SQLDialect;
 import org.jooq.SelectConditionStep;
@@ -27,7 +26,6 @@ public class ConditionalQueryBuilderTest {
   private static final String ANY_NAME_3 = "name3";
   private static final String ANY_NAME_4 = "name4";
   private static final int ANY_INT = 1;
-  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
 
   @Mock private SelectConditionStep<org.jooq.Record> select;
 
@@ -57,9 +55,8 @@ public class ConditionalQueryBuilderTest {
     SelectConditionStep<org.jooq.Record> testSelect =
         DSL.using(SQLDialect.DEFAULT).selectFrom("Record r").where(DSL.field("r.id").eq(ANY_ID));
     PutIf condition =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.getAsInt()))
-            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.getAsInt()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT))
             .and(ConditionBuilder.column(ANY_NAME_3).isNullInt())
             .and(ConditionBuilder.column(ANY_NAME_4).isNotNullInt())
             .build();
@@ -96,9 +93,8 @@ public class ConditionalQueryBuilderTest {
   public void visit_PutIfAcceptCalled_ShouldCallWhere() {
     // Arrange
     PutIf condition =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT))
             .build();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 
@@ -140,9 +136,8 @@ public class ConditionalQueryBuilderTest {
   public void visit_DeleteIfAcceptCalled_ShouldCallWhere() {
     // Arrange
     DeleteIf condition =
-        ConditionBuilder.deleteIf(
-                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT))
             .build();
     ConditionalQueryBuilder builder = new ConditionalQueryBuilder(select);
 

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -8,7 +8,6 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,7 +29,6 @@ public class CosmosMutationTest {
   private static final int ANY_INT_1 = 1;
   private static final int ANY_INT_2 = 2;
   private static final int ANY_INT_3 = 3;
-  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
 
   @Mock private TableMetadata metadata;
 
@@ -203,9 +201,8 @@ public class CosmosMutationTest {
   public void makeConditionalQuery_MutationWithConditionsGiven_ShouldReturnQuery() {
     // Arrange
     PutIf conditions =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_3))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_3))
             .build();
     Put put = Put.newBuilder(preparePut()).condition(conditions).build();
     CosmosMutation cosmosMutation = new CosmosMutation(put, metadata);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
@@ -7,7 +7,6 @@ import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
-import com.scalar.db.io.IntValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -18,7 +17,6 @@ public class ConditionExpressionBuilderTest {
   private static final String ANY_NAME_3 = "name3";
   private static final String ANY_NAME_4 = "name4";
   private static final int ANY_INT = 1;
-  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -43,9 +41,8 @@ public class ConditionExpressionBuilderTest {
   public void build_PutIfAcceptCalled_ShouldReturnCondition() {
     // Arrange
     PutIf condition =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.getAsInt()))
-            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.getAsInt()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT))
             .and(ConditionBuilder.column(ANY_NAME_3).isNullInt())
             .and(ConditionBuilder.column(ANY_NAME_4).isNotNullInt())
             .build();
@@ -101,9 +98,8 @@ public class ConditionExpressionBuilderTest {
   public void visit_DeleteIfAcceptCalled_ShouldCallWhere() {
     // Arrange
     DeleteIf condition =
-        ConditionBuilder.deleteIf(
-                ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_VALUE.getAsInt()))
-            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT_VALUE.getAsInt()))
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT))
+            .and(ConditionBuilder.column(ANY_NAME_2).isGreaterThanInt(ANY_INT))
             .and(ConditionBuilder.column(ANY_NAME_3).isNullInt())
             .and(ConditionBuilder.column(ANY_NAME_4).isNotNullInt())
             .build();

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -7,7 +7,6 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +30,6 @@ public class DynamoMutationTest {
   private static final int ANY_INT_1 = 1;
   private static final int ANY_INT_2 = 2;
   private static final int ANY_INT_3 = 3;
-  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
 
   @Mock private TableMetadata metadata;
 
@@ -98,9 +96,8 @@ public class DynamoMutationTest {
   public void getCondition_PutGiven_ShouldReturnCondition() {
     // Arrange
     PutIf conditions =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_3))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_3))
             .build();
     Put put = Put.newBuilder(preparePut()).condition(conditions).build();
 
@@ -126,9 +123,8 @@ public class DynamoMutationTest {
   public void getConditionColumnMap_PutGiven_ShouldReturnCondition() {
     // Arrange
     PutIf conditions =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_3))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_3))
             .build();
     Put put = Put.newBuilder(preparePut()).condition(conditions).build();
 
@@ -172,9 +168,8 @@ public class DynamoMutationTest {
   public void getConditionBindMap_PutWithPutIfGiven_ShouldReturnBindMap() {
     // Arrange
     PutIf conditions =
-        ConditionBuilder.putIf(
-                ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_VALUE.get()))
-            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_VALUE.get()))
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_NAME_3).isEqualToInt(ANY_INT_3))
+            .and(ConditionBuilder.column(ANY_NAME_4).isGreaterThanInt(ANY_INT_3))
             .build();
     Put put = Put.newBuilder(preparePut()).condition(conditions).build();
     Map<String, AttributeValue> expected = new HashMap<>();

--- a/core/src/test/java/com/scalar/db/storage/dynamo/bytes/KeyBytesEncoderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/bytes/KeyBytesEncoderTest.java
@@ -7,16 +7,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.UnsignedBytes;
 import com.scalar.db.api.Scan.Ordering.Order;
-import com.scalar.db.io.BigIntValue;
-import com.scalar.db.io.BlobValue;
-import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
-import com.scalar.db.io.DoubleValue;
-import com.scalar.db.io.FloatValue;
-import com.scalar.db.io.IntValue;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
-import com.scalar.db.io.Value;
+import com.scalar.db.io.TextColumn;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -236,62 +236,62 @@ public class KeyBytesEncoderTest {
     IntStream.range(0, ATTEMPT_COUNT).forEach(i -> test.run());
   }
 
-  private Value<?> getMinValue(String columnName, DataType dataType) {
+  private Column<?> getMinValue(String columnName, DataType dataType) {
     switch (dataType) {
       case BIGINT:
-        return new BigIntValue(columnName, BigIntValue.MIN_VALUE);
+        return BigIntColumn.of(columnName, BigIntColumn.MIN_VALUE);
       case INT:
-        return new IntValue(columnName, Integer.MIN_VALUE);
+        return IntColumn.of(columnName, Integer.MIN_VALUE);
       case FLOAT:
-        return new FloatValue(columnName, Float.MIN_VALUE);
+        return FloatColumn.of(columnName, Float.MIN_VALUE);
       case DOUBLE:
-        return new DoubleValue(columnName, Double.MIN_VALUE);
+        return DoubleColumn.of(columnName, Double.MIN_VALUE);
       case BLOB:
-        return new BlobValue(columnName, new byte[0]);
+        return BlobColumn.of(columnName, new byte[0]);
       case TEXT:
-        return new TextValue(columnName, "");
+        return TextColumn.of(columnName, "");
       case BOOLEAN:
-        return new BooleanValue(columnName, false);
+        return BooleanColumn.of(columnName, false);
       default:
         throw new AssertionError();
     }
   }
 
-  private Value<?> getMaxValue(String columnName, DataType dataType) {
+  private Column<?> getMaxValue(String columnName, DataType dataType) {
     switch (dataType) {
       case BIGINT:
-        return new BigIntValue(columnName, BigIntValue.MAX_VALUE);
+        return BigIntColumn.of(columnName, BigIntColumn.MAX_VALUE);
       case INT:
-        return new IntValue(columnName, Integer.MAX_VALUE);
+        return IntColumn.of(columnName, Integer.MAX_VALUE);
       case FLOAT:
-        return new FloatValue(columnName, Float.MAX_VALUE);
+        return FloatColumn.of(columnName, Float.MAX_VALUE);
       case DOUBLE:
-        return new DoubleValue(columnName, Double.MAX_VALUE);
+        return DoubleColumn.of(columnName, Double.MAX_VALUE);
       case BLOB:
         byte[] blobBytes = new byte[BLOB_MAX_LENGTH];
         Arrays.fill(blobBytes, (byte) 0xff);
-        return new BlobValue(columnName, blobBytes);
+        return BlobColumn.of(columnName, blobBytes);
       case TEXT:
         byte[] textBytes = new byte[TEXT_MAX_COUNT];
         Arrays.fill(textBytes, (byte) 0xff);
-        return new TextValue(columnName, new String(textBytes, StandardCharsets.UTF_8));
+        return TextColumn.of(columnName, new String(textBytes, StandardCharsets.UTF_8));
       case BOOLEAN:
-        return new BooleanValue(columnName, true);
+        return BooleanColumn.of(columnName, true);
       default:
         throw new AssertionError();
     }
   }
 
-  private static Value<?> getRandomValue(String columnName, DataType dataType, Order order) {
+  private static Column<?> getRandomValue(String columnName, DataType dataType, Order order) {
     switch (dataType) {
       case BIGINT:
-        return new BigIntValue(columnName, nextBigInt());
+        return BigIntColumn.of(columnName, nextBigInt());
       case INT:
-        return new IntValue(columnName, random.nextInt());
+        return IntColumn.of(columnName, random.nextInt());
       case FLOAT:
-        return new FloatValue(columnName, nextFloat());
+        return FloatColumn.of(columnName, nextFloat());
       case DOUBLE:
-        return new DoubleValue(columnName, nextDouble());
+        return DoubleColumn.of(columnName, nextDouble());
       case BLOB:
         int length = random.nextInt(BLOB_MAX_LENGTH);
         byte[] bytes = new byte[length];
@@ -306,13 +306,13 @@ public class KeyBytesEncoderTest {
           }
         }
 
-        return new BlobValue(columnName, bytes);
+        return BlobColumn.of(columnName, bytes);
       case TEXT:
         int count = random.nextInt(TEXT_MAX_COUNT);
-        return new TextValue(
+        return TextColumn.of(
             columnName, RandomStringUtils.random(count, 0, 0, true, true, null, random));
       case BOOLEAN:
-        return new BooleanValue(columnName, random.nextBoolean());
+        return BooleanColumn.of(columnName, random.nextBoolean());
       default:
         throw new AssertionError();
     }
@@ -320,7 +320,7 @@ public class KeyBytesEncoderTest {
 
   private static long nextBigInt() {
     OptionalLong randomLong =
-        random.longs(BigIntValue.MIN_VALUE, (BigIntValue.MAX_VALUE + 1)).limit(1).findFirst();
+        random.longs(BigIntColumn.MIN_VALUE, (BigIntColumn.MAX_VALUE + 1)).limit(1).findFirst();
     return randomLong.orElse(0);
   }
 
@@ -353,8 +353,8 @@ public class KeyBytesEncoderTest {
 
       ComparisonChain comparisonChain = ComparisonChain.start();
       for (int i = 0; i < o1.size(); i++) {
-        Value<?> left = o1.get().get(i);
-        Value<?> right = o2.get().get(i);
+        Column<?> left = o1.getColumns().get(i);
+        Column<?> right = o2.getColumns().get(i);
         if (!left.getName().equals(right.getName())) {
           throw new IllegalArgumentException("The value name is different");
         }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.BigIntColumn;
-import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DateColumn;
@@ -87,7 +86,7 @@ public class ResultInterpreterTest {
     when(resultSet.getString(ANY_NAME_2)).thenReturn(ANY_TEXT_2);
     when(resultSet.getBoolean(ANY_COLUMN_NAME_1)).thenReturn(true);
     when(resultSet.getInt(ANY_COLUMN_NAME_2)).thenReturn(Integer.MAX_VALUE);
-    when(resultSet.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntValue.MAX_VALUE);
+    when(resultSet.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntColumn.MAX_VALUE);
     when(resultSet.getDouble(ANY_COLUMN_NAME_4)).thenReturn((double) Float.MAX_VALUE);
     when(resultSet.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(resultSet.getString(ANY_COLUMN_NAME_6)).thenReturn("string");

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -28,7 +28,6 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.io.TextValue;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import java.util.Arrays;
@@ -183,7 +182,8 @@ public class CoordinatorTest {
     Put put = coordinator.createPutWith(state);
 
     // Assert
-    assertThat(put.getPartitionKey().get().get(0)).isEqualTo(new TextValue(Attribute.ID, ANY_ID_1));
+    assertThat(put.getPartitionKey().getColumnName(0)).isEqualTo(Attribute.ID);
+    assertThat(put.getPartitionKey().getTextValue(0)).isEqualTo(ANY_ID_1);
     assertThat(put.getColumns().get(Attribute.STATE))
         .isEqualTo(IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()));
     assertThat(put.getColumns().get(Attribute.CREATED_AT))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -27,9 +27,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
-import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
@@ -70,14 +68,10 @@ public class CoordinatorTest {
       throws ExecutionException, CoordinatorException {
     // Arrange
     Result result = mock(Result.class);
-    when(result.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, ANY_ID_1)));
-    when(result.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, EMPTY_CHILD_IDS)));
-    when(result.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
-    when(result.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(result.getText(Attribute.ID)).thenReturn(ANY_ID_1);
+    when(result.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
+    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
@@ -118,14 +112,10 @@ public class CoordinatorTest {
             UUID.randomUUID().toString());
 
     Result result = mock(Result.class);
-    when(result.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(result.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, childIdsStr)));
-    when(result.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, TransactionState.ABORTED.get())));
-    when(result.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(result.getText(Attribute.ID)).thenReturn(parentId);
+    when(result.getText(Attribute.CHILD_IDS)).thenReturn(childIdsStr);
+    when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.ABORTED.get());
+    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
@@ -149,14 +139,10 @@ public class CoordinatorTest {
         keyManipulator.fullKey(keyManipulator.generateParentKey(), UUID.randomUUID().toString());
 
     Result result = mock(Result.class);
-    when(result.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, fullId)));
-    when(result.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, EMPTY_CHILD_IDS)));
-    when(result.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, TransactionState.ABORTED.get())));
-    when(result.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(result.getText(Attribute.ID)).thenReturn(fullId);
+    when(result.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.ABORTED.get());
+    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
@@ -233,14 +219,10 @@ public class CoordinatorTest {
     coordinator = new Coordinator(storage, config);
 
     Result result = mock(Result.class);
-    when(result.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, ANY_ID_1)));
-    when(result.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, EMPTY_CHILD_IDS)));
-    when(result.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
-    when(result.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(result.getText(Attribute.ID)).thenReturn(ANY_ID_1);
+    when(result.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
+    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
@@ -314,14 +296,11 @@ public class CoordinatorTest {
     List<String> childIds = Arrays.asList(childId1, childId2);
 
     Result resultForGroupCommitState = mock(Result.class);
-    when(resultForGroupCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(childIds))));
-    when(resultForGroupCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS))
+        .thenReturn(Joiner.on(',').join(childIds));
+    when(resultForGroupCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     // Assuming these states exist:
     //
@@ -373,25 +352,17 @@ public class CoordinatorTest {
     List<String> dummyChildIds = Arrays.asList(dummyChildId1, dummyChildId2);
 
     Result resultForGroupCommitState = mock(Result.class);
-    when(resultForGroupCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(
-            Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(dummyChildIds))));
-    when(resultForGroupCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS))
+        .thenReturn(Joiner.on(',').join(dummyChildIds));
+    when(resultForGroupCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     Result resultForSingleCommitState = mock(Result.class);
-    when(resultForSingleCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, fullId)));
-    when(resultForSingleCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, EMPTY_CHILD_IDS)));
-    when(resultForSingleCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForSingleCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForSingleCommitState.getText(Attribute.ID)).thenReturn(fullId);
+    when(resultForSingleCommitState.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(resultForSingleCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForSingleCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     // Assuming these states exist:
     //
@@ -438,14 +409,11 @@ public class CoordinatorTest {
         Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     Result resultForGroupCommitState = mock(Result.class);
-    when(resultForGroupCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(childIds))));
-    when(resultForGroupCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS))
+        .thenReturn(Joiner.on(',').join(childIds));
+    when(resultForGroupCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     // Look up with the same parent ID and a wrong child ID.
     String targetFullId = keyManipulator.fullKey(parentId, UUID.randomUUID().toString());
@@ -495,24 +463,17 @@ public class CoordinatorTest {
     String targetFullId = keyManipulator.fullKey(parentId, UUID.randomUUID().toString());
 
     Result resultForGroupCommitState = mock(Result.class);
-    when(resultForGroupCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(childIds))));
-    when(resultForGroupCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS))
+        .thenReturn(Joiner.on(',').join(childIds));
+    when(resultForGroupCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     Result resultForSingleCommitState = mock(Result.class);
-    when(resultForSingleCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, targetFullId)));
-    when(resultForSingleCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, EMPTY_CHILD_IDS)));
-    when(resultForSingleCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForSingleCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForSingleCommitState.getText(Attribute.ID)).thenReturn(targetFullId);
+    when(resultForSingleCommitState.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(resultForSingleCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForSingleCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     // Assuming these states exist:
     //
@@ -560,14 +521,11 @@ public class CoordinatorTest {
         Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     Result resultForGroupCommitState = mock(Result.class);
-    when(resultForGroupCommitState.getValue(Attribute.ID))
-        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
-    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
-        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(childIds))));
-    when(resultForGroupCommitState.getValue(Attribute.STATE))
-        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
-    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
-        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS))
+        .thenReturn(Joiner.on(',').join(childIds));
+    when(resultForGroupCommitState.getInt(Attribute.STATE)).thenReturn(transactionState.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
 
     // Look up with the same parent ID and a wrong child ID.
     // Also, the full ID doesn't match any single committed state.

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -916,7 +916,7 @@ public class CrudHandlerTest {
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
     TransactionResult expected = new TransactionResult(result);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
@@ -959,7 +959,7 @@ public class CrudHandlerTest {
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
     TransactionResult expected = new TransactionResult(result);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
@@ -1045,7 +1045,7 @@ public class CrudHandlerTest {
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
     TransactionResult expected = new TransactionResult(result);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
@@ -1084,7 +1084,7 @@ public class CrudHandlerTest {
     }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
 
     when(snapshot.getId()).thenReturn(ANY_ID_1);
 
@@ -1141,7 +1141,7 @@ public class CrudHandlerTest {
     }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
 
     when(snapshot.getId()).thenReturn(ANY_ID_1);
 
@@ -1207,7 +1207,7 @@ public class CrudHandlerTest {
     }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
 
     when(snapshot.getId()).thenReturn(ANY_ID_1);
 
@@ -1257,7 +1257,7 @@ public class CrudHandlerTest {
       when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
     }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
-    Snapshot.Key key = new Snapshot.Key(scanForStorage, result);
+    Snapshot.Key key = new Snapshot.Key(scanForStorage, result, TABLE_METADATA);
     when(snapshot.getResults(scanForStorage))
         .thenReturn(Optional.empty())
         .thenReturn(Optional.of(Maps.newLinkedHashMap(ImmutableMap.of(key, expected))));
@@ -1489,7 +1489,7 @@ public class CrudHandlerTest {
     Scan scan = prepareCrossPartitionScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     } else {
@@ -1524,7 +1524,7 @@ public class CrudHandlerTest {
     Scan scanForStorage = toScanForStorageFrom(scan);
 
     result = prepareResult(TransactionState.PREPARED);
-    Snapshot.Key key = new Snapshot.Key(scanForStorage, result);
+    Snapshot.Key key = new Snapshot.Key(scanForStorage, result, TABLE_METADATA);
     when(snapshot.getId()).thenReturn(ANY_ID_1);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
@@ -1585,7 +1585,7 @@ public class CrudHandlerTest {
     Scan scanForStorage = toScanForStorageFrom(scan);
 
     result = prepareResult(TransactionState.PREPARED);
-    Snapshot.Key key = new Snapshot.Key(scanForStorage, result);
+    Snapshot.Key key = new Snapshot.Key(scanForStorage, result, TABLE_METADATA);
     when(snapshot.getId()).thenReturn(ANY_ID_1);
     if (scanType == ScanType.SCAN) {
       when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
@@ -1645,8 +1645,8 @@ public class CrudHandlerTest {
     Result result1 = prepareResult(ANY_TEXT_1, ANY_TEXT_2, TransactionState.COMMITTED);
     Result result2 = prepareResult(ANY_TEXT_1, ANY_TEXT_3, TransactionState.COMMITTED);
 
-    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, result1);
-    Snapshot.Key key2 = new Snapshot.Key(scanWithLimit, result2);
+    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, result1, TABLE_METADATA);
+    Snapshot.Key key2 = new Snapshot.Key(scanWithLimit, result2, TABLE_METADATA);
 
     TransactionResult transactionResult1 = new TransactionResult(result1);
     TransactionResult transactionResult2 = new TransactionResult(result2);
@@ -1699,7 +1699,7 @@ public class CrudHandlerTest {
     Scan scanForStorage = toScanForStorageFrom(scanWithoutLimit);
 
     Result result = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, result);
+    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, result, TABLE_METADATA);
     TransactionResult transactionResult1 = new TransactionResult(result);
 
     // Set up mock scanner to return one result (less than limit)
@@ -1734,9 +1734,9 @@ public class CrudHandlerTest {
     Result uncommittedResult2 = prepareResult(ANY_TEXT_1, ANY_TEXT_3, TransactionState.PREPARED);
     Result uncommittedResult3 = prepareResult(ANY_TEXT_1, ANY_TEXT_4, TransactionState.PREPARED);
 
-    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, uncommittedResult1);
-    Snapshot.Key key2 = new Snapshot.Key(scanWithLimit, uncommittedResult2);
-    Snapshot.Key key3 = new Snapshot.Key(scanWithLimit, uncommittedResult3);
+    Snapshot.Key key1 = new Snapshot.Key(scanWithLimit, uncommittedResult1, TABLE_METADATA);
+    Snapshot.Key key2 = new Snapshot.Key(scanWithLimit, uncommittedResult2, TABLE_METADATA);
+    Snapshot.Key key3 = new Snapshot.Key(scanWithLimit, uncommittedResult3, TABLE_METADATA);
 
     // Set up mock scanner to return one committed and one uncommitted result
     if (scanType == ScanType.SCAN) {
@@ -1891,7 +1891,7 @@ public class CrudHandlerTest {
     Scan scanForStorage = toScanForStorageFrom(scan);
     Result result1 = prepareResult(TransactionState.COMMITTED);
     Result result2 = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key1 = new Snapshot.Key(scan, result1);
+    Snapshot.Key key1 = new Snapshot.Key(scan, result1, TABLE_METADATA);
     TransactionResult txResult1 = new TransactionResult(result1);
     when(scanner.one())
         .thenReturn(Optional.of(result1))
@@ -1980,7 +1980,7 @@ public class CrudHandlerTest {
     Scan scanForStorage = toScanForStorageFrom(scan);
     Result result1 = prepareResult(TransactionState.COMMITTED);
     Result result2 = prepareResult(TransactionState.COMMITTED);
-    Snapshot.Key key1 = new Snapshot.Key(scan, result1);
+    Snapshot.Key key1 = new Snapshot.Key(scan, result1, TABLE_METADATA);
     TransactionResult txResult1 = new TransactionResult(result1);
     when(scanner.one())
         .thenReturn(Optional.of(result1))
@@ -2620,8 +2620,11 @@ public class CrudHandlerTest {
           throws CrudException, ExecutionException {
     // Arrange
     when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
-    when(result.getPartitionKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
-    when(result.getClusteringKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
+    when(result.getColumns())
+        .thenReturn(
+            ImmutableMap.of(
+                ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1),
+                ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2)));
     when(storage.get(any())).thenReturn(Optional.of(result));
 
     Get getWithIndex =
@@ -2639,7 +2642,8 @@ public class CrudHandlerTest {
     verify(storage).get(any());
     verify(snapshot)
         .putIntoReadSet(
-            new Snapshot.Key(getWithIndex, result), Optional.of(new TransactionResult(result)));
+            new Snapshot.Key(getWithIndex, result, TABLE_METADATA),
+            Optional.of(new TransactionResult(result)));
     verify(snapshot).putIntoGetSet(getWithIndex, Optional.of(new TransactionResult(result)));
   }
 
@@ -2649,8 +2653,11 @@ public class CrudHandlerTest {
           throws ExecutionException, CrudException {
     // Arrange
     when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.PREPARED.get());
-    when(result.getPartitionKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
-    when(result.getClusteringKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
+    when(result.getColumns())
+        .thenReturn(
+            ImmutableMap.of(
+                ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1),
+                ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2)));
     when(storage.get(any())).thenReturn(Optional.of(result));
 
     Get getWithIndex =
@@ -2662,7 +2669,7 @@ public class CrudHandlerTest {
     when(snapshot.containsKeyInGetSet(getWithIndex)).thenReturn(false);
     when(snapshot.getId()).thenReturn(ANY_ID_1);
 
-    Snapshot.Key key = new Snapshot.Key(getWithIndex, result);
+    Snapshot.Key key = new Snapshot.Key(getWithIndex, result, TABLE_METADATA);
 
     TransactionResult recoveredResult = mock(TransactionResult.class);
     @SuppressWarnings("unchecked")
@@ -3048,8 +3055,11 @@ public class CrudHandlerTest {
       throws CrudException, ExecutionException {
     // Arrange
     when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
-    when(result.getPartitionKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_1, ANY_TEXT_1)));
-    when(result.getClusteringKey()).thenReturn(Optional.of(Key.ofText(ANY_NAME_2, ANY_TEXT_2)));
+    when(result.getColumns())
+        .thenReturn(
+            ImmutableMap.of(
+                ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1),
+                ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2)));
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(any())).thenReturn(scanner);
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -40,17 +40,17 @@ public class FilteredResultTest {
               .addClusteringKey(ACCOUNT_TYPE)
               .build());
 
-  private static final IntValue ACCOUNT_ID_VALUE = new IntValue(ACCOUNT_ID, 0);
-  private static final IntValue ACCOUNT_TYPE_VALUE = new IntValue(ACCOUNT_TYPE, 1);
-  private static final IntValue BALANCE_VALUE = new IntValue(BALANCE, 2);
+  private static final IntColumn ACCOUNT_ID_VALUE = IntColumn.of(ACCOUNT_ID, 0);
+  private static final IntColumn ACCOUNT_TYPE_VALUE = IntColumn.of(ACCOUNT_TYPE, 1);
+  private static final IntColumn BALANCE_VALUE = IntColumn.of(BALANCE, 2);
   private static final TextColumn ID_VALUE = TextColumn.of(Attribute.ID, "aaa");
   private static final IntColumn STATE_VALUE =
       IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get());
   private static final IntColumn VERSION_VALUE = IntColumn.of(Attribute.VERSION, 4);
   private static final BigIntColumn PREPARED_AT_VALUE = BigIntColumn.of(Attribute.PREPARED_AT, 5);
   private static final BigIntColumn COMMITTED_AT_VALUE = BigIntColumn.of(Attribute.COMMITTED_AT, 6);
-  private static final IntValue BEFORE_BALANCE_VALUE =
-      new IntValue(Attribute.BEFORE_PREFIX + BALANCE, 7);
+  private static final IntColumn BEFORE_BALANCE_VALUE =
+      IntColumn.of(Attribute.BEFORE_PREFIX + BALANCE, 7);
   private static final TextColumn BEFORE_ID_VALUE = TextColumn.of(Attribute.BEFORE_ID, "bbb");
   private static final IntColumn BEFORE_STATE_VALUE =
       IntColumn.of(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get());
@@ -67,15 +67,15 @@ public class FilteredResultTest {
     // Arrange
     Map<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
-            .put(ACCOUNT_ID, ScalarDbUtils.toColumn(ACCOUNT_ID_VALUE))
-            .put(ACCOUNT_TYPE, ScalarDbUtils.toColumn(ACCOUNT_TYPE_VALUE))
-            .put(BALANCE, ScalarDbUtils.toColumn(BALANCE_VALUE))
+            .put(ACCOUNT_ID, ACCOUNT_ID_VALUE)
+            .put(ACCOUNT_TYPE, ACCOUNT_TYPE_VALUE)
+            .put(BALANCE, BALANCE_VALUE)
             .put(Attribute.ID, ID_VALUE)
             .put(Attribute.STATE, STATE_VALUE)
             .put(Attribute.VERSION, VERSION_VALUE)
             .put(Attribute.PREPARED_AT, PREPARED_AT_VALUE)
             .put(Attribute.COMMITTED_AT, COMMITTED_AT_VALUE)
-            .put(Attribute.BEFORE_PREFIX + BALANCE, ScalarDbUtils.toColumn(BEFORE_BALANCE_VALUE))
+            .put(Attribute.BEFORE_PREFIX + BALANCE, BEFORE_BALANCE_VALUE)
             .put(Attribute.BEFORE_ID, BEFORE_ID_VALUE)
             .put(Attribute.BEFORE_STATE, BEFORE_STATE_VALUE)
             .put(Attribute.BEFORE_VERSION, BEFORE_VERSION_VALUE)
@@ -94,19 +94,24 @@ public class FilteredResultTest {
 
     // Act Assert
     assertThat(filteredResult.getPartitionKey()).isPresent();
-    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_ID_VALUE);
 
     assertThat(filteredResult.getClusteringKey()).isPresent();
-    assertThat(filteredResult.getClusteringKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getClusteringKey().get().get().get(0)).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getClusteringKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getClusteringKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_TYPE_VALUE);
 
     assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_ID_VALUE));
     assertThat(filteredResult.getValue(ACCOUNT_TYPE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get()).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_TYPE_VALUE));
     assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).get())
+        .isEqualTo(ScalarDbUtils.toValue(BALANCE_VALUE));
 
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
@@ -159,18 +164,24 @@ public class FilteredResultTest {
 
     // Act Assert
     assertThat(filteredResult.getPartitionKey()).isPresent();
-    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_ID_VALUE);
 
     assertThat(filteredResult.getClusteringKey()).isPresent();
     assertThat(filteredResult.getClusteringKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getClusteringKey().get().get().get(0)).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getClusteringKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_TYPE_VALUE);
+
     assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_ID_VALUE));
     assertThat(filteredResult.getValue(ACCOUNT_TYPE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get()).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_TYPE_VALUE));
     assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).get())
+        .isEqualTo(ScalarDbUtils.toValue(BALANCE_VALUE));
 
     assertThat(filteredResult.getValue(Attribute.ID)).isPresent();
     assertThat(filteredResult.getValue(Attribute.ID).get())
@@ -189,7 +200,7 @@ public class FilteredResultTest {
         .isEqualTo(new BigIntValue(Attribute.COMMITTED_AT, 6));
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE).get())
-        .isEqualTo(BEFORE_BALANCE_VALUE);
+        .isEqualTo(ScalarDbUtils.toValue(BEFORE_BALANCE_VALUE));
     assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_ID).get())
         .isEqualTo(new TextValue(Attribute.BEFORE_ID, "bbb"));
@@ -305,17 +316,20 @@ public class FilteredResultTest {
 
     // Act Assert
     assertThat(filteredResult.getPartitionKey()).isPresent();
-    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_ID_VALUE);
 
     assertThat(catchThrowable(filteredResult::getClusteringKey))
         .isInstanceOf(IllegalStateException.class);
 
     assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_ID_VALUE));
     assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
     assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).get())
+        .isEqualTo(ScalarDbUtils.toValue(BALANCE_VALUE));
 
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
@@ -370,17 +384,20 @@ public class FilteredResultTest {
 
     // Act Assert
     assertThat(filteredResult.getPartitionKey()).isPresent();
-    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_ID_VALUE);
 
     assertThat(catchThrowable(filteredResult::getClusteringKey))
         .isInstanceOf(IllegalStateException.class);
 
     assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_ID_VALUE));
     assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
     assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).get())
+        .isEqualTo(ScalarDbUtils.toValue(BALANCE_VALUE));
 
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
@@ -391,7 +408,7 @@ public class FilteredResultTest {
     assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE).get())
-        .isEqualTo(BEFORE_BALANCE_VALUE);
+        .isEqualTo(ScalarDbUtils.toValue(BEFORE_BALANCE_VALUE));
     assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
@@ -445,14 +462,16 @@ public class FilteredResultTest {
 
     // Act Assert
     assertThat(filteredResult.getPartitionKey()).isPresent();
-    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
-    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_ID_VALUE);
 
     assertThat(catchThrowable(filteredResult::getClusteringKey))
         .isInstanceOf(IllegalStateException.class);
 
     assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_ID_VALUE));
     assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
     assertThat(filteredResult.getValue(BALANCE)).isNotPresent();
 
@@ -505,13 +524,14 @@ public class FilteredResultTest {
         .isInstanceOf(IllegalStateException.class);
 
     assertThat(filteredResult.getClusteringKey()).isPresent();
-    assertThat(filteredResult.getClusteringKey().get().size()).isEqualTo(1);
-
-    assertThat(filteredResult.getClusteringKey().get().get().get(0)).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getClusteringKey().get().getColumns().size()).isEqualTo(1);
+    assertThat(filteredResult.getClusteringKey().get().getColumns().get(0))
+        .isEqualTo(ACCOUNT_TYPE_VALUE);
 
     assertThat(filteredResult.getValue(ACCOUNT_ID)).isNotPresent();
     assertThat(filteredResult.getValue(ACCOUNT_TYPE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get()).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get())
+        .isEqualTo(ScalarDbUtils.toValue(ACCOUNT_TYPE_VALUE));
     assertThat(filteredResult.getValue(BALANCE)).isNotPresent();
 
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
@@ -567,7 +587,8 @@ public class FilteredResultTest {
     assertThat(filteredResult.getValue(ACCOUNT_ID)).isNotPresent();
     assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
     assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
-    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).get())
+        .isEqualTo(ScalarDbUtils.toValue(BALANCE_VALUE));
 
     assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
     assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
@@ -664,11 +685,11 @@ public class FilteredResultTest {
         new ResultImpl(
             ImmutableMap.of(
                 ACCOUNT_ID,
-                ScalarDbUtils.toColumn(ACCOUNT_ID_VALUE),
+                ACCOUNT_ID_VALUE,
                 ACCOUNT_TYPE,
-                ScalarDbUtils.toColumn(ACCOUNT_TYPE_VALUE),
+                ACCOUNT_TYPE_VALUE,
                 BALANCE,
-                ScalarDbUtils.toColumn(BALANCE_VALUE)),
+                BALANCE_VALUE),
             TABLE_METADATA);
 
     // Act
@@ -696,9 +717,7 @@ public class FilteredResultTest {
     // Arrange
     Result filteredResult =
         new FilteredResult(result, Collections.singletonList(BALANCE), TABLE_METADATA, false);
-    Result anotherResult =
-        new ResultImpl(
-            ImmutableMap.of(BALANCE, ScalarDbUtils.toColumn(BALANCE_VALUE)), TABLE_METADATA);
+    Result anotherResult = new ResultImpl(ImmutableMap.of(BALANCE, BALANCE_VALUE), TABLE_METADATA);
 
     // Act
     boolean isEqual = filteredResult.equals(anotherResult);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -27,8 +27,6 @@ import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.io.TextValue;
-import com.scalar.db.util.ScalarDbUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -80,7 +78,7 @@ public class RecoveryHandlerTest {
   private TransactionResult prepareResult(long preparedAt, TransactionState transactionState) {
     ImmutableMap<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
-            .put(ANY_NAME_1, ScalarDbUtils.toColumn(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
             .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_1))
             .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, preparedAt))
             .put(Attribute.STATE, IntColumn.of(Attribute.STATE, transactionState.get()))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -43,6 +43,7 @@ import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TimeColumn;
 import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
+import com.scalar.db.util.ScalarDbUtils;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -714,7 +715,7 @@ public class RollbackMutationComposerTest {
             .namespace(scan.forNamespace().get())
             .table(scan.forTable().get())
             .partitionKey(scan.getPartitionKey())
-            .clusteringKey(result.getClusteringKey().orElse(null))
+            .clusteringKey(ScalarDbUtils.getClusteringKey(result, TABLE_METADATA).orElse(null))
             .consistency(Consistency.LINEARIZABLE)
             .condition(
                 ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2))
@@ -762,7 +763,7 @@ public class RollbackMutationComposerTest {
             .namespace(scan.forNamespace().get())
             .table(scan.forTable().get())
             .partitionKey(scan.getPartitionKey())
-            .clusteringKey(result.getClusteringKey().orElse(null))
+            .clusteringKey(ScalarDbUtils.getClusteringKey(result, TABLE_METADATA).orElse(null))
             .consistency(Consistency.LINEARIZABLE)
             .condition(
                 ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2))
@@ -810,7 +811,7 @@ public class RollbackMutationComposerTest {
             .namespace(scan.forNamespace().get())
             .table(scan.forTable().get())
             .partitionKey(scan.getPartitionKey())
-            .clusteringKey(result.getClusteringKey().orElse(null))
+            .clusteringKey(ScalarDbUtils.getClusteringKey(result, TABLE_METADATA).orElse(null))
             .consistency(Consistency.LINEARIZABLE)
             .condition(
                 ConditionBuilder.deleteIf(ConditionBuilder.column(ID).isEqualToText(ANY_ID_2))

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -70,7 +70,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     initialize(getTestName());
     Properties properties = getProperties(getTestName());
     storageFactory = StorageFactory.create(properties);
-    admin = storageFactory.getAdmin();
+    admin = storageFactory.getStorageAdmin();
     namespace1 = getNamespace1();
     namespace2 = getNamespace2();
     namespace3 = getNamespace3();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -76,7 +76,7 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     createTable();
     storage = factory.getStorage();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -88,7 +88,7 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     createTable();
     storage = factory.getStorage();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -62,7 +62,7 @@ public abstract class DistributedStorageIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(getTestName());
     StorageFactory factory = StorageFactory.create(getProperties(getTestName()));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     createTable();
     storage = factory.getStorage();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -10,13 +10,10 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.BlobColumn;
 import com.scalar.db.io.BooleanColumn;
-import com.scalar.db.io.BooleanValue;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.io.TextValue;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.TestUtils;
 import com.scalar.db.util.TestUtils.ExpectedResult;
@@ -314,10 +311,10 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(actual.get().getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
+    assertThat(actual.get().contains(getColumnName1())).isTrue();
+    assertThat(actual.get().getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(actual.get().contains(getColumnName4())).isTrue();
+    assertThat(actual.get().getInt(getColumnName4())).isEqualTo(0);
   }
 
   @Test
@@ -477,18 +474,18 @@ public abstract class DistributedStorageIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
 
     assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(results.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(results.get(2).contains(getColumnName1())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(2).contains(getColumnName4())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(2);
 
     scanner.close();
   }
@@ -518,10 +515,10 @@ public abstract class DistributedStorageIntegrationTestBase {
     double t4 = System.currentTimeMillis();
 
     // Assert
-    assertThat(actual.get(0).getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(actual.get(0).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(0);
     System.err.println("first: " + (t2 - t1) + " (ms)");
     System.err.println("second: " + (t3 - t2) + " (ms)");
     System.err.println("third: " + (t4 - t3) + " (ms)");
@@ -547,14 +544,14 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // verify
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(1);
   }
 
   @Test
@@ -577,14 +574,14 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // verify
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -608,12 +605,12 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.size()).isEqualTo(3);
-    assertThat(actual.get(0).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
-    assertThat(actual.get(1).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 1)));
-    assertThat(actual.get(2).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 2)));
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(2).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -637,12 +634,12 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.size()).isEqualTo(3);
-    assertThat(actual.get(0).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 2)));
-    assertThat(actual.get(1).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 1)));
-    assertThat(actual.get(2).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(2);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(2).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName4())).isEqualTo(0);
   }
 
   @Test
@@ -666,8 +663,8 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // verify
     assertThat(actual.size()).isEqualTo(1);
-    assertThat(actual.get(0).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 2)));
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -722,18 +719,18 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.size()).isEqualTo(3);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(actual.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(2).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(2).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(2).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -758,20 +755,20 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(result.get().getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(result.get().getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(result.get().getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
+    assertThat(result.get().contains(getColumnName1())).isTrue();
+    assertThat(result.get().getInt(getColumnName1())).isEqualTo(0);
+    assertThat(result.get().contains(getColumnName4())).isTrue();
+    assertThat(result.get().getInt(getColumnName4())).isEqualTo(0);
 
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -796,18 +793,18 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(all.size()).isEqualTo(3);
-    assertThat(all.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(all.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(all.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(all.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(all.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(all.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(all.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(all.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(all.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(all.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(all.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(all.get(2).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(all.get(0).contains(getColumnName1())).isTrue();
+    assertThat(all.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(all.get(0).contains(getColumnName4())).isTrue();
+    assertThat(all.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(all.get(1).contains(getColumnName1())).isTrue();
+    assertThat(all.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(all.get(1).contains(getColumnName4())).isTrue();
+    assertThat(all.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(all.get(2).contains(getColumnName1())).isTrue();
+    assertThat(all.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(all.get(2).contains(getColumnName4())).isTrue();
+    assertThat(all.get(2).getInt(getColumnName4())).isEqualTo(2);
 
     assertThat(actual).isEmpty();
   }
@@ -835,18 +832,18 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.size()).isEqualTo(3);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
-    assertThat(actual.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(2).getValue(getColumnName4()).get().getAsInt()).isEqualTo(2);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(1);
+    assertThat(actual.get(2).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(2).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(2).getInt(getColumnName4())).isEqualTo(2);
   }
 
   @Test
@@ -871,16 +868,16 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(actual.get().getValue(getColumnName2()))
-        .isEqualTo(Optional.of(new TextValue(getColumnName2(), Integer.toString(pKey + cKey))));
-    assertThat(actual.get().getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), pKey + cKey)));
-    assertThat(actual.get().getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(actual.get().getValue(getColumnName5()))
-        .isEqualTo(Optional.of(new BooleanValue(getColumnName5(), cKey % 2 == 0)));
+    assertThat(actual.get().contains(getColumnName1())).isTrue();
+    assertThat(actual.get().getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(actual.get().contains(getColumnName2())).isTrue();
+    assertThat(actual.get().getText(getColumnName2())).isEqualTo(Integer.toString(pKey + cKey));
+    assertThat(actual.get().contains(getColumnName3())).isTrue();
+    assertThat(actual.get().getInt(getColumnName3())).isEqualTo(pKey + cKey);
+    assertThat(actual.get().contains(getColumnName4())).isTrue();
+    assertThat(actual.get().getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(actual.get().contains(getColumnName5())).isTrue();
+    assertThat(actual.get().getBoolean(getColumnName5())).isEqualTo(cKey % 2 == 0);
   }
 
   @Test
@@ -913,16 +910,16 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(actual.get().getValue(getColumnName2()))
-        .isEqualTo(Optional.of(new TextValue(getColumnName2(), Integer.toString(pKey + cKey))));
-    assertThat(actual.get().getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), pKey + cKey)));
-    assertThat(actual.get().getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(actual.get().getValue(getColumnName5()))
-        .isEqualTo(Optional.of(new BooleanValue(getColumnName5(), cKey % 2 == 0)));
+    assertThat(actual.get().contains(getColumnName1())).isTrue();
+    assertThat(actual.get().getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(actual.get().contains(getColumnName2())).isTrue();
+    assertThat(actual.get().getText(getColumnName2())).isEqualTo(Integer.toString(pKey + cKey));
+    assertThat(actual.get().contains(getColumnName3())).isTrue();
+    assertThat(actual.get().getInt(getColumnName3())).isEqualTo(pKey + cKey);
+    assertThat(actual.get().contains(getColumnName4())).isTrue();
+    assertThat(actual.get().getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(actual.get().contains(getColumnName5())).isTrue();
+    assertThat(actual.get().getBoolean(getColumnName5())).isEqualTo(cKey % 2 == 0);
   }
 
   @Test
@@ -945,20 +942,18 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<Result> results = scanAll(scan);
     assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(pKey + cKey);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 1);
-    assertThat(results.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 2);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(pKey + cKey);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(pKey + cKey + 1);
+    assertThat(results.get(2).contains(getColumnName1())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(2).contains(getColumnName4())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(pKey + cKey + 2);
   }
 
   @Test
@@ -985,20 +980,18 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<Result> results = scanAll(scan);
     assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(pKey + cKey);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 1);
-    assertThat(results.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 2);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(pKey + cKey);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(pKey + cKey + 1);
+    assertThat(results.get(2).contains(getColumnName1())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(2).contains(getColumnName4())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(pKey + cKey + 2);
   }
 
   @Test
@@ -1096,8 +1089,8 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<Result> results = scanAll(scan);
     assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0).getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), pKey + cKey)));
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(pKey + cKey);
   }
 
   @Test
@@ -1128,14 +1121,14 @@ public abstract class DistributedStorageIntegrationTestBase {
                 .partitionKey(Key.ofInt(getColumnName1(), 0))
                 .build());
     assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(1);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(1);
   }
 
   @Test
@@ -1180,12 +1173,12 @@ public abstract class DistributedStorageIntegrationTestBase {
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
     Result result = actual.get();
-    assertThat(result.getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(result.getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(result.getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), Integer.MAX_VALUE)));
+    assertThat(result.contains(getColumnName1())).isTrue();
+    assertThat(result.getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(result.contains(getColumnName4())).isTrue();
+    assertThat(result.getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(result.contains(getColumnName3())).isTrue();
+    assertThat(result.getInt(getColumnName3())).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test
@@ -1216,12 +1209,12 @@ public abstract class DistributedStorageIntegrationTestBase {
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
     Result result = actual.get();
-    assertThat(result.getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(result.getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(result.getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), Integer.MAX_VALUE)));
+    assertThat(result.contains(getColumnName1())).isTrue();
+    assertThat(result.getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(result.contains(getColumnName4())).isTrue();
+    assertThat(result.getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(result.contains(getColumnName3())).isTrue();
+    assertThat(result.getInt(getColumnName3())).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test
@@ -1252,12 +1245,12 @@ public abstract class DistributedStorageIntegrationTestBase {
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
     Result result = actual.get();
-    assertThat(result.getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(result.getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(result.getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), pKey + cKey)));
+    assertThat(result.contains(getColumnName1())).isTrue();
+    assertThat(result.getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(result.contains(getColumnName4())).isTrue();
+    assertThat(result.getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(result.contains(getColumnName3())).isTrue();
+    assertThat(result.getInt(getColumnName3())).isEqualTo(pKey + cKey);
   }
 
   @Test
@@ -1279,16 +1272,16 @@ public abstract class DistributedStorageIntegrationTestBase {
     Optional<Result> actual = storage.get(prepareGet(0, 0));
     assertThat(actual.isPresent()).isTrue();
     Result result = actual.get();
-    assertThat(result.getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), 0)));
-    assertThat(result.getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
-    assertThat(result.getValue(getColumnName2()))
-        .isEqualTo(Optional.of(new TextValue(getColumnName2(), (String) null)));
-    assertThat(result.getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), 0)));
-    assertThat(result.getValue(getColumnName5()))
-        .isEqualTo(Optional.of(new BooleanValue(getColumnName5(), false)));
+    assertThat(result.contains(getColumnName1())).isTrue();
+    assertThat(result.getInt(getColumnName1())).isEqualTo(0);
+    assertThat(result.contains(getColumnName4())).isTrue();
+    assertThat(result.getInt(getColumnName4())).isEqualTo(0);
+    assertThat(result.contains(getColumnName2())).isTrue();
+    assertThat(result.isNull(getColumnName2())).isTrue();
+    assertThat(result.contains(getColumnName3())).isTrue();
+    assertThat(result.getInt(getColumnName3())).isEqualTo(0);
+    assertThat(result.contains(getColumnName5())).isTrue();
+    assertThat(result.isNull(getColumnName5())).isTrue();
 
     assertThat(result.getContainedColumnNames())
         .isEqualTo(
@@ -1374,14 +1367,14 @@ public abstract class DistributedStorageIntegrationTestBase {
                 .partitionKey(partitionKey)
                 .build());
     assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(cKey + 1);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(cKey + 2);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(cKey + 1);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(cKey + 2);
   }
 
   @Test
@@ -1560,20 +1553,18 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<Result> results = scanAll(scan);
     assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(pKey + cKey);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 1);
-    assertThat(results.get(2).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(2).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(results.get(2).getValue(getColumnName4()).get().getAsInt())
-        .isEqualTo(pKey + cKey + 2);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName4())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(pKey + cKey);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName4())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(pKey + cKey + 1);
+    assertThat(results.get(2).contains(getColumnName1())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(2).contains(getColumnName4())).isTrue();
+    assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(pKey + cKey + 2);
   }
 
   @Test
@@ -1611,16 +1602,14 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<Result> results = scanAll(scan);
     assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(0).getValue(getColumnName3()).isPresent()).isTrue();
-    assertThat(results.get(0).getValue(getColumnName3()).get().getAsInt())
-        .isEqualTo(Integer.MAX_VALUE);
-    assertThat(results.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(results.get(1).getValue(getColumnName3()).isPresent()).isTrue();
-    assertThat(results.get(1).getValue(getColumnName3()).get().getAsInt())
-        .isEqualTo(Integer.MIN_VALUE);
+    assertThat(results.get(0).contains(getColumnName1())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(0).contains(getColumnName3())).isTrue();
+    assertThat(results.get(0).getInt(getColumnName3())).isEqualTo(Integer.MAX_VALUE);
+    assertThat(results.get(1).contains(getColumnName1())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(results.get(1).contains(getColumnName3())).isTrue();
+    assertThat(results.get(1).getInt(getColumnName3())).isEqualTo(Integer.MIN_VALUE);
   }
 
   @Test
@@ -1645,16 +1634,16 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     Optional<Result> actual = storage.get(get);
     assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), pKey)));
-    assertThat(actual.get().getValue(getColumnName2()))
-        .isEqualTo(Optional.of(new TextValue(getColumnName2(), Integer.toString(pKey + cKey))));
-    assertThat(actual.get().getValue(getColumnName3()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName3(), pKey + cKey)));
-    assertThat(actual.get().getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), cKey)));
-    assertThat(actual.get().getValue(getColumnName5()))
-        .isEqualTo(Optional.of(new BooleanValue(getColumnName5(), cKey % 2 == 0)));
+    assertThat(actual.get().contains(getColumnName1())).isTrue();
+    assertThat(actual.get().getInt(getColumnName1())).isEqualTo(pKey);
+    assertThat(actual.get().contains(getColumnName2())).isTrue();
+    assertThat(actual.get().getText(getColumnName2())).isEqualTo(Integer.toString(pKey + cKey));
+    assertThat(actual.get().contains(getColumnName3())).isTrue();
+    assertThat(actual.get().getInt(getColumnName3())).isEqualTo(pKey + cKey);
+    assertThat(actual.get().contains(getColumnName4())).isTrue();
+    assertThat(actual.get().getInt(getColumnName4())).isEqualTo(cKey);
+    assertThat(actual.get().contains(getColumnName5())).isTrue();
+    assertThat(actual.get().getBoolean(getColumnName5())).isEqualTo(cKey % 2 == 0);
   }
 
   @Test
@@ -1688,14 +1677,14 @@ public abstract class DistributedStorageIntegrationTestBase {
                 .partitionKey(partitionKey)
                 .build());
     assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(0).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(0).getValue(getColumnName4()).get().getAsInt()).isEqualTo(cKey + 1);
-    assertThat(actual.get(1).getValue(getColumnName1()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName1()).get().getAsInt()).isEqualTo(0);
-    assertThat(actual.get(1).getValue(getColumnName4()).isPresent()).isTrue();
-    assertThat(actual.get(1).getValue(getColumnName4()).get().getAsInt()).isEqualTo(cKey + 2);
+    assertThat(actual.get(0).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(0).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(0).getInt(getColumnName4())).isEqualTo(cKey + 1);
+    assertThat(actual.get(1).contains(getColumnName1())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get(1).contains(getColumnName4())).isTrue();
+    assertThat(actual.get(1).getInt(getColumnName4())).isEqualTo(cKey + 2);
   }
 
   @Test
@@ -1778,10 +1767,10 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Assert
     assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(getColumnName1()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName1(), 0)));
-    assertThat(actual.get().getValue(getColumnName4()))
-        .isEqualTo(Optional.of(new IntValue(getColumnName4(), 0)));
+    assertThat(actual.get().contains(getColumnName1())).isTrue();
+    assertThat(actual.get().getInt(getColumnName1())).isEqualTo(0);
+    assertThat(actual.get().contains(getColumnName4())).isTrue();
+    assertThat(actual.get().getInt(getColumnName4())).isEqualTo(0);
   }
 
   @Test
@@ -1870,11 +1859,11 @@ public abstract class DistributedStorageIntegrationTestBase {
         new ArrayList<>(
             Arrays.asList(Arrays.asList(1, 2), Arrays.asList(2, 1), Arrays.asList(3, 0)));
     for (Result result : actual) {
-      assertThat(result.getValue(getColumnName1()).isPresent()).isTrue();
-      assertThat(result.getValue(getColumnName4()).isPresent()).isTrue();
+      assertThat(result.contains(getColumnName1())).isTrue();
+      assertThat(result.contains(getColumnName4())).isTrue();
 
-      int col1Val = result.getValue(getColumnName1()).get().getAsInt();
-      int col4Val = result.getValue(getColumnName4()).get().getAsInt();
+      int col1Val = result.getInt(getColumnName1());
+      int col4Val = result.getInt(getColumnName4());
       List<Integer> col1AndCol4 = Arrays.asList(col1Val, col4Val);
       assertThat(expectedValues).contains(col1AndCol4);
       expectedValues.remove(col1AndCol4);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -80,7 +80,7 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespaceBaseName = getNamespaceBaseName();
     clusteringKeyTypes = getClusteringKeyTypes();
     executorService = Executors.newFixedThreadPool(getThreadNum());

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
@@ -64,7 +64,7 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespaceBaseName = getNamespaceBaseName();
     partitionKeyTypes = getPartitionKeyTypes();
     executorService = Executors.newFixedThreadPool(getThreadNum());

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -51,7 +51,7 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     secondaryIndexTypes = getSecondaryIndexTypes();
     createTables();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -61,7 +61,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     clusteringKeyTypes = getClusteringKeyTypes();
     createTables();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -52,7 +52,7 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getAdmin();
+    admin = factory.getStorageAdmin();
     namespace = getNamespace();
     partitionKeyTypes = getPartitionKeyTypes();
     createTables();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -25,7 +25,6 @@ import com.scalar.db.io.DateColumn;
 import com.scalar.db.io.DoubleColumn;
 import com.scalar.db.io.FloatColumn;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TimeColumn;
@@ -816,17 +815,19 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
     Optional<Result> fromResult = transaction.get(gets.get(fromId));
     assertThat(fromResult.isPresent()).isTrue();
-    IntValue fromBalance = new IntValue(BALANCE, getBalance(fromResult.get()) - amount);
 
     Optional<Result> toResult = transaction.get(gets.get(toId));
     assertThat(toResult.isPresent()).isTrue();
-    IntValue toBalance = new IntValue(BALANCE, getBalance(toResult.get()) + amount);
 
     List<Put> puts = preparePuts();
-    puts.get(fromId).withValue(fromBalance);
-    puts.get(toId).withValue(toBalance);
-    transaction.put(puts.get(fromId));
-    transaction.put(puts.get(toId));
+    transaction.put(
+        Put.newBuilder(puts.get(fromId))
+            .intValue(BALANCE, getBalance(fromResult.get()) - amount)
+            .build());
+    transaction.put(
+        Put.newBuilder(puts.get(toId))
+            .intValue(BALANCE, getBalance(toResult.get()) + amount)
+            .build());
 
     transaction.commit();
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -31,7 +31,6 @@ import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TimeColumn;
 import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
-import com.scalar.db.io.Value;
 import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.util.TestUtils;
 import com.scalar.db.util.TestUtils.ExpectedResult;
@@ -2781,9 +2780,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   protected int getBalance(Result result) {
-    Optional<Value<?>> balance = result.getValue(BALANCE);
-    assertThat(balance).isPresent();
-    return balance.get().getAsInt();
+    assertThat(result.contains(BALANCE)).isTrue();
+    return result.getInt(BALANCE);
   }
 
   protected boolean isTimestampTypeSupported() {

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -31,7 +31,6 @@ import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TimeColumn;
 import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
-import com.scalar.db.io.Value;
 import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.util.TestUtils;
 import com.scalar.db.util.TestUtils.ExpectedResult;
@@ -3086,9 +3085,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   protected int getBalance(Result result) {
-    Optional<Value<?>> balance = result.getValue(BALANCE);
-    assertThat(balance).isPresent();
-    return balance.get().getAsInt();
+    assertThat(result.contains(BALANCE)).isTrue();
+    return result.getInt(BALANCE);
   }
 
   protected boolean isTimestampTypeSupported() {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -25,7 +25,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Collections;
@@ -2500,18 +2499,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       int amount)
       throws TransactionException {
     int fromBalance =
-        fromTx
-            .get(prepareGet(fromId, fromType, fromNamespace, fromTable))
-            .get()
-            .getValue(BALANCE)
-            .get()
-            .getAsInt();
-    int toBalance =
-        toTx.get(prepareGet(toId, toType, toNamespace, toTable))
-            .get()
-            .getValue(BALANCE)
-            .get()
-            .getAsInt();
+        fromTx.get(prepareGet(fromId, fromType, fromNamespace, fromTable)).get().getInt(BALANCE);
+    int toBalance = toTx.get(prepareGet(toId, toType, toNamespace, toTable)).get().getInt(BALANCE);
     fromTx.put(
         Put.newBuilder(preparePut(fromId, fromType, fromNamespace, fromTable))
             .intValue(BALANCE, fromBalance - amount)
@@ -2599,21 +2588,18 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private int getAccountId(Result result) {
-    Optional<Value<?>> id = result.getValue(ACCOUNT_ID);
-    assertThat(id).isPresent();
-    return id.get().getAsInt();
+    assertThat(result.contains(ACCOUNT_ID)).isTrue();
+    return result.getInt(ACCOUNT_ID);
   }
 
   private int getAccountType(Result result) {
-    Optional<Value<?>> type = result.getValue(ACCOUNT_TYPE);
-    assertThat(type).isPresent();
-    return type.get().getAsInt();
+    assertThat(result.contains(ACCOUNT_TYPE)).isTrue();
+    return result.getInt(ACCOUNT_TYPE);
   }
 
   private int getBalance(Result result) {
-    Optional<Value<?>> balance = result.getValue(BALANCE);
-    assertThat(balance).isPresent();
-    return balance.get().getAsInt();
+    assertThat(result.contains(BALANCE)).isTrue();
+    return result.getInt(BALANCE);
   }
 
   private enum SelectionType {

--- a/integration-test/src/main/java/com/scalar/db/util/TestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/util/TestUtils.java
@@ -6,7 +6,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.io.BigIntColumn;
-import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.BlobColumn;
 import com.scalar.db.io.BooleanColumn;
 import com.scalar.db.io.Column;
@@ -167,7 +166,7 @@ public final class TestUtils {
       String columnName, DataType dataType, boolean allowEmpty) {
     switch (dataType) {
       case BIGINT:
-        return BigIntColumn.of(columnName, BigIntValue.MIN_VALUE);
+        return BigIntColumn.of(columnName, BigIntColumn.MIN_VALUE);
       case INT:
         return IntColumn.of(columnName, Integer.MIN_VALUE);
       case FLOAT:
@@ -196,7 +195,7 @@ public final class TestUtils {
   public static Column<?> getColumnWithMaxValue(String columnName, DataType dataType) {
     switch (dataType) {
       case BIGINT:
-        return BigIntColumn.of(columnName, BigIntValue.MAX_VALUE);
+        return BigIntColumn.of(columnName, BigIntColumn.MAX_VALUE);
       case INT:
         return IntColumn.of(columnName, Integer.MAX_VALUE);
       case FLOAT:


### PR DESCRIPTION
## Description

This PR removes deprecated API usages. The changes were primarily made using Claude Code.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2947
- https://github.com/scalar-labs/scalardb/pull/2957

## Changes made

- Removed deprecated methods usages of `Result`.
- Removed deprecated XXXValue classes usages.
- Removed other deprecated usages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
