### PR TITLE
Use HikariCP in JDBC adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         azureBlobStorageVersion = '12.32.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.41.1'
-        commonsDbcp2Version = '2.14.0'
+        hikariCpVersion = '4.0.3'
         mysqlDriverVersion = '8.4.0'
         postgresqlDriverVersion = '42.7.8'
         oracleDriverVersion = '23.26.0.0.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     implementation 'software.amazon.awssdk:aws-crt-client'
     testImplementation 'software.amazon.awssdk:iam'
     testImplementation 'software.amazon.awssdk:iam-policy-builder'
-    implementation "org.apache.commons:commons-dbcp2:${commonsDbcp2Version}"
+    implementation "com.zaxxer:HikariCP:${hikariCpVersion}"
     implementation "com.mysql:mysql-connector-j:${mysqlDriverVersion}"
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -26,6 +26,7 @@ import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TimeColumn;
 import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
+import com.zaxxer.hikari.HikariDataSource;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -44,7 +45,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class JdbcAdminImportTestUtils {
   static final String SUPPORTED_TABLE_NAME = "supported_table";
@@ -121,7 +121,7 @@ public class JdbcAdminImportTestUtils {
 
   private final RdbEngineStrategy rdbEngine;
   private final int majorVersion;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
   private final boolean requiresExplicitCommit;
 
   public JdbcAdminImportTestUtils(Properties properties) {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -7,18 +7,18 @@ import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.util.AdminTestUtils;
 import com.scalar.db.util.ThrowableFunction;
+import com.zaxxer.hikari.HikariDataSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class JdbcAdminTestUtils extends AdminTestUtils {
 
   private final String metadataSchema;
   private final RdbEngineStrategy rdbEngine;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
   private final boolean requiresExplicitCommit;
 
   public JdbcAdminTestUtils(Properties properties) {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -40,7 +40,8 @@ public final class JdbcEnv {
     // Metadata cache expiration time
     properties.setProperty(DatabaseConfig.METADATA_CACHE_EXPIRATION_TIME_SECS, "1");
 
-    // Connection pool settings for tests
+    // Set connection pool minIdle to 0 because HikariCP creates minIdle connections at startup,
+    // which may waste resources in the CI environment
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "0");
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "0");
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "0");

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -40,6 +40,11 @@ public final class JdbcEnv {
     // Metadata cache expiration time
     properties.setProperty(DatabaseConfig.METADATA_CACHE_EXPIRATION_TIME_SECS, "1");
 
+    // Connection pool settings for tests
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "0");
+    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "0");
+    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "0");
+
     return properties;
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcPermissionTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcPermissionTestUtils.java
@@ -2,16 +2,16 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.util.PermissionTestUtils;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class JdbcPermissionTestUtils implements PermissionTestUtils {
   public static final int DDL_WAIT_SECONDS = 1;
   private final RdbEngineStrategy rdbEngine;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
 
   public JdbcPermissionTestUtils(Properties properties) {
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
@@ -17,6 +17,7 @@ import com.scalar.db.storage.jdbc.RdbEngineFactory;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.db.storage.jdbc.TableMetadataService;
 import com.scalar.db.util.AdminTestUtils;
+import com.zaxxer.hikari.HikariDataSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -24,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class MultiStorageAdminTestUtils extends AdminTestUtils {
   // for Cassandra
@@ -33,7 +33,7 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   // for JDBC
   private final String jdbcMetadataSchema;
   private final RdbEngineStrategy rdbEngine;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
 
   public MultiStorageAdminTestUtils(Properties cassandraProperties, Properties jdbcProperties) {
     // Cassandra has the coordinator tables

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -21,6 +21,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.ThrowableConsumer;
 import com.scalar.db.util.ThrowableFunction;
+import com.zaxxer.hikari.HikariDataSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -40,15 +41,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.sql.DataSource;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
 @ThreadSafe
 public class JdbcAdmin implements DistributedStorageAdmin {
-  private static final Logger logger = LoggerFactory.getLogger(JdbcAdmin.class);
-
   @VisibleForTesting static final String JDBC_COL_COLUMN_NAME = "COLUMN_NAME";
   @VisibleForTesting static final String JDBC_COL_DATA_TYPE = "DATA_TYPE";
   @VisibleForTesting static final String JDBC_COL_TYPE_NAME = "TYPE_NAME";
@@ -58,7 +54,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   private static final String INDEX_NAME_PREFIX = "index";
 
   private final RdbEngineStrategy rdbEngine;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
   private final String metadataSchema;
   private final TableMetadataService tableMetadataService;
   private final NamespaceMetadataService namespaceMetadataService;
@@ -81,7 +77,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public JdbcAdmin(BasicDataSource dataSource, JdbcConfig config) {
+  public JdbcAdmin(HikariDataSource dataSource, JdbcConfig config) {
     rdbEngine = RdbEngineFactory.create(config);
     this.dataSource = dataSource;
     metadataSchema = config.getMetadataSchema();
@@ -95,7 +91,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public JdbcAdmin(BasicDataSource dataSource, JdbcConfig config, boolean requiresExplicitCommit) {
+  public JdbcAdmin(HikariDataSource dataSource, JdbcConfig config, boolean requiresExplicitCommit) {
     rdbEngine = RdbEngineFactory.create(config);
     this.dataSource = dataSource;
     metadataSchema = config.getMetadataSchema();
@@ -110,7 +106,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   @VisibleForTesting
   JdbcAdmin(
-      BasicDataSource dataSource,
+      HikariDataSource dataSource,
       JdbcConfig config,
       VirtualTableMetadataService virtualTableMetadataService,
       boolean requiresExplicitCommit) {
@@ -127,7 +123,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   @VisibleForTesting
   JdbcAdmin(
-      BasicDataSource dataSource,
+      HikariDataSource dataSource,
       JdbcConfig config,
       TableMetadataService tableMetadataService,
       NamespaceMetadataService namespaceMetadataService,
@@ -623,11 +619,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the dataSource", e);
-    }
+    dataSource.close();
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
@@ -132,19 +133,16 @@ public class JdbcConfig {
               + "'");
     }
 
-    String[] removedProperties =
-        new String[] {
-          PREFIX + "connection_pool.max_idle",
-          PREFIX + "prepared_statements_pool.enabled",
-          PREFIX + "prepared_statements_pool.max_open",
-          PREFIX + "table_metadata.connection_pool.max_idle",
-          PREFIX + "admin.connection_pool.max_idle"
-        };
-    for (String property : removedProperties) {
-      if (databaseConfig.getProperties().containsKey(property)) {
-        logger.warn("The configuration property {} is removed and will be ignored", property);
-      }
-    }
+    Stream.of(
+            "connection_pool.max_idle",
+            "prepared_statements_pool.enabled",
+            "prepared_statements_pool.max_open",
+            "table_metadata.connection_pool.max_idle",
+            "admin.connection_pool.max_idle")
+        .map(p -> PREFIX + p)
+        .filter(databaseConfig.getProperties()::containsKey)
+        .forEach(
+            p -> logger.warn("The configuration property {} is removed and will be ignored", p));
 
     if (databaseConfig.getContactPoints().isEmpty()) {
       throw new IllegalArgumentException(CoreError.INVALID_CONTACT_POINTS.buildMessage());

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.config.ConfigUtils.getInt;
+import static com.scalar.db.config.ConfigUtils.getLong;
 import static com.scalar.db.config.ConfigUtils.getString;
 
 import com.scalar.db.common.CoreError;
@@ -24,6 +25,14 @@ public class JdbcConfig {
   public static final String PREFIX = DatabaseConfig.PREFIX + STORAGE_NAME + ".";
   public static final String CONNECTION_POOL_MIN_IDLE = PREFIX + "connection_pool.min_idle";
   public static final String CONNECTION_POOL_MAX_TOTAL = PREFIX + "connection_pool.max_total";
+  public static final String CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS =
+      PREFIX + "connection_pool.connection_timeout_millis";
+  public static final String CONNECTION_POOL_IDLE_TIMEOUT_MILLIS =
+      PREFIX + "connection_pool.idle_timeout_millis";
+  public static final String CONNECTION_POOL_MAX_LIFETIME_MILLIS =
+      PREFIX + "connection_pool.max_lifetime_millis";
+  public static final String CONNECTION_POOL_KEEPALIVE_TIME_MILLIS =
+      PREFIX + "connection_pool.keepalive_time_millis";
 
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
 
@@ -34,11 +43,27 @@ public class JdbcConfig {
       PREFIX + "table_metadata.connection_pool.min_idle";
   public static final String TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL =
       PREFIX + "table_metadata.connection_pool.max_total";
+  public static final String TABLE_METADATA_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS =
+      PREFIX + "table_metadata.connection_pool.connection_timeout_millis";
+  public static final String TABLE_METADATA_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS =
+      PREFIX + "table_metadata.connection_pool.idle_timeout_millis";
+  public static final String TABLE_METADATA_CONNECTION_POOL_MAX_LIFETIME_MILLIS =
+      PREFIX + "table_metadata.connection_pool.max_lifetime_millis";
+  public static final String TABLE_METADATA_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS =
+      PREFIX + "table_metadata.connection_pool.keepalive_time_millis";
 
   public static final String ADMIN_CONNECTION_POOL_MIN_IDLE =
       PREFIX + "admin.connection_pool.min_idle";
   public static final String ADMIN_CONNECTION_POOL_MAX_TOTAL =
       PREFIX + "admin.connection_pool.max_total";
+  public static final String ADMIN_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS =
+      PREFIX + "admin.connection_pool.connection_timeout_millis";
+  public static final String ADMIN_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS =
+      PREFIX + "admin.connection_pool.idle_timeout_millis";
+  public static final String ADMIN_CONNECTION_POOL_MAX_LIFETIME_MILLIS =
+      PREFIX + "admin.connection_pool.max_lifetime_millis";
+  public static final String ADMIN_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS =
+      PREFIX + "admin.connection_pool.keepalive_time_millis";
 
   public static final String MYSQL_VARIABLE_KEY_COLUMN_SIZE =
       PREFIX + "mysql.variable_key_column_size";
@@ -101,6 +126,10 @@ public class JdbcConfig {
 
   private final int connectionPoolMinIdle;
   private final int connectionPoolMaxTotal;
+  @Nullable private final Long connectionPoolConnectionTimeoutMillis;
+  @Nullable private final Long connectionPoolIdleTimeoutMillis;
+  @Nullable private final Long connectionPoolMaxLifetimeMillis;
+  @Nullable private final Long connectionPoolKeepaliveTimeMillis;
 
   @Nullable private final Isolation isolation;
 
@@ -108,9 +137,17 @@ public class JdbcConfig {
 
   private final int tableMetadataConnectionPoolMinIdle;
   private final int tableMetadataConnectionPoolMaxTotal;
+  @Nullable private final Long tableMetadataConnectionPoolConnectionTimeoutMillis;
+  @Nullable private final Long tableMetadataConnectionPoolIdleTimeoutMillis;
+  @Nullable private final Long tableMetadataConnectionPoolMaxLifetimeMillis;
+  @Nullable private final Long tableMetadataConnectionPoolKeepaliveTimeMillis;
 
   private final int adminConnectionPoolMinIdle;
   private final int adminConnectionPoolMaxTotal;
+  @Nullable private final Long adminConnectionPoolConnectionTimeoutMillis;
+  @Nullable private final Long adminConnectionPoolIdleTimeoutMillis;
+  @Nullable private final Long adminConnectionPoolMaxLifetimeMillis;
+  @Nullable private final Long adminConnectionPoolKeepaliveTimeMillis;
 
   private final int mysqlVariableKeyColumnSize;
   private final int oracleVariableKeyColumnSize;
@@ -162,6 +199,14 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             CONNECTION_POOL_MAX_TOTAL,
             DEFAULT_CONNECTION_POOL_MAX_TOTAL);
+    connectionPoolConnectionTimeoutMillis =
+        getLong(databaseConfig.getProperties(), CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, null);
+    connectionPoolIdleTimeoutMillis =
+        getLong(databaseConfig.getProperties(), CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, null);
+    connectionPoolMaxLifetimeMillis =
+        getLong(databaseConfig.getProperties(), CONNECTION_POOL_MAX_LIFETIME_MILLIS, null);
+    connectionPoolKeepaliveTimeMillis =
+        getLong(databaseConfig.getProperties(), CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, null);
 
     String isolationLevel = getString(databaseConfig.getProperties(), ISOLATION_LEVEL, null);
     if (isolationLevel != null) {
@@ -180,6 +225,26 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL,
             DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
+    tableMetadataConnectionPoolConnectionTimeoutMillis =
+        getLong(
+            databaseConfig.getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS,
+            null);
+    tableMetadataConnectionPoolIdleTimeoutMillis =
+        getLong(
+            databaseConfig.getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS,
+            null);
+    tableMetadataConnectionPoolMaxLifetimeMillis =
+        getLong(
+            databaseConfig.getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_MAX_LIFETIME_MILLIS,
+            null);
+    tableMetadataConnectionPoolKeepaliveTimeMillis =
+        getLong(
+            databaseConfig.getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS,
+            null);
 
     adminConnectionPoolMinIdle =
         getInt(
@@ -191,6 +256,15 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             ADMIN_CONNECTION_POOL_MAX_TOTAL,
             DEFAULT_ADMIN_CONNECTION_POOL_MAX_TOTAL);
+    adminConnectionPoolConnectionTimeoutMillis =
+        getLong(
+            databaseConfig.getProperties(), ADMIN_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, null);
+    adminConnectionPoolIdleTimeoutMillis =
+        getLong(databaseConfig.getProperties(), ADMIN_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, null);
+    adminConnectionPoolMaxLifetimeMillis =
+        getLong(databaseConfig.getProperties(), ADMIN_CONNECTION_POOL_MAX_LIFETIME_MILLIS, null);
+    adminConnectionPoolKeepaliveTimeMillis =
+        getLong(databaseConfig.getProperties(), ADMIN_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, null);
 
     mysqlVariableKeyColumnSize =
         getInt(
@@ -274,6 +348,22 @@ public class JdbcConfig {
     return connectionPoolMaxTotal;
   }
 
+  public Optional<Long> getConnectionPoolConnectionTimeoutMillis() {
+    return Optional.ofNullable(connectionPoolConnectionTimeoutMillis);
+  }
+
+  public Optional<Long> getConnectionPoolIdleTimeoutMillis() {
+    return Optional.ofNullable(connectionPoolIdleTimeoutMillis);
+  }
+
+  public Optional<Long> getConnectionPoolMaxLifetimeMillis() {
+    return Optional.ofNullable(connectionPoolMaxLifetimeMillis);
+  }
+
+  public Optional<Long> getConnectionPoolKeepaliveTimeMillis() {
+    return Optional.ofNullable(connectionPoolKeepaliveTimeMillis);
+  }
+
   public Optional<Isolation> getIsolation() {
     return Optional.ofNullable(isolation);
   }
@@ -290,12 +380,44 @@ public class JdbcConfig {
     return tableMetadataConnectionPoolMaxTotal;
   }
 
+  public Optional<Long> getTableMetadataConnectionPoolConnectionTimeoutMillis() {
+    return Optional.ofNullable(tableMetadataConnectionPoolConnectionTimeoutMillis);
+  }
+
+  public Optional<Long> getTableMetadataConnectionPoolIdleTimeoutMillis() {
+    return Optional.ofNullable(tableMetadataConnectionPoolIdleTimeoutMillis);
+  }
+
+  public Optional<Long> getTableMetadataConnectionPoolMaxLifetimeMillis() {
+    return Optional.ofNullable(tableMetadataConnectionPoolMaxLifetimeMillis);
+  }
+
+  public Optional<Long> getTableMetadataConnectionPoolKeepaliveTimeMillis() {
+    return Optional.ofNullable(tableMetadataConnectionPoolKeepaliveTimeMillis);
+  }
+
   public int getAdminConnectionPoolMinIdle() {
     return adminConnectionPoolMinIdle;
   }
 
   public int getAdminConnectionPoolMaxTotal() {
     return adminConnectionPoolMaxTotal;
+  }
+
+  public Optional<Long> getAdminConnectionPoolConnectionTimeoutMillis() {
+    return Optional.ofNullable(adminConnectionPoolConnectionTimeoutMillis);
+  }
+
+  public Optional<Long> getAdminConnectionPoolIdleTimeoutMillis() {
+    return Optional.ofNullable(adminConnectionPoolIdleTimeoutMillis);
+  }
+
+  public Optional<Long> getAdminConnectionPoolMaxLifetimeMillis() {
+    return Optional.ofNullable(adminConnectionPoolMaxLifetimeMillis);
+  }
+
+  public Optional<Long> getAdminConnectionPoolKeepaliveTimeMillis() {
+    return Optional.ofNullable(adminConnectionPoolKeepaliveTimeMillis);
   }
 
   public int getMysqlVariableKeyColumnSize() {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -133,6 +133,7 @@ public class JdbcConfig {
               + "'");
     }
 
+    // Show a warning when removed properties are set. We will keep checking them until 5.0.0.
     Stream.of(
             "connection_pool.max_idle",
             "prepared_statements_pool.enabled",

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -1,6 +1,5 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.config.ConfigUtils.getBoolean;
 import static com.scalar.db.config.ConfigUtils.getInt;
 import static com.scalar.db.config.ConfigUtils.getString;
 
@@ -23,12 +22,7 @@ public class JdbcConfig {
   public static final String TRANSACTION_MANAGER_NAME = STORAGE_NAME;
   public static final String PREFIX = DatabaseConfig.PREFIX + STORAGE_NAME + ".";
   public static final String CONNECTION_POOL_MIN_IDLE = PREFIX + "connection_pool.min_idle";
-  public static final String CONNECTION_POOL_MAX_IDLE = PREFIX + "connection_pool.max_idle";
   public static final String CONNECTION_POOL_MAX_TOTAL = PREFIX + "connection_pool.max_total";
-  public static final String PREPARED_STATEMENTS_POOL_ENABLED =
-      PREFIX + "prepared_statements_pool.enabled";
-  public static final String PREPARED_STATEMENTS_POOL_MAX_OPEN =
-      PREFIX + "prepared_statements_pool.max_open";
 
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
 
@@ -37,15 +31,11 @@ public class JdbcConfig {
 
   public static final String TABLE_METADATA_CONNECTION_POOL_MIN_IDLE =
       PREFIX + "table_metadata.connection_pool.min_idle";
-  public static final String TABLE_METADATA_CONNECTION_POOL_MAX_IDLE =
-      PREFIX + "table_metadata.connection_pool.max_idle";
   public static final String TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL =
       PREFIX + "table_metadata.connection_pool.max_total";
 
   public static final String ADMIN_CONNECTION_POOL_MIN_IDLE =
       PREFIX + "admin.connection_pool.min_idle";
-  public static final String ADMIN_CONNECTION_POOL_MAX_IDLE =
-      PREFIX + "admin.connection_pool.max_idle";
   public static final String ADMIN_CONNECTION_POOL_MAX_TOTAL =
       PREFIX + "admin.connection_pool.max_total";
 
@@ -59,17 +49,12 @@ public class JdbcConfig {
   public static final String DB2_TIME_COLUMN_DEFAULT_DATE_COMPONENT =
       PREFIX + "db2.time_column.default_date_component";
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 20;
-  public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 50;
   public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 200;
-  public static final boolean DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED = false;
-  public static final int DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN = -1;
 
   public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE = 5;
-  public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE = 10;
   public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL = 25;
 
   public static final int DEFAULT_ADMIN_CONNECTION_POOL_MIN_IDLE = 5;
-  public static final int DEFAULT_ADMIN_CONNECTION_POOL_MAX_IDLE = 10;
   public static final int DEFAULT_ADMIN_CONNECTION_POOL_MAX_TOTAL = 25;
 
   // MySQL, Oracle and Db2 have limitations regarding the total size of key columns. Thus, we should
@@ -114,20 +99,16 @@ public class JdbcConfig {
   @Nullable private final String password;
 
   private final int connectionPoolMinIdle;
-  private final int connectionPoolMaxIdle;
   private final int connectionPoolMaxTotal;
-  private final boolean preparedStatementsPoolEnabled;
-  private final int preparedStatementsPoolMaxOpen;
 
   @Nullable private final Isolation isolation;
 
   private final String metadataSchema;
+
   private final int tableMetadataConnectionPoolMinIdle;
-  private final int tableMetadataConnectionPoolMaxIdle;
   private final int tableMetadataConnectionPoolMaxTotal;
 
   private final int adminConnectionPoolMinIdle;
-  private final int adminConnectionPoolMaxIdle;
   private final int adminConnectionPoolMaxTotal;
 
   private final int mysqlVariableKeyColumnSize;
@@ -151,6 +132,20 @@ public class JdbcConfig {
               + "'");
     }
 
+    String[] removedProperties =
+        new String[] {
+          PREFIX + "connection_pool.max_idle",
+          PREFIX + "prepared_statements_pool.enabled",
+          PREFIX + "prepared_statements_pool.max_open",
+          PREFIX + "table_metadata.connection_pool.max_idle",
+          PREFIX + "admin.connection_pool.max_idle"
+        };
+    for (String property : removedProperties) {
+      if (databaseConfig.getProperties().containsKey(property)) {
+        logger.warn("The configuration property {} is removed and will be ignored", property);
+      }
+    }
+
     if (databaseConfig.getContactPoints().isEmpty()) {
       throw new IllegalArgumentException(CoreError.INVALID_CONTACT_POINTS.buildMessage());
     }
@@ -163,26 +158,11 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             CONNECTION_POOL_MIN_IDLE,
             DEFAULT_CONNECTION_POOL_MIN_IDLE);
-    connectionPoolMaxIdle =
-        getInt(
-            databaseConfig.getProperties(),
-            CONNECTION_POOL_MAX_IDLE,
-            DEFAULT_CONNECTION_POOL_MAX_IDLE);
     connectionPoolMaxTotal =
         getInt(
             databaseConfig.getProperties(),
             CONNECTION_POOL_MAX_TOTAL,
             DEFAULT_CONNECTION_POOL_MAX_TOTAL);
-    preparedStatementsPoolEnabled =
-        getBoolean(
-            databaseConfig.getProperties(),
-            PREPARED_STATEMENTS_POOL_ENABLED,
-            DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
-    preparedStatementsPoolMaxOpen =
-        getInt(
-            databaseConfig.getProperties(),
-            PREPARED_STATEMENTS_POOL_MAX_OPEN,
-            DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
 
     String isolationLevel = getString(databaseConfig.getProperties(), ISOLATION_LEVEL, null);
     if (isolationLevel != null) {
@@ -196,11 +176,6 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             TABLE_METADATA_CONNECTION_POOL_MIN_IDLE,
             DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE);
-    tableMetadataConnectionPoolMaxIdle =
-        getInt(
-            databaseConfig.getProperties(),
-            TABLE_METADATA_CONNECTION_POOL_MAX_IDLE,
-            DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE);
     tableMetadataConnectionPoolMaxTotal =
         getInt(
             databaseConfig.getProperties(),
@@ -212,11 +187,6 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             ADMIN_CONNECTION_POOL_MIN_IDLE,
             DEFAULT_ADMIN_CONNECTION_POOL_MIN_IDLE);
-    adminConnectionPoolMaxIdle =
-        getInt(
-            databaseConfig.getProperties(),
-            ADMIN_CONNECTION_POOL_MAX_IDLE,
-            DEFAULT_ADMIN_CONNECTION_POOL_MAX_IDLE);
     adminConnectionPoolMaxTotal =
         getInt(
             databaseConfig.getProperties(),
@@ -301,20 +271,8 @@ public class JdbcConfig {
     return connectionPoolMinIdle;
   }
 
-  public int getConnectionPoolMaxIdle() {
-    return connectionPoolMaxIdle;
-  }
-
   public int getConnectionPoolMaxTotal() {
     return connectionPoolMaxTotal;
-  }
-
-  public boolean isPreparedStatementsPoolEnabled() {
-    return preparedStatementsPoolEnabled;
-  }
-
-  public int getPreparedStatementsPoolMaxOpen() {
-    return preparedStatementsPoolMaxOpen;
   }
 
   public Optional<Isolation> getIsolation() {
@@ -329,20 +287,12 @@ public class JdbcConfig {
     return tableMetadataConnectionPoolMinIdle;
   }
 
-  public int getTableMetadataConnectionPoolMaxIdle() {
-    return tableMetadataConnectionPoolMaxIdle;
-  }
-
   public int getTableMetadataConnectionPoolMaxTotal() {
     return tableMetadataConnectionPoolMaxTotal;
   }
 
   public int getAdminConnectionPoolMinIdle() {
     return adminConnectionPoolMinIdle;
-  }
-
-  public int getAdminConnectionPoolMaxIdle() {
-    return adminConnectionPoolMaxIdle;
   }
 
   public int getAdminConnectionPoolMaxTotal() {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -36,6 +36,7 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.util.ScalarDbUtils;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -46,7 +47,6 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +63,8 @@ public class JdbcDatabase extends AbstractDistributedStorage {
   private static final Logger logger = LoggerFactory.getLogger(JdbcDatabase.class);
 
   private final RdbEngineStrategy rdbEngine;
-  private final BasicDataSource dataSource;
-  private final BasicDataSource tableMetadataDataSource;
+  private final HikariDataSource dataSource;
+  private final HikariDataSource tableMetadataDataSource;
   private final TableMetadataManager tableMetadataManager;
   private final VirtualTableInfoManager virtualTableInfoManager;
   private final JdbcService jdbcService;
@@ -99,8 +99,8 @@ public class JdbcDatabase extends AbstractDistributedStorage {
   JdbcDatabase(
       DatabaseConfig databaseConfig,
       RdbEngineStrategy rdbEngine,
-      BasicDataSource dataSource,
-      BasicDataSource tableMetadataDataSource,
+      HikariDataSource dataSource,
+      HikariDataSource tableMetadataDataSource,
       TableMetadataManager tableMetadataManager,
       VirtualTableInfoManager virtualTableInfoManager,
       JdbcService jdbcService,
@@ -568,15 +568,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the dataSource", e);
-    }
-    try {
-      tableMetadataDataSource.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the table metadata dataSource", e);
-    }
+    dataSource.close();
+    tableMetadataDataSource.close();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -7,6 +7,7 @@ import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 public final class JdbcUtils {
@@ -23,7 +24,11 @@ public final class JdbcUtils {
         rdbEngine,
         transactional,
         config.getConnectionPoolMinIdle(),
-        config.getConnectionPoolMaxTotal());
+        config.getConnectionPoolMaxTotal(),
+        config.getConnectionPoolConnectionTimeoutMillis().orElse(null),
+        config.getConnectionPoolIdleTimeoutMillis().orElse(null),
+        config.getConnectionPoolMaxLifetimeMillis().orElse(null),
+        config.getConnectionPoolKeepaliveTimeMillis().orElse(null));
   }
 
   public static HikariDataSource initDataSourceForTableMetadata(
@@ -33,7 +38,11 @@ public final class JdbcUtils {
         rdbEngine,
         false,
         config.getTableMetadataConnectionPoolMinIdle(),
-        config.getTableMetadataConnectionPoolMaxTotal());
+        config.getTableMetadataConnectionPoolMaxTotal(),
+        config.getTableMetadataConnectionPoolConnectionTimeoutMillis().orElse(null),
+        config.getTableMetadataConnectionPoolIdleTimeoutMillis().orElse(null),
+        config.getTableMetadataConnectionPoolMaxLifetimeMillis().orElse(null),
+        config.getTableMetadataConnectionPoolKeepaliveTimeMillis().orElse(null));
   }
 
   public static HikariDataSource initDataSourceForAdmin(
@@ -43,7 +52,11 @@ public final class JdbcUtils {
         rdbEngine,
         false,
         config.getAdminConnectionPoolMinIdle(),
-        config.getAdminConnectionPoolMaxTotal());
+        config.getAdminConnectionPoolMaxTotal(),
+        config.getAdminConnectionPoolConnectionTimeoutMillis().orElse(null),
+        config.getAdminConnectionPoolIdleTimeoutMillis().orElse(null),
+        config.getAdminConnectionPoolMaxLifetimeMillis().orElse(null),
+        config.getAdminConnectionPoolKeepaliveTimeMillis().orElse(null));
   }
 
   private static HikariDataSource createDataSource(
@@ -51,7 +64,11 @@ public final class JdbcUtils {
       RdbEngineStrategy rdbEngine,
       boolean transactional,
       int minIdle,
-      int maxTotal) {
+      int maxTotal,
+      @Nullable Long connectionTimeout,
+      @Nullable Long idleTimeout,
+      @Nullable Long maxLifetime,
+      @Nullable Long keepaliveTime) {
     HikariConfig hikariConfig = new HikariConfig();
 
     /*
@@ -78,6 +95,19 @@ public final class JdbcUtils {
     hikariConfig.setReadOnly(false);
     hikariConfig.setMinimumIdle(minIdle);
     hikariConfig.setMaximumPoolSize(maxTotal);
+
+    if (connectionTimeout != null) {
+      hikariConfig.setConnectionTimeout(connectionTimeout);
+    }
+    if (idleTimeout != null) {
+      hikariConfig.setIdleTimeout(idleTimeout);
+    }
+    if (maxLifetime != null) {
+      hikariConfig.setMaxLifetime(maxLifetime);
+    }
+    if (keepaliveTime != null) {
+      hikariConfig.setKeepaliveTime(keepaliveTime);
+    }
 
     for (Entry<String, String> entry : rdbEngine.getConnectionProperties(config).entrySet()) {
       hikariConfig.addDataSourceProperty(entry.getKey(), entry.getValue());

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,139 +1,139 @@
 package com.scalar.db.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.util.Map.Entry;
-import org.apache.commons.dbcp2.BasicDataSource;
+import javax.sql.DataSource;
 
 public final class JdbcUtils {
   private JdbcUtils() {}
 
-  public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
+  public static HikariDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
     return initDataSource(config, rdbEngine, false);
   }
 
   @VisibleForTesting
-  static BasicDataSource createDataSource() {
-    return new BasicDataSource();
+  static HikariDataSource createDataSource(HikariConfig hikariConfig) {
+    return new HikariDataSource(hikariConfig);
   }
 
-  public static BasicDataSource initDataSource(
+  public static HikariDataSource initDataSource(
       JdbcConfig config, RdbEngineStrategy rdbEngine, boolean transactional) {
-    BasicDataSource dataSource = createDataSource();
+    HikariConfig hikariConfig = new HikariConfig();
 
     /*
      * We need to set the driver class of an underlying database to the dataSource in order
      * to avoid the "No suitable driver" error in case when ServiceLoader in java.sql.DriverManager
      * doesn't work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriver());
+    hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
 
-    dataSource.setUrl(config.getJdbcUrl());
-    config.getUsername().ifPresent(dataSource::setUsername);
-    config.getPassword().ifPresent(dataSource::setPassword);
+    hikariConfig.setJdbcUrl(config.getJdbcUrl());
+    config.getUsername().ifPresent(hikariConfig::setUsername);
+    config.getPassword().ifPresent(hikariConfig::setPassword);
 
     if (transactional) {
-      dataSource.setDefaultAutoCommit(false);
-      dataSource.setAutoCommitOnReturn(false);
+      hikariConfig.setAutoCommit(false);
     }
 
     config
         .getIsolation()
         .ifPresent(
             isolation ->
-                dataSource.setDefaultTransactionIsolation(toJdbcTransactionIsolation(isolation)));
+                hikariConfig.setTransactionIsolation(toHikariTransactionIsolation(isolation)));
 
-    dataSource.setDefaultReadOnly(false);
+    hikariConfig.setReadOnly(false);
 
-    dataSource.setMinIdle(config.getConnectionPoolMinIdle());
-    dataSource.setMaxIdle(config.getConnectionPoolMaxIdle());
-    dataSource.setMaxTotal(config.getConnectionPoolMaxTotal());
-    dataSource.setPoolPreparedStatements(config.isPreparedStatementsPoolEnabled());
-    dataSource.setMaxOpenPreparedStatements(config.getPreparedStatementsPoolMaxOpen());
+    hikariConfig.setMinimumIdle(config.getConnectionPoolMinIdle());
+    hikariConfig.setMaximumPoolSize(config.getConnectionPoolMaxTotal());
+
     for (Entry<String, String> entry : rdbEngine.getConnectionProperties(config).entrySet()) {
-      dataSource.addConnectionProperty(entry.getKey(), entry.getValue());
+      hikariConfig.addDataSourceProperty(entry.getKey(), entry.getValue());
     }
 
-    return dataSource;
+    return createDataSource(hikariConfig);
   }
 
-  public static BasicDataSource initDataSourceForTableMetadata(
+  public static HikariDataSource initDataSourceForTableMetadata(
       JdbcConfig config, RdbEngineStrategy rdbEngine) {
-    BasicDataSource dataSource = createDataSource();
+    HikariConfig hikariConfig = new HikariConfig();
 
     /*
      * We need to set the driver class of an underlying database to the dataSource in order
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriver());
+    hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
 
-    dataSource.setUrl(config.getJdbcUrl());
-    config.getUsername().ifPresent(dataSource::setUsername);
-    config.getPassword().ifPresent(dataSource::setPassword);
+    hikariConfig.setJdbcUrl(config.getJdbcUrl());
+    config.getUsername().ifPresent(hikariConfig::setUsername);
+    config.getPassword().ifPresent(hikariConfig::setPassword);
 
     config
         .getIsolation()
         .ifPresent(
             isolation ->
-                dataSource.setDefaultTransactionIsolation(toJdbcTransactionIsolation(isolation)));
+                hikariConfig.setTransactionIsolation(toHikariTransactionIsolation(isolation)));
 
-    dataSource.setDefaultReadOnly(false);
+    hikariConfig.setReadOnly(false);
 
-    dataSource.setMinIdle(config.getTableMetadataConnectionPoolMinIdle());
-    dataSource.setMaxIdle(config.getTableMetadataConnectionPoolMaxIdle());
-    dataSource.setMaxTotal(config.getTableMetadataConnectionPoolMaxTotal());
+    hikariConfig.setMinimumIdle(config.getTableMetadataConnectionPoolMinIdle());
+    hikariConfig.setMaximumPoolSize(config.getTableMetadataConnectionPoolMaxTotal());
+
     for (Entry<String, String> entry : rdbEngine.getConnectionProperties(config).entrySet()) {
-      dataSource.addConnectionProperty(entry.getKey(), entry.getValue());
+      hikariConfig.addDataSourceProperty(entry.getKey(), entry.getValue());
     }
 
-    return dataSource;
+    return createDataSource(hikariConfig);
   }
 
-  public static BasicDataSource initDataSourceForAdmin(
+  public static HikariDataSource initDataSourceForAdmin(
       JdbcConfig config, RdbEngineStrategy rdbEngine) {
-    BasicDataSource dataSource = createDataSource();
+    HikariConfig hikariConfig = new HikariConfig();
 
     /*
      * We need to set the driver class of an underlying database to the dataSource in order
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriver());
+    hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
 
-    dataSource.setUrl(config.getJdbcUrl());
-    config.getUsername().ifPresent(dataSource::setUsername);
-    config.getPassword().ifPresent(dataSource::setPassword);
+    hikariConfig.setJdbcUrl(config.getJdbcUrl());
+    config.getUsername().ifPresent(hikariConfig::setUsername);
+    config.getPassword().ifPresent(hikariConfig::setPassword);
 
     config
         .getIsolation()
         .ifPresent(
             isolation ->
-                dataSource.setDefaultTransactionIsolation(toJdbcTransactionIsolation(isolation)));
+                hikariConfig.setTransactionIsolation(toHikariTransactionIsolation(isolation)));
 
-    dataSource.setDefaultReadOnly(false);
+    hikariConfig.setReadOnly(false);
 
-    dataSource.setMinIdle(config.getAdminConnectionPoolMinIdle());
-    dataSource.setMaxIdle(config.getAdminConnectionPoolMaxIdle());
-    dataSource.setMaxTotal(config.getAdminConnectionPoolMaxTotal());
+    hikariConfig.setMinimumIdle(config.getAdminConnectionPoolMinIdle());
+    hikariConfig.setMaximumPoolSize(config.getAdminConnectionPoolMaxTotal());
+
     for (Entry<String, String> entry : rdbEngine.getConnectionProperties(config).entrySet()) {
-      dataSource.addConnectionProperty(entry.getKey(), entry.getValue());
+      hikariConfig.addDataSourceProperty(entry.getKey(), entry.getValue());
     }
-    return dataSource;
+
+    return createDataSource(hikariConfig);
   }
 
-  private static int toJdbcTransactionIsolation(Isolation isolation) {
+  private static String toHikariTransactionIsolation(Isolation isolation) {
     switch (isolation) {
       case READ_UNCOMMITTED:
-        return Connection.TRANSACTION_READ_UNCOMMITTED;
+        return "TRANSACTION_READ_UNCOMMITTED";
       case READ_COMMITTED:
-        return Connection.TRANSACTION_READ_COMMITTED;
+        return "TRANSACTION_READ_COMMITTED";
       case REPEATABLE_READ:
-        return Connection.TRANSACTION_REPEATABLE_READ;
+        return "TRANSACTION_REPEATABLE_READ";
       case SERIALIZABLE:
-        return Connection.TRANSACTION_SERIALIZABLE;
+        return "TRANSACTION_SERIALIZABLE";
       default:
         throw new AssertionError();
     }
@@ -172,8 +172,7 @@ public final class JdbcUtils {
    * @param rdbEngine the RDB engine strategy
    * @return true if explicit commit is required, false otherwise
    */
-  public static boolean requiresExplicitCommit(
-      BasicDataSource dataSource, RdbEngineStrategy rdbEngine) {
+  public static boolean requiresExplicitCommit(DataSource dataSource, RdbEngineStrategy rdbEngine) {
     try (Connection connection = dataSource.getConnection()) {
       return rdbEngine.requiresExplicitCommit(connection.getTransactionIsolation());
     } catch (SQLException e) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -21,7 +21,6 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -59,8 +58,8 @@ class RdbEngineDb2 extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    return new com.ibm.db2.jcc.DB2Driver();
+  public String getDriverClassName() {
+    return com.ibm.db2.jcc.DB2Driver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
@@ -1,9 +1,9 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.common.CoreError;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 /** Factory class of subclasses of {@link RdbEngineStrategy} */
 public final class RdbEngineFactory {
@@ -46,7 +46,7 @@ public final class RdbEngineFactory {
    */
   private static RdbEngineStrategy createMysqlOrTidbEngine(JdbcConfig config) {
     RdbEngineMysql mysqlEngine = new RdbEngineMysql(config);
-    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, mysqlEngine);
+    try (HikariDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, mysqlEngine);
         Connection connection = dataSource.getConnection()) {
       String version = connection.getMetaData().getDatabaseProductVersion();
       if (version.contains("TiDB")) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.io.DataType;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -11,8 +10,8 @@ import javax.annotation.Nullable;
 
 class RdbEngineMariaDB extends RdbEngineMysql {
   @Override
-  public Driver getDriver() {
-    return new org.mariadb.jdbc.Driver();
+  public String getDriverClassName() {
+    return org.mariadb.jdbc.Driver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -12,7 +12,6 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -422,12 +421,8 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    try {
-      return new com.mysql.cj.jdbc.Driver();
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
+  public String getDriverClassName() {
+    return com.mysql.cj.jdbc.Driver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -19,7 +19,6 @@ import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -437,8 +436,8 @@ class RdbEngineOracle extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    return new oracle.jdbc.driver.OracleDriver();
+  public String getDriverClassName() {
+    return oracle.jdbc.driver.OracleDriver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -11,7 +11,6 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -382,8 +381,8 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    return new org.postgresql.Driver();
+  public String getDriverClassName() {
+    return org.postgresql.Driver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -11,7 +11,6 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithTop;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -387,8 +386,8 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    return new com.microsoft.sqlserver.jdbc.SQLServerDriver();
+  public String getDriverClassName() {
+    return com.microsoft.sqlserver.jdbc.SQLServerDriver.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -15,7 +15,6 @@ import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -320,8 +319,8 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public Driver getDriver() {
-    return new org.sqlite.JDBC();
+  public String getDriverClassName() {
+    return org.sqlite.JDBC.class.getName();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -13,7 +13,6 @@ import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -163,7 +162,7 @@ public interface RdbEngineStrategy {
 
   UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder);
 
-  Driver getDriver();
+  String getDriverClassName();
 
   default void throwIfImportNotSupported() {}
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineYugabyte.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineYugabyte.java
@@ -1,10 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
-import java.sql.Driver;
-
 class RdbEngineYugabyte extends RdbEnginePostgresql {
   @Override
-  public Driver getDriver() {
-    return new com.yugabyte.Driver();
+  public String getDriverClassName() {
+    return com.yugabyte.Driver.class.getName();
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -40,6 +40,7 @@ import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngineFactory;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.db.util.ThrowableFunction;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -47,7 +48,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,8 +55,8 @@ import org.slf4j.LoggerFactory;
 public class JdbcTransactionManager extends AbstractDistributedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(JdbcTransactionManager.class);
 
-  private final BasicDataSource dataSource;
-  private final BasicDataSource tableMetadataDataSource;
+  private final HikariDataSource dataSource;
+  private final HikariDataSource tableMetadataDataSource;
   private final RdbEngineStrategy rdbEngine;
   private final JdbcService jdbcService;
 
@@ -84,8 +84,8 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
   @VisibleForTesting
   JdbcTransactionManager(
       DatabaseConfig databaseConfig,
-      BasicDataSource dataSource,
-      BasicDataSource tableMetadataDataSource,
+      HikariDataSource dataSource,
+      HikariDataSource tableMetadataDataSource,
       RdbEngineStrategy rdbEngine,
       JdbcService jdbcService) {
     super(databaseConfig);
@@ -443,15 +443,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the dataSource", e);
-    }
-    try {
-      tableMetadataDataSource.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the table metadata dataSource", e);
-    }
+    dataSource.close();
+    tableMetadataDataSource.close();
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -42,6 +42,7 @@ import com.scalar.db.api.VirtualTableJoinType;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
+import com.zaxxer.hikari.HikariDataSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -60,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -101,7 +101,7 @@ public class JdbcAdminTest {
           RdbEngine.DB2,
           new RdbEngineDb2());
 
-  @Mock private BasicDataSource dataSource;
+  @Mock private HikariDataSource dataSource;
   @Mock private Connection connection;
   @Mock private JdbcConfig config;
   @Mock private TableMetadataService tableMetadataService;

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -28,11 +28,23 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.SYSTEM_NAMESPACE_NAME, ANY_METADATA_SCHEMA);
     props.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "1");
     props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "500");
+    props.setProperty(JdbcConfig.CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "10000");
+    props.setProperty(JdbcConfig.CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "300000");
+    props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_LIFETIME_MILLIS, "900000");
+    props.setProperty(JdbcConfig.CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "60000");
     props.setProperty(JdbcConfig.ISOLATION_LEVEL, Isolation.SERIALIZABLE.name());
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "20000");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "400000");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_LIFETIME_MILLIS, "1000000");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "70000");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "50");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "200");
+    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "30000");
+    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "500000");
+    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_LIFETIME_MILLIS, "1100000");
+    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "80000");
     props.setProperty(JdbcConfig.MYSQL_VARIABLE_KEY_COLUMN_SIZE, "64");
     props.setProperty(JdbcConfig.ORACLE_VARIABLE_KEY_COLUMN_SIZE, "64");
     props.setProperty(JdbcConfig.DB2_VARIABLE_KEY_COLUMN_SIZE, "64");
@@ -50,13 +62,25 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getConnectionPoolMinIdle()).isEqualTo(1);
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(500);
+    assertThat(config.getConnectionPoolConnectionTimeoutMillis()).hasValue(10000L);
+    assertThat(config.getConnectionPoolIdleTimeoutMillis()).hasValue(300000L);
+    assertThat(config.getConnectionPoolMaxLifetimeMillis()).hasValue(900000L);
+    assertThat(config.getConnectionPoolKeepaliveTimeMillis()).hasValue(60000L);
     assertThat(config.getIsolation()).isPresent();
     assertThat(config.getIsolation().get()).isEqualTo(Isolation.SERIALIZABLE);
     assertThat(config.getMetadataSchema()).isEqualTo(ANY_METADATA_SCHEMA);
     assertThat(config.getTableMetadataConnectionPoolMinIdle()).isEqualTo(100);
     assertThat(config.getTableMetadataConnectionPoolMaxTotal()).isEqualTo(300);
+    assertThat(config.getTableMetadataConnectionPoolConnectionTimeoutMillis()).hasValue(20000L);
+    assertThat(config.getTableMetadataConnectionPoolIdleTimeoutMillis()).hasValue(400000L);
+    assertThat(config.getTableMetadataConnectionPoolMaxLifetimeMillis()).hasValue(1000000L);
+    assertThat(config.getTableMetadataConnectionPoolKeepaliveTimeMillis()).hasValue(70000L);
     assertThat(config.getAdminConnectionPoolMinIdle()).isEqualTo(50);
     assertThat(config.getAdminConnectionPoolMaxTotal()).isEqualTo(200);
+    assertThat(config.getAdminConnectionPoolConnectionTimeoutMillis()).hasValue(30000L);
+    assertThat(config.getAdminConnectionPoolIdleTimeoutMillis()).hasValue(500000L);
+    assertThat(config.getAdminConnectionPoolMaxLifetimeMillis()).hasValue(1100000L);
+    assertThat(config.getAdminConnectionPoolKeepaliveTimeMillis()).hasValue(80000L);
     assertThat(config.getMysqlVariableKeyColumnSize()).isEqualTo(64);
     assertThat(config.getOracleVariableKeyColumnSize()).isEqualTo(64);
     assertThat(config.getDb2VariableKeyColumnSize()).isEqualTo(64);
@@ -89,12 +113,28 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
     assertThat(config.getConnectionPoolMaxTotal())
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MAX_TOTAL);
+    assertThat(config.getConnectionPoolConnectionTimeoutMillis()).isEmpty();
+    assertThat(config.getConnectionPoolIdleTimeoutMillis()).isEmpty();
+    assertThat(config.getConnectionPoolMaxLifetimeMillis()).isEmpty();
+    assertThat(config.getConnectionPoolKeepaliveTimeMillis()).isEmpty();
     assertThat(config.getIsolation()).isNotPresent();
     assertThat(config.getMetadataSchema()).isEqualTo(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     assertThat(config.getTableMetadataConnectionPoolMinIdle())
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE);
     assertThat(config.getTableMetadataConnectionPoolMaxTotal())
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
+    assertThat(config.getTableMetadataConnectionPoolConnectionTimeoutMillis()).isEmpty();
+    assertThat(config.getTableMetadataConnectionPoolIdleTimeoutMillis()).isEmpty();
+    assertThat(config.getTableMetadataConnectionPoolMaxLifetimeMillis()).isEmpty();
+    assertThat(config.getTableMetadataConnectionPoolKeepaliveTimeMillis()).isEmpty();
+    assertThat(config.getAdminConnectionPoolMinIdle())
+        .isEqualTo(JdbcConfig.DEFAULT_ADMIN_CONNECTION_POOL_MIN_IDLE);
+    assertThat(config.getAdminConnectionPoolMaxTotal())
+        .isEqualTo(JdbcConfig.DEFAULT_ADMIN_CONNECTION_POOL_MAX_TOTAL);
+    assertThat(config.getAdminConnectionPoolConnectionTimeoutMillis()).isEmpty();
+    assertThat(config.getAdminConnectionPoolIdleTimeoutMillis()).isEmpty();
+    assertThat(config.getAdminConnectionPoolMaxLifetimeMillis()).isEmpty();
+    assertThat(config.getAdminConnectionPoolKeepaliveTimeMillis()).isEmpty();
     assertThat(config.getMysqlVariableKeyColumnSize())
         .isEqualTo(JdbcConfig.DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
     assertThat(config.getOracleVariableKeyColumnSize())

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -27,16 +27,11 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(DatabaseConfig.SYSTEM_NAMESPACE_NAME, ANY_METADATA_SCHEMA);
     props.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "1");
-    props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "100");
     props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "500");
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "300");
     props.setProperty(JdbcConfig.ISOLATION_LEVEL, Isolation.SERIALIZABLE.name());
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
-    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "200");
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "50");
-    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_IDLE, "150");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "200");
     props.setProperty(JdbcConfig.MYSQL_VARIABLE_KEY_COLUMN_SIZE, "64");
     props.setProperty(JdbcConfig.ORACLE_VARIABLE_KEY_COLUMN_SIZE, "64");
@@ -54,18 +49,13 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getConnectionPoolMinIdle()).isEqualTo(1);
-    assertThat(config.getConnectionPoolMaxIdle()).isEqualTo(100);
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(500);
-    assertThat(config.isPreparedStatementsPoolEnabled()).isEqualTo(true);
-    assertThat(config.getPreparedStatementsPoolMaxOpen()).isEqualTo(300);
     assertThat(config.getIsolation()).isPresent();
     assertThat(config.getIsolation().get()).isEqualTo(Isolation.SERIALIZABLE);
     assertThat(config.getMetadataSchema()).isEqualTo(ANY_METADATA_SCHEMA);
     assertThat(config.getTableMetadataConnectionPoolMinIdle()).isEqualTo(100);
-    assertThat(config.getTableMetadataConnectionPoolMaxIdle()).isEqualTo(200);
     assertThat(config.getTableMetadataConnectionPoolMaxTotal()).isEqualTo(300);
     assertThat(config.getAdminConnectionPoolMinIdle()).isEqualTo(50);
-    assertThat(config.getAdminConnectionPoolMaxIdle()).isEqualTo(150);
     assertThat(config.getAdminConnectionPoolMaxTotal()).isEqualTo(200);
     assertThat(config.getMysqlVariableKeyColumnSize()).isEqualTo(64);
     assertThat(config.getOracleVariableKeyColumnSize()).isEqualTo(64);
@@ -97,20 +87,12 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getConnectionPoolMinIdle())
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
-    assertThat(config.getConnectionPoolMaxIdle())
-        .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MAX_IDLE);
     assertThat(config.getConnectionPoolMaxTotal())
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MAX_TOTAL);
-    assertThat(config.isPreparedStatementsPoolEnabled())
-        .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
-    assertThat(config.getPreparedStatementsPoolMaxOpen())
-        .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
     assertThat(config.getIsolation()).isNotPresent();
     assertThat(config.getMetadataSchema()).isEqualTo(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     assertThat(config.getTableMetadataConnectionPoolMinIdle())
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE);
-    assertThat(config.getTableMetadataConnectionPoolMaxIdle())
-        .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE);
     assertThat(config.getTableMetadataConnectionPoolMaxTotal())
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
     assertThat(config.getMysqlVariableKeyColumnSize())
@@ -149,27 +131,7 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "aaa");
-    props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "bbb");
     props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "ccc");
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "ddd");
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "eee");
-
-    // Act Assert
-    assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props)))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      constructor_PropertiesWithInvalidPreparedStatementsPoolPropertiesGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_JDBC_URL);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "ddd");
-    props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "eee");
 
     // Act Assert
     assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props)))
@@ -202,7 +164,6 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "aaa");
-    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "bbb");
     props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "ccc");
 
     // Act Assert
@@ -220,7 +181,6 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "aaa");
-    props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_IDLE, "bbb");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "ccc");
 
     // Act Assert

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -28,6 +28,7 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
+import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -37,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -50,8 +50,8 @@ public class JdbcDatabaseTest {
   private static final String TABLE = "tbl";
 
   @Mock private DatabaseConfig databaseConfig;
-  @Mock private BasicDataSource dataSource;
-  @Mock private BasicDataSource tableMetadataDataSource;
+  @Mock private HikariDataSource dataSource;
+  @Mock private HikariDataSource tableMetadataDataSource;
   @Mock private TableMetadataManager tableMetadataManager;
   @Mock private VirtualTableInfoManager virtualTableInfoManager;
   @Mock private JdbcService jdbcService;

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -1,21 +1,16 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.config.DatabaseConfig;
-import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.SQLException;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.util.Collections;
 import java.util.Properties;
-import org.apache.commons.dbcp2.BasicDataSource;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
@@ -34,7 +29,7 @@ public class JdbcUtilsTest {
   }
 
   @Test
-  public void initDataSource_NonTransactional_ShouldReturnProperDataSource() throws SQLException {
+  public void initDataSource_NonTransactional_ShouldConfigureHikariConfigProperly() {
     // Arrange
     Properties properties = new Properties();
     properties.setProperty(DatabaseConfig.CONTACT_POINTS, "jdbc:mysql://localhost:3306/");
@@ -43,42 +38,48 @@ public class JdbcUtilsTest {
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "10");
-    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "20");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "30");
-    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
-    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "100");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    Driver driver = new com.mysql.cj.jdbc.Driver();
-    when(rdbEngine.getDriver()).thenReturn(driver);
+    when(rdbEngine.getDriverClassName()).thenReturn("com.mysql.cj.jdbc.Driver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
 
-    // Act
-    BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine);
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSource(config, rdbEngine);
+    }
 
     // Assert
-    assertThat(dataSource.getDriver()).isEqualTo(driver);
-    assertThat(dataSource.getUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
-    assertThat(dataSource.getUsername()).isEqualTo("root");
-    assertThat(dataSource.getPassword()).isEqualTo("mysql");
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(hikariConfig.getJdbcUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
+    assertThat(hikariConfig.getUsername()).isEqualTo("root");
+    assertThat(hikariConfig.getPassword()).isEqualTo("mysql");
 
-    assertThat(dataSource.getDefaultAutoCommit()).isEqualTo(null);
-    assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(true);
-    assertThat(dataSource.getDefaultTransactionIsolation())
-        .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
-    assertThat(dataSource.getDefaultReadOnly()).isFalse();
+    // Non-transactional mode does not set autoCommit to false, so it defaults to true
+    assertThat(hikariConfig.isAutoCommit()).isTrue();
+    assertThat(hikariConfig.getTransactionIsolation()).isEqualTo("TRANSACTION_SERIALIZABLE");
+    assertThat(hikariConfig.isReadOnly()).isFalse();
 
-    assertThat(dataSource.getMinIdle()).isEqualTo(10);
-    assertThat(dataSource.getMaxIdle()).isEqualTo(20);
-    assertThat(dataSource.getMaxTotal()).isEqualTo(30);
-    assertThat(dataSource.isPoolPreparedStatements()).isEqualTo(true);
-    assertThat(dataSource.getMaxOpenPreparedStatements()).isEqualTo(100);
-
-    dataSource.close();
+    assertThat(hikariConfig.getMinimumIdle()).isEqualTo(10);
+    assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(30);
   }
 
   @Test
-  public void initDataSource_Transactional_ShouldReturnProperDataSource() throws SQLException {
+  public void initDataSource_Transactional_ShouldConfigureHikariConfigProperly() {
     // Arrange
     Properties properties = new Properties();
     properties.setProperty(DatabaseConfig.CONTACT_POINTS, "jdbc:postgresql://localhost:5432/");
@@ -87,42 +88,48 @@ public class JdbcUtilsTest {
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "READ_COMMITTED");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "30");
-    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "40");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "50");
-    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
-    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "200");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    Driver driver = new org.postgresql.Driver();
-    when(rdbEngine.getDriver()).thenReturn(driver);
+    when(rdbEngine.getDriverClassName()).thenReturn("org.postgresql.Driver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
 
-    // Act
-    BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine, true);
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSource(config, rdbEngine, true);
+    }
 
     // Assert
-    assertThat(dataSource.getDriver()).isEqualTo(driver);
-    assertThat(dataSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/");
-    assertThat(dataSource.getUsername()).isEqualTo("user");
-    assertThat(dataSource.getPassword()).isEqualTo("postgres");
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("org.postgresql.Driver");
+    assertThat(hikariConfig.getJdbcUrl()).isEqualTo("jdbc:postgresql://localhost:5432/");
+    assertThat(hikariConfig.getUsername()).isEqualTo("user");
+    assertThat(hikariConfig.getPassword()).isEqualTo("postgres");
 
-    assertThat(dataSource.getDefaultAutoCommit()).isEqualTo(false);
-    assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(false);
-    assertThat(dataSource.getDefaultTransactionIsolation())
-        .isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
-    assertThat(dataSource.getDefaultReadOnly()).isFalse();
+    // Transactional mode sets autoCommit to false
+    assertThat(hikariConfig.isAutoCommit()).isFalse();
+    assertThat(hikariConfig.getTransactionIsolation()).isEqualTo("TRANSACTION_READ_COMMITTED");
+    assertThat(hikariConfig.isReadOnly()).isFalse();
 
-    assertThat(dataSource.getMinIdle()).isEqualTo(30);
-    assertThat(dataSource.getMaxIdle()).isEqualTo(40);
-    assertThat(dataSource.getMaxTotal()).isEqualTo(50);
-    assertThat(dataSource.isPoolPreparedStatements()).isEqualTo(true);
-    assertThat(dataSource.getMaxOpenPreparedStatements()).isEqualTo(200);
-
-    dataSource.close();
+    assertThat(hikariConfig.getMinimumIdle()).isEqualTo(30);
+    assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(50);
   }
 
   @Test
-  public void initDataSource_WithRdbEngineConnectionProperties_ShouldAddProperties() {
+  public void initDataSource_WithRdbEngineConnectionProperties_ShouldAddDataSourceProperties() {
     // Arrange
     Properties properties = new Properties();
     properties.setProperty(
@@ -133,29 +140,36 @@ public class JdbcUtilsTest {
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    Driver driver = new com.microsoft.sqlserver.jdbc.SQLServerDriver();
-    when(rdbEngine.getDriver()).thenReturn(driver);
+    when(rdbEngine.getDriverClassName()).thenReturn("com.microsoft.sqlserver.jdbc.SQLServerDriver");
     when(rdbEngine.getConnectionProperties(config))
         .thenReturn(ImmutableMap.of("prop1", "prop1Value", "prop2", "prop2Value"));
+
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
     try (MockedStatic<JdbcUtils> jdbcUtils =
         Mockito.mockStatic(
             JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-      BasicDataSource dataSource = spy(BasicDataSource.class);
-      jdbcUtils.when(JdbcUtils::createDataSource).thenReturn(dataSource);
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
 
       // Act
-      jdbcUtils.when(() -> JdbcUtils.initDataSource(config, rdbEngine)).thenCallRealMethod();
-
-      // Assert
-      verify(dataSource).addConnectionProperty("prop1", "prop1Value");
-      verify(dataSource).addConnectionProperty("prop2", "prop2Value");
-      verify(dataSource, never()).setConnectionProperties(anyString());
+      JdbcUtils.initDataSource(config, rdbEngine);
     }
+
+    // Assert
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDataSourceProperties().getProperty("prop1")).isEqualTo("prop1Value");
+    assertThat(hikariConfig.getDataSourceProperties().getProperty("prop2")).isEqualTo("prop2Value");
   }
 
   @Test
-  public void initDataSourceForTableMetadata_ShouldReturnProperDataSource() throws SQLException {
+  public void initDataSourceForTableMetadata_ShouldConfigureHikariConfigProperly() {
     // Arrange
     Properties properties = new Properties();
     properties.setProperty(
@@ -165,37 +179,46 @@ public class JdbcUtilsTest {
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "REPEATABLE_READ");
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
-    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "200");
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    Driver driver = new oracle.jdbc.driver.OracleDriver();
-    when(rdbEngine.getDriver()).thenReturn(driver);
+    when(rdbEngine.getDriverClassName()).thenReturn("oracle.jdbc.driver.OracleDriver");
+    when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
 
-    // Act
-    BasicDataSource tableMetadataDataSource =
-        JdbcUtils.initDataSourceForTableMetadata(config, rdbEngine);
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSourceForTableMetadata(config, rdbEngine);
+    }
 
     // Assert
-    assertThat(tableMetadataDataSource.getDriver()).isEqualTo(driver);
-    assertThat(tableMetadataDataSource.getUrl())
-        .isEqualTo("jdbc:oracle:thin:@localhost:1521/XEPDB1");
-    assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
-    assertThat(tableMetadataDataSource.getPassword()).isEqualTo("oracle");
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("oracle.jdbc.driver.OracleDriver");
+    assertThat(hikariConfig.getJdbcUrl()).isEqualTo("jdbc:oracle:thin:@localhost:1521/XEPDB1");
+    assertThat(hikariConfig.getUsername()).isEqualTo("user");
+    assertThat(hikariConfig.getPassword()).isEqualTo("oracle");
 
-    assertThat(tableMetadataDataSource.getDefaultTransactionIsolation())
-        .isEqualTo(Connection.TRANSACTION_REPEATABLE_READ);
-    assertThat(tableMetadataDataSource.getDefaultReadOnly()).isFalse();
+    assertThat(hikariConfig.getTransactionIsolation()).isEqualTo("TRANSACTION_REPEATABLE_READ");
+    assertThat(hikariConfig.isReadOnly()).isFalse();
 
-    assertThat(tableMetadataDataSource.getMinIdle()).isEqualTo(100);
-    assertThat(tableMetadataDataSource.getMaxIdle()).isEqualTo(200);
-    assertThat(tableMetadataDataSource.getMaxTotal()).isEqualTo(300);
-
-    tableMetadataDataSource.close();
+    assertThat(hikariConfig.getMinimumIdle()).isEqualTo(100);
+    assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(300);
   }
 
   @Test
-  public void initDataSourceForAdmin_ShouldReturnProperDataSource() throws SQLException {
+  public void initDataSourceForAdmin_ShouldConfigureHikariConfigProperly() {
     // Arrange
     Properties properties = new Properties();
     properties.setProperty(DatabaseConfig.CONTACT_POINTS, "jdbc:sqlserver://localhost:1433");
@@ -204,30 +227,42 @@ public class JdbcUtilsTest {
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "READ_UNCOMMITTED");
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "100");
-    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_IDLE, "200");
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "300");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    Driver driver = new com.microsoft.sqlserver.jdbc.SQLServerDriver();
-    when(rdbEngine.getDriver()).thenReturn(driver);
+    when(rdbEngine.getDriverClassName()).thenReturn("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+    when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
 
-    // Act
-    BasicDataSource adminDataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
+    }
 
     // Assert
-    assertThat(adminDataSource.getDriver()).isEqualTo(driver);
-    assertThat(adminDataSource.getUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
-    assertThat(adminDataSource.getUsername()).isEqualTo("user");
-    assertThat(adminDataSource.getPassword()).isEqualTo("sqlserver");
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName())
+        .isEqualTo("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+    assertThat(hikariConfig.getJdbcUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
+    assertThat(hikariConfig.getUsername()).isEqualTo("user");
+    assertThat(hikariConfig.getPassword()).isEqualTo("sqlserver");
 
-    assertThat(adminDataSource.getDefaultTransactionIsolation())
-        .isEqualTo(Connection.TRANSACTION_READ_UNCOMMITTED);
-    assertThat(adminDataSource.getDefaultReadOnly()).isFalse();
+    assertThat(hikariConfig.getTransactionIsolation()).isEqualTo("TRANSACTION_READ_UNCOMMITTED");
+    assertThat(hikariConfig.isReadOnly()).isFalse();
 
-    assertThat(adminDataSource.getMinIdle()).isEqualTo(100);
-    assertThat(adminDataSource.getMaxIdle()).isEqualTo(200);
-    assertThat(adminDataSource.getMaxTotal()).isEqualTo(300);
-
-    adminDataSource.close();
+    assertThat(hikariConfig.getMinimumIdle()).isEqualTo(100);
+    assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(300);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -39,6 +39,10 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "10");
     properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "30");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "15000");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "300000");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_LIFETIME_MILLIS, "900000");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "60000");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("com.mysql.cj.jdbc.Driver");
@@ -76,6 +80,10 @@ public class JdbcUtilsTest {
 
     assertThat(hikariConfig.getMinimumIdle()).isEqualTo(10);
     assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(30);
+    assertThat(hikariConfig.getConnectionTimeout()).isEqualTo(15000);
+    assertThat(hikariConfig.getIdleTimeout()).isEqualTo(300000);
+    assertThat(hikariConfig.getMaxLifetime()).isEqualTo(900000);
+    assertThat(hikariConfig.getKeepaliveTime()).isEqualTo(60000);
   }
 
   @Test
@@ -180,6 +188,13 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "REPEATABLE_READ");
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
+    properties.setProperty(
+        JdbcConfig.TABLE_METADATA_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "20000");
+    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "400000");
+    properties.setProperty(
+        JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_LIFETIME_MILLIS, "1000000");
+    properties.setProperty(
+        JdbcConfig.TABLE_METADATA_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "70000");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("oracle.jdbc.driver.OracleDriver");
@@ -215,6 +230,10 @@ public class JdbcUtilsTest {
 
     assertThat(hikariConfig.getMinimumIdle()).isEqualTo(100);
     assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(300);
+    assertThat(hikariConfig.getConnectionTimeout()).isEqualTo(20000);
+    assertThat(hikariConfig.getIdleTimeout()).isEqualTo(400000);
+    assertThat(hikariConfig.getMaxLifetime()).isEqualTo(1000000);
+    assertThat(hikariConfig.getKeepaliveTime()).isEqualTo(70000);
   }
 
   @Test
@@ -228,6 +247,10 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "READ_UNCOMMITTED");
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "100");
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "300");
+    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_CONNECTION_TIMEOUT_MILLIS, "25000");
+    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_IDLE_TIMEOUT_MILLIS, "500000");
+    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_LIFETIME_MILLIS, "1100000");
+    properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "80000");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("com.microsoft.sqlserver.jdbc.SQLServerDriver");
@@ -264,5 +287,9 @@ public class JdbcUtilsTest {
 
     assertThat(hikariConfig.getMinimumIdle()).isEqualTo(100);
     assertThat(hikariConfig.getMaximumPoolSize()).isEqualTo(300);
+    assertThat(hikariConfig.getConnectionTimeout()).isEqualTo(25000);
+    assertThat(hikariConfig.getIdleTimeout()).isEqualTo(500000);
+    assertThat(hikariConfig.getMaxLifetime()).isEqualTo(1100000);
+    assertThat(hikariConfig.getKeepaliveTime()).isEqualTo(80000);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -42,6 +42,7 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.RdbEngine;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -49,7 +50,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -62,8 +62,8 @@ public class JdbcTransactionManagerTest {
   private static final String ANY_ID = "id";
 
   @Mock private DatabaseConfig databaseConfig;
-  @Mock private BasicDataSource dataSource;
-  @Mock private BasicDataSource tableMetadataDataSource;
+  @Mock private HikariDataSource dataSource;
+  @Mock private HikariDataSource tableMetadataDataSource;
   @Mock private JdbcService jdbcService;
   @Mock private Connection connection;
   @Mock private SQLException sqlException;


### PR DESCRIPTION
## Description

This PR migrates the JDBC adapter's connection pooling library from Apache Commons DBCP2 to HikariCP for improved performance and reliability. HikariCP 4.0.3 is used to maintain Java 8 compatibility.

The following configuration properties have been removed (a warning is logged if they are still set) because HikariCP does not support related features:

- scalar.db.jdbc.connection_pool.max_idle
- scalar.db.jdbc.table_metadata.connection_pool.max_idle
- scalar.db.jdbc.admin.connection_pool.max_idle
- scalar.db.jdbc.prepared_statements_pool.enabled
- scalar.db.jdbc.prepared_statements_pool.max_open

The following properties remain supported:

- scalar.db.jdbc.connection_pool.min_idle
- scalar.db.jdbc.connection_pool.max_total
- scalar.db.jdbc.table_metadata.connection_pool.min_idle
- scalar.db.jdbc.table_metadata.connection_pool.max_total
- scalar.db.jdbc.admin.connection_pool.min_idle
- scalar.db.jdbc.admin.connection_pool.max_total

And new configuration properties are as follows:

- Connection pool settings
  - scalar.db.jdbc.connection_pool.connection_timeout_millis
    - The maximum time in milliseconds to wait for a connection from the pool. If this time is exceeded, a SQLException will be thrown. (Default: 30000)
  - scalar.db.jdbc.connection_pool.idle_timeout_millis
    - The maximum time in milliseconds that a connection is allowed to sit idle in the pool. This setting only applies when min_idle is less than max_total. A value of 0 means idle connections are never removed. (Default: 600000)
  - scalar.db.jdbc.connection_pool.max_lifetime_millis
    - The maximum lifetime in milliseconds of a connection in the pool. Connections that exceed this lifetime will be retired. This value should be set to a few seconds shorter than any database or infrastructure-imposed connection timeout. A value of 0 means no maximum lifetime. (Default: 1800000)
  - scalar.db.jdbc.connection_pool.keepalive_time_millis
    - The interval in milliseconds at which the pool will attempt to keep connections alive to prevent them from being timed out by the database or network infrastructure. This value must be less than max_lifetime_millis. A value of 0 disables keepalive. (Default: 0)

- Table metadata connection pool settings
  - scalar.db.jdbc.table_metadata.connection_pool.connection_timeout_millis
    - Same as connection_pool.connection_timeout_millis, but for the table metadata connection pool. (Default: 30000)
  - scalar.db.jdbc.table_metadata.connection_pool.idle_timeout_millis
    - Same as connection_pool.idle_timeout_millis, but for the table metadata connection pool. (Default: 600000)
  - scalar.db.jdbc.table_metadata.connection_pool.max_lifetime_millis
    - Same as connection_pool.max_lifetime_millis, but for the table metadata connection pool. (Default: 1800000)
  - scalar.db.jdbc.table_metadata.connection_pool.keepalive_time_millis
    - Same as connection_pool.keepalive_time_millis, but for the table metadata connection pool. (Default: 0)

- Admin connection pool settings
  - scalar.db.jdbc.admin.connection_pool.connection_timeout_millis
    - Same as connection_pool.connection_timeout_millis, but for the admin connection pool. (Default: 30000)
  - scalar.db.jdbc.admin.connection_pool.idle_timeout_millis
    - Same as connection_pool.idle_timeout_millis, but for the admin connection pool. (Default: 600000)
  - scalar.db.jdbc.admin.connection_pool.max_lifetime_millis
    - Same as connection_pool.max_lifetime_millis, but for the admin connection pool. (Default: 1800000)
  - scalar.db.jdbc.admin.connection_pool.keepalive_time_millis
    - Same as connection_pool.keepalive_time_millis, but for the admin connection pool. (Default: 0)

Note: If these properties are not specified, HikariCP's default values will be used.

## Related issues and/or PRs

N/A

## Changes made

- Replace `org.apache.commons:commons-dbcp2:2.14.0` with `com.zaxxer:HikariCP:4.0.3`
- `RdbEngineStrategy.getDriver()` → `RdbEngineStrategy.getDriverClassName()`
  - Returns the driver class name as a String instead of a Driver instance
- Removed configuration properties listed above

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Migrated the JDBC adapter's connection pooling library from Apache Commons DBCP2 to HikariCP for improved performance and reliability.

Breaking changes:
- The following configuration properties are no longer supported and are ignored (with a warning logged) if set:
  - `scalar.db.jdbc.connection_pool.max_idle`
  - `scalar.db.jdbc.table_metadata.connection_pool.max_idle`
  - `scalar.db.jdbc.admin.connection_pool.max_idle`
  - `scalar.db.jdbc.prepared_statements_pool.enabled`
  - `scalar.db.jdbc.prepared_statements_pool.max_open`
- Prepared statement pooling is no longer available, as HikariCP has no equivalent feature.
- Connection pool defaults now follow HikariCP rather than DBCP2, which may change runtime behavior even without configuration changes (e.g., connection acquisition timeout, idle eviction).
                                                                                                                                                                                                                                                                                                                   
New configuration properties are available for tuning the connection, table metadata, and admin pools: `connection_timeout_millis`, `idle_timeout_millis`, `max_lifetime_millis`, `keepalive_time_millis`. See the documentation for defaults and details.                                                               
 
                         
