### PR TITLE
Set --log-raw-record default to true for all failure logs

### DIFF
--- a/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
+++ b/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
@@ -94,7 +94,7 @@ public class ExportCommandOptions {
   protected Integer maxThreads;
 
   /**
-   * @deprecated As of release 3.6.2. Will be removed in release 4.0.0. Use --max-threads instead
+   * @deprecated As of release 3.17.0. Will be removed in release 4.0.0. Use --max-threads instead
    */
   @Deprecated
   @CommandLine.Option(
@@ -118,7 +118,10 @@ public class ExportCommandOptions {
   // TODO: test that -si false, works
   protected boolean scanStartInclusive;
 
-  // Deprecated option - kept for backward compatibility
+  /**
+   * @deprecated As of release 3.17.0. Will be removed in release 4.0.0. Use --start-inclusive
+   *     instead (inverted logic).
+   */
   @CommandLine.Option(
       names = {DEPRECATED_START_EXCLUSIVE_OPTION},
       description = "Deprecated: Use --start-inclusive instead (inverted logic)",
@@ -139,7 +142,10 @@ public class ExportCommandOptions {
       defaultValue = "true")
   protected boolean scanEndInclusive;
 
-  // Deprecated option - kept for backward compatibility
+  /**
+   * @deprecated As of release 3.17.0. Will be removed in release 4.0.0. Use --end-inclusive instead
+   *     (inverted logic).
+   */
   @CommandLine.Option(
       names = {DEPRECATED_END_EXCLUSIVE_OPTION},
       description = "Deprecated: Use --end-inclusive instead (inverted logic)",

--- a/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataimport/ImportCommandOptions.java
+++ b/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataimport/ImportCommandOptions.java
@@ -46,7 +46,7 @@ public class ImportCommandOptions {
   protected Integer maxThreads;
 
   /**
-   * @deprecated As of release 3.6.2. Will be removed in release 4.0.0. Use --max-threads instead
+   * @deprecated As of release 3.17.0. Will be removed in release 4.0.0. Use --max-threads instead
    */
   @Deprecated
   @CommandLine.Option(
@@ -75,7 +75,7 @@ public class ImportCommandOptions {
   protected String controlFilePath;
 
   /**
-   * @deprecated As of release 3.6.2. Will be removed in release 4.0.0. Use --enable-log-success
+   * @deprecated As of release 3.17.0. Will be removed in release 4.0.0. Use --enable-log-success
    *     instead
    */
   @Deprecated
@@ -125,8 +125,8 @@ public class ImportCommandOptions {
 
   @CommandLine.Option(
       names = {"--log-raw-record", "-lr"},
-      description = "Include the original source record in the log file output (default: false)",
-      defaultValue = "false")
+      description = "Include the original source record in the log file output (default: true)",
+      defaultValue = "true")
   protected boolean logRawRecord;
 
   @CommandLine.Option(

--- a/data-loader/cli/src/test/java/com/scalar/db/dataloader/cli/command/dataimport/ImportCommandTest.java
+++ b/data-loader/cli/src/test/java/com/scalar/db/dataloader/cli/command/dataimport/ImportCommandTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.dataloader.cli.command.dataimport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -278,5 +279,52 @@ public class ImportCommandTest {
 
     // Verify it was set to available processors
     assertEquals(Runtime.getRuntime().availableProcessors(), command.maxThreads);
+  }
+
+  @Test
+  void call_withoutSpecifyingLogRawRecord_shouldUseDefaultTrueValue() {
+    // Simulate command line parsing with --max-threads
+    String[] args = {
+      "--config",
+      "scalardb.properties",
+      "--file",
+      "import.json",
+      "--namespace",
+      "scalar",
+      "--table",
+      "asset",
+      "--max-threads",
+      "8"
+    };
+    ImportCommand command = new ImportCommand();
+    CommandLine cmd = new CommandLine(command);
+    cmd.parseArgs(args);
+
+    // Verify the value was parsed
+    assertTrue(command.logRawRecord);
+  }
+
+  @Test
+  void call_withSpecifyingLogRawRecordFalse_shouldUseFalsee() {
+    // Simulate command line parsing with --max-threads
+    String[] args = {
+      "--config",
+      "scalardb.properties",
+      "--file",
+      "import.json",
+      "--namespace",
+      "scalar",
+      "--table",
+      "asset",
+      "--max-threads",
+      "8",
+      "--log-raw-record=false"
+    };
+    ImportCommand command = new ImportCommand();
+    CommandLine cmd = new CommandLine(command);
+    cmd.parseArgs(args);
+
+    // Verify the value was parsed
+    assertFalse(command.logRawRecord);
   }
 }

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportOptions.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportOptions.java
@@ -27,7 +27,7 @@ public class ImportOptions {
   @Builder.Default private final char delimiter = ',';
 
   @Builder.Default private final boolean logSuccessRecords = false;
-  @Builder.Default private final boolean logRawRecord = false;
+  @Builder.Default private final boolean logRawRecord = true;
 
   private final int dataChunkSize;
   private final int transactionBatchSize;

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/AbstractImportLogger.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/AbstractImportLogger.java
@@ -75,6 +75,10 @@ public abstract class AbstractImportLogger implements ImportEventListener {
     if (shouldSkipLoggingSuccess(batchResult)) {
       return;
     }
+    // Skip logging records if log raw records is not enabled and execution is not success
+    if (!batchResult.isSuccess() && !config.isLogRawSourceRecordsEnabled()) {
+      return;
+    }
 
     logTransactionBatch(batchResult);
     notifyTransactionBatchCompleted(batchResult);


### PR DESCRIPTION
## Description

This PR updates the default value of `--log-raw-record` to true by default so that raw records are logged in failure log unless the user specifies otherwise.

It was set to false by default but that is not really the expected behavior users want.  The feature will not be deprecated though so the users have the option to still disable it.

This PR also fixes a few comments that mention the wrong target version for deprecation.

## Related issues and/or PRs

NA

## Changes made

* Updated default value for `--log-raw-record` to true
* Added a conditional check to log transaction batch to avoid logging raw records if the paramter ``-log-raw-record` is set to false as it was logged always irrespective of flag value set (bug fix)
* Updated comments for deprecated paramaters
  * Updated deprecated version to 3.17.0 
  * Updated comments to specify the deprecation version and removal version 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA

## Release notes

Update default value for `--log-raw-record` to true
