### PR TITLE
Fix to use default credential providers

### DIFF
--- a/.github/workflows/object-storage-adapter-check.yaml
+++ b/.github/workflows/object-storage-adapter-check.yaml
@@ -91,6 +91,7 @@ jobs:
         run: |
           container_id=$(docker create "container-registry.oracle.com/java/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}")
           docker cp -L "$container_id:/usr/java/default" /usr/lib/jvm/oracle-jdk && docker rm "$container_id"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
@@ -145,11 +146,17 @@ jobs:
         run: |
           container_id=$(docker create "container-registry.oracle.com/java/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}")
           docker cp -L "$container_id:/usr/java/default" /usr/lib/jvm/oracle-jdk && docker rm "$container_id"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Prepare Google Cloud Credentials
+        run: |
+          echo '${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}' > $HOME/gcloud_service_account.json
+          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud_service_account.json
+
       - name: Execute Gradle 'integrationTestObjectStorage' task
-        run: ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.storage=cloud-storage -Dscalardb.object_storage.endpoint=scalardb-test-bucket -Dscalardb.object_storage.username=${{ env.CLOUD_STORAGE_PROJECT_ID }} -Dscalardb.object_storage.password=${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }} ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+        run: ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.storage=cloud-storage -Dscalardb.object_storage.endpoint=scalardb-test-bucket -Dscalardb.object_storage.username=${{ env.CLOUD_STORAGE_PROJECT_ID }} ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
 
       - name: Upload Gradle test reports
         if: always()

--- a/.github/workflows/object-storage-adapter-check.yaml
+++ b/.github/workflows/object-storage-adapter-check.yaml
@@ -152,10 +152,11 @@ jobs:
 
       - name: Prepare Google Cloud Credentials
         run: |
-          echo '${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}' > $HOME/gcloud_service_account.json
-          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud_service_account.json
+          echo '${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}' > ${{ runner.temp }}/gcloud_service_account.json
 
       - name: Execute Gradle 'integrationTestObjectStorage' task
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/gcloud_service_account.json
         run: ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.storage=cloud-storage -Dscalardb.object_storage.endpoint=scalardb-test-bucket -Dscalardb.object_storage.username=${{ env.CLOUD_STORAGE_PROJECT_ID }} ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
 
       - name: Upload Gradle test reports

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -931,18 +931,6 @@ public enum CoreError implements ScalarDbError {
       "Conditions on indexed columns in cross-partition scan operations are not allowed in the SERIALIZABLE isolation level",
       "",
       ""),
-  OBJECT_STORAGE_CLOUD_STORAGE_SERVICE_ACCOUNT_KEY_NOT_FOUND(
-      Category.USER_ERROR,
-      "0263",
-      "The service account key for Cloud Storage was not found.",
-      "",
-      ""),
-  OBJECT_STORAGE_CLOUD_STORAGE_SERVICE_ACCOUNT_KEY_LOAD_FAILED(
-      Category.USER_ERROR,
-      "0264",
-      "Failed to load the service account key for Cloud Storage.",
-      "",
-      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/ObjectStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/ObjectStorageConfig.java
@@ -10,13 +10,6 @@ public interface ObjectStorageConfig {
   String getStorageName();
 
   /**
-   * Returns the password for authentication.
-   *
-   * @return the password
-   */
-  String getPassword();
-
-  /**
    * Returns the bucket name.
    *
    * @return the bucket name

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/blobstorage/BlobStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/blobstorage/BlobStorageConfig.java
@@ -79,11 +79,6 @@ public class BlobStorageConfig implements ObjectStorageConfig {
   }
 
   @Override
-  public String getPassword() {
-    return password;
-  }
-
-  @Override
   public String getBucket() {
     return bucket;
   }
@@ -99,6 +94,10 @@ public class BlobStorageConfig implements ObjectStorageConfig {
 
   public String getUsername() {
     return username;
+  }
+
+  public String getPassword() {
+    return password;
   }
 
   public Optional<Long> getParallelUploadBlockSizeInBytes() {

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageConfig.java
@@ -2,14 +2,8 @@ package com.scalar.db.storage.objectstorage.cloudstorage;
 
 import static com.scalar.db.config.ConfigUtils.getInt;
 
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.objectstorage.ObjectStorageConfig;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +16,6 @@ public class CloudStorageConfig implements ObjectStorageConfig {
       PREFIX + "parallel_upload_block_size_in_bytes";
 
   private static final Logger logger = LoggerFactory.getLogger(CloudStorageConfig.class);
-  private final String password;
   private final String bucket;
   private final String metadataNamespace;
   private final String projectId;
@@ -39,7 +32,6 @@ public class CloudStorageConfig implements ObjectStorageConfig {
     }
     bucket = databaseConfig.getContactPoints().get(0);
     projectId = databaseConfig.getUsername().orElse(null);
-    password = databaseConfig.getPassword().orElse(null);
     metadataNamespace = databaseConfig.getSystemNamespaceName();
 
     if (databaseConfig.getScanFetchSize() != DatabaseConfig.DEFAULT_SCAN_FETCH_SIZE) {
@@ -59,11 +51,6 @@ public class CloudStorageConfig implements ObjectStorageConfig {
   }
 
   @Override
-  public String getPassword() {
-    return password;
-  }
-
-  @Override
   public String getBucket() {
     return bucket;
   }
@@ -75,21 +62,6 @@ public class CloudStorageConfig implements ObjectStorageConfig {
 
   public String getProjectId() {
     return projectId;
-  }
-
-  public Credentials getCredentials() {
-    String serviceAccountJson = getPassword();
-    if (serviceAccountJson == null) {
-      throw new IllegalArgumentException(
-          CoreError.OBJECT_STORAGE_CLOUD_STORAGE_SERVICE_ACCOUNT_KEY_NOT_FOUND.buildMessage());
-    }
-    try (ByteArrayInputStream keyStream =
-        new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8))) {
-      return ServiceAccountCredentials.fromStream(keyStream);
-    } catch (IOException e) {
-      throw new IllegalArgumentException(
-          CoreError.OBJECT_STORAGE_CLOUD_STORAGE_SERVICE_ACCOUNT_KEY_LOAD_FAILED.buildMessage());
-    }
   }
 
   public Optional<Integer> getParallelUploadBlockSizeInBytes() {

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapper.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapper.java
@@ -34,12 +34,7 @@ public class CloudStorageWrapper implements ObjectStorageWrapper {
   private final Integer parallelUploadBlockSizeInBytes;
 
   public CloudStorageWrapper(CloudStorageConfig config) {
-    storage =
-        StorageOptions.newBuilder()
-            .setProjectId(config.getProjectId())
-            .setCredentials(config.getCredentials())
-            .build()
-            .getService();
+    storage = StorageOptions.newBuilder().setProjectId(config.getProjectId()).build().getService();
     bucket = config.getBucket();
     parallelUploadBlockSizeInBytes = config.getParallelUploadBlockSizeInBytes().orElse(null);
   }

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/s3/S3Config.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/s3/S3Config.java
@@ -25,8 +25,6 @@ public class S3Config implements ObjectStorageConfig {
   public static final String REQUEST_TIMEOUT_IN_SECONDS = PREFIX + "request_timeout_in_seconds";
 
   private static final Logger logger = LoggerFactory.getLogger(S3Config.class);
-  private final String username;
-  private final String password;
   private final String bucket;
   private final String metadataNamespace;
   private final String region;
@@ -56,8 +54,6 @@ public class S3Config implements ObjectStorageConfig {
       throw new IllegalArgumentException(
           "Invalid contact points format. Expected: S3_REGION/BUCKET_NAME");
     }
-    username = databaseConfig.getUsername().orElse(null);
-    password = databaseConfig.getPassword().orElse(null);
     metadataNamespace = databaseConfig.getSystemNamespaceName();
 
     if (databaseConfig.getScanFetchSize() != DatabaseConfig.DEFAULT_SCAN_FETCH_SIZE) {
@@ -83,11 +79,6 @@ public class S3Config implements ObjectStorageConfig {
   }
 
   @Override
-  public String getPassword() {
-    return password;
-  }
-
-  @Override
   public String getBucket() {
     return bucket;
   }
@@ -99,10 +90,6 @@ public class S3Config implements ObjectStorageConfig {
 
   public String getRegion() {
     return region;
-  }
-
-  public String getUsername() {
-    return username;
   }
 
   public Optional<Long> getParallelUploadBlockSizeInBytes() {

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/s3/S3Wrapper.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/s3/S3Wrapper.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -61,9 +59,6 @@ public class S3Wrapper implements ObjectStorageWrapper {
     this.client =
         S3AsyncClient.builder()
             .region(Region.of(config.getRegion()))
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(config.getUsername(), config.getPassword())))
             .httpClientBuilder(httpClientBuilder)
             .multipartConfiguration(multipartConfigBuilder.build())
             .overrideConfiguration(overrideConfigBuilder.build())

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageConfigTest.java
@@ -35,7 +35,6 @@ public class CloudStorageConfigTest {
     // Assert
     assertThat(config.getProjectId()).isEqualTo(ANY_PROJECT_ID);
     assertThat(config.getBucket()).isEqualTo(ANY_BUCKET);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getMetadataNamespace()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
     assertThat(config.getParallelUploadBlockSizeInBytes()).isNotEmpty();
     assertThat(config.getParallelUploadBlockSizeInBytes().get()).isEqualTo(5242880);
@@ -56,7 +55,6 @@ public class CloudStorageConfigTest {
     // Assert
     assertThat(config.getProjectId()).isEqualTo(ANY_PROJECT_ID);
     assertThat(config.getBucket()).isEqualTo(ANY_BUCKET);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getMetadataNamespace())
         .isEqualTo(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     assertThat(config.getParallelUploadBlockSizeInBytes()).isEmpty();

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/s3/S3ConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/s3/S3ConfigTest.java
@@ -43,8 +43,6 @@ public class S3ConfigTest {
     // Assert
     assertThat(config.getRegion()).isEqualTo(ANY_REGION);
     assertThat(config.getBucket()).isEqualTo(ANY_BUCKET);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getMetadataNamespace()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
     assertThat(config.getParallelUploadBlockSizeInBytes()).isNotEmpty();
     assertThat(config.getParallelUploadBlockSizeInBytes().get()).isEqualTo(5242880);
@@ -71,8 +69,6 @@ public class S3ConfigTest {
     // Assert
     assertThat(config.getRegion()).isEqualTo(ANY_REGION);
     assertThat(config.getBucket()).isEqualTo(ANY_BUCKET);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getMetadataNamespace())
         .isEqualTo(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     assertThat(config.getParallelUploadBlockSizeInBytes()).isEmpty();


### PR DESCRIPTION
## Description

This PR updates the Object Storage adapter to use default credentials providers, which are more secure.

## Related issues and/or PRs
 
- #3141 
- #3179 

## Changes made

- Updated S3Wrapper to use [Default credentials provider](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html).
- Updated CloudStorageWrapper to use [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/provide-credentials-adc).
- Updated the workflow.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A