### PR TITLE
Add configuration option to enable/disable active transaction management

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/api/AbstractDistributedTransactionProvider.java
@@ -1,0 +1,52 @@
+package com.scalar.db.api;
+
+import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
+import com.scalar.db.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
+import com.scalar.db.common.StateManagedDistributedTransactionManager;
+import com.scalar.db.config.DatabaseConfig;
+import javax.annotation.Nullable;
+
+public abstract class AbstractDistributedTransactionProvider
+    implements DistributedTransactionProvider {
+
+  @Override
+  public DistributedTransactionManager createDistributedTransactionManager(DatabaseConfig config) {
+    DistributedTransactionManager transactionManager =
+        new StateManagedDistributedTransactionManager(
+            createRawDistributedTransactionManager(config));
+
+    if (config.isActiveTransactionManagementEnabled()) {
+      transactionManager =
+          new ActiveTransactionManagedDistributedTransactionManager(
+              transactionManager, config.getActiveTransactionManagementExpirationTimeMillis());
+    }
+
+    return transactionManager;
+  }
+
+  protected abstract DistributedTransactionManager createRawDistributedTransactionManager(
+      DatabaseConfig config);
+
+  @Nullable
+  @Override
+  public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
+      DatabaseConfig config) {
+    TwoPhaseCommitTransactionManager transactionManager =
+        createRawTwoPhaseCommitTransactionManager(config);
+
+    if (transactionManager == null) {
+      return null;
+    }
+
+    if (config.isActiveTransactionManagementEnabled()) {
+      transactionManager =
+          new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+              transactionManager, config.getActiveTransactionManagementExpirationTimeMillis());
+    }
+
+    return transactionManager;
+  }
+
+  protected abstract TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
+      DatabaseConfig config);
+}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -20,14 +20,9 @@ import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.util.ActiveExpiringMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,53 +31,24 @@ import org.slf4j.LoggerFactory;
 public class ActiveTransactionManagedDistributedTransactionManager
     extends DecoratedDistributedTransactionManager {
 
-  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
-
   private static final Logger logger =
       LoggerFactory.getLogger(ActiveTransactionManagedDistributedTransactionManager.class);
 
-  private final ActiveExpiringMap<String, ActiveTransaction> activeTransactions;
+  private final ActiveTransactionRegistry<DistributedTransaction> registry;
 
-  private final AtomicReference<BiConsumer<String, DistributedTransaction>>
-      transactionExpirationHandler =
-          new AtomicReference<>(
-              (id, t) -> {
-                try {
-                  t.rollback();
-                } catch (Exception e) {
-                  logger.warn("Rollback failed. Transaction ID: {}", id, e);
-                }
-              });
+  public ActiveTransactionManagedDistributedTransactionManager(
+      DistributedTransactionManager transactionManager, long expirationTimeMillis) {
+    super(transactionManager);
+    registry =
+        new ActiveTransactionRegistry<>(expirationTimeMillis, DistributedTransaction::rollback);
+  }
 
   public ActiveTransactionManagedDistributedTransactionManager(
       DistributedTransactionManager transactionManager,
-      long activeTransactionManagementExpirationTimeMillis) {
+      long expirationTimeMillis,
+      ActiveTransactionRegistry.TransactionRollback<DistributedTransaction> rollbackFunction) {
     super(transactionManager);
-    activeTransactions =
-        new ActiveExpiringMap<>(
-            activeTransactionManagementExpirationTimeMillis,
-            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
-            (id, t) -> {
-              logger.warn("The transaction is expired. Transaction ID: {}", id);
-              transactionExpirationHandler.get().accept(id, t);
-            });
-  }
-
-  @Override
-  public void setTransactionExpirationHandler(BiConsumer<String, DistributedTransaction> handler) {
-    transactionExpirationHandler.set(handler);
-  }
-
-  private void add(ActiveTransaction transaction) throws TransactionException {
-    if (activeTransactions.putIfAbsent(transaction.getId(), transaction).isPresent()) {
-      transaction.rollback();
-      throw new TransactionException(
-          CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), transaction.getId());
-    }
-  }
-
-  private void remove(String transactionId) {
-    activeTransactions.remove(transactionId);
+    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, rollbackFunction);
   }
 
   @Override
@@ -98,7 +64,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
 
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
-    return activeTransactions
+    return registry
         .get(txId)
         .orElseThrow(
             () ->
@@ -117,7 +83,18 @@ public class ActiveTransactionManagedDistributedTransactionManager
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
       super(transaction);
-      add(this);
+      if (!registry.add(getId(), this)) {
+        try {
+          transaction.rollback();
+        } catch (RollbackException e) {
+          logger.warn(
+              "Rollback failed during duplicate transaction handling. Transaction ID: {}",
+              getId(),
+              e);
+        }
+        throw new TransactionException(
+            CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), getId());
+      }
     }
 
     @Override
@@ -132,37 +109,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
 
     @Override
     public synchronized Scanner getScanner(Scan scan) throws CrudException {
-      Scanner scanner = super.getScanner(scan);
-      return new Scanner() {
-        @Override
-        public Optional<Result> one() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            return scanner.one();
-          }
-        }
-
-        @Override
-        public List<Result> all() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            return scanner.all();
-          }
-        }
-
-        @Override
-        public void close() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            scanner.close();
-          }
-        }
-
-        @Nonnull
-        @Override
-        public Iterator<Result> iterator() {
-          synchronized (ActiveTransaction.this) {
-            return scanner.iterator();
-          }
-        }
-      };
+      return new SynchronizedScanner(this, super.getScanner(scan));
     }
 
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -220,7 +167,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
     @Override
     public synchronized void commit() throws CommitException, UnknownTransactionStatusException {
       super.commit();
-      remove(getId());
+      registry.remove(getId());
     }
 
     @Override
@@ -228,7 +175,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
       try {
         super.rollback();
       } finally {
-        remove(getId());
+        registry.remove(getId());
       }
     }
 
@@ -237,7 +184,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
       try {
         super.abort();
       } finally {
-        remove(getId());
+        registry.remove(getId());
       }
     }
   }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -22,14 +22,9 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.util.ActiveExpiringMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,54 +33,24 @@ import org.slf4j.LoggerFactory;
 public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
 
-  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
-
   private static final Logger logger =
       LoggerFactory.getLogger(ActiveTransactionManagedTwoPhaseCommitTransactionManager.class);
 
-  private final ActiveExpiringMap<String, ActiveTransaction> activeTransactions;
+  private final ActiveTransactionRegistry<TwoPhaseCommitTransaction> registry;
 
-  private final AtomicReference<BiConsumer<String, TwoPhaseCommitTransaction>>
-      transactionExpirationHandler =
-          new AtomicReference<>(
-              (id, t) -> {
-                try {
-                  t.rollback();
-                } catch (Exception e) {
-                  logger.warn("Rollback failed. Transaction ID: {}", id, e);
-                }
-              });
+  public ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+      TwoPhaseCommitTransactionManager transactionManager, long expirationTimeMillis) {
+    super(transactionManager);
+    registry =
+        new ActiveTransactionRegistry<>(expirationTimeMillis, TwoPhaseCommitTransaction::rollback);
+  }
 
   public ActiveTransactionManagedTwoPhaseCommitTransactionManager(
       TwoPhaseCommitTransactionManager transactionManager,
-      long activeTransactionManagementExpirationTimeMillis) {
+      long expirationTimeMillis,
+      ActiveTransactionRegistry.TransactionRollback<TwoPhaseCommitTransaction> rollbackFunction) {
     super(transactionManager);
-    activeTransactions =
-        new ActiveExpiringMap<>(
-            activeTransactionManagementExpirationTimeMillis,
-            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
-            (id, t) -> {
-              logger.warn("The transaction is expired. Transaction ID: {}", id);
-              transactionExpirationHandler.get().accept(id, t);
-            });
-  }
-
-  @Override
-  public void setTransactionExpirationHandler(
-      BiConsumer<String, TwoPhaseCommitTransaction> handler) {
-    transactionExpirationHandler.set(handler);
-  }
-
-  private void add(ActiveTransaction transaction) throws TransactionException {
-    if (activeTransactions.putIfAbsent(transaction.getId(), transaction).isPresent()) {
-      transaction.rollback();
-      throw new TransactionException(
-          CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), transaction.getId());
-    }
-  }
-
-  private void remove(String transactionId) {
-    activeTransactions.remove(transactionId);
+    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, rollbackFunction);
   }
 
   @Override
@@ -96,15 +61,16 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
 
   @Override
   public TwoPhaseCommitTransaction join(String txId) throws TransactionException {
-    if (activeTransactions.containsKey(txId)) {
-      return resume(txId);
+    Optional<TwoPhaseCommitTransaction> transaction = registry.get(txId);
+    if (transaction.isPresent()) {
+      return transaction.get();
     }
     return new ActiveTransaction(super.join(txId));
   }
 
   @Override
   public TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException {
-    return activeTransactions
+    return registry
         .get(txId)
         .orElseThrow(
             () ->
@@ -123,7 +89,18 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
       super(transaction);
-      add(this);
+      if (!registry.add(getId(), this)) {
+        try {
+          transaction.rollback();
+        } catch (RollbackException e) {
+          logger.warn(
+              "Rollback failed during duplicate transaction handling. Transaction ID: {}",
+              getId(),
+              e);
+        }
+        throw new TransactionException(
+            CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), getId());
+      }
     }
 
     @Override
@@ -138,37 +115,7 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
 
     @Override
     public synchronized Scanner getScanner(Scan scan) throws CrudException {
-      Scanner scanner = super.getScanner(scan);
-      return new Scanner() {
-        @Override
-        public Optional<Result> one() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            return scanner.one();
-          }
-        }
-
-        @Override
-        public List<Result> all() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            return scanner.all();
-          }
-        }
-
-        @Override
-        public void close() throws CrudException {
-          synchronized (ActiveTransaction.this) {
-            scanner.close();
-          }
-        }
-
-        @Nonnull
-        @Override
-        public Iterator<Result> iterator() {
-          synchronized (ActiveTransaction.this) {
-            return scanner.iterator();
-          }
-        }
-      };
+      return new SynchronizedScanner(this, super.getScanner(scan));
     }
 
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -236,7 +183,7 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @Override
     public synchronized void commit() throws CommitException, UnknownTransactionStatusException {
       super.commit();
-      remove(getId());
+      registry.remove(getId());
     }
 
     @Override
@@ -244,7 +191,7 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       try {
         super.rollback();
       } finally {
-        remove(getId());
+        registry.remove(getId());
       }
     }
 
@@ -253,7 +200,7 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       try {
         super.abort();
       } finally {
-        remove(getId());
+        registry.remove(getId());
       }
     }
   }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
@@ -1,0 +1,85 @@
+package com.scalar.db.common;
+
+import com.scalar.db.util.ActiveExpiringMap;
+import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A registry for managing active transactions with expiration support.
+ *
+ * @param <T> the type of transaction to manage
+ */
+@ThreadSafe
+public class ActiveTransactionRegistry<T> {
+
+  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
+
+  private static final Logger logger = LoggerFactory.getLogger(ActiveTransactionRegistry.class);
+
+  private final ActiveExpiringMap<String, T> activeTransactions;
+
+  /**
+   * Constructs an ActiveTransactionRegistry.
+   *
+   * @param expirationTimeMillis the expiration time in milliseconds
+   * @param rollbackFunction the function to rollback a transaction
+   */
+  public ActiveTransactionRegistry(
+      long expirationTimeMillis, TransactionRollback<T> rollbackFunction) {
+    this.activeTransactions =
+        new ActiveExpiringMap<>(
+            expirationTimeMillis,
+            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
+            (id, t) -> {
+              logger.warn("The transaction is expired. Transaction ID: {}", id);
+              try {
+                rollbackFunction.rollback(t);
+              } catch (Exception e) {
+                logger.warn("Rollback failed. Transaction ID: {}", id, e);
+              }
+            });
+  }
+
+  /**
+   * Adds a transaction to the registry.
+   *
+   * @param id the transaction ID
+   * @param transaction the transaction to add
+   * @return true if the transaction was added, false if a transaction with the same ID already
+   *     exists
+   */
+  public boolean add(String id, T transaction) {
+    return !activeTransactions.putIfAbsent(id, transaction).isPresent();
+  }
+
+  /**
+   * Removes a transaction from the registry.
+   *
+   * @param id the transaction ID
+   */
+  public void remove(String id) {
+    activeTransactions.remove(id);
+  }
+
+  /**
+   * Gets a transaction from the registry.
+   *
+   * @param id the transaction ID
+   * @return an Optional containing the transaction if found
+   */
+  public Optional<T> get(String id) {
+    return activeTransactions.get(id);
+  }
+
+  /**
+   * Functional interface for rolling back a transaction.
+   *
+   * @param <T> the type of transaction
+   */
+  @FunctionalInterface
+  public interface TransactionRollback<T> {
+    void rollback(T transaction) throws Exception;
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -21,10 +21,9 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 public abstract class DecoratedDistributedTransactionManager
-    implements DistributedTransactionManager, DistributedTransactionExpirationHandlerSettable {
+    implements DistributedTransactionManager {
 
   private final DistributedTransactionManager transactionManager;
 
@@ -262,13 +261,5 @@ public abstract class DecoratedDistributedTransactionManager
           .getOriginalTransactionManager();
     }
     return transactionManager;
-  }
-
-  @Override
-  public void setTransactionExpirationHandler(BiConsumer<String, DistributedTransaction> handler) {
-    if (transactionManager instanceof DistributedTransactionExpirationHandlerSettable) {
-      ((DistributedTransactionExpirationHandlerSettable) transactionManager)
-          .setTransactionExpirationHandler(handler);
-    }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -19,11 +19,9 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 public abstract class DecoratedTwoPhaseCommitTransactionManager
-    implements TwoPhaseCommitTransactionManager,
-        TwoPhaseCommitTransactionExpirationHandlerSettable {
+    implements TwoPhaseCommitTransactionManager {
 
   private final TwoPhaseCommitTransactionManager transactionManager;
 
@@ -196,14 +194,5 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
           .getOriginalTransactionManager();
     }
     return transactionManager;
-  }
-
-  @Override
-  public void setTransactionExpirationHandler(
-      BiConsumer<String, TwoPhaseCommitTransaction> handler) {
-    if (transactionManager instanceof TwoPhaseCommitTransactionExpirationHandlerSettable) {
-      ((TwoPhaseCommitTransactionExpirationHandlerSettable) transactionManager)
-          .setTransactionExpirationHandler(handler);
-    }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/DistributedTransactionExpirationHandlerSettable.java
+++ b/core/src/main/java/com/scalar/db/common/DistributedTransactionExpirationHandlerSettable.java
@@ -1,9 +1,0 @@
-package com.scalar.db.common;
-
-import com.scalar.db.api.DistributedTransaction;
-import java.util.function.BiConsumer;
-
-@FunctionalInterface
-public interface DistributedTransactionExpirationHandlerSettable {
-  void setTransactionExpirationHandler(BiConsumer<String, DistributedTransaction> handler);
-}

--- a/core/src/main/java/com/scalar/db/common/SynchronizedScanner.java
+++ b/core/src/main/java/com/scalar/db/common/SynchronizedScanner.java
@@ -1,0 +1,62 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import com.scalar.db.exception.transaction.CrudException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * A decorator that wraps a Scanner with synchronized access for thread safety.
+ *
+ * <p>This class is used to ensure thread-safe access to a Scanner instance when multiple threads
+ * may access it concurrently, particularly in the context of active transaction management where
+ * the rollback() method may be called from an expiration handler in a different thread.
+ */
+public class SynchronizedScanner implements Scanner {
+
+  private final Object lock;
+  private final Scanner delegate;
+
+  /**
+   * Constructs a SynchronizedScanner.
+   *
+   * @param lock the object to synchronize on
+   * @param delegate the underlying Scanner to delegate to
+   */
+  public SynchronizedScanner(Object lock, Scanner delegate) {
+    this.lock = lock;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Optional<Result> one() throws CrudException {
+    synchronized (lock) {
+      return delegate.one();
+    }
+  }
+
+  @Override
+  public List<Result> all() throws CrudException {
+    synchronized (lock) {
+      return delegate.all();
+    }
+  }
+
+  @Override
+  public void close() throws CrudException {
+    synchronized (lock) {
+      delegate.close();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<Result> iterator() {
+    synchronized (lock) {
+      return delegate.iterator();
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionExpirationHandlerSettable.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionExpirationHandlerSettable.java
@@ -1,9 +1,0 @@
-package com.scalar.db.common;
-
-import com.scalar.db.api.TwoPhaseCommitTransaction;
-import java.util.function.BiConsumer;
-
-@FunctionalInterface
-public interface TwoPhaseCommitTransactionExpirationHandlerSettable {
-  void setTransactionExpirationHandler(BiConsumer<String, TwoPhaseCommitTransaction> handler);
-}

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -32,6 +32,7 @@ public class DatabaseConfig {
   private String storage;
   private String transactionManager;
   private long metadataCacheExpirationTimeSecs;
+  private boolean activeTransactionManagementEnabled;
   private long activeTransactionManagementExpirationTimeMillis;
   @Nullable private String defaultNamespaceName;
   private boolean crossPartitionScanEnabled;
@@ -49,6 +50,8 @@ public class DatabaseConfig {
   public static final String TRANSACTION_MANAGER = PREFIX + "transaction_manager";
   public static final String METADATA_CACHE_EXPIRATION_TIME_SECS =
       PREFIX + "metadata.cache_expiration_time_secs";
+  public static final String ACTIVE_TRANSACTION_MANAGEMENT_ENABLED =
+      PREFIX + "active_transaction_management.enabled";
   public static final String ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS =
       PREFIX + "active_transaction_management.expiration_time_millis";
   public static final String DEFAULT_NAMESPACE_NAME = PREFIX + "default_namespace_name";
@@ -103,6 +106,8 @@ public class DatabaseConfig {
     password = getString(getProperties(), PASSWORD, null);
     transactionManager = getTransactionManager(getProperties());
     metadataCacheExpirationTimeSecs = getMetadataCacheExpirationTimeSecs(getProperties());
+    activeTransactionManagementEnabled =
+        getBoolean(getProperties(), ACTIVE_TRANSACTION_MANAGEMENT_ENABLED, true);
     activeTransactionManagementExpirationTimeMillis =
         getActiveTransactionManagementExpirationTimeMillis(getProperties());
     defaultNamespaceName = getString(getProperties(), DEFAULT_NAMESPACE_NAME, null);
@@ -151,6 +156,10 @@ public class DatabaseConfig {
 
   public long getMetadataCacheExpirationTimeSecs() {
     return metadataCacheExpirationTimeSecs;
+  }
+
+  public boolean isActiveTransactionManagementEnabled() {
+    return activeTransactionManagementEnabled;
   }
 
   public long getActiveTransactionManagementExpirationTimeMillis() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -1,26 +1,22 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
-import com.scalar.db.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
-import com.scalar.db.common.StateManagedDistributedTransactionManager;
-import com.scalar.db.common.StateManagedTwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 
-public class ConsensusCommitProvider implements DistributedTransactionProvider {
+public class ConsensusCommitProvider extends AbstractDistributedTransactionProvider {
+
   @Override
   public String getName() {
     return ConsensusCommitConfig.TRANSACTION_MANAGER_NAME;
   }
 
   @Override
-  public DistributedTransactionManager createDistributedTransactionManager(DatabaseConfig config) {
-    return new ActiveTransactionManagedDistributedTransactionManager(
-        new StateManagedDistributedTransactionManager(new ConsensusCommitManager(config)),
-        config.getActiveTransactionManagementExpirationTimeMillis());
+  public DistributedTransactionManager createRawDistributedTransactionManager(
+      DatabaseConfig config) {
+    return new ConsensusCommitManager(config);
   }
 
   @Override
@@ -29,11 +25,8 @@ public class ConsensusCommitProvider implements DistributedTransactionProvider {
   }
 
   @Override
-  public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
+  public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
-    return new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
-        new StateManagedTwoPhaseCommitTransactionManager(
-            new TwoPhaseConsensusCommitManager(config)),
-        config.getActiveTransactionManagementExpirationTimeMillis());
+    return new TwoPhaseConsensusCommitManager(config);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -1,26 +1,24 @@
 package com.scalar.db.transaction.jdbc;
 
+import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
-import com.scalar.db.common.StateManagedDistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import javax.annotation.Nullable;
 
-public class JdbcTransactionProvider implements DistributedTransactionProvider {
+public class JdbcTransactionProvider extends AbstractDistributedTransactionProvider {
+
   @Override
   public String getName() {
     return JdbcConfig.TRANSACTION_MANAGER_NAME;
   }
 
   @Override
-  public DistributedTransactionManager createDistributedTransactionManager(DatabaseConfig config) {
-    return new ActiveTransactionManagedDistributedTransactionManager(
-        new StateManagedDistributedTransactionManager(new JdbcTransactionManager(config)),
-        config.getActiveTransactionManagementExpirationTimeMillis());
+  public DistributedTransactionManager createRawDistributedTransactionManager(
+      DatabaseConfig config) {
+    return new JdbcTransactionManager(config);
   }
 
   @Override
@@ -30,7 +28,7 @@ public class JdbcTransactionProvider implements DistributedTransactionProvider {
 
   @Nullable
   @Override
-  public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
+  public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     return null;
   }

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
@@ -172,24 +172,6 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest {
   }
 
   @Test
-  public void join_ActiveTransactionAlreadyCommitted_ShouldThrowTransactionNotFoundException()
-      throws TransactionException {
-    String txId = "txId1";
-
-    TwoPhaseCommitTransaction wrappedTransaction = mock(TwoPhaseCommitTransaction.class);
-    when(wrappedTransaction.getId()).thenReturn(txId);
-
-    when(wrappedTransactionManager.begin(txId)).thenReturn(wrappedTransaction);
-
-    TwoPhaseCommitTransaction transaction = transactionManager.begin(txId);
-    transaction.commit();
-
-    // Act Assert
-    assertThatThrownBy(() -> transactionManager.resume(txId))
-        .isInstanceOf(TransactionNotFoundException.class);
-  }
-
-  @Test
   public void resume_ShouldReturnBegunActiveTransaction() throws TransactionException {
     // Arrange
     String txId = "txId1";

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
@@ -3,11 +3,14 @@ package com.scalar.db.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +53,55 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest {
     assertThat(transaction2)
         .isInstanceOf(
             ActiveTransactionManagedTwoPhaseCommitTransactionManager.ActiveTransaction.class);
+  }
+
+  @Test
+  public void begin_TransactionAlreadyExists_ShouldRollbackAndThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    String txId = "txId1";
+
+    TwoPhaseCommitTransaction wrappedTransaction1 = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction1.getId()).thenReturn(txId);
+
+    TwoPhaseCommitTransaction wrappedTransaction2 = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction2.getId()).thenReturn(txId);
+
+    when(wrappedTransactionManager.begin(txId))
+        .thenReturn(wrappedTransaction1)
+        .thenReturn(wrappedTransaction2);
+
+    transactionManager.begin(txId);
+
+    // Act Assert
+    assertThatThrownBy(() -> transactionManager.begin(txId))
+        .isInstanceOf(TransactionException.class);
+    verify(wrappedTransaction2).rollback();
+  }
+
+  @Test
+  public void begin_TransactionAlreadyExistsAndRollbackFails_ShouldThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    String txId = "txId1";
+
+    TwoPhaseCommitTransaction wrappedTransaction1 = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction1.getId()).thenReturn(txId);
+
+    TwoPhaseCommitTransaction wrappedTransaction2 = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction2.getId()).thenReturn(txId);
+    doThrow(new RollbackException("rollback failed", txId)).when(wrappedTransaction2).rollback();
+
+    when(wrappedTransactionManager.begin(txId))
+        .thenReturn(wrappedTransaction1)
+        .thenReturn(wrappedTransaction2);
+
+    transactionManager.begin(txId);
+
+    // Act Assert
+    assertThatThrownBy(() -> transactionManager.begin(txId))
+        .isInstanceOf(TransactionException.class);
+    verify(wrappedTransaction2).rollback();
   }
 
   @Test
@@ -117,6 +169,24 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest {
     assertThat(actual)
         .isInstanceOf(
             ActiveTransactionManagedTwoPhaseCommitTransactionManager.ActiveTransaction.class);
+  }
+
+  @Test
+  public void join_ActiveTransactionAlreadyCommitted_ShouldThrowTransactionNotFoundException()
+      throws TransactionException {
+    String txId = "txId1";
+
+    TwoPhaseCommitTransaction wrappedTransaction = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction.getId()).thenReturn(txId);
+
+    when(wrappedTransactionManager.begin(txId)).thenReturn(wrappedTransaction);
+
+    TwoPhaseCommitTransaction transaction = transactionManager.begin(txId);
+    transaction.commit();
+
+    // Act Assert
+    assertThatThrownBy(() -> transactionManager.resume(txId))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -37,6 +37,7 @@ public class DatabaseConfigTest {
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
     assertThat(config.getMetadataCacheExpirationTimeSecs())
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
+    assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -65,6 +66,7 @@ public class DatabaseConfigTest {
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
     assertThat(config.getMetadataCacheExpirationTimeSecs())
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
+    assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
@@ -94,6 +96,7 @@ public class DatabaseConfigTest {
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
     assertThat(config.getMetadataCacheExpirationTimeSecs())
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
+    assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
@@ -125,6 +128,7 @@ public class DatabaseConfigTest {
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
     assertThat(config.getMetadataCacheExpirationTimeSecs())
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
+    assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
@@ -327,6 +331,7 @@ public class DatabaseConfigTest {
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props.setProperty(DatabaseConfig.ACTIVE_TRANSACTION_MANAGEMENT_ENABLED, "false");
     props.setProperty(DatabaseConfig.ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS, "3600");
 
     // Act
@@ -339,6 +344,7 @@ public class DatabaseConfigTest {
     assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.isActiveTransactionManagementEnabled()).isFalse();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(3600);
   }
 


### PR DESCRIPTION
## Description

This PR adds `scalar.db.active_transaction_management.enabled` configuration option to enable/disable the active transaction management. The default value is `true` for backward compatibility.

## Related issues and/or PRs

N/A

## Changes made

- Added `scalar.db.active_transaction_management.enabled` configuration option to enable/disable the active transaction management (default: `true`).
- Introduced `AbstractDistributedTransactionProvider` as a base class to consolidate wrapper logic for transaction managers.
- Refactored `ConsensusCommitProvider` and `JdbcTransactionProvider` to extend the new abstract class.
- Refactored `ActiveTransactionManagedDistributedTransactionManager` and
  `ActiveTransactionManagedTwoPhaseCommitTransactionManager`.
  - Extracted common logic from both classes into `ActiveTransactionRegistry`
    and `SynchronizedScanner`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
