### PR TITLE
Add rename column

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -4,6 +4,7 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegration
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class ConsensusCommitAdminIntegrationTestWithCosmos
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -22,4 +23,20 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminCaseSensitivityIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedStorageAdminCaseSensitivityIntegrationTestBa
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class CosmosAdminCaseSensitivityIntegrationTest
     extends DistributedStorageAdminCaseSensitivityIntegrationTestBase {
@@ -22,4 +23,20 @@ public class CosmosAdminCaseSensitivityIntegrationTest
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -21,4 +22,20 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class SingleCrudOperationTransactionAdminIntegrationTestWithCosmos
     extends SingleCrudOperationTransactionAdminIntegrationTestBase {
@@ -16,4 +17,20 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithCosmos
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("Cosmos DB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -4,6 +4,7 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegration
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class ConsensusCommitAdminIntegrationTestWithDynamo
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -27,4 +28,20 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new DynamoAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminCaseSensitivityIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedStorageAdminCaseSensitivityIntegrationTestBa
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class DynamoAdminCaseSensitivityIntegrationTest
     extends DistributedStorageAdminCaseSensitivityIntegrationTestBase {
@@ -27,4 +28,20 @@ public class DynamoAdminCaseSensitivityIntegrationTest
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new DynamoAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -26,4 +27,20 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new DynamoAdminTestUtils(getProperties(testName));
   }
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminPermissionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminPermissionIntegrationTest.java
@@ -59,4 +59,9 @@ public class DynamoAdminPermissionIntegrationTest
   @Override
   @Disabled("Import-related functionality is not supported in DynamoDB")
   public void importTable_WithSufficientPermission_ShouldSucceed() {}
+
+  @Test
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_WithSufficientPermission_ShouldSucceed() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/SingleCrudOperationTransactionAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/SingleCrudOperationTransactionAdminIntegrationTestWithDynamo.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.dynamo;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 
 public class SingleCrudOperationTransactionAdminIntegrationTestWithDynamo
     extends SingleCrudOperationTransactionAdminIntegrationTestBase {
@@ -21,4 +22,20 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithDynamo
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
   }
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ShouldRenameColumnCorrectly() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {}
+
+  @Override
+  @Disabled("DynamoDB does not support renaming columns")
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {}
 }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -442,6 +442,21 @@ public interface Admin {
   }
 
   /**
+   * Renames an existing column of an existing table.
+   *
+   * @param namespace the table namespace
+   * @param table the table name
+   * @param oldColumnName the current name of the column to rename
+   * @param newColumnName the new name of the column
+   * @throws IllegalArgumentException if the table or the old column does not exist, the new column
+   *     already exists, or the column is a partition key column, clustering key column, or is
+   *     indexed
+   * @throws ExecutionException if the operation fails
+   */
+  void renameColumn(String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException;
+
+  /**
    * Imports an existing table that is not managed by ScalarDB.
    *
    * @param namespace an existing namespace

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -678,6 +678,18 @@ public enum CoreError implements ScalarDbError {
       "Mutations across multiple storages are not allowed. Mutations: %s",
       "",
       ""),
+  COLUMN_SPECIFIED_AS_PRIMARY_KEY_OR_INDEX_KEY(
+      Category.USER_ERROR,
+      "0216",
+      "The column %s is specified as a primary key or an index key",
+      "",
+      ""),
+  COSMOS_RENAME_COLUMN_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0217",
+      "Rename column functionality is not supported in Cosmos DB",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -960,6 +972,12 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0057", "Recovering records failed. Details: %s", "", ""),
   CONSENSUS_COMMIT_COMMITTING_RECORDS_FAILED(
       Category.INTERNAL_ERROR, "0058", "Committing records failed. Details: %s", "", ""),
+  RENAMING_COLUMN_FAILED(
+      Category.INTERNAL_ERROR,
+      "0059",
+      "Renaming the column failed. Table: %s; Old column name: %s; New column name: %s",
+      "",
+      ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -188,6 +188,13 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    distributedTransactionAdmin.renameColumn(namespace, table, oldColumnName, newColumnName);
+  }
+
+  @Override
   public void addNewColumnToTable(
       String namespace, String table, String columnName, DataType columnType, boolean encrypted)
       throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -95,6 +95,13 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    admin.renameColumn(namespace, table, oldColumnName, newColumnName);
+  }
+
+  @Override
   public TableMetadata getImportTableMetadata(
       String namespace, String table, Map<String, DataType> overrideColumnsType)
       throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -416,6 +416,29 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    try {
+      String alterTableQuery =
+          SchemaBuilder.alterTable(quoteIfNecessary(namespace), quoteIfNecessary(table))
+              .renameColumn(quoteIfNecessary(oldColumnName))
+              .to(quoteIfNecessary(newColumnName))
+              .getQueryString();
+
+      clusterManager.getSession().execute(alterTableQuery);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ExecutionException(
+          String.format(
+              "Renaming the %s column to %s in the %s table failed",
+              oldColumnName, newColumnName, getFullTableName(namespace, table)),
+          e);
+    }
+  }
+
+  @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
     try {
       if (clusterManager.getMetadata(metadataKeyspace, NAMESPACES_TABLE) == null) {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -645,6 +645,13 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName) {
+    throw new UnsupportedOperationException(
+        CoreError.COSMOS_RENAME_COLUMN_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
   public TableMetadata getImportTableMetadata(
       String namespace, String table, Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(CoreError.COSMOS_IMPORT_NOT_SUPPORTED.buildMessage());

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1441,6 +1441,14 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    throw new UnsupportedOperationException(
+        "Rename column functionality is not supported in DynamoDB");
+  }
+
+  @Override
   public TableMetadata getImportTableMetadata(
       String namespace, String table, Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -102,6 +102,18 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   }
 
   @Override
+  public String renameColumnSql(
+      String namespace, String table, String oldColumnName, String newColumnName) {
+    return "EXEC sp_rename '"
+        + encloseFullTableName(namespace, table)
+        + "."
+        + enclose(oldColumnName)
+        + "', '"
+        + newColumnName
+        + "', 'COLUMN'";
+  }
+
+  @Override
   public String alterColumnTypeSql(
       String namespace, String table, String columnName, String columnType) {
     // SQLServer does not require changes in column data types when making indices.

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -98,6 +98,16 @@ public interface RdbEngineStrategy {
   void dropNamespaceTranslateSQLException(SQLException e, String namespace)
       throws ExecutionException;
 
+  default String renameColumnSql(
+      String namespace, String table, String oldColumnName, String newColumnName) {
+    return "ALTER TABLE "
+        + encloseFullTableName(namespace, table)
+        + " RENAME COLUMN "
+        + enclose(oldColumnName)
+        + " TO "
+        + enclose(newColumnName);
+  }
+
   String alterColumnTypeSql(String namespace, String table, String columnName, String columnType);
 
   String tableExistsInternalTableCheckSql(String fullTableName);

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -206,6 +206,13 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    getAdmin(namespace, table).renameColumn(namespace, table, oldColumnName, newColumnName);
+  }
+
+  @Override
   public TableMetadata getImportTableMetadata(
       String namespace, String table, Map<String, DataType> overrideColumnsType)
       throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -239,6 +239,24 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    checkNamespace(namespace);
+
+    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    if (tableMetadata == null) {
+      throw new IllegalArgumentException(
+          CoreError.TABLE_NOT_FOUND.buildMessage(ScalarDbUtils.getFullTableName(namespace, table)));
+    }
+    String oldBeforeColumnName = getBeforeImageColumnName(oldColumnName, tableMetadata);
+    String newBeforeColumnName = getBeforeImageColumnName(newColumnName, tableMetadata);
+
+    admin.renameColumn(namespace, table, oldColumnName, newColumnName);
+    admin.renameColumn(namespace, table, oldBeforeColumnName, newBeforeColumnName);
+  }
+
+  @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
     return admin.getNamespaceNames().stream()
         .filter(namespace -> !namespace.equals(coordinatorNamespace))

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -161,6 +161,13 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    jdbcAdmin.renameColumn(namespace, table, oldColumnName, newColumnName);
+  }
+
+  @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
     return jdbcAdmin.getNamespaceNames();
   }

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
@@ -110,6 +110,13 @@ public class SingleCrudOperationTransactionAdmin implements DistributedTransacti
   }
 
   @Override
+  public void renameColumn(
+      String namespace, String table, String oldColumnName, String newColumnName)
+      throws ExecutionException {
+    distributedStorageAdmin.renameColumn(namespace, table, oldColumnName, newColumnName);
+  }
+
+  @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
     return distributedStorageAdmin.getNamespaceNames();
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -866,6 +866,26 @@ public class CassandraAdminTest {
   }
 
   @Test
+  public void renameColumn_ShouldWorkProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "sample_ns";
+    String table = "tbl";
+    String oldColumnName = "c2";
+    String newColumnName = "c3";
+
+    // Act
+    cassandraAdmin.renameColumn(namespace, table, oldColumnName, newColumnName);
+
+    // Assert
+    String alterTableQuery =
+        SchemaBuilder.alterTable(namespace, table)
+            .renameColumn(oldColumnName)
+            .to(newColumnName)
+            .getQueryString();
+    verify(cassandraSession).execute(alterTableQuery);
+  }
+
+  @Test
   public void getNamespacesNames_WithNonExistingKeyspaces_ShouldReturnEmptySet()
       throws ExecutionException {
     // Arrange

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -1149,11 +1149,14 @@ public class CosmosAdminTest {
             () ->
                 admin.importTable(
                     namespace, table, Collections.emptyMap(), Collections.emptyMap()));
+    Throwable thrown4 =
+        catchThrowable(() -> admin.renameColumn(namespace, table, column, "newCol"));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown4).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1717,11 +1717,13 @@ public abstract class DynamoAdminTestBase {
             () ->
                 admin.importTable(
                     NAMESPACE, TABLE, Collections.emptyMap(), Collections.emptyMap()));
+    Throwable thrown4 = catchThrowable(() -> admin.renameColumn(NAMESPACE, TABLE, "c1", "c2"));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown4).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -2940,6 +2940,160 @@ public class JdbcAdminTest {
   }
 
   @Test
+  public void renameColumn_ForMysql_ShouldWorkProperly() throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.MYSQL,
+        "SELECT `column_name`,`data_type`,`key_type`,`clustering_order`,`indexed` FROM `"
+            + METADATA_SCHEMA
+            + "`.`metadata` WHERE `full_table_name`=? ORDER BY `ordinal_position` ASC",
+        "ALTER TABLE `ns`.`table` RENAME COLUMN `c2` TO `c3`",
+        "DELETE FROM `" + METADATA_SCHEMA + "`.`metadata` WHERE `full_table_name` = 'ns.table'",
+        "INSERT INTO `"
+            + METADATA_SCHEMA
+            + "`.`metadata` VALUES ('ns.table','c1','TEXT','PARTITION',NULL,false,1)",
+        "INSERT INTO `"
+            + METADATA_SCHEMA
+            + "`.`metadata` VALUES ('ns.table','c3','INT',NULL,NULL,false,2)");
+  }
+
+  @Test
+  public void renameColumn_ForOracle_ShouldWorkProperly() throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.ORACLE,
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "ALTER TABLE \"ns\".\"table\" RENAME COLUMN \"c2\" TO \"c3\"",
+        "DELETE FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" = 'ns.table'",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,0,1)",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c3','INT',NULL,NULL,0,2)");
+  }
+
+  @Test
+  public void renameColumn_ForPostgresql_ShouldWorkProperly()
+      throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.POSTGRESQL,
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "ALTER TABLE \"ns\".\"table\" RENAME COLUMN \"c2\" TO \"c3\"",
+        "DELETE FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" = 'ns.table'",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,false,1)",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c3','INT',NULL,NULL,false,2)");
+  }
+
+  @Test
+  public void renameColumn_ForSqlServer_ShouldWorkProperly()
+      throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.SQL_SERVER,
+        "SELECT [column_name],[data_type],[key_type],[clustering_order],[indexed] FROM ["
+            + METADATA_SCHEMA
+            + "].[metadata] WHERE [full_table_name]=? ORDER BY [ordinal_position] ASC",
+        "EXEC sp_rename '[ns].[table].[c2]', 'c3', 'COLUMN'",
+        "DELETE FROM [" + METADATA_SCHEMA + "].[metadata] WHERE [full_table_name] = 'ns.table'",
+        "INSERT INTO ["
+            + METADATA_SCHEMA
+            + "].[metadata] VALUES ('ns.table','c1','TEXT','PARTITION',NULL,0,1)",
+        "INSERT INTO ["
+            + METADATA_SCHEMA
+            + "].[metadata] VALUES ('ns.table','c3','INT',NULL,NULL,0,2)");
+  }
+
+  @Test
+  public void renameColumn_ForSqlite_ShouldWorkProperly() throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.SQLITE,
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
+            + METADATA_SCHEMA
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "ALTER TABLE \"ns$table\" RENAME COLUMN \"c2\" TO \"c3\"",
+        "DELETE FROM \"" + METADATA_SCHEMA + "$metadata\" WHERE \"full_table_name\" = 'ns.table'",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "$metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,FALSE,1)",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "$metadata\" VALUES ('ns.table','c3','INT',NULL,NULL,FALSE,2)");
+  }
+
+  @Test
+  public void renameColumn_ForDb2_ShouldWorkProperly() throws SQLException, ExecutionException {
+    renameColumn_ForX_ShouldWorkProperly(
+        RdbEngine.DB2,
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "ALTER TABLE \"ns\".\"table\" RENAME COLUMN \"c2\" TO \"c3\"",
+        "DELETE FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" = 'ns.table'",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,false,1)",
+        "INSERT INTO \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" VALUES ('ns.table','c3','INT',NULL,NULL,false,2)");
+  }
+
+  private void renameColumn_ForX_ShouldWorkProperly(
+      RdbEngine rdbEngine, String expectedGetMetadataStatement, String... expectedSqlStatements)
+      throws SQLException, ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "table";
+    String columnName1 = "c1";
+    String columnName2 = "c2";
+    String columnName3 = "c3";
+
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                columnName1, DataType.TEXT.toString(), "PARTITION", null, false),
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                columnName2, DataType.INT.toString(), null, null, false));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    List<Statement> expectedStatements = new ArrayList<>();
+    for (int i = 0; i < expectedSqlStatements.length; i++) {
+      Statement expectedStatement = mock(Statement.class);
+      expectedStatements.add(expectedStatement);
+    }
+    when(connection.createStatement())
+        .thenReturn(
+            expectedStatements.get(0),
+            expectedStatements.subList(1, expectedStatements.size()).toArray(new Statement[0]));
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    // Act
+    admin.renameColumn(namespace, table, columnName2, columnName3);
+
+    // Assert
+    verify(selectStatement).setString(1, getFullTableName(namespace, table));
+    verify(connection).prepareStatement(expectedGetMetadataStatement);
+    for (int i = 0; i < expectedSqlStatements.length; i++) {
+      verify(expectedStatements.get(i)).execute(expectedSqlStatements[i]);
+    }
+  }
+
+  @Test
   public void getNamespaceNames_forMysql_ShouldReturnNamespaceNames() throws Exception {
     getNamespaceNames_forX_ShouldReturnNamespaceNames(
         RdbEngine.MYSQL, "SELECT * FROM `" + METADATA_SCHEMA + "`.`namespaces`");

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -500,6 +500,70 @@ public class MultiStorageAdminTest {
   }
 
   @Test
+  public void renameColumn_ForTable1InNamespace1_ShouldCallRenameColumnOfAdmin1()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    String column1 = "c1";
+    String column2 = "c2";
+
+    // Act
+    multiStorageAdmin.renameColumn(namespace, table, column1, column2);
+
+    // Assert
+    verify(admin1).renameColumn(namespace, table, column1, column2);
+  }
+
+  @Test
+  public void renameColumn_ForTable2InNamespace1_ShouldShouldCallRenameColumnOfAdmin2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    String column1 = "c1";
+    String column2 = "c2";
+
+    // Act
+    multiStorageAdmin.renameColumn(namespace, table, column1, column2);
+
+    // Assert
+    verify(admin2).renameColumn(namespace, table, column1, column2);
+  }
+
+  @Test
+  public void renameColumn_ForTable3InNamespace1_ShouldCallRenameColumnOfDefaultAdmin()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    String column1 = "c1";
+    String column2 = "c2";
+
+    // Act
+    multiStorageAdmin.renameColumn(namespace, table, column1, column2);
+
+    // Assert
+    verify(admin3).renameColumn(namespace, table, column1, column2);
+  }
+
+  @Test
+  public void renameColumn_ForTable1InNamespace2_ShouldCallRenameColumnOfAdmin2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    String column1 = "c1";
+    String column2 = "c2";
+
+    // Act
+    multiStorageAdmin.renameColumn(namespace, table, column1, column2);
+
+    // Assert
+    verify(admin2).renameColumn(namespace, table, column1, column2);
+  }
+
+  @Test
   public void
       getNamespaceNames_WithExistingNamespacesNotInMapping_ShouldReturnExistingNamespacesInMappingAndFromDefaultAdmin()
           throws ExecutionException {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -603,6 +603,35 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
+  public void renameColumn_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    String existingColumnName = "col2";
+    String newColumnName = "col3";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("col1", DataType.INT)
+            .addColumn(existingColumnName, DataType.INT)
+            .addPartitionKey("col1")
+            .build();
+    when(distributedStorageAdmin.getTableMetadata(any(), any()))
+        .thenReturn(ConsensusCommitUtils.buildTransactionTableMetadata(tableMetadata));
+
+    // Act
+    admin.renameColumn(NAMESPACE, TABLE, existingColumnName, newColumnName);
+
+    // Assert
+    verify(distributedStorageAdmin).getTableMetadata(NAMESPACE, TABLE);
+    verify(distributedStorageAdmin)
+        .renameColumn(NAMESPACE, TABLE, existingColumnName, newColumnName);
+    verify(distributedStorageAdmin)
+        .renameColumn(
+            NAMESPACE,
+            TABLE,
+            Attribute.BEFORE_PREFIX + existingColumnName,
+            Attribute.BEFORE_PREFIX + newColumnName);
+  }
+
+  @Test
   public void importTable_ShouldCallStorageAdminProperly() throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -229,6 +229,21 @@ public class JdbcTransactionAdminTest {
   }
 
   @Test
+  public void renameColumn_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    String columnName1 = "c1";
+    String columnName2 = "c2";
+
+    // Act
+    admin.renameColumn(namespace, table, columnName1, columnName2);
+
+    // Assert
+    verify(jdbcAdmin).renameColumn(namespace, table, columnName1, columnName2);
+  }
+
+  @Test
   public void importTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
     // Arrange
     String namespace = "ns";

--- a/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
@@ -234,6 +234,21 @@ public class SingleCrudOperationTransactionAdminTest {
   }
 
   @Test
+  public void renameColumn_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    String columnName1 = "c1";
+    String columnName2 = "c2";
+
+    // Act
+    admin.renameColumn(namespace, table, columnName1, columnName2);
+
+    // Assert
+    verify(distributedStorageAdmin).renameColumn(namespace, table, columnName1, columnName2);
+  }
+
+  @Test
   public void importTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
     String namespace = "ns";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
@@ -309,6 +309,16 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   }
 
   @Test
+  public void renameColumn_WithSufficientPermission_ShouldSucceed() throws ExecutionException {
+    // Arrange
+    createNamespaceByRoot();
+    createTableByRoot();
+    // Act Assert
+    assertThatCode(() -> adminForNormalUser.renameColumn(NAMESPACE, TABLE, COL_NAME3, NEW_COL_NAME))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   public void importTable_WithSufficientPermission_ShouldSucceed() throws Exception {
     // Arrange
     createNamespaceByRoot();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -887,6 +887,66 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   @Test
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addPartitionKey("c1")
+              .build();
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+
+      // Act
+      admin.renameColumn(namespace1, TABLE4, "c2", "c3");
+
+      // Assert
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addPartitionKey("c1")
+              .build();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4)).isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  public void renameColumn_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.renameColumn(namespace1, TABLE4, "c2", "c3"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void renameColumn_ForNonExistingColumn_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.renameColumn(namespace1, TABLE1, "nonExistingColumn", "c3"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void renameColumn_ForPrimaryOrIndexKeyColumn_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.renameColumn(namespace1, TABLE1, "c1", "newColumnName"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> admin.renameColumn(namespace1, TABLE1, "c3", "newColumnName"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> admin.renameColumn(namespace1, TABLE1, "c5", "newColumnName"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()
       throws ExecutionException {
     // Arrange


### PR DESCRIPTION
## Description

This PR adds support for renaming columns in ScalarDB.

Currently, ScalarDB does not support renaming columns and users must recreate tables to rename columns. This feature will provide more flexibility in managing database schemas without requiring recreating tables.

## Related issues and/or PRs

- #2960 
- #2983 

## Changes made

- Added `renameColumn` method in the `Admin` interface.
- Added unit tests for the method.
- Added integration tests for the method.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added support for renaming columns in ScalarDB.