### PR TITLE
Update Blob Storage SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.12.1'
         azureCosmosVersion = '4.76.0'
-        azureBlobStorageVersion = '12.32.0'
+        azureBlobStorageVersion = '12.33.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.41.1'
         hikariCpVersion = '4.0.3'

--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -13,7 +13,13 @@
 blob-storage:
   - label: blob-storage
     display_name: Blob Storage
-    setup: docker run -d --name azurite -e AZURITE_ACCOUNTS=test:test -p 10000:10000 mcr.microsoft.com/azure-storage/azurite
+    # Start azurite with `--skipApiVersionCheck` to avoid API version check issues
+    setup: |
+      docker run -d --name azurite \
+        -e AZURITE_ACCOUNTS=test:test \
+        -p 10000:10000 \
+        mcr.microsoft.com/azure-storage/azurite \
+        azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --location /data --skipApiVersionCheck
     run: |
       az storage container create \
             --name test-container \

--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -19,7 +19,7 @@ blob-storage:
         -e AZURITE_ACCOUNTS=test:test \
         -p 10000:10000 \
         mcr.microsoft.com/azure-storage/azurite \
-        azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --location /data --skipApiVersionCheck
+        azurite --blobHost 0.0.0.0 --location /data --skipApiVersionCheck
     run: |
       az storage container create \
             --name test-container \


### PR DESCRIPTION
## Description

This updates the Azure Blob Storage SDK `com.azure:azure-storage-blob` to the version `12.33.0`
Since the Blob Storage emulator "Azurite" does not yet support the latest SDK version, we temporarily need to add the `--skipApiVersionCheck` flag to suppress API mismatch check error. 

```
ERROR: The API version 2026-02-06 is not supported by Azurite. Please upgrade Azurite to latest version and retry. If you are using Azurite in Visual Studio, please check you have installed latest Visual Studio patch. Azurite command line parameter "--skipApiVersionCheck" or Visual Studio Code configuration "Skip Api Version Check" can skip this error. 
```

Once Azurite supports the latest Blob Storage SDK, we can remove this workaround.

## Related issues and/or PRs

N/A

## Changes made

- In the Blob Storage CI, add the `--skipApiVersionCheck` option when starting Azurite to suppress API mismatch check error.
- Updates the Blob Storage SDK `com.azure:azure-storage-blob` to version `12.33.0`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I confirmed the CI passed for Blob Storage in https://github.com/scalar-labs/scalardb/actions/runs/21347622054

## Release notes

N/A
