### PR TITLE
Add --mode argument to data loader export command

### DIFF
--- a/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
+++ b/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
@@ -1,6 +1,7 @@
 package com.scalar.db.dataloader.cli.command.dataexport;
 
 import com.scalar.db.api.Scan;
+import com.scalar.db.dataloader.cli.ScalarDbMode;
 import com.scalar.db.dataloader.core.ColumnKeyValue;
 import com.scalar.db.dataloader.core.FileFormat;
 import java.util.ArrayList;
@@ -21,6 +22,13 @@ public class ExportCommandOptions {
   public static final String DEPRECATED_THREADS_OPTION = "--threads";
   public static final String DEPRECATED_INCLUDE_METADATA_OPTION = "--include-metadata";
   public static final String DEPRECATED_INCLUDE_METADATA_OPTION_SHORT = "-m";
+
+  @CommandLine.Option(
+      names = {"--mode"},
+      description = "ScalarDB mode (STORAGE, TRANSACTION) (default: STORAGE)",
+      paramLabel = "<MODE>",
+      defaultValue = "STORAGE")
+  protected ScalarDbMode scalarDbMode;
 
   @CommandLine.Option(
       names = {"--config", "-c"},

--- a/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
+++ b/data-loader/cli/src/main/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandOptions.java
@@ -25,7 +25,9 @@ public class ExportCommandOptions {
 
   @CommandLine.Option(
       names = {"--mode"},
-      description = "ScalarDB mode (STORAGE, TRANSACTION) (default: STORAGE)",
+      description =
+          "ScalarDB mode (STORAGE, TRANSACTION). Accepted for import/export parity and "
+              + "currently has no effect on export. (default: STORAGE)",
       paramLabel = "<MODE>",
       defaultValue = "STORAGE")
   protected ScalarDbMode scalarDbMode;

--- a/data-loader/cli/src/test/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandTest.java
+++ b/data-loader/cli/src/test/java/com/scalar/db/dataloader/cli/command/dataexport/ExportCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.scalar.db.dataloader.cli.ScalarDbMode;
 import com.scalar.db.dataloader.core.DataLoaderError;
 import com.scalar.db.dataloader.core.FileFormat;
 import java.io.File;
@@ -326,6 +327,53 @@ class ExportCommandTest {
         cmdShort
             .getParseResult()
             .hasMatchedOption(ExportCommandOptions.DEPRECATED_INCLUDE_METADATA_OPTION_SHORT));
+  }
+
+  @Test
+  void call_withModeStorage_shouldParseCorrectly() {
+    String[] args = {
+      "--config", "scalardb.properties",
+      "--namespace", "scalar",
+      "--table", "asset",
+      "--format", "JSON",
+      "--mode", "STORAGE"
+    };
+    ExportCommand command = new ExportCommand();
+    CommandLine cmd = new CommandLine(command);
+    cmd.parseArgs(args);
+
+    assertEquals(ScalarDbMode.STORAGE, command.scalarDbMode);
+  }
+
+  @Test
+  void call_withModeTransaction_shouldParseCorrectly() {
+    String[] args = {
+      "--config", "scalardb.properties",
+      "--namespace", "scalar",
+      "--table", "asset",
+      "--format", "JSON",
+      "--mode", "TRANSACTION"
+    };
+    ExportCommand command = new ExportCommand();
+    CommandLine cmd = new CommandLine(command);
+    cmd.parseArgs(args);
+
+    assertEquals(ScalarDbMode.TRANSACTION, command.scalarDbMode);
+  }
+
+  @Test
+  void call_withoutMode_shouldDefaultToStorage() {
+    String[] args = {
+      "--config", "scalardb.properties",
+      "--namespace", "scalar",
+      "--table", "asset",
+      "--format", "JSON"
+    };
+    ExportCommand command = new ExportCommand();
+    CommandLine cmd = new CommandLine(command);
+    cmd.parseArgs(args);
+
+    assertEquals(ScalarDbMode.STORAGE, command.scalarDbMode);
   }
 
   @Test


### PR DESCRIPTION
## Description

The data loader `export` command did not support `--mode`, while `import` did. This caused confusion for users who assumed both subcommands accepted the same arguments — particularly those passing `--mode TRANSACTION` uniformly to both. In reality, `--mode` has no effect on export (the `DistributedTransactionManager` handles reads the same way regardless of mode), but the missing flag caused script failures and user confusion. This PR adds `--mode` to export to keep both commands in parity.

## Related issues and/or PRs

N/A

## Changes made

- Added `--mode` option to `ExportCommandOptions` (accepts `STORAGE` or `TRANSACTION`, defaults to `STORAGE`)
- The argument is accepted and parsed but does not affect export behaviour — reads work identically in both modes

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Unlike `import`, where `--mode` determines how writes are batched (single CRUD vs consensus commit transactions), export only performs reads. The `DistributedTransactionManager` handles both storage and transaction reads transparently, so the flag is intentionally a no-op on the export side.

## Release notes

Added `--mode` argument to the data loader `export` command to match the `import` command interface. The argument accepts `STORAGE` (default) or `TRANSACTION` but does not affect export behaviour.