### PR TITLE
Use CoreError for messages of UnsupportedOperationException in Cassandra adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -736,6 +736,12 @@ public enum CoreError implements ScalarDbError {
       "The BOOLEAN type is not supported for index columns in DynamoDB. Column: %s",
       "",
       ""),
+  CASSANDRA_TIMESTAMP_TYPE_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0227",
+      "The TIMESTAMP type is not supported in Cassandra. Column: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -77,7 +77,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     for (String column : metadata.getColumnNames()) {
       if (metadata.getColumnDataTypes().get(column).equals(DataType.TIMESTAMP)) {
         throw new UnsupportedOperationException(
-            "The TIMESTAMP data type is not supported in Cassandra. column: " + column);
+            CoreError.CASSANDRA_TIMESTAMP_TYPE_NOT_SUPPORTED.buildMessage(column));
       }
     }
     try {
@@ -394,7 +394,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     if (columnType == DataType.TIMESTAMP) {
       throw new UnsupportedOperationException(
-          "The TIMESTAMP data type is not supported in Cassandra. column: " + columnName);
+          CoreError.CASSANDRA_TIMESTAMP_TYPE_NOT_SUPPORTED.buildMessage(columnName));
     }
     try {
       String alterTableQuery =

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ResultInterpreter.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cassandra;
 import com.datastax.driver.core.Row;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.CoreError;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
@@ -86,7 +87,7 @@ public class ResultInterpreter {
             : TimeColumn.of(name, LocalTime.ofNanoOfDay(row.getTime(name)));
       case TIMESTAMP:
         throw new UnsupportedOperationException(
-            "The TIMESTAMP type is not supported with Cassandra.");
+            CoreError.CASSANDRA_TIMESTAMP_TYPE_NOT_SUPPORTED.buildMessage(name));
       case TIMESTAMPTZ:
         return row.isNull(name)
             ? TimestampTZColumn.ofNull(name)

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ValueBinder.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ValueBinder.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cassandra;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.datastax.driver.core.BoundStatement;
+import com.scalar.db.common.CoreError;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
 import com.scalar.db.io.BooleanColumn;
@@ -134,7 +135,8 @@ public final class ValueBinder implements ColumnVisitor {
 
   @Override
   public void visit(TimestampColumn column) {
-    throw new UnsupportedOperationException("The TIMESTAMP type is not supported with Cassandra");
+    throw new UnsupportedOperationException(
+        CoreError.CASSANDRA_TIMESTAMP_TYPE_NOT_SUPPORTED.buildMessage(column.getName()));
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR updates the Cassandra adapter to use `CoreError` for messages of `UnsupportedOperationException`.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3007

## Changes made

- Updated the Cassandra adapter to use `CoreError` for messages of `UnsupportedOperationException`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
