### PR TITLE
Backport to branch(3) : For IBM Db2, change the data type for BLOB column to support storing up to 2GB

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -122,8 +122,8 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
   }
 
   @Override
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
-    // "admin.createIndex()" for TEXT and BLOB columns fails (the "create index" query runs
+  protected boolean isCreateIndexOnTextColumnEnabled() {
+    // "admin.createIndex()" for TEXT column fails (the "create index" query runs
     // indefinitely) on the Db2 community edition docker version which we use for the CI.
     // However, the index creation is successful on Db2 hosted on IBM Cloud.
     // So we disable these tests until the issue with the Db2 community edition is resolved.
@@ -179,5 +179,10 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
     }
+  }
+
+  @Override
+  protected boolean isIndexOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminCaseSensitivityIntegrationTest.java
@@ -106,8 +106,8 @@ public class JdbcAdminCaseSensitivityIntegrationTest
   }
 
   @Override
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
-    // "admin.createIndex()" for TEXT and BLOB columns fails (the "create index" query runs
+  protected boolean isCreateIndexOnTextColumnEnabled() {
+    // "admin.createIndex()" for TEXT column fails (the "create index" query runs
     // indefinitely) on Db2 community edition version but works on Db2 hosted on IBM Cloud.
     // So we disable these tests until the issue is resolved.
     return !JdbcTestUtils.isDb2(rdbEngine);
@@ -171,5 +171,10 @@ public class JdbcAdminCaseSensitivityIntegrationTest
     } finally {
       admin.dropTable(getNamespace1(), getTable4(), true);
     }
+  }
+
+  @Override
+  protected boolean isIndexOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -105,8 +105,8 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   }
 
   @Override
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
-    // "admin.createIndex()" for TEXT and BLOB columns fails (the "create index" query runs
+  protected boolean isCreateIndexOnTextColumnEnabled() {
+    // "admin.createIndex()" for TEXT columns fails (the "create index" query runs
     // indefinitely) on Db2 community edition version but works on Db2 hosted on IBM Cloud.
     // So we disable these tests until the issue is resolved.
     return !JdbcTestUtils.isDb2(rdbEngine);
@@ -170,5 +170,10 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
     } finally {
       admin.dropTable(getNamespace1(), getTable4(), true);
     }
+  }
+
+  @Override
+  protected boolean isIndexOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
@@ -80,4 +80,9 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
     }
     return Stream.of(Arguments.of(allColumnNames));
   }
+
+  @Override
+  protected boolean isOrderingOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
@@ -94,9 +94,14 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
   @Override
   protected List<DataType> getDataTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
+    // BLOB type cannot be used as a clustering key in Db2
     return JdbcTestUtils.filterDataTypes(
         super.getDataTypes(),
         rdbEngine,
-        ImmutableMap.of(RdbEngineOracle.class, ImmutableList.of(DataType.TIMESTAMPTZ)));
+        ImmutableMap.of(
+            RdbEngineOracle.class,
+            ImmutableList.of(DataType.TIMESTAMPTZ),
+            RdbEngineDb2.class,
+            ImmutableList.of(DataType.BLOB)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
@@ -88,6 +88,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
   protected List<DataType> getDataTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // FLOAT and DOUBLE types cannot be used as partition key in Yugabyte
+    // BLOB type cannot be used as a partition key in Db2
     return JdbcTestUtils.filterDataTypes(
         super.getDataTypes(),
         rdbEngine,
@@ -95,6 +96,8 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
             RdbEngineOracle.class,
             ImmutableList.of(DataType.TIMESTAMPTZ),
             RdbEngineYugabyte.class,
-            ImmutableList.of(DataType.FLOAT, DataType.DOUBLE)));
+            ImmutableList.of(DataType.FLOAT, DataType.DOUBLE),
+            RdbEngineDb2.class,
+            ImmutableList.of(DataType.BLOB)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
@@ -1,12 +1,17 @@
 package com.scalar.db.storage.jdbc;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.TestUtils;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 
 public class JdbcDatabaseSecondaryIndexIntegrationTest
     extends DistributedStorageSecondaryIndexIntegrationTestBase {
@@ -67,5 +72,15 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
       }
     }
     return super.getColumnWithMaxValue(columnName, dataType);
+  }
+
+  @Override
+  protected Set<DataType> getSecondaryIndexTypes() {
+    // BLOB type cannot be used as a secondary index in Db2
+    return Sets.newHashSet(
+        JdbcTestUtils.filterDataTypes(
+            Arrays.asList(DataType.values()),
+            rdbEngine,
+            ImmutableMap.of(RdbEngineDb2.class, ImmutableList.of(DataType.BLOB))));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
@@ -70,9 +70,14 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
   @Override
   protected List<DataType> getClusteringKeyTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
+    // BLOB type cannot be used as a clustering key in Db2
     return JdbcTestUtils.filterDataTypes(
         super.getClusteringKeyTypes(),
         rdbEngine,
-        ImmutableMap.of(RdbEngineOracle.class, ImmutableList.of(DataType.TIMESTAMPTZ)));
+        ImmutableMap.of(
+            RdbEngineOracle.class,
+            ImmutableList.of(DataType.TIMESTAMPTZ),
+            RdbEngineDb2.class,
+            ImmutableList.of(DataType.BLOB)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
@@ -71,6 +71,7 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
   protected List<DataType> getPartitionKeyTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // FLOAT and DOUBLE types cannot be used as partition key in Yugabyte
+    // BLOB type cannot be used as a partition key in Db2
     return JdbcTestUtils.filterDataTypes(
         super.getPartitionKeyTypes(),
         rdbEngine,
@@ -78,6 +79,8 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
             RdbEngineOracle.class,
             ImmutableList.of(DataType.TIMESTAMPTZ),
             RdbEngineYugabyte.class,
-            ImmutableList.of(DataType.FLOAT, DataType.DOUBLE)));
+            ImmutableList.of(DataType.FLOAT, DataType.DOUBLE),
+            RdbEngineDb2.class,
+            ImmutableList.of(DataType.BLOB)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
@@ -106,8 +106,8 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
   }
 
   @Override
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
-    // "admin.createIndex()" for TEXT and BLOB columns fails (the "create index" query runs
+  protected boolean isCreateIndexOnTextColumnEnabled() {
+    // "admin.createIndex()" for TEXT column fails (the "create index" query runs
     // indefinitely) on the Db2 community edition docker version which we use for the CI.
     // However, the index creation is successful on Db2 hosted on IBM Cloud.
     // So we disable these tests until the issue with the Db2 community edition is resolved.
@@ -163,5 +163,10 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
     }
+  }
+
+  @Override
+  protected boolean isIndexOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -173,8 +173,8 @@ public class JdbcTransactionAdminIntegrationTest
   }
 
   @Override
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
-    // "admin.createIndex()" for TEXT and BLOB columns fails (the "create index" query runs
+  protected boolean isCreateIndexOnTextColumnEnabled() {
+    // "admin.createIndex()" for TEXT column fails (the "create index" query runs
     // indefinitely) on the Db2 community edition docker version which we use for the CI.
     // However, the index creation is successful on Db2 hosted on IBM Cloud.
     // So we disable these tests until the issue with the Db2 community edition is resolved.
@@ -230,5 +230,10 @@ public class JdbcTransactionAdminIntegrationTest
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
     }
+  }
+
+  @Override
+  protected boolean isIndexOnBlobColumnSupported() {
+    return !JdbcTestUtils.isDb2(rdbEngine);
   }
 }

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -742,6 +742,18 @@ public enum CoreError implements ScalarDbError {
       "The TIMESTAMP type is not supported in Cassandra. Column: %s",
       "",
       ""),
+  JDBC_DB2_INDEX_OR_KEY_ON_BLOB_COLUMN_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0228",
+      "With Db2, using a BLOB column as partition key, clustering key or secondary index is not supported.",
+      "",
+      ""),
+  JDBC_DB2_CROSS_PARTITION_SCAN_ORDERING_ON_BLOB_COLUMN_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0229",
+      "With Db2, setting an ordering on a BLOB column when using a cross partition scan operation is not supported. Ordering: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
@@ -159,7 +159,7 @@ public class OperationChecker {
       throw new IllegalArgumentException(
           CoreError.OPERATION_CHECK_ERROR_CROSS_PARTITION_SCAN_ORDERING.buildMessage(scanAll));
     }
-    checkOrderings(scanAll, metadata);
+    checkOrderingsForScanAll(scanAll, metadata);
 
     if (!config.isCrossPartitionScanFilteringEnabled() && !scanAll.getConjunctions().isEmpty()) {
       throw new IllegalArgumentException(
@@ -258,7 +258,7 @@ public class OperationChecker {
     }
   }
 
-  private void checkOrderings(ScanAll scanAll, TableMetadata metadata) {
+  protected void checkOrderingsForScanAll(ScanAll scanAll, TableMetadata metadata) {
     for (Scan.Ordering ordering : scanAll.getOrderings()) {
       if (!metadata.getColumnNames().contains(ordering.getColumnName())) {
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -59,8 +59,8 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     TableMetadataManager tableMetadataManager =
         new TableMetadataManager(jdbcAdmin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     OperationChecker operationChecker =
-        new OperationChecker(
-            databaseConfig, tableMetadataManager, new StorageInfoProvider(jdbcAdmin));
+        new JdbcOperationChecker(
+            databaseConfig, tableMetadataManager, new StorageInfoProvider(jdbcAdmin), rdbEngine);
 
     jdbcService =
         new JdbcService(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcOperationChecker.java
@@ -1,0 +1,29 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoProvider;
+import com.scalar.db.common.TableMetadataManager;
+import com.scalar.db.common.checker.OperationChecker;
+import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class JdbcOperationChecker extends OperationChecker {
+  private final RdbEngineStrategy rdbEngine;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public JdbcOperationChecker(
+      DatabaseConfig config,
+      TableMetadataManager tableMetadataManager,
+      StorageInfoProvider storageInfoProvider,
+      RdbEngineStrategy rdbEngine) {
+    super(config, tableMetadataManager, storageInfoProvider);
+    this.rdbEngine = rdbEngine;
+  }
+
+  @Override
+  protected void checkOrderingsForScanAll(ScanAll scanAll, TableMetadata metadata) {
+    super.checkOrderingsForScanAll(scanAll, metadata);
+    rdbEngine.throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(scanAll, metadata);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -6,6 +6,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.ibm.db2.jcc.DB2BaseDataSource;
 import com.scalar.db.api.LikeExpression;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -31,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -64,7 +67,7 @@ class RdbEngineDb2 extends AbstractRdbEngine {
       case BIGINT:
         return "BIGINT";
       case BLOB:
-        return "VARBINARY(32672)";
+        return "BLOB(2G)";
       case BOOLEAN:
         return "BOOLEAN";
       case FLOAT:
@@ -352,7 +355,8 @@ class RdbEngineDb2 extends AbstractRdbEngine {
       case TEXT:
         return "VARCHAR(" + keyColumnSize + ") NOT NULL";
       case BLOB:
-        return "VARBINARY(" + keyColumnSize + ") NOT NULL";
+        throw new UnsupportedOperationException(
+            CoreError.JDBC_DB2_INDEX_OR_KEY_ON_BLOB_COLUMN_NOT_SUPPORTED.buildMessage());
       default:
         return getDataTypeForEngine(dataType) + " NOT NULL";
     }
@@ -365,7 +369,8 @@ class RdbEngineDb2 extends AbstractRdbEngine {
       case TEXT:
         return "VARCHAR(" + keyColumnSize + ")";
       case BLOB:
-        return "VARBINARY(" + keyColumnSize + ")";
+        throw new UnsupportedOperationException(
+            CoreError.JDBC_DB2_INDEX_OR_KEY_ON_BLOB_COLUMN_NOT_SUPPORTED.buildMessage());
       default:
         return null;
     }
@@ -517,5 +522,20 @@ class RdbEngineDb2 extends AbstractRdbEngine {
       return "CHAR(" + enclose(columnName) + ") AS " + enclose(columnName);
     }
     return enclose(columnName);
+  }
+
+  @Override
+  public void throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+      ScanAll scanAll, TableMetadata metadata) {
+    Optional<Ordering> orderingOnBlobColumn =
+        scanAll.getOrderings().stream()
+            .filter(
+                ordering -> metadata.getColumnDataType(ordering.getColumnName()) == DataType.BLOB)
+            .findFirst();
+    if (orderingOnBlobColumn.isPresent()) {
+      throw new UnsupportedOperationException(
+          CoreError.JDBC_DB2_CROSS_PARTITION_SCAN_ORDERING_ON_BLOB_COLUMN_NOT_SUPPORTED
+              .buildMessage(orderingOnBlobColumn.get()));
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.LikeExpression;
+import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -283,4 +284,16 @@ public interface RdbEngineStrategy {
       throws SQLException {
     connection.setReadOnly(readOnly);
   }
+
+  /**
+   * Throws an exception if a cross-partition scan operation with ordering on a blob column is
+   * specified and is not supported in the underlying storage.
+   *
+   * @param scanAll the ScanAll operation
+   * @param metadata the table metadata
+   * @throws UnsupportedOperationException if the ScanAll operation contains an ordering on a blob
+   *     column, and it is not supported in the underlying storage
+   */
+  default void throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+      ScanAll scanAll, TableMetadata metadata) {}
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -443,8 +443,8 @@ public abstract class JdbcAdminTestBase {
             + "`indexed` BOOLEAN NOT NULL,"
             + "`ordinal_position` INTEGER NOT NULL,"
             + "PRIMARY KEY (`full_table_name`, `column_name`))",
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(128),`c4` VARBINARY(128),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c4`))",
-        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(128),`c5` INT,`c2` BIGINT,`c4` LONGBLOB,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c5`))",
+        "CREATE INDEX `index_my_ns_foo_table_c5` ON `my_ns`.`foo_table` (`c5`)",
         "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "INSERT INTO `"
             + tableMetadataSchemaName
@@ -454,13 +454,13 @@ public abstract class JdbcAdminTestBase {
             + "`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',true,2)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -487,8 +487,8 @@ public abstract class JdbcAdminTestBase {
             + "`indexed` BOOLEAN NOT NULL,"
             + "`ordinal_position` INTEGER NOT NULL,"
             + "PRIMARY KEY (`full_table_name`, `column_name`))",
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c4`))",
-        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c5` INT,`c2` BIGINT,`c4` LONGBLOB,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c5`))",
+        "CREATE INDEX `index_my_ns_foo_table_c5` ON `my_ns`.`foo_table` (`c5`)",
         "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "INSERT INTO `"
             + tableMetadataSchemaName
@@ -498,13 +498,13 @@ public abstract class JdbcAdminTestBase {
             + "`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',true,2)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -530,8 +530,8 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c5\" INT,\"c2\" BIGINT,\"c4\" BYTEA,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -541,13 +541,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',true,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -573,9 +573,8 @@ public abstract class JdbcAdminTestBase {
             + "[indexed] BIT NOT NULL,"
             + "[ordinal_position] INTEGER NOT NULL,"
             + "PRIMARY KEY ([full_table_name], [column_name]))",
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
-            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c4]))",
-        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),[c5] INT,[c2] BIGINT,[c4] VARBINARY(8000),[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c5]))",
+        "CREATE INDEX [index_my_ns_foo_table_c5] ON [my_ns].[foo_table] ([c5])",
         "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "INSERT INTO ["
             + tableMetadataSchemaName
@@ -585,13 +584,13 @@ public abstract class JdbcAdminTestBase {
             + "].[metadata] VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',1,2)",
         "INSERT INTO ["
             + tableMetadataSchemaName
-            + "].[metadata] VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+            + "].[metadata] VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',1,3)",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
         "INSERT INTO ["
             + tableMetadataSchemaName
-            + "].[metadata] VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+            + "].[metadata] VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,0,5)",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
@@ -610,9 +609,9 @@ public abstract class JdbcAdminTestBase {
         "CREATE TABLE \""
             + tableMetadataSchemaName
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c4\" RAW(128),\"c2\" NUMBER(16),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" RAW(2000),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -622,13 +621,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',1,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',1,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,0,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
@@ -648,9 +647,9 @@ public abstract class JdbcAdminTestBase {
         "CREATE TABLE \""
             + tableMetadataSchemaName
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(16),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" RAW(2000),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -660,13 +659,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',1,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',1,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,0,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
@@ -691,8 +690,8 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c5\" INT,\"c2\" BIGINT,\"c4\" BLOB,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c5\" ON \"my_ns$foo_table\" (\"c5\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -702,13 +701,13 @@ public abstract class JdbcAdminTestBase {
             + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',TRUE,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',TRUE,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,FALSE,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
@@ -734,8 +733,8 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c4\" VARBINARY(128) NOT NULL,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -745,13 +744,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',true,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -778,8 +777,8 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(64) NOT NULL,\"c4\" VARBINARY(64) NOT NULL,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(64) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -789,13 +788,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',true,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -821,7 +820,7 @@ public abstract class JdbcAdminTestBase {
         TableMetadata.newBuilder()
             .addPartitionKey("c3")
             .addClusteringKey("c1")
-            .addClusteringKey("c4")
+            .addClusteringKey("c5")
             .addColumn("c1", DataType.TEXT)
             .addColumn("c2", DataType.BIGINT)
             .addColumn("c3", DataType.BOOLEAN)
@@ -830,7 +829,7 @@ public abstract class JdbcAdminTestBase {
             .addColumn("c6", DataType.DOUBLE)
             .addColumn("c7", DataType.FLOAT)
             .addSecondaryIndex("c1")
-            .addSecondaryIndex("c4")
+            .addSecondaryIndex("c5")
             .build();
 
     List<Statement> mockedStatements = new ArrayList<>();
@@ -871,8 +870,8 @@ public abstract class JdbcAdminTestBase {
             + "`indexed` BOOLEAN NOT NULL,"
             + "`ordinal_position` INTEGER NOT NULL,"
             + "PRIMARY KEY (`full_table_name`, `column_name`))",
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(128),`c4` VARBINARY(128),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL,`c8` DATE,`c9` TIME(6),`c10` DATETIME(3),`c11` DATETIME(3), PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
-        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(128),`c5` INT,`c2` BIGINT,`c4` LONGBLOB,`c6` DOUBLE,`c7` REAL,`c8` DATE,`c9` TIME(6),`c10` DATETIME(3),`c11` DATETIME(3), PRIMARY KEY (`c3` ASC,`c1` DESC,`c5` ASC))",
+        "CREATE INDEX `index_my_ns_foo_table_c5` ON `my_ns`.`foo_table` (`c5`)",
         "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "INSERT INTO `"
             + tableMetadataSchemaName
@@ -882,13 +881,13 @@ public abstract class JdbcAdminTestBase {
             + "`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',true,2)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO `"
             + tableMetadataSchemaName
-            + "`.`metadata` VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -926,9 +925,9 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL,\"c8\" DATE,\"c9\" TIME,\"c10\" TIMESTAMP,\"c11\" TIMESTAMP WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c5\" INT,\"c2\" BIGINT,\"c4\" BYTEA,\"c6\" DOUBLE PRECISION,\"c7\" REAL,\"c8\" DATE,\"c9\" TIME,\"c10\" TIMESTAMP,\"c11\" TIMESTAMP WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE INDEX \"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -938,13 +937,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',true,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -982,9 +981,8 @@ public abstract class JdbcAdminTestBase {
             + "[indexed] BIT NOT NULL,"
             + "[ordinal_position] INTEGER NOT NULL,"
             + "PRIMARY KEY ([full_table_name], [column_name]))",
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
-            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24),[c8] DATE,[c9] TIME(6),[c10] DATETIME2(3),[c11] DATETIMEOFFSET(3), PRIMARY KEY ([c3] ASC,[c1] DESC,[c4] ASC))",
-        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),[c5] INT,[c2] BIGINT,[c4] VARBINARY(8000),[c6] FLOAT,[c7] FLOAT(24),[c8] DATE,[c9] TIME(6),[c10] DATETIME2(3),[c11] DATETIMEOFFSET(3), PRIMARY KEY ([c3] ASC,[c1] DESC,[c5] ASC))",
+        "CREATE INDEX [index_my_ns_foo_table_c5] ON [my_ns].[foo_table] ([c5])",
         "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "INSERT INTO ["
             + tableMetadataSchemaName
@@ -994,13 +992,13 @@ public abstract class JdbcAdminTestBase {
             + "].[metadata] VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',1,2)",
         "INSERT INTO ["
             + tableMetadataSchemaName
-            + "].[metadata] VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+            + "].[metadata] VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',1,3)",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
         "INSERT INTO ["
             + tableMetadataSchemaName
-            + "].[metadata] VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+            + "].[metadata] VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,0,5)",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
@@ -1031,10 +1029,10 @@ public abstract class JdbcAdminTestBase {
         "CREATE TABLE \""
             + tableMetadataSchemaName
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c4\" RAW(128),\"c2\" NUMBER(16),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" RAW(2000),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -1044,13 +1042,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',1,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',1,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,0,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
@@ -1087,8 +1085,8 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT,\"c8\" INT,\"c9\" BIGINT,\"c10\" BIGINT,\"c11\" BIGINT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c5\" INT,\"c2\" BIGINT,\"c4\" BLOB,\"c6\" DOUBLE,\"c7\" FLOAT,\"c8\" INT,\"c9\" BIGINT,\"c10\" BIGINT,\"c11\" BIGINT, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c5\" ON \"my_ns$foo_table\" (\"c5\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -1098,13 +1096,13 @@ public abstract class JdbcAdminTestBase {
             + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',TRUE,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',TRUE,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,FALSE,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
@@ -1142,9 +1140,9 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c4\" VARBINARY(128) NOT NULL,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" REAL,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3), PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
-        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3), PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
+        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
@@ -1154,13 +1152,13 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',true,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT','CLUSTERING','ASC',true,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+            + "\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB',NULL,NULL,false,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
@@ -1191,7 +1189,7 @@ public abstract class JdbcAdminTestBase {
         TableMetadata.newBuilder()
             .addPartitionKey("c3")
             .addClusteringKey("c1", Order.DESC)
-            .addClusteringKey("c4", Order.ASC)
+            .addClusteringKey("c5", Order.ASC)
             .addColumn("c1", DataType.TEXT)
             .addColumn("c2", DataType.BIGINT)
             .addColumn("c3", DataType.BOOLEAN)
@@ -1204,7 +1202,7 @@ public abstract class JdbcAdminTestBase {
             .addColumn("c10", DataType.TIMESTAMP)
             .addColumn("c11", DataType.TIMESTAMPTZ)
             .addSecondaryIndex("c1")
-            .addSecondaryIndex("c4")
+            .addSecondaryIndex("c5")
             .build();
 
     List<Statement> mockedStatements = new ArrayList<>();
@@ -3726,6 +3724,74 @@ public abstract class JdbcAdminTestBase {
     verify(getTableMetadataNamespacesStatementMock)
         .executeQuery(getTableMetadataNamespacesStatement);
     assertThat(actual).containsOnly(tableMetadataSchemaName);
+  }
+
+  @Test
+  void createTableInternal_Db2_WithBlobColumnAsKeyOrIndex_ShouldThrowUnsupportedOperationException()
+      throws SQLException {
+    // Arrange
+    TableMetadata metadata1 =
+        TableMetadata.newBuilder().addPartitionKey("pk").addColumn("pk", DataType.BLOB).build();
+    TableMetadata metadata2 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck")
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck", DataType.BLOB)
+            .build();
+    TableMetadata metadata3 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addColumn("pk", DataType.INT)
+            .addColumn("col", DataType.BLOB)
+            .addSecondaryIndex("col")
+            .build();
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.DB2);
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.createTable("ns", "tbl", metadata1, false))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContainingAll("BLOB", "key");
+    assertThatThrownBy(() -> admin.createTable("ns", "tbl", metadata2, false))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContainingAll("BLOB", "key");
+    assertThatThrownBy(() -> admin.createTable("ns", "tbl", metadata3, false))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContainingAll("BLOB", "index");
+  }
+
+  @Test
+  void createIndex_Db2_WithBlobColumnAsKeyOrIndex_ShouldThrowUnsupportedOperationException()
+      throws SQLException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "my_tbl";
+    String indexColumn = "index_col";
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.DB2);
+
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            Arrays.asList(
+                new GetColumnsResultSetMocker.Row(
+                    "pk", DataType.BOOLEAN.toString(), "PARTITION", null, false),
+                new GetColumnsResultSetMocker.Row(
+                    indexColumn, DataType.BLOB.toString(), null, null, false)));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
+    Statement statement = mock(Statement.class);
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> admin.createIndex(namespace, table, indexColumn, Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContainingAll("BLOB", "index");
   }
 
   private PreparedStatement prepareStatementForNamespaceCheck() throws SQLException {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcOperationCheckerTest.java
@@ -1,0 +1,65 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoProvider;
+import com.scalar.db.common.TableMetadataManager;
+import com.scalar.db.config.DatabaseConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class JdbcOperationCheckerTest {
+
+  @Mock private DatabaseConfig databaseConfig;
+  @Mock private TableMetadataManager tableMetadataManager;
+  @Mock private StorageInfoProvider storageInfoProvider;
+  @Mock private RdbEngineStrategy rdbEngine;
+  @Mock private ScanAll scanAll;
+  @Mock private TableMetadata tableMetadata;
+  private JdbcOperationChecker operationChecker;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    operationChecker =
+        new JdbcOperationChecker(
+            databaseConfig, tableMetadataManager, storageInfoProvider, rdbEngine);
+  }
+
+  @Test
+  public void checkOrderingsForScanAll_ShouldInvokeAdditionalCheckOnRdbEngine() {
+    // Arrange
+    // Act
+    operationChecker.checkOrderingsForScanAll(scanAll, tableMetadata);
+
+    // Assert
+    verify(rdbEngine)
+        .throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(scanAll, tableMetadata);
+  }
+
+  @Test
+  public void checkOrderingsForScanAll_WhenAdditionalCheckThrows_ShouldPropagateException() {
+    // Arrange
+    Exception exception = new RuntimeException();
+    doThrow(exception)
+        .when(rdbEngine)
+        .throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(any(), any());
+
+    // Act
+    Assertions.assertThatThrownBy(
+            () -> operationChecker.checkOrderingsForScanAll(scanAll, tableMetadata))
+        .isEqualTo(exception);
+
+    // Assert
+    verify(rdbEngine)
+        .throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(scanAll, tableMetadata);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineDb2Test.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineDb2Test.java
@@ -1,0 +1,102 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RdbEngineDb2Test {
+
+  @Mock private ScanAll scanAll;
+  @Mock private TableMetadata metadata;
+
+  private RdbEngineDb2 rdbEngineDb2;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    rdbEngineDb2 = new RdbEngineDb2();
+  }
+
+  @Test
+  public void
+      throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported_WithBlobOrdering_ShouldThrowException() {
+    // Arrange
+    Scan.Ordering blobOrdering = Scan.Ordering.asc("blob_column");
+    Scan.Ordering intOrdering = Scan.Ordering.desc("int_column");
+
+    when(scanAll.getOrderings()).thenReturn(Arrays.asList(intOrdering, blobOrdering));
+    when(metadata.getColumnDataType("blob_column")).thenReturn(DataType.BLOB);
+    when(metadata.getColumnDataType("int_column")).thenReturn(DataType.INT);
+
+    // Act & Assert
+    assertThatThrownBy(
+            () ->
+                rdbEngineDb2.throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+                    scanAll, metadata))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("blob_column");
+  }
+
+  @Test
+  public void
+      throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported_WithoutBlobOrdering_ShouldNotThrowException() {
+    // Arrange
+    Scan.Ordering intOrdering = Scan.Ordering.asc("int_column");
+    Scan.Ordering textOrdering = Scan.Ordering.desc("text_column");
+
+    when(scanAll.getOrderings()).thenReturn(Arrays.asList(intOrdering, textOrdering));
+    when(metadata.getColumnDataType("int_column")).thenReturn(DataType.INT);
+    when(metadata.getColumnDataType("text_column")).thenReturn(DataType.TEXT);
+
+    // Act & Assert
+    assertThatCode(
+            () ->
+                rdbEngineDb2.throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+                    scanAll, metadata))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported_WithNoOrderings_ShouldNotThrowException() {
+    // Arrange
+    when(scanAll.getOrderings()).thenReturn(Arrays.asList());
+
+    // Act & Assert
+    assertThatCode(
+            () ->
+                rdbEngineDb2.throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+                    scanAll, metadata))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported_WithMultipleBlobOrderings_ShouldThrowForFirst() {
+    // Arrange
+    Scan.Ordering blobOrdering1 = Scan.Ordering.asc("blob_column1");
+    Scan.Ordering blobOrdering2 = Scan.Ordering.desc("blob_column2");
+
+    when(scanAll.getOrderings()).thenReturn(Arrays.asList(blobOrdering1, blobOrdering2));
+    when(metadata.getColumnDataType("blob_column1")).thenReturn(DataType.BLOB);
+    when(metadata.getColumnDataType("blob_column2")).thenReturn(DataType.BLOB);
+
+    // Act & Assert
+    assertThatThrownBy(
+            () ->
+                rdbEngineDb2.throwIfCrossPartitionScanOrderingOnBlobColumnNotSupported(
+                    scanAll, metadata))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("blob_column1");
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -643,11 +643,17 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
 
       // Act
       admin.createIndex(namespace1, getTable4(), getColumnName2(), options);
+      if (isCreateIndexOnTextColumnEnabled()) {
+        admin.createIndex(namespace1, getTable4(), getColumnName3(), options);
+      }
       admin.createIndex(namespace1, getTable4(), getColumnName4(), options);
       admin.createIndex(namespace1, getTable4(), getColumnName5(), options);
       admin.createIndex(namespace1, getTable4(), getColumnName6(), options);
       if (isIndexOnBooleanColumnSupported()) {
         admin.createIndex(namespace1, getTable4(), getColumnName7(), options);
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        admin.createIndex(namespace1, getTable4(), getColumnName8(), options);
       }
       admin.createIndex(namespace1, getTable4(), getColumnName10(), options);
       admin.createIndex(namespace1, getTable4(), getColumnName11(), options);
@@ -655,18 +661,20 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       if (isTimestampTypeSupported()) {
         admin.createIndex(namespace1, getTable4(), getColumnName13(), options);
       }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        admin.createIndex(namespace1, getTable4(), getColumnName3(), options);
-        admin.createIndex(namespace1, getTable4(), getColumnName8(), options);
-      }
 
       // Assert
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName2())).isTrue();
+      if (isCreateIndexOnTextColumnEnabled()) {
+        assertThat(admin.indexExists(namespace1, getTable4(), getColumnName3())).isTrue();
+      }
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName4())).isTrue();
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName5())).isTrue();
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName6())).isTrue();
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(admin.indexExists(namespace1, getTable4(), getColumnName7())).isTrue();
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, getTable4(), getColumnName8())).isTrue();
       }
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName9())).isTrue();
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName10())).isTrue();
@@ -674,10 +682,6 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName12())).isTrue();
       if (isTimestampTypeSupported()) {
         assertThat(admin.indexExists(namespace1, getTable4(), getColumnName13())).isTrue();
-      }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        assertThat(admin.indexExists(namespace1, getTable4(), getColumnName3())).isTrue();
-        assertThat(admin.indexExists(namespace1, getTable4(), getColumnName8())).isTrue();
       }
 
       Set<String> actualSecondaryIndexNames =
@@ -700,9 +704,13 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
         assertThat(actualSecondaryIndexNames).contains(getColumnName13());
         indexCount++;
       }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        assertThat(actualSecondaryIndexNames).contains(getColumnName3(), getColumnName8());
-        indexCount += 2;
+      if (isCreateIndexOnTextColumnEnabled()) {
+        assertThat(actualSecondaryIndexNames).contains(getColumnName3());
+        indexCount++;
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        assertThat(actualSecondaryIndexNames).contains(getColumnName8());
+        indexCount++;
       }
       assertThat(actualSecondaryIndexNames).hasSize(indexCount);
 
@@ -817,7 +825,6 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
               .addSecondaryIndex(getColumnName4())
               .addSecondaryIndex(getColumnName5())
               .addSecondaryIndex(getColumnName6())
-              .addSecondaryIndex(getColumnName8())
               .addSecondaryIndex(getColumnName9())
               .addSecondaryIndex(getColumnName10())
               .addSecondaryIndex(getColumnName11())
@@ -828,6 +835,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       if (isTimestampTypeSupported()) {
         metadataBuilder.addColumn(getColumnName13(), DataType.TIMESTAMP);
         metadataBuilder.addSecondaryIndex(getColumnName13());
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        metadataBuilder.addSecondaryIndex(getColumnName8());
       }
       admin.createTable(namespace1, getTable4(), metadataBuilder.build(), options);
       storage = storageFactory.getStorage();
@@ -866,7 +876,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       if (isIndexOnBooleanColumnSupported()) {
         admin.dropIndex(namespace1, getTable4(), getColumnName7());
       }
-      admin.dropIndex(namespace1, getTable4(), getColumnName8());
+      if (isIndexOnBlobColumnSupported()) {
+        admin.dropIndex(namespace1, getTable4(), getColumnName8());
+      }
       admin.dropIndex(namespace1, getTable4(), getColumnName10());
       admin.dropIndex(namespace1, getTable4(), getColumnName11());
       admin.dropIndex(namespace1, getTable4(), getColumnName12());
@@ -1289,11 +1301,15 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     return true;
   }
 
+  protected boolean isIndexOnBlobColumnSupported() {
+    return true;
+  }
+
   protected boolean isTimestampTypeSupported() {
     return true;
   }
 
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
+  protected boolean isCreateIndexOnTextColumnEnabled() {
     return true;
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
@@ -924,7 +924,13 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
 
     List<Callable<Void>> testCallables = new ArrayList<>();
     for (DataType firstColumnType : columnTypes.keySet()) {
+      if (firstColumnType == DataType.BLOB && !isOrderingOnBlobColumnSupported()) {
+        continue;
+      }
       for (DataType secondColumnType : columnTypes.get(firstColumnType)) {
+        if (secondColumnType == DataType.BLOB && !isOrderingOnBlobColumnSupported()) {
+          continue;
+        }
         testCallables.add(
             () -> {
               random.get().setSeed(seed);
@@ -1250,6 +1256,10 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
   }
 
   protected boolean isTimestampTypeSupported() {
+    return true;
+  }
+
+  protected boolean isOrderingOnBlobColumnSupported() {
     return true;
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -563,11 +563,17 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
 
       // Act
       admin.createIndex(namespace1, TABLE4, COL_NAME2, options);
+      if (isCreateIndexOnTextColumnEnabled()) {
+        admin.createIndex(namespace1, TABLE4, COL_NAME3, options);
+      }
       admin.createIndex(namespace1, TABLE4, COL_NAME4, options);
       admin.createIndex(namespace1, TABLE4, COL_NAME5, options);
       admin.createIndex(namespace1, TABLE4, COL_NAME6, options);
       if (isIndexOnBooleanColumnSupported()) {
         admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        admin.createIndex(namespace1, TABLE4, COL_NAME8, options);
       }
       admin.createIndex(namespace1, TABLE4, COL_NAME10, options);
       admin.createIndex(namespace1, TABLE4, COL_NAME11, options);
@@ -575,18 +581,20 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       if (isTimestampTypeSupported()) {
         admin.createIndex(namespace1, TABLE4, COL_NAME13, options);
       }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        admin.createIndex(namespace1, TABLE4, COL_NAME3, options);
-        admin.createIndex(namespace1, TABLE4, COL_NAME8, options);
-      }
 
       // Assert
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME2)).isTrue();
+      if (isCreateIndexOnTextColumnEnabled()) {
+        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isTrue();
+      }
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME4)).isTrue();
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME5)).isTrue();
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isTrue();
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isTrue();
       }
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME9)).isTrue();
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME10)).isTrue();
@@ -594,10 +602,6 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME12)).isTrue();
       if (isTimestampTypeSupported()) {
         assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME13)).isTrue();
-      }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isTrue();
-        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isTrue();
       }
 
       Set<String> actualSecondaryIndexNames =
@@ -613,9 +617,13 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
         assertThat(actualSecondaryIndexNames).contains(COL_NAME13);
         indexCount++;
       }
-      if (isCreateIndexOnTextAndBlobColumnsEnabled()) {
-        assertThat(actualSecondaryIndexNames).contains(COL_NAME3, COL_NAME8);
-        indexCount += 2;
+      if (isCreateIndexOnTextColumnEnabled()) {
+        assertThat(actualSecondaryIndexNames).contains(COL_NAME3);
+        indexCount += 1;
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        assertThat(actualSecondaryIndexNames).contains(COL_NAME8);
+        indexCount += 1;
       }
       assertThat(actualSecondaryIndexNames).hasSize(indexCount);
 
@@ -722,7 +730,6 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
               .addSecondaryIndex(COL_NAME4)
               .addSecondaryIndex(COL_NAME5)
               .addSecondaryIndex(COL_NAME6)
-              .addSecondaryIndex(COL_NAME8)
               .addSecondaryIndex(COL_NAME9)
               .addSecondaryIndex(COL_NAME9)
               .addSecondaryIndex(COL_NAME10)
@@ -730,6 +737,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
               .addSecondaryIndex(COL_NAME12);
       if (isIndexOnBooleanColumnSupported()) {
         metadataBuilder = metadataBuilder.addSecondaryIndex(COL_NAME7);
+      }
+      if (isIndexOnBlobColumnSupported()) {
+        metadataBuilder = metadataBuilder.addSecondaryIndex(COL_NAME8);
       }
       if (isTimestampTypeSupported()) {
         metadataBuilder.addColumn(COL_NAME13, DataType.TIMESTAMP);
@@ -771,7 +781,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       if (isIndexOnBooleanColumnSupported()) {
         admin.dropIndex(namespace1, TABLE4, COL_NAME7);
       }
-      admin.dropIndex(namespace1, TABLE4, COL_NAME8);
+      if (isIndexOnBlobColumnSupported()) {
+        admin.dropIndex(namespace1, TABLE4, COL_NAME8);
+      }
       admin.dropIndex(namespace1, TABLE4, COL_NAME10);
       admin.dropIndex(namespace1, TABLE4, COL_NAME11);
       admin.dropIndex(namespace1, TABLE4, COL_NAME12);
@@ -1277,11 +1289,15 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     return true;
   }
 
+  protected boolean isIndexOnBlobColumnSupported() {
+    return true;
+  }
+
   protected boolean isTimestampTypeSupported() {
     return true;
   }
 
-  protected boolean isCreateIndexOnTextAndBlobColumnsEnabled() {
+  protected boolean isCreateIndexOnTextColumnEnabled() {
     return true;
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3000
- **Commit to backport:** f1765d6aa7707205efe3d5082d9cd623c47ebe82

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3000 &&
git cherry-pick --no-rerere-autoupdate -m1 f1765d6aa7707205efe3d5082d9cd623c47ebe82
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!