### PR TITLE
Add a new line between ARRANGE and ACT/ASSERT sections in permission tests

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
@@ -120,6 +120,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.getImportTableMetadata(NAMESPACE, TABLE))
         .doesNotThrowAnyException();
@@ -131,6 +132,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(
             () ->
@@ -142,6 +144,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   @Test
   public void createNamespace_WithSufficientPermission_ShouldSucceed() {
     // Arrange
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.createNamespace(NAMESPACE, getCreationOptions()))
         .doesNotThrowAnyException();
@@ -151,6 +154,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   public void createTable_WithSufficientPermission_ShouldSucceed() throws ExecutionException {
     // Arrange
     createNamespaceByRoot();
+
     // Act Assert
     assertThatCode(
             () ->
@@ -164,6 +168,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.dropTable(NAMESPACE, TABLE)).doesNotThrowAnyException();
   }
@@ -172,6 +177,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   public void dropNamespace_WithSufficientPermission_ShouldSucceed() throws ExecutionException {
     // Arrange
     createNamespaceByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.dropNamespace(NAMESPACE, true))
         .doesNotThrowAnyException();
@@ -182,6 +188,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.truncateTable(NAMESPACE, TABLE))
         .doesNotThrowAnyException();
@@ -192,6 +199,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(
             () -> adminForNormalUser.createIndex(NAMESPACE, TABLE, COL_NAME3, getCreationOptions()))
@@ -203,6 +211,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.dropIndex(NAMESPACE, TABLE, COL_NAME4))
         .doesNotThrowAnyException();
@@ -213,6 +222,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.indexExists(NAMESPACE, TABLE, COL_NAME4))
         .doesNotThrowAnyException();
@@ -223,6 +233,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.getTableMetadata(NAMESPACE, TABLE))
         .doesNotThrowAnyException();
@@ -234,6 +245,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.getNamespaceTableNames(NAMESPACE))
         .doesNotThrowAnyException();
@@ -244,6 +256,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.namespaceExists(NAMESPACE)).doesNotThrowAnyException();
   }
@@ -253,6 +266,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.tableExists(NAMESPACE, TABLE))
         .doesNotThrowAnyException();
@@ -269,6 +283,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     } finally {
       adminTestUtils.close();
     }
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.repairNamespace(NAMESPACE, getCreationOptions()))
         .doesNotThrowAnyException();
@@ -286,6 +301,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     } finally {
       adminTestUtils.close();
     }
+
     // Act Assert
     assertThatCode(
             () ->
@@ -300,6 +316,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     // Arrange
     createNamespaceByRoot();
     createTableByRoot();
+
     // Act Assert
     assertThatCode(
             () ->
@@ -320,6 +337,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     } finally {
       adminTestUtils.close();
     }
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.importTable(NAMESPACE, TABLE, getCreationOptions()))
         .doesNotThrowAnyException();
@@ -329,6 +347,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   public void getNamespaceNames_WithSufficientPermission_ShouldSucceed() throws ExecutionException {
     // Arrange
     createNamespaceByRoot();
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.getNamespaceNames()).doesNotThrowAnyException();
   }
@@ -344,6 +363,7 @@ public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
     } finally {
       adminTestUtils.close();
     }
+
     // Act Assert
     assertThatCode(() -> adminForNormalUser.upgrade(getCreationOptions()))
         .doesNotThrowAnyException();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
@@ -117,6 +117,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             .partitionKey(Key.ofInt(COL_NAME1, PARTITION_KEY_VALUE))
             .clusteringKey(Key.ofText(COL_NAME2, CLUSTERING_KEY_VALUE1))
             .build();
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.get(get)).doesNotThrowAnyException();
   }
@@ -130,6 +131,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             .table(TABLE)
             .indexKey(Key.ofInt("c3", INT_COLUMN_VALUE1))
             .build();
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.get(get)).doesNotThrowAnyException();
   }
@@ -143,6 +145,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             .table(TABLE)
             .partitionKey(Key.ofInt(COL_NAME1, PARTITION_KEY_VALUE))
             .build();
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.scan(scan).close()).doesNotThrowAnyException();
   }
@@ -156,6 +159,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             .table(TABLE)
             .indexKey(Key.ofInt("c3", INT_COLUMN_VALUE1))
             .build();
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.scan(scan).close()).doesNotThrowAnyException();
   }
@@ -164,6 +168,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
   public void scanAll_WithSufficientPermission_ShouldSucceed() {
     // Arrange
     Scan scan = Scan.newBuilder().namespace(namespace).table(TABLE).all().build();
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.scan(scan).close()).doesNotThrowAnyException();
   }
@@ -172,6 +177,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
   public void put_WithoutCondition_WithSufficientPermission_ShouldSucceed() {
     // Arrange
     Put put = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(put)).doesNotThrowAnyException();
   }
@@ -181,6 +187,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Put putWithPutIfNotExists =
         createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, ConditionBuilder.putIfNotExists());
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(putWithPutIfNotExists))
         .doesNotThrowAnyException();
@@ -194,6 +201,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     storageForNormalUser.put(put);
     Put putWithPutIfExists =
         createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE2, ConditionBuilder.putIfExists());
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(putWithPutIfExists)).doesNotThrowAnyException();
   }
@@ -210,6 +218,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             ConditionBuilder.putIf(
                     ConditionBuilder.column(COL_NAME3).isEqualToInt(INT_COLUMN_VALUE1))
                 .build());
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(putWithPutIf)).doesNotThrowAnyException();
   }
@@ -219,6 +228,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Put put1 = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
     Put put2 = createPut(CLUSTERING_KEY_VALUE2, INT_COLUMN_VALUE2, null);
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.put(Arrays.asList(put1, put2)))
         .doesNotThrowAnyException();
@@ -228,6 +238,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
   public void delete_WithSufficientPermission_ShouldSucceed() {
     // Arrange
     Delete delete = createDelete(CLUSTERING_KEY_VALUE1, null);
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.delete(delete)).doesNotThrowAnyException();
   }
@@ -239,6 +250,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     Put put = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
     storageForNormalUser.put(put);
     Delete delete = createDelete(CLUSTERING_KEY_VALUE1, ConditionBuilder.deleteIfExists());
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.delete(delete)).doesNotThrowAnyException();
   }
@@ -255,6 +267,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
             ConditionBuilder.deleteIf(
                     ConditionBuilder.column(COL_NAME3).isEqualToInt(INT_COLUMN_VALUE1))
                 .build());
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.delete(delete)).doesNotThrowAnyException();
   }
@@ -264,6 +277,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Delete delete1 = createDelete(CLUSTERING_KEY_VALUE1, null);
     Delete delete2 = createDelete(CLUSTERING_KEY_VALUE2, null);
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.delete(Arrays.asList(delete1, delete2)))
         .doesNotThrowAnyException();
@@ -274,6 +288,7 @@ public abstract class DistributedStoragePermissionIntegrationTestBase {
     // Arrange
     Put put = createPut(CLUSTERING_KEY_VALUE1, INT_COLUMN_VALUE1, null);
     Delete delete = createDelete(CLUSTERING_KEY_VALUE2, null);
+
     // Act Assert
     assertThatCode(() -> storageForNormalUser.mutate(Arrays.asList(put, delete)))
         .doesNotThrowAnyException();


### PR DESCRIPTION
## Description

This PR improves the readability of permission tests by adding a new line between the ARRANGE section and the ACT/ASSERT sections. This change helps to clearly separate the setup phase from the execution and verification phases of the tests like other tests in this repository.

## Related issues and/or PRs

N/A

## Changes made

Added a new line between the ARRANGE section and the ACT/ASSERT sections in permission tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A