### PR TITLE
Fix index-based Get and Scan to not miss PREPARED/DELETED records by adding before-image index check

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -1,10 +1,23 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithDynamo
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -105,4 +118,98 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   @Override
   @Disabled("DynamoDB does not support renaming tables")
   public void renameTable_IfOnlyOneTableExists_ShouldRenameTableCorrectly() {}
+
+  @Override
+  @Disabled("Replaced by createIndexAndDropIndex test to avoid DynamoDB GSI per-table limit")
+  public void createIndex_ForAllDataTypesWithExistingData_ShouldCreateIndexesCorrectly() {}
+
+  @Override
+  @Disabled("Replaced by createIndexAndDropIndex test to avoid DynamoDB GSI per-table limit")
+  public void dropIndex_ForAllDataTypesWithExistingData_ShouldDropIndexCorrectly() {}
+
+  // This test merges createIndex and dropIndex tests into one to avoid exceeding DynamoDB's
+  // 20 GSI per-table limit. With before-image secondary indexes, each user index creates two
+  // GSIs, so creating indexes on all columns at once would exceed the limit.
+  @Test
+  public void
+      createIndexAndDropIndex_ForAllDataTypesWithExistingData_ShouldCreateAndDropIndexCorrectly()
+          throws Exception {
+    String table = "tbl_for_create_drop_idx";
+
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata metadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.BIGINT)
+              .addColumn(COL_NAME5, DataType.FLOAT)
+              .addColumn(COL_NAME6, DataType.DOUBLE)
+              .addColumn(COL_NAME7, DataType.BOOLEAN)
+              .addColumn(COL_NAME8, DataType.BLOB)
+              .addColumn(COL_NAME9, DataType.TEXT)
+              .addColumn(COL_NAME10, DataType.DATE)
+              .addColumn(COL_NAME11, DataType.TIME)
+              .addColumn(COL_NAME12, DataType.TIMESTAMPTZ)
+              .addColumn(COL_NAME13, DataType.TIMESTAMP)
+              .addPartitionKey(COL_NAME1)
+              .addSecondaryIndex(COL_NAME9)
+              .build();
+      admin.createTable(namespace1, table, metadata, options);
+
+      transactionalInsert(
+          Insert.newBuilder()
+              .namespace(namespace1)
+              .table(table)
+              .partitionKey(Key.ofInt(COL_NAME1, 1))
+              .intValue(COL_NAME2, 2)
+              .textValue(COL_NAME3, "3")
+              .bigIntValue(COL_NAME4, 4)
+              .floatValue(COL_NAME5, 5)
+              .doubleValue(COL_NAME6, 6)
+              .booleanValue(COL_NAME7, true)
+              .blobValue(COL_NAME8, "8".getBytes(StandardCharsets.UTF_8))
+              .textValue(COL_NAME9, "9")
+              .dateValue(COL_NAME10, LocalDate.of(2020, 6, 2))
+              .timeValue(COL_NAME11, LocalTime.of(12, 2, 6, 123_456_000))
+              .timestampTZValue(
+                  COL_NAME12,
+                  LocalDateTime.of(LocalDate.of(2020, 6, 2), LocalTime.of(12, 2, 6, 123_000_000))
+                      .toInstant(ZoneOffset.UTC))
+              .timestampValue(
+                  COL_NAME13,
+                  LocalDateTime.of(LocalDate.of(2020, 6, 2), LocalTime.of(12, 2, 6, 123_000_000)))
+              .build());
+
+      // Act Assert: create and drop each index one by one
+      createIndexAssertAndDrop(namespace1, table, COL_NAME2, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME3, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME4, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME5, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME6, options);
+      // DynamoDB does not support index on BOOLEAN column
+      createIndexAssertAndDrop(namespace1, table, COL_NAME10, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME11, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME12, options);
+      createIndexAssertAndDrop(namespace1, table, COL_NAME13, options);
+
+      // Verify COL_NAME9 index still exists
+      Set<String> finalIndexNames =
+          admin.getTableMetadata(namespace1, table).getSecondaryIndexNames();
+      assertThat(finalIndexNames).containsOnly(COL_NAME9);
+    } finally {
+      admin.dropTable(namespace1, table, true);
+    }
+  }
+
+  private void createIndexAssertAndDrop(
+      String namespace, String table, String column, Map<String, String> options) throws Exception {
+    admin.createIndex(namespace, table, column, options);
+    assertThat(admin.indexExists(namespace, table, column)).isTrue();
+    assertThat(admin.getTableMetadata(namespace, table).getSecondaryIndexNames()).contains(column);
+    admin.dropIndex(namespace, table, column);
+    assertThat(admin.indexExists(namespace, table, column)).isFalse();
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
@@ -28,9 +28,9 @@ public class MultiStorageAdminIntegrationTest {
   private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
   private static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
-  private static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
+  private static final String TABLE1 = "tbl1";
+  private static final String TABLE2 = "tbl2";
+  private static final String TABLE3 = "tbl3";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageEnv.java
@@ -40,7 +40,7 @@ public final class MultiStorageEnv {
     properties.setProperty(DatabaseConfig.PASSWORD, password);
     properties.setProperty(DatabaseConfig.STORAGE, "cassandra");
     properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN, "true");
-    properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_FILTERING, "false");
+    properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_FILTERING, "true");
     properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_ORDERING, "false");
 
     // Add testName as a metadata schema suffix

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -40,9 +40,9 @@ public class MultiStorageIntegrationTest {
   private static final String TEST_NAME = "mstorage";
   private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
-  private static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
+  private static final String TABLE1 = "tbl1";
+  private static final String TABLE2 = "tbl2";
+  private static final String TABLE3 = "tbl3";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -96,4 +96,182 @@ public class ConsensusCommitSpecificIntegrationTestWithObjectStorage
   @Override
   @Disabled("Object Storage does not support index-related operations")
   public void scanAndUpdate_ScanWithIndexGiven_ShouldUpdate(Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnResult(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void get_GetWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+      Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnResult(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnEmpty(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void get_GetWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+      Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation) {}
 }

--- a/core/src/main/java/com/scalar/db/api/TableMetadata.java
+++ b/core/src/main/java/com/scalar/db/api/TableMetadata.java
@@ -458,6 +458,15 @@ public class TableMetadata {
                       .buildMessage(k));
             }
           });
+      secondaryIndexNames.forEach(
+          k -> {
+            if (!columns.containsKey(k)) {
+              throw new IllegalStateException(
+                  CoreError
+                      .TABLE_METADATA_BUILD_ERROR_SECONDARY_INDEX_COLUMN_DEFINITION_NOT_SPECIFIED
+                      .buildMessage(k));
+            }
+          });
       return new TableMetadata(
           columns,
           partitionKeyNames,

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1038,6 +1038,12 @@ public enum CoreError implements ScalarDbError {
       "The condition for the Update operation must be UpdateIf or UpdateIfExists. Operation: %s",
       "",
       ""),
+  TABLE_METADATA_BUILD_ERROR_SECONDARY_INDEX_COLUMN_DEFINITION_NOT_SPECIFIED(
+      Category.USER_ERROR,
+      "0281",
+      "The column definition must be specified since %s is specified as a secondary index",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -1169,6 +1175,18 @@ public enum CoreError implements ScalarDbError {
       Category.CONCURRENCY_ERROR,
       "0027",
       "A transaction conflict occurred in the mutation. Details: %s",
+      "",
+      ""),
+  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED(
+      Category.CONCURRENCY_ERROR,
+      "0028",
+      "Before-image index recovery retry limit exceeded. Transaction ID: %s",
+      "",
+      ""),
+  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER(
+      Category.CONCURRENCY_ERROR,
+      "0029",
+      "Records that need recovery were found during the before-image index check when closing the scanner. Transaction ID: %s",
       "",
       ""),
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -41,6 +41,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   private final DistributedStorageAdmin admin;
   private final String coordinatorNamespace;
   private final boolean isIncludeMetadataEnabled;
+  private final boolean isIndexEventuallyConsistentReadEnabled;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
@@ -49,6 +50,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
 
   public ConsensusCommitAdmin(DatabaseConfig databaseConfig) {
@@ -58,6 +60,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
 
   @VisibleForTesting
@@ -68,6 +71,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     this.admin = admin;
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
+    isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
 
   @Override
@@ -147,7 +151,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
       admin.createTable(
           namespace,
           txMetadataTableName,
-          ConsensusCommitUtils.buildTransactionMetadataTableMetadata(metadata),
+          ConsensusCommitUtils.buildTransactionMetadataTableMetadata(
+              metadata, isIndexEventuallyConsistentReadEnabled),
           options);
 
       // Create a virtual table based on the data table and the transaction metadata table
@@ -163,7 +168,11 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
       return;
     }
 
-    admin.createTable(namespace, table, buildTransactionTableMetadata(metadata), options);
+    admin.createTable(
+        namespace,
+        table,
+        buildTransactionTableMetadata(metadata, isIndexEventuallyConsistentReadEnabled),
+        options);
   }
 
   @Override
@@ -223,6 +232,17 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     checkNamespace(namespace);
 
     admin.createIndex(namespace, table, columnName, options);
+
+    if (!isIndexEventuallyConsistentReadEnabled) {
+      // Also create an index on the before image column if it exists
+      TableMetadata rawMetadata = admin.getTableMetadata(namespace, table);
+      if (rawMetadata != null) {
+        String beforeColumnName = Attribute.BEFORE_PREFIX + columnName;
+        if (rawMetadata.getColumnNames().contains(beforeColumnName)) {
+          admin.createIndex(namespace, table, beforeColumnName, options);
+        }
+      }
+    }
   }
 
   @Override
@@ -231,6 +251,17 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     checkNamespace(namespace);
 
     admin.dropIndex(namespace, table, columnName);
+
+    if (!isIndexEventuallyConsistentReadEnabled) {
+      // Also drop the index on the before image column if it exists
+      TableMetadata rawMetadata = admin.getTableMetadata(namespace, table);
+      if (rawMetadata != null) {
+        String beforeColumnName = Attribute.BEFORE_PREFIX + columnName;
+        if (rawMetadata.getColumnNames().contains(beforeColumnName)) {
+          admin.dropIndex(namespace, table, beforeColumnName, true);
+        }
+      }
+    }
   }
 
   @Override
@@ -293,7 +324,11 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     checkNamespace(namespace);
     throwIfTransactionMetadataDecouplingApplied(namespace, table, "repairTable()");
 
-    admin.repairTable(namespace, table, buildTransactionTableMetadata(metadata), options);
+    admin.repairTable(
+        namespace,
+        table,
+        buildTransactionTableMetadata(metadata, isIndexEventuallyConsistentReadEnabled),
+        options);
   }
 
   @Override
@@ -438,7 +473,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
       admin.createTable(
           namespace,
           txMetadataTableName,
-          ConsensusCommitUtils.buildTransactionMetadataTableMetadata(dataTableMetadata),
+          ConsensusCommitUtils.buildTransactionMetadataTableMetadata(
+              dataTableMetadata, isIndexEventuallyConsistentReadEnabled),
           options);
 
       // create a virtual table based on the data table and the transaction metadata table

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -39,6 +39,8 @@ public class ConsensusCommitConfig {
   public static final String PARALLEL_IMPLICIT_PRE_READ =
       PREFIX + "parallel_implicit_pre_read.enabled";
   public static final String INCLUDE_METADATA_ENABLED = PREFIX + "include_metadata.enabled";
+  public static final String INDEX_EVENTUALLY_CONSISTENT_READ_ENABLED =
+      PREFIX + "index.eventually_consistent_read.enabled";
 
   public static final String COORDINATOR_GROUP_COMMIT_PREFIX = PREFIX + "coordinator.group_commit.";
   public static final String COORDINATOR_GROUP_COMMIT_ENABLED =
@@ -79,6 +81,7 @@ public class ConsensusCommitConfig {
   private final boolean onePhaseCommitEnabled;
   private final boolean parallelImplicitPreReadEnabled;
   private final boolean includeMetadataEnabled;
+  private final boolean indexEventuallyConsistentReadEnabled;
 
   private final boolean coordinatorGroupCommitEnabled;
   private final int coordinatorGroupCommitSlotCapacity;
@@ -152,6 +155,8 @@ public class ConsensusCommitConfig {
     parallelImplicitPreReadEnabled = getBoolean(properties, PARALLEL_IMPLICIT_PRE_READ, true);
 
     includeMetadataEnabled = getBoolean(properties, INCLUDE_METADATA_ENABLED, false);
+    indexEventuallyConsistentReadEnabled =
+        getBoolean(properties, INDEX_EVENTUALLY_CONSISTENT_READ_ENABLED, false);
 
     coordinatorGroupCommitEnabled = getBoolean(properties, COORDINATOR_GROUP_COMMIT_ENABLED, false);
     coordinatorGroupCommitSlotCapacity =
@@ -233,6 +238,10 @@ public class ConsensusCommitConfig {
 
   public boolean isIncludeMetadataEnabled() {
     return includeMetadataEnabled;
+  }
+
+  public boolean isIndexEventuallyConsistentReadEnabled() {
+    return indexEventuallyConsistentReadEnabled;
   }
 
   public boolean isCoordinatorGroupCommitEnabled() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -84,6 +84,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             recoveryExecutor,
             tableMetadataManager,
             config.isIncludeMetadataEnabled(),
+            config.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     StorageInfoProvider storageInfoProvider = new StorageInfoProvider(admin);
     commit = createCommitHandler(config, storageInfoProvider);
@@ -96,6 +97,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             virtualTableInfoManager,
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
+
+    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
   }
 
   protected ConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -119,6 +122,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             recoveryExecutor,
             tableMetadataManager,
             config.isIncludeMetadataEnabled(),
+            config.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     StorageInfoProvider storageInfoProvider = new StorageInfoProvider(admin);
     commit = createCommitHandler(config, storageInfoProvider);
@@ -131,6 +135,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             virtualTableInfoManager,
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
+
+    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationChecker.java
@@ -175,7 +175,7 @@ public class ConsensusCommitOperationChecker {
           for (ConditionalExpression condition : conjunction.getConditions()) {
             String column = condition.getColumn().getName();
             // If the column is an indexed column but is part of the primary key, it's allowed
-            if (metadata.getSecondaryIndexNames().contains(column)
+            if (tableMetadata.getSecondaryIndexNames().contains(column)
                 && !tableMetadata.getPartitionKeyNames().contains(column)
                 && !tableMetadata.getClusteringKeyNames().contains(column)) {
               throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -714,8 +714,12 @@ public final class ConsensusCommitUtils {
           }
 
           Set<String> secondaryIndexNames = metadata.getSecondaryIndexNames();
+          Set<String> partitionKeyNames = metadata.getPartitionKeyNames();
+          Set<String> clusteringKeyNames = metadata.getClusteringKeyNames();
           for (String indexName : secondaryIndexNames) {
             if (!indexName.startsWith(Attribute.BEFORE_PREFIX)
+                && !partitionKeyNames.contains(indexName)
+                && !clusteringKeyNames.contains(indexName)
                 && !secondaryIndexNames.contains(Attribute.BEFORE_PREFIX + indexName)) {
               tablesWithMissingIndexes.add(ScalarDbUtils.getFullTableName(namespace, table));
               break;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -687,11 +687,22 @@ public final class ConsensusCommitUtils {
   }
 
   /**
-   * Checks all tables for missing before-image secondary indexes and logs warnings. Tables that
-   * have secondary indexes but lack corresponding before-image indexes should be repaired using
-   * {@code repairTable()}. This check is only relevant when the isolation level is SNAPSHOT or
-   * READ_COMMITTED and the index eventually consistent read is disabled, because in those cases
-   * index-based operations can miss PREPARED/DELETED records without before-image indexes.
+   * Checks all tables for missing before-image secondary indexes and logs warnings at startup.
+   * Tables that have secondary indexes but lack corresponding before-image indexes should be
+   * repaired using {@code repairTable()}.
+   *
+   * <p>This check is skipped in the following cases:
+   *
+   * <ul>
+   *   <li>SERIALIZABLE isolation: Operations that require before-image index checks will fail with
+   *       an error prompting the user to run {@code repairTable()}, so a startup warning is
+   *       unnecessary.
+   *   <li>Index eventually consistent read is enabled: Before-image indexes are not used, so the
+   *       check is not relevant.
+   * </ul>
+   *
+   * <p>In other isolation levels (SNAPSHOT, READ_COMMITTED), index-based operations can silently
+   * miss PREPARED/DELETED records without before-image index checks, so the warning is important.
    *
    * @param admin a distributed storage admin
    * @param config a consensus commit config

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -6,6 +6,7 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionSetBuilder;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.GetBuilder;
 import com.scalar.db.api.Insert;
@@ -29,14 +30,22 @@ import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ConsensusCommitUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitUtils.class);
 
   private static final ImmutableMap<String, DataType> BEFORE_IMAGE_META_COLUMNS =
       ImmutableMap.<String, DataType>builder()
@@ -71,6 +80,19 @@ public final class ConsensusCommitUtils {
    * @return a transaction table metadata based on the table metadata
    */
   public static TableMetadata buildTransactionTableMetadata(TableMetadata tableMetadata) {
+    return buildTransactionTableMetadata(tableMetadata, false);
+  }
+
+  /**
+   * Builds a transaction table metadata based on the specified table metadata.
+   *
+   * @param tableMetadata the base table metadata to build a transaction table metadata
+   * @param isIndexEventuallyConsistentReadEnabled if true, secondary indexes on before-image
+   *     columns are not added
+   * @return a transaction table metadata based on the table metadata
+   */
+  public static TableMetadata buildTransactionTableMetadata(
+      TableMetadata tableMetadata, boolean isIndexEventuallyConsistentReadEnabled) {
     checkIsNotTransactionMetaColumn(tableMetadata.getColumnNames());
     Set<String> nonPrimaryKeyColumns = getNonPrimaryKeyColumns(tableMetadata);
     checkBeforeColumnsDoNotAlreadyExist(nonPrimaryKeyColumns, tableMetadata);
@@ -80,6 +102,14 @@ public final class ConsensusCommitUtils {
     TRANSACTION_META_COLUMNS.forEach(builder::addColumn);
     nonPrimaryKeyColumns.forEach(
         c -> builder.addColumn(Attribute.BEFORE_PREFIX + c, tableMetadata.getColumnDataType(c)));
+
+    if (!isIndexEventuallyConsistentReadEnabled) {
+      // Add secondary indexes on before image columns for columns that have secondary indexes
+      tableMetadata.getSecondaryIndexNames().stream()
+          .filter(nonPrimaryKeyColumns::contains)
+          .forEach(indexCol -> builder.addSecondaryIndex(Attribute.BEFORE_PREFIX + indexCol));
+    }
+
     return builder.build();
   }
 
@@ -91,6 +121,20 @@ public final class ConsensusCommitUtils {
    * @return the table metadata of a transaction metadata table
    */
   public static TableMetadata buildTransactionMetadataTableMetadata(TableMetadata tableMetadata) {
+    return buildTransactionMetadataTableMetadata(tableMetadata, false);
+  }
+
+  /**
+   * Builds a table metadata of a decoupled transaction metadata table based on the specified table
+   * metadata. This is for the transaction metadata decoupling feature.
+   *
+   * @param tableMetadata the table metadata of the data table
+   * @param isIndexEventuallyConsistentReadEnabled if true, secondary indexes on before-image
+   *     columns are not added
+   * @return the table metadata of a transaction metadata table
+   */
+  public static TableMetadata buildTransactionMetadataTableMetadata(
+      TableMetadata tableMetadata, boolean isIndexEventuallyConsistentReadEnabled) {
     checkIsNotTransactionMetaColumn(tableMetadata.getColumnNames());
     Set<String> nonPrimaryKeyColumns = getNonPrimaryKeyColumns(tableMetadata);
     checkBeforeColumnsDoNotAlreadyExist(nonPrimaryKeyColumns, tableMetadata);
@@ -114,6 +158,13 @@ public final class ConsensusCommitUtils {
     // Add before image columns for non-primary key columns
     nonPrimaryKeyColumns.forEach(
         c -> builder.addColumn(Attribute.BEFORE_PREFIX + c, tableMetadata.getColumnDataType(c)));
+
+    if (!isIndexEventuallyConsistentReadEnabled) {
+      // Add secondary indexes on before image columns for columns that have secondary indexes
+      tableMetadata.getSecondaryIndexNames().stream()
+          .filter(nonPrimaryKeyColumns::contains)
+          .forEach(indexCol -> builder.addSecondaryIndex(Attribute.BEFORE_PREFIX + indexCol));
+    }
 
     return builder.build();
   }
@@ -237,7 +288,9 @@ public final class ConsensusCommitUtils {
     tableMetadata.getColumnNames().stream()
         .filter(c -> !transactionMetaColumns.contains(c))
         .forEach(c -> builder.addColumn(c, tableMetadata.getColumnDataType(c)));
-    tableMetadata.getSecondaryIndexNames().forEach(builder::addSecondaryIndex);
+    tableMetadata.getSecondaryIndexNames().stream()
+        .filter(c -> !transactionMetaColumns.contains(c))
+        .forEach(builder::addSecondaryIndex);
     return builder.build();
   }
 
@@ -517,44 +570,168 @@ public final class ConsensusCommitUtils {
 
     // Add conditions on the before image
     for (Selection.Conjunction conjunction : conjunctions) {
-      Set<ConditionalExpression> conditions = new HashSet<>(conjunction.getConditions().size());
-      for (ConditionalExpression condition : conjunction.getConditions()) {
-        String columnName = condition.getColumn().getName();
-
-        if (metadata.getPartitionKeyNames().contains(columnName)
-            || metadata.getClusteringKeyNames().contains(columnName)) {
-          // If the condition is on the primary key, we don't need to convert it
-          conditions.add(condition);
-          continue;
-        }
-
-        if (!convertIndexedColumns && metadata.getSecondaryIndexNames().contains(columnName)) {
-          conditions.add(condition);
-          continue;
-        }
-
-        // Convert the condition to use the before image column
-        ConditionalExpression convertedCondition;
-        if (condition instanceof LikeExpression) {
-          LikeExpression likeExpression = (LikeExpression) condition;
-          convertedCondition =
-              ConditionBuilder.buildLikeExpression(
-                  likeExpression.getColumn().copyWith(Attribute.BEFORE_PREFIX + columnName),
-                  likeExpression.getOperator(),
-                  likeExpression.getEscape());
-        } else {
-          convertedCondition =
-              ConditionBuilder.buildConditionalExpression(
-                  condition.getColumn().copyWith(Attribute.BEFORE_PREFIX + columnName),
-                  condition.getOperator());
-        }
-
-        conditions.add(convertedCondition);
-      }
-
-      converted.add(ConditionSetBuilder.andConditionSet(conditions).build());
+      converted.add(convertConjunctionToBeforeImage(conjunction, metadata, convertIndexedColumns));
     }
 
     return converted;
+  }
+
+  /**
+   * Converts a single conjunction to its before-image equivalent. Primary key conditions are kept
+   * as-is, while non-primary-key conditions are converted to use before image columns.
+   *
+   * @param conjunction the conjunction to convert
+   * @param metadata the table metadata of the target table
+   * @param convertIndexedColumns whether to convert conditions on indexed columns
+   * @return the converted conjunction as an {@link AndConditionSet}
+   */
+  private static AndConditionSet convertConjunctionToBeforeImage(
+      Selection.Conjunction conjunction, TableMetadata metadata, boolean convertIndexedColumns) {
+    Set<ConditionalExpression> conditions = new HashSet<>(conjunction.getConditions().size());
+    for (ConditionalExpression condition : conjunction.getConditions()) {
+      String columnName = condition.getColumn().getName();
+
+      if (metadata.getPartitionKeyNames().contains(columnName)
+          || metadata.getClusteringKeyNames().contains(columnName)) {
+        // If the condition is on the primary key, we don't need to convert it
+        conditions.add(condition);
+        continue;
+      }
+
+      if (!convertIndexedColumns && metadata.getSecondaryIndexNames().contains(columnName)) {
+        conditions.add(condition);
+        continue;
+      }
+
+      // Convert the condition to use the before image column
+      ConditionalExpression convertedCondition;
+      if (condition instanceof LikeExpression) {
+        LikeExpression likeExpression = (LikeExpression) condition;
+        convertedCondition =
+            ConditionBuilder.buildLikeExpression(
+                likeExpression.getColumn().copyWith(Attribute.BEFORE_PREFIX + columnName),
+                likeExpression.getOperator(),
+                likeExpression.getEscape());
+      } else {
+        convertedCondition =
+            ConditionBuilder.buildConditionalExpression(
+                condition.getColumn().copyWith(Attribute.BEFORE_PREFIX + columnName),
+                condition.getOperator());
+      }
+
+      conditions.add(convertedCondition);
+    }
+
+    return ConditionSetBuilder.andConditionSet(conditions).build();
+  }
+
+  /**
+   * Creates a ScanWithIndex that scans using the before-image index column corresponding to the
+   * original selection's index key. This is used to find PREPARED/DELETED records whose committed
+   * (before-image) values match the original query.
+   *
+   * <p>The caller must ensure that the index column is not a primary key column, since primary key
+   * columns do not have before-image columns.
+   *
+   * @param original the original index-based selection (Get or Scan with index)
+   * @return a Scan using the before-image index column
+   */
+  static Scan createBeforeIndexScan(Selection original) {
+    assert original.forNamespace().isPresent() && original.forTable().isPresent();
+
+    Column<?> originalColumn = original.getPartitionKey().getColumns().get(0);
+    String indexColumnName = originalColumn.getName();
+    Key beforeIndexKey =
+        Key.newBuilder()
+            .add(originalColumn.copyWith(Attribute.BEFORE_PREFIX + indexColumnName))
+            .build();
+
+    return Scan.newBuilder()
+        .namespace(original.forNamespace().get())
+        .table(original.forTable().get())
+        .indexKey(beforeIndexKey)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  /**
+   * Creates a ScanAll that scans using before-image column conditions corresponding to the original
+   * ScanAll's indexed column conditions. This is used to find PREPARED/DELETED records whose
+   * committed (before-image) values match the original query's indexed column conditions.
+   *
+   * <p>The caller must ensure that at least one non-primary-key indexed column condition with a
+   * corresponding before-image secondary index exists in the conjunctions.
+   *
+   * @param original the original ScanAll with indexed column conditions
+   * @param metadata the table metadata (transaction table metadata)
+   * @return a ScanAll using before-image column conditions
+   */
+  static Scan createBeforeIndexScanAll(ScanAll original, TableMetadata metadata) {
+    assert original.forNamespace().isPresent() && original.forTable().isPresent();
+
+    // Convert conjunctions to before-image equivalents.
+    // convertIndexedColumns=true because we want to convert indexed column conditions to
+    // before_* equivalents for cross-partition scans
+    Set<AndConditionSet> converted = new HashSet<>(original.getConjunctions().size());
+    for (Selection.Conjunction conjunction : original.getConjunctions()) {
+      converted.add(convertConjunctionToBeforeImage(conjunction, metadata, true));
+    }
+
+    return Scan.newBuilder()
+        .namespace(original.forNamespace().get())
+        .table(original.forTable().get())
+        .all()
+        .whereOr(converted)
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  /**
+   * Checks all tables for missing before-image secondary indexes and logs warnings. Tables that
+   * have secondary indexes but lack corresponding before-image indexes should be repaired using
+   * {@code repairTable()}. This check is only relevant when the isolation level is SNAPSHOT or
+   * READ_COMMITTED and the index eventually consistent read is disabled, because in those cases
+   * index-based operations can miss PREPARED/DELETED records without before-image indexes.
+   *
+   * @param admin a distributed storage admin
+   * @param config a consensus commit config
+   */
+  static void warnIfBeforeImageIndexesAreMissing(
+      DistributedStorageAdmin admin, ConsensusCommitConfig config) {
+    if (config.getIsolation() == Isolation.SERIALIZABLE
+        || config.isIndexEventuallyConsistentReadEnabled()) {
+      return;
+    }
+
+    try {
+      List<String> tablesWithMissingIndexes = new ArrayList<>();
+
+      for (String namespace : admin.getNamespaceNames()) {
+        for (String table : admin.getNamespaceTableNames(namespace)) {
+          TableMetadata metadata = admin.getTableMetadata(namespace, table);
+          if (metadata == null || !isTransactionTableMetadata(metadata)) {
+            continue;
+          }
+
+          Set<String> secondaryIndexNames = metadata.getSecondaryIndexNames();
+          for (String indexName : secondaryIndexNames) {
+            if (!indexName.startsWith(Attribute.BEFORE_PREFIX)
+                && !secondaryIndexNames.contains(Attribute.BEFORE_PREFIX + indexName)) {
+              tablesWithMissingIndexes.add(ScalarDbUtils.getFullTableName(namespace, table));
+              break;
+            }
+          }
+        }
+      }
+
+      if (!tablesWithMissingIndexes.isEmpty()) {
+        logger.warn(
+            "The following tables have secondary indexes but lack before-image indexes: {}. "
+                + "Run repairTable() for these tables to create before-image indexes",
+            tablesWithMissingIndexes);
+      }
+    } catch (ExecutionException e) {
+      logger.warn("Failed to check for missing before-image indexes", e);
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitOperationAttributes.isImplicitPreReadEnabled;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -13,6 +14,7 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
@@ -43,10 +45,12 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class CrudHandler {
   private static final Logger logger = LoggerFactory.getLogger(CrudHandler.class);
+  private static final int MAX_BEFORE_INDEX_CHECK_RETRIES = 3;
   private final DistributedStorage storage;
   private final RecoveryExecutor recoveryExecutor;
   private final TransactionTableMetadataManager tableMetadataManager;
   private final boolean isIncludeMetadataEnabled;
+  private final boolean isIndexEventuallyConsistentReadEnabled;
   private final MutationConditionsValidator mutationConditionsValidator;
   private final ParallelExecutor parallelExecutor;
 
@@ -56,11 +60,13 @@ public class CrudHandler {
       RecoveryExecutor recoveryExecutor,
       TransactionTableMetadataManager tableMetadataManager,
       boolean isIncludeMetadataEnabled,
+      boolean isIndexEventuallyConsistentReadEnabled,
       ParallelExecutor parallelExecutor) {
     this.storage = checkNotNull(storage);
     this.recoveryExecutor = checkNotNull(recoveryExecutor);
     this.tableMetadataManager = checkNotNull(tableMetadataManager);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
+    this.isIndexEventuallyConsistentReadEnabled = isIndexEventuallyConsistentReadEnabled;
     this.mutationConditionsValidator = new MutationConditionsValidator();
     this.parallelExecutor = checkNotNull(parallelExecutor);
   }
@@ -71,18 +77,21 @@ public class CrudHandler {
       RecoveryExecutor recoveryExecutor,
       TransactionTableMetadataManager tableMetadataManager,
       boolean isIncludeMetadataEnabled,
+      boolean isIndexEventuallyConsistentReadEnabled,
       MutationConditionsValidator mutationConditionsValidator,
       ParallelExecutor parallelExecutor) {
     this.storage = checkNotNull(storage);
     this.recoveryExecutor = checkNotNull(recoveryExecutor);
     this.tableMetadataManager = checkNotNull(tableMetadataManager);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
+    this.isIndexEventuallyConsistentReadEnabled = isIndexEventuallyConsistentReadEnabled;
     this.mutationConditionsValidator = checkNotNull(mutationConditionsValidator);
     this.parallelExecutor = checkNotNull(parallelExecutor);
   }
 
   public Optional<Result> get(Get get, TransactionContext context) throws CrudException {
-    TableMetadata metadata = getTableMetadata(get, context.transactionId);
+    TransactionTableMetadata txMetadata = getTransactionTableMetadata(get, context.transactionId);
+    TableMetadata metadata = txMetadata.getTableMetadata();
 
     Snapshot.Key key;
     if (ScalarDbUtils.isSecondaryIndexSpecified(get, metadata)) {
@@ -93,14 +102,14 @@ public class CrudHandler {
     }
 
     if (isSnapshotReadRequired(context)) {
-      readUnread(key, get, context, metadata);
+      readUnread(key, get, context, txMetadata);
       return context
           .snapshot
           .getResult(key, get)
           .map(
               r -> new FilteredResult(r, get.getProjections(), metadata, isIncludeMetadataEnabled));
     } else {
-      Optional<TransactionResult> result = read(key, get, context, metadata);
+      Optional<TransactionResult> result = read(key, get, context, txMetadata);
       return context
           .snapshot
           .mergeResult(key, result, get.getConjunctions())
@@ -112,65 +121,91 @@ public class CrudHandler {
   // Only for a Get with index, the argument `key` is null
   @VisibleForTesting
   void readUnread(
-      @Nullable Snapshot.Key key, Get get, TransactionContext context, TableMetadata metadata)
+      @Nullable Snapshot.Key key,
+      Get get,
+      TransactionContext context,
+      TransactionTableMetadata txMetadata)
       throws CrudException {
     if (!context.snapshot.containsKeyInGetSet(get)) {
-      read(key, get, context, metadata);
+      read(key, get, context, txMetadata);
     }
   }
 
-  // Although this class is not thread-safe, this method is actually thread-safe, so we call it
-  // concurrently in the implicit pre-read
   @VisibleForTesting
   Optional<TransactionResult> read(
-      @Nullable Snapshot.Key key, Get get, TransactionContext context, TableMetadata metadata)
+      @Nullable Snapshot.Key key,
+      Get get,
+      TransactionContext context,
+      TransactionTableMetadata txMetadata)
       throws CrudException {
-    Optional<TransactionResult> result = getFromStorage(get, metadata, context.transactionId);
-    if (result.isPresent() && !result.get().isCommitted()) {
-      // Lazy recovery
+    TableMetadata metadata = txMetadata.getTableMetadata();
+    boolean beforeIndexCheckRequired = requiresBeforeIndexCheck(get, txMetadata);
 
-      if (key == null) {
-        // Only for a Get with index, the argument `key` is null. In that case, create a key from
-        // the result
-        key = new Snapshot.Key(get, result.get(), metadata);
+    for (int i = 0; ; i++) {
+      Optional<TransactionResult> result = getFromStorage(get, metadata, context.transactionId);
+      if (result.isPresent() && !result.get().isCommitted()) {
+        // Lazy recovery
+
+        if (key == null) {
+          // Only for a Get with index, the argument `key` is null. In that case, create a key from
+          // the result
+          key = new Snapshot.Key(get, result.get(), metadata);
+        }
+
+        RecoveryExecutor.Result recoveryResult = executeRecovery(key, get, result.get(), context);
+        context.recoveryResults.add(recoveryResult);
+        result = recoveryResult.recoveredResult;
       }
 
-      result = executeRecovery(key, get, result.get(), context);
-    }
+      if (!get.getConjunctions().isEmpty()) {
+        // Because we also get records whose before images match the conjunctions, we need to check
+        // if the current status of the records actually match the conjunctions.
+        result =
+            result.filter(
+                r ->
+                    ScalarDbUtils.columnsMatchAnyOfConjunctions(
+                        r.getColumns(), get.getConjunctions()));
+      }
 
-    if (!get.getConjunctions().isEmpty()) {
-      // Because we also get records whose before images match the conjunctions, we need to check if
-      // the current status of the records actually match the conjunctions.
-      result =
-          result.filter(
-              r ->
-                  ScalarDbUtils.columnsMatchAnyOfConjunctions(
-                      r.getColumns(), get.getConjunctions()));
-    }
+      // Check if there are PREPARED/DELETED records whose committed (before-image) values match
+      // the query. If any were rolled back, the storage read result may be stale, so retry from
+      // the beginning before caching into the snapshot.
+      if (beforeIndexCheckRequired && checkAndRecoverBeforeIndexRecords(get, context, txMetadata)) {
+        if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
+          throw new CrudConflictException(
+              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
+                  .buildMessage(context.transactionId),
+              context.transactionId);
+        }
+        continue;
+      }
 
-    if (result.isPresent() || get.getConjunctions().isEmpty()) {
-      // We put the result into the read set only if a get operation has no conjunction or the
-      // result exists. This is because we don’t know whether the record actually exists or not
-      // due to the conjunction.
+      // Put the result in the snapshot
+      if (result.isPresent() || get.getConjunctions().isEmpty()) {
+        // We put the result into the read set only if a get operation has no conjunction or the
+        // result exists. This is because we don’t know whether the record actually exists or not
+        // due to the conjunction.
 
-      if (key != null) {
-        putIntoReadSetInSnapshot(key, result, context);
-      } else {
-        // Only for a Get with index, the argument `key` is null
-
-        if (result.isPresent()) {
-          // Only when we can get the record with the Get with index, we can put it into the read
-          // set
-          key = new Snapshot.Key(get, result.get(), metadata);
+        if (key != null) {
           putIntoReadSetInSnapshot(key, result, context);
+        } else {
+          // Only for a Get with index, the argument `key` is null
+
+          if (result.isPresent()) {
+            // Only when we can get the record with the Get with index, we can put it into the read
+            // set
+            key = new Snapshot.Key(get, result.get(), metadata);
+            putIntoReadSetInSnapshot(key, result, context);
+          }
         }
       }
+      putIntoGetSetInSnapshot(get, result, context);
+
+      return result;
     }
-    putIntoGetSetInSnapshot(get, result, context);
-    return result;
   }
 
-  private Optional<TransactionResult> executeRecovery(
+  private RecoveryExecutor.Result executeRecovery(
       Snapshot.Key key, Selection selection, TransactionResult result, TransactionContext context)
       throws CrudException {
     RecoveryExecutor.RecoveryType recoveryType;
@@ -179,9 +214,10 @@ public class CrudHandler {
 
       if (context.readOnly) {
         // In read-only mode, we don't recover the record, but return the committed result
+        // (before-image)
         recoveryType = RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_NOT_RECOVER;
       } else {
-        // In read-write mode, we recover the record and return the committed result
+        // In read-write mode, we recover the record and return the committed result (before-image)
         recoveryType = RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_RECOVER;
       }
     } else {
@@ -190,16 +226,14 @@ public class CrudHandler {
       recoveryType = RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER;
     }
 
-    RecoveryExecutor.Result recoveryResult =
-        recoveryExecutor.execute(key, selection, result, context.transactionId, recoveryType);
-
-    context.recoveryResults.add(recoveryResult);
-    return recoveryResult.recoveredResult;
+    return recoveryExecutor.execute(key, selection, result, context.transactionId, recoveryType);
   }
 
   public List<Result> scan(Scan scan, TransactionContext context) throws CrudException {
-    TableMetadata metadata = getTableMetadata(scan, context.transactionId);
-    LinkedHashMap<Snapshot.Key, TransactionResult> results = scanInternal(scan, context, metadata);
+    TransactionTableMetadata txMetadata = getTransactionTableMetadata(scan, context.transactionId);
+    TableMetadata metadata = txMetadata.getTableMetadata();
+    LinkedHashMap<Snapshot.Key, TransactionResult> results =
+        scanInternal(scan, context, txMetadata);
     verifyNoOverlap(scan, results, context);
     return results.values().stream()
         .map(r -> new FilteredResult(r, scan.getProjections(), metadata, isIncludeMetadataEnabled))
@@ -207,47 +241,69 @@ public class CrudHandler {
   }
 
   private LinkedHashMap<Snapshot.Key, TransactionResult> scanInternal(
-      Scan scan, TransactionContext context, TableMetadata metadata) throws CrudException {
+      Scan scan, TransactionContext context, TransactionTableMetadata txMetadata)
+      throws CrudException {
+    TableMetadata metadata = txMetadata.getTableMetadata();
+
     Optional<LinkedHashMap<Snapshot.Key, TransactionResult>> resultsInSnapshot =
         context.snapshot.getResults(scan);
     if (resultsInSnapshot.isPresent()) {
       return resultsInSnapshot.get();
     }
 
-    LinkedHashMap<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
+    boolean beforeIndexCheckRequired = requiresBeforeIndexCheck(scan, txMetadata);
 
-    try (Scanner scanner = scanFromStorage(scan, metadata, context.transactionId)) {
-      for (Result r : scanner) {
-        TransactionResult result = new TransactionResult(r);
-        Snapshot.Key key = new Snapshot.Key(scan, r, metadata);
-        Optional<TransactionResult> processedScanResult =
-            processScanResult(key, scan, result, context);
-        processedScanResult.ifPresent(res -> results.put(key, res));
+    for (int i = 0; ; i++) {
+      LinkedHashMap<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
 
-        if (scan.getLimit() > 0 && results.size() >= scan.getLimit()) {
-          // If the scan has a limit, we stop scanning when we reach the limit.
-          break;
+      try (Scanner scanner = scanFromStorage(scan, metadata, context.transactionId)) {
+        for (Result r : scanner) {
+          TransactionResult result = new TransactionResult(r);
+          Snapshot.Key key = new Snapshot.Key(scan, r, metadata);
+          Optional<TransactionResult> processedScanResult =
+              processScanResult(key, scan, result, context);
+          processedScanResult.ifPresent(res -> results.put(key, res));
+
+          if (scan.getLimit() > 0 && results.size() >= scan.getLimit()) {
+            // If the scan has a limit, we stop scanning when we reach the limit.
+            break;
+          }
         }
+      } catch (RuntimeException e) {
+        Exception exception;
+        if (e.getCause() instanceof ExecutionException) {
+          exception = (ExecutionException) e.getCause();
+        } else {
+          exception = e;
+        }
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
+                exception.getMessage()),
+            exception,
+            context.transactionId);
+      } catch (IOException e) {
+        logger.warn("Failed to close the scanner. Transaction ID: {}", context.transactionId, e);
       }
-    } catch (RuntimeException e) {
-      Exception exception;
-      if (e.getCause() instanceof ExecutionException) {
-        exception = (ExecutionException) e.getCause();
-      } else {
-        exception = e;
+
+      // Check if there are PREPARED/DELETED records whose committed (before-image) values match
+      // the query. If any were rolled back, the scan result may be stale, so retry from the
+      // beginning before caching into the snapshot.
+      if (beforeIndexCheckRequired
+          && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
+        if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
+          throw new CrudConflictException(
+              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
+                  .buildMessage(context.transactionId),
+              context.transactionId);
+        }
+        continue;
       }
-      throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
-              exception.getMessage()),
-          exception,
-          context.transactionId);
-    } catch (IOException e) {
-      logger.warn("Failed to close the scanner. Transaction ID: {}", context.transactionId, e);
+
+      // Put the results in the snapshot
+      putIntoScanSetInSnapshot(scan, results, context);
+
+      return results;
     }
-
-    putIntoScanSetInSnapshot(scan, results, context);
-
-    return results;
   }
 
   private Optional<TransactionResult> processScanResult(
@@ -256,7 +312,9 @@ public class CrudHandler {
     Optional<TransactionResult> ret;
     if (!result.isCommitted()) {
       // Lazy recovery
-      ret = executeRecovery(key, scan, result, context);
+      RecoveryExecutor.Result recoveryResult = executeRecovery(key, scan, result, context);
+      context.recoveryResults.add(recoveryResult);
+      ret = recoveryResult.recoveredResult;
     } else {
       ret = Optional.of(result);
     }
@@ -280,7 +338,8 @@ public class CrudHandler {
 
   public TransactionCrudOperable.Scanner getScanner(Scan scan, TransactionContext context)
       throws CrudException {
-    TableMetadata metadata = getTableMetadata(scan, context.transactionId);
+    TransactionTableMetadata txMetadata = getTransactionTableMetadata(scan, context.transactionId);
+    TableMetadata metadata = txMetadata.getTableMetadata();
     ConsensusCommitScanner scanner;
     Optional<LinkedHashMap<Snapshot.Key, TransactionResult>> resultsInSnapshot =
         context.snapshot.getResults(scan);
@@ -288,7 +347,7 @@ public class CrudHandler {
       scanner =
           new ConsensusCommitSnapshotScanner(scan, context, metadata, resultsInSnapshot.get());
     } else {
-      scanner = new ConsensusCommitStorageScanner(scan, context, metadata);
+      scanner = new ConsensusCommitStorageScanner(scan, context, txMetadata);
     }
 
     context.scanners.add(scanner);
@@ -355,7 +414,7 @@ public class CrudHandler {
   }
 
   public void put(Put put, TransactionContext context) throws CrudException {
-    TableMetadata metadata = getTableMetadata(put, context.transactionId);
+    TransactionTableMetadata txMetadata = getTransactionTableMetadata(put, context.transactionId);
     Snapshot.Key key = new Snapshot.Key(put);
 
     if (put.getCondition().isPresent()
@@ -368,7 +427,7 @@ public class CrudHandler {
 
     if (put.getCondition().isPresent()) {
       if (isImplicitPreReadEnabled(put) && !context.snapshot.containsKeyInReadSet(key)) {
-        read(key, createGet(key), context, metadata);
+        read(key, createGet(key), context, txMetadata);
       }
       mutationConditionsValidator.checkIfConditionIsSatisfied(
           put, context.snapshot.getResult(key).orElse(null), context.transactionId);
@@ -378,12 +437,13 @@ public class CrudHandler {
   }
 
   public void delete(Delete delete, TransactionContext context) throws CrudException {
-    TableMetadata metadata = getTableMetadata(delete, context.transactionId);
+    TransactionTableMetadata txMetadata =
+        getTransactionTableMetadata(delete, context.transactionId);
     Snapshot.Key key = new Snapshot.Key(delete);
 
     if (delete.getCondition().isPresent()) {
       if (!context.snapshot.containsKeyInReadSet(key)) {
-        read(key, createGet(key), context, metadata);
+        read(key, createGet(key), context, txMetadata);
       }
       mutationConditionsValidator.checkIfConditionIsSatisfied(
           delete, context.snapshot.getResult(key).orElse(null), context.transactionId);
@@ -403,8 +463,9 @@ public class CrudHandler {
         Snapshot.Key key = entry.getKey();
         if (!context.snapshot.containsKeyInReadSet(key)) {
           Get get = createGet(key);
-          TableMetadata metadata = getTableMetadata(get, context.transactionId);
-          tasks.add(() -> read(key, get, context, metadata));
+          TransactionTableMetadata txMetadata =
+              getTransactionTableMetadata(get, context.transactionId);
+          tasks.add(() -> read(key, get, context, txMetadata));
         }
       }
     }
@@ -414,8 +475,9 @@ public class CrudHandler {
       Snapshot.Key key = entry.getKey();
       if (!context.snapshot.containsKeyInReadSet(key)) {
         Get get = createGet(key);
-        TableMetadata metadata = getTableMetadata(get, context.transactionId);
-        tasks.add(() -> read(key, get, context, metadata));
+        TransactionTableMetadata txMetadata =
+            getTransactionTableMetadata(get, context.transactionId);
+        tasks.add(() -> read(key, get, context, txMetadata));
       }
     }
 
@@ -467,27 +529,10 @@ public class CrudHandler {
   public void waitForRecoveryCompletionIfNecessary(TransactionContext context)
       throws CrudException {
     for (RecoveryExecutor.Result recoveryResult : context.recoveryResults) {
-      try {
-        if (context.snapshot.containsKeyInWriteSet(recoveryResult.key)
-            || context.snapshot.containsKeyInDeleteSet(recoveryResult.key)
-            || context.isValidationPossiblyRequired()) {
-          recoveryResult.recoveryFuture.get();
-        }
-      } catch (java.util.concurrent.ExecutionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof CrudException) {
-          throw (CrudException) cause;
-        }
-
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(cause.getMessage()),
-            cause,
-            context.transactionId);
-      } catch (Exception e) {
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
-            e,
-            context.transactionId);
+      if (context.snapshot.containsKeyInWriteSet(recoveryResult.key)
+          || context.snapshot.containsKeyInDeleteSet(recoveryResult.key)
+          || context.isValidationPossiblyRequired()) {
+        waitForRecoveryCompletion(recoveryResult, context.transactionId);
       }
     }
   }
@@ -495,29 +540,32 @@ public class CrudHandler {
   @VisibleForTesting
   void waitForRecoveryCompletion(TransactionContext context) throws CrudException {
     for (RecoveryExecutor.Result recoveryResult : context.recoveryResults) {
-      try {
-        recoveryResult.recoveryFuture.get();
-      } catch (java.util.concurrent.ExecutionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof CrudException) {
-          throw (CrudException) cause;
-        }
-
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(cause.getMessage()),
-            cause,
-            context.transactionId);
-      } catch (Exception e) {
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
-            e,
-            context.transactionId);
-      }
+      waitForRecoveryCompletion(recoveryResult, context.transactionId);
     }
   }
 
-  // Although this class is not thread-safe, this method is actually thread-safe because the storage
-  // is thread-safe
+  private void waitForRecoveryCompletion(
+      RecoveryExecutor.Result recoveryResult, String transactionId) throws CrudException {
+    try {
+      recoveryResult.recoveryFuture.get();
+    } catch (java.util.concurrent.ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof CrudException) {
+        throw (CrudException) cause;
+      }
+
+      throw new CrudException(
+          CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(cause.getMessage()),
+          cause,
+          transactionId);
+    } catch (Exception e) {
+      throw new CrudException(
+          CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+          e,
+          transactionId);
+    }
+  }
+
   @VisibleForTesting
   Optional<TransactionResult> getFromStorage(Get get, TableMetadata metadata, String transactionId)
       throws CrudException {
@@ -547,19 +595,135 @@ public class CrudHandler {
     }
   }
 
-  private TableMetadata getTableMetadata(Operation operation, String transactionId)
-      throws CrudException {
+  private TransactionTableMetadata getTransactionTableMetadata(
+      Operation operation, String transactionId) throws CrudException {
     assert operation.forFullTableName().isPresent();
 
     try {
-      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, operation)
-          .getTableMetadata();
+      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, operation);
     } catch (ExecutionException e) {
       throw new CrudException(
           CoreError.GETTING_TABLE_METADATA_FAILED.buildMessage(operation.forFullTableName().get()),
           e,
           transactionId);
     }
+  }
+
+  /**
+   * Returns whether the given selection requires a before-image index check. This is true when the
+   * selection uses a secondary index that has a corresponding before-image secondary index.
+   *
+   * @param selection the selection operation
+   * @param metadata the transaction table metadata
+   * @return true if before-image index check is required
+   */
+  @VisibleForTesting
+  boolean requiresBeforeIndexCheck(Selection selection, TransactionTableMetadata metadata) {
+    if (isIndexEventuallyConsistentReadEnabled) {
+      return false;
+    }
+
+    if (selection instanceof ScanAll) {
+      // For ScanAll, check if any conjunction condition is on a column that has a before-image
+      // secondary index
+      for (Selection.Conjunction conjunction : selection.getConjunctions()) {
+        for (ConditionalExpression condition : conjunction.getConditions()) {
+          if (metadata.hasBeforeImageSecondaryIndex(condition.getColumn().getName())) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    if (ScalarDbUtils.isSecondaryIndexSpecified(selection, metadata.getTableMetadata())) {
+      String indexColumnName = selection.getPartitionKey().getColumns().get(0).getName();
+      return metadata.hasBeforeImageSecondaryIndex(indexColumnName);
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if there are PREPARED/DELETED records that match the before-image index conditions of
+   * the given selection, and if so, executes recovery on them.
+   *
+   * <p>This method scans using the before-image index to find uncommitted records whose committed
+   * values match the original query. If such records are found, recovery is executed.
+   *
+   * <p>A retry is only needed when a record is rolled back, because rolling back restores the
+   * before-image values, which means the record will now match the original query's index
+   * conditions and should be included in the results. In contrast, when a record is rolled forward,
+   * the current (after-image) values are committed as-is, so the original query's results are
+   * unaffected.
+   *
+   * <p>Note: This method calls {@code storage.scan()} directly instead of {@code scanFromStorage()}
+   * because the before-index scan is already prepared with the correct consistency and conditions.
+   * Passing it through {@code prepareScanForStorage()} would incorrectly double-convert the
+   * before-image column conditions.
+   *
+   * @param selection the original selection operation
+   * @param context the transaction context
+   * @param metadata the transaction table metadata
+   * @return true if any records were rolled back, indicating a retry is needed
+   * @throws CrudException if scanning or recovery fails
+   */
+  @VisibleForTesting
+  boolean checkAndRecoverBeforeIndexRecords(
+      Selection selection, TransactionContext context, TransactionTableMetadata metadata)
+      throws CrudException {
+    Scan beforeIndexScan;
+    if (selection instanceof ScanAll) {
+      beforeIndexScan =
+          ConsensusCommitUtils.createBeforeIndexScanAll(
+              (ScanAll) selection, metadata.getTableMetadata());
+    } else {
+      beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(selection);
+    }
+
+    boolean needsRetry = false;
+    List<RecoveryExecutor.Result> rolledBackRecoveryResults = new ArrayList<>();
+
+    try (Scanner scanner = storage.scan(beforeIndexScan)) {
+      for (Result r : scanner) {
+        TransactionResult result = new TransactionResult(r);
+        if (!result.isCommitted()) {
+          Snapshot.Key key = new Snapshot.Key(beforeIndexScan, r, metadata.getTableMetadata());
+          // Always use RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation level because
+          // recovery must actually execute; otherwise, the PREPARED/DELETED record remains in
+          // storage and retrying would be useless
+          RecoveryExecutor.Result recoveryResult =
+              recoveryExecutor.execute(
+                  key,
+                  beforeIndexScan,
+                  result,
+                  context.transactionId,
+                  RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+          if (recoveryResult.rolledBack) {
+            rolledBackRecoveryResults.add(recoveryResult);
+            needsRetry = true;
+          } else {
+            // For rolled-forward records, track the recovery asynchronously
+            context.recoveryResults.add(recoveryResult);
+          }
+        }
+      }
+    } catch (ExecutionException e) {
+      throw new CrudException(
+          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
+              e.getMessage()),
+          e,
+          context.transactionId);
+    } catch (IOException e) {
+      logger.warn("Failed to close the scanner. Transaction ID: {}", context.transactionId, e);
+    }
+
+    // Wait for all rolled-back recoveries to complete before retrying
+    for (RecoveryExecutor.Result rolledBackResult : rolledBackRecoveryResults) {
+      waitForRecoveryCompletion(rolledBackResult, context.transactionId);
+    }
+
+    return needsRetry;
   }
 
   @NotThreadSafe
@@ -569,6 +733,7 @@ public class CrudHandler {
     private final Scan scan;
     private final TransactionContext context;
     private final TableMetadata metadata;
+    private final TransactionTableMetadata txMetadata;
     private final Scanner scanner;
 
     @Nullable private final LinkedHashMap<Snapshot.Key, TransactionResult> results;
@@ -577,10 +742,12 @@ public class CrudHandler {
     private final AtomicBoolean closed = new AtomicBoolean();
 
     public ConsensusCommitStorageScanner(
-        Scan scan, TransactionContext context, TableMetadata metadata) throws CrudException {
+        Scan scan, TransactionContext context, TransactionTableMetadata txMetadata)
+        throws CrudException {
       this.scan = scan;
       this.context = context;
-      this.metadata = metadata;
+      this.txMetadata = txMetadata;
+      this.metadata = txMetadata.getTableMetadata();
 
       scanner = scanFromStorage(scan, metadata, context.transactionId);
 
@@ -663,12 +830,24 @@ public class CrudHandler {
     }
 
     @Override
-    public void close() {
+    public void close() throws CrudException {
       if (closed.get()) {
         return;
       }
 
       closeScanner();
+
+      // Check if there are PREPARED/DELETED records whose committed (before-image) values match
+      // the query. If any were rolled back, the scan results may be incomplete. Unlike read() and
+      // scanInternal(), the scanner cannot retry internally, so throw CrudConflictException to
+      // prompt a transaction-level retry.
+      if (requiresBeforeIndexCheck(scan, txMetadata)
+          && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
+        throw new CrudConflictException(
+            CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER.buildMessage(
+                context.transactionId),
+            context.transactionId);
+      }
 
       if (fullyScanned.get()) {
         // If the scanner is fully scanned, we can treat it as a normal scan, and put the results

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -133,7 +133,7 @@ public class CrudHandler {
 
   @VisibleForTesting
   Optional<TransactionResult> read(
-      @Nullable Snapshot.Key key,
+      @Nullable Snapshot.Key originalKey,
       Get get,
       TransactionContext context,
       TransactionTableMetadata txMetadata)
@@ -142,6 +142,8 @@ public class CrudHandler {
     boolean beforeIndexCheckRequired = requiresBeforeIndexCheck(get, txMetadata);
 
     for (int i = 0; ; i++) {
+      @Nullable Snapshot.Key key = originalKey;
+
       Optional<TransactionResult> result = getFromStorage(get, metadata, context.transactionId);
       if (result.isPresent() && !result.get().isCommitted()) {
         // Lazy recovery

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -73,6 +73,7 @@ public class RecoveryExecutor implements AutoCloseable {
 
     Optional<TransactionResult> recoveredResult;
     Future<Void> future;
+    boolean rolledBack;
 
     switch (recoveryType) {
       case RETURN_LATEST_RESULT_AND_RECOVER:
@@ -80,6 +81,8 @@ public class RecoveryExecutor implements AutoCloseable {
 
         throwUncommittedRecordExceptionIfTransactionNotExpired(
             state, selection, result, transactionId);
+
+        rolledBack = !state.isPresent() || state.get().getState() == TransactionState.ABORTED;
 
         // Return the latest result
         recoveredResult = createRecoveredResult(state, selection, result, transactionId);
@@ -96,6 +99,10 @@ public class RecoveryExecutor implements AutoCloseable {
       case RETURN_COMMITTED_RESULT_AND_RECOVER:
         // Return the committed result
         recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
+
+        // The rollback/rollforward decision is deferred to the recovery thread, but since we
+        // return the committed (before-image) result, we treat this as rolled back
+        rolledBack = true;
 
         // Recover the record
         future =
@@ -115,6 +122,9 @@ public class RecoveryExecutor implements AutoCloseable {
         // Return the committed result
         recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
 
+        // No recovery is performed, but the committed (before-image) result is returned
+        rolledBack = true;
+
         // No need to recover the record
         future = Futures.immediateFuture(null);
 
@@ -123,7 +133,7 @@ public class RecoveryExecutor implements AutoCloseable {
         throw new AssertionError("Unknown recovery type: " + recoveryType);
     }
 
-    return new Result(key, recoveredResult, future);
+    return new Result(key, recoveredResult, future, rolledBack);
   }
 
   private Optional<Coordinator.State> getCoordinatorState(String transactionId)
@@ -320,13 +330,18 @@ public class RecoveryExecutor implements AutoCloseable {
     // The future that completes when the recovery is done
     public final Future<Void> recoveryFuture;
 
+    // Whether the record was rolled back (true) or rolled forward (false)
+    public final boolean rolledBack;
+
     public Result(
         Snapshot.Key key,
         Optional<TransactionResult> recoveredResult,
-        Future<Void> recoveryFuture) {
+        Future<Void> recoveryFuture,
+        boolean rolledBack) {
       this.key = key;
       this.recoveredResult = recoveredResult;
       this.recoveryFuture = recoveryFuture;
+      this.rolledBack = rolledBack;
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import com.scalar.db.exception.transaction.CrudException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class TransactionContext {
 
@@ -28,7 +29,7 @@ public class TransactionContext {
 
   // A list of recovery results for asynchronously executed recoveries. These are tracked so that
   // their completion can be awaited before committing the transaction if necessary.
-  public final List<RecoveryExecutor.Result> recoveryResults = new ArrayList<>();
+  public final List<RecoveryExecutor.Result> recoveryResults = new CopyOnWriteArrayList<>();
 
   public TransactionContext(
       String transactionId,

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
@@ -26,7 +26,8 @@ public class TransactionContext {
   // A list of scanners opened in the transaction
   public final List<ConsensusCommitScanner> scanners = new ArrayList<>();
 
-  // A list of recovery results performed in the transaction
+  // A list of recovery results for asynchronously executed recoveries. These are tracked so that
+  // their completion can be awaited before committing the transaction if necessary.
   public final List<RecoveryExecutor.Result> recoveryResults = new ArrayList<>();
 
   public TransactionContext(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
@@ -20,6 +20,7 @@ public class TransactionTableMetadata {
   private final ImmutableLinkedHashSet<String> transactionMetaColumnNames;
   private final ImmutableLinkedHashSet<String> beforeImageColumnNames;
   private final ImmutableLinkedHashSet<String> afterImageColumnNames;
+  private final ImmutableLinkedHashSet<String> columnsWithBeforeImageSecondaryIndex;
 
   public TransactionTableMetadata(TableMetadata tableMetadata) {
     this.tableMetadata = tableMetadata;
@@ -44,6 +45,15 @@ public class TransactionTableMetadata {
             tableMetadata.getColumnNames().stream()
                 .filter(c -> ConsensusCommitUtils.isAfterImageColumn(c, tableMetadata))
                 .collect(Collectors.toList()));
+
+    // Compute which user-visible indexed columns have a corresponding before_* secondary index
+    Set<String> secondaryIndexNames = tableMetadata.getSecondaryIndexNames();
+    columnsWithBeforeImageSecondaryIndex =
+        new ImmutableLinkedHashSet<>(
+            secondaryIndexNames.stream()
+                .filter(
+                    indexName -> secondaryIndexNames.contains(Attribute.BEFORE_PREFIX + indexName))
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
   }
 
   public TableMetadata getTableMetadata() {
@@ -92,5 +102,15 @@ public class TransactionTableMetadata {
 
   public LinkedHashSet<String> getAfterImageColumnNames() {
     return afterImageColumnNames;
+  }
+
+  /**
+   * Returns whether the specified column has a corresponding before-image secondary index.
+   *
+   * @param columnName a column name
+   * @return whether the column has a before-image secondary index
+   */
+  public boolean hasBeforeImageSecondaryIndex(String columnName) {
+    return columnsWithBeforeImageSecondaryIndex.contains(columnName);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -85,6 +85,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             recoveryExecutor,
             tableMetadataManager,
             config.isIncludeMetadataEnabled(),
+            config.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     StorageInfoProvider storageInfoProvider = new StorageInfoProvider(admin);
     commit =
@@ -104,6 +105,8 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             virtualTableInfoManager,
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
+
+    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
   }
 
   public TwoPhaseConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -125,6 +128,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             recoveryExecutor,
             tableMetadataManager,
             config.isIncludeMetadataEnabled(),
+            config.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     StorageInfoProvider storageInfoProvider = new StorageInfoProvider(admin);
     commit =
@@ -144,6 +148,8 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             virtualTableInfoManager,
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
+
+    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/test/java/com/scalar/db/api/TableMetadataTest.java
+++ b/core/src/test/java/com/scalar/db/api/TableMetadataTest.java
@@ -180,6 +180,21 @@ public class TableMetadataTest {
   }
 
   @Test
+  public void
+      builder_SecondaryIndexGivenButNoColumnDefinitionOfItGiven_ShouldThrowIllegalStateException() {
+    // Arrange
+    TableMetadata.Builder builder =
+        TableMetadata.newBuilder()
+            .addColumn(COL_NAME1, DataType.INT)
+            .addColumn(COL_NAME2, DataType.TEXT)
+            .addPartitionKey(COL_NAME1)
+            .addSecondaryIndex(COL_NAME3);
+
+    // Act Assert
+    assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
   public void builder_basedOnAnotherTableMetadata_ShouldReturnProperTableMetadata() {
     // Arrange
     TableMetadata base =
@@ -331,7 +346,10 @@ public class TableMetadataTest {
 
     // Act
     TableMetadata tableMetadata =
-        builder.renameSecondaryIndex(COL_NAME5, "new_" + COL_NAME5).build();
+        builder
+            .renameColumn(COL_NAME5, "new_" + COL_NAME5)
+            .renameSecondaryIndex(COL_NAME5, "new_" + COL_NAME5)
+            .build();
 
     // Assert
     assertThat(tableMetadata.getSecondaryIndexNames().size()).isEqualTo(2);

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -32,9 +32,9 @@ public class MultiStorageAdminTest {
   protected static final String NAMESPACE1 = "test_ns1";
   protected static final String NAMESPACE2 = "test_ns2";
   protected static final String NAMESPACE3 = "test_ns3";
-  protected static final String TABLE1 = "test_table1";
-  protected static final String TABLE2 = "test_table2";
-  protected static final String TABLE3 = "test_table3";
+  protected static final String TABLE1 = "tbl1";
+  protected static final String TABLE2 = "tbl2";
+  protected static final String TABLE3 = "tbl3";
 
   @Mock private DistributedStorageAdmin admin1;
   @Mock private DistributedStorageAdmin admin2;

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -32,9 +32,9 @@ public class MultiStorageAdminTest {
   protected static final String NAMESPACE1 = "test_ns1";
   protected static final String NAMESPACE2 = "test_ns2";
   protected static final String NAMESPACE3 = "test_ns3";
-  protected static final String TABLE1 = "tbl1";
-  protected static final String TABLE2 = "tbl2";
-  protected static final String TABLE3 = "tbl3";
+  protected static final String TABLE1 = "test_table1";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE3 = "test_table3";
 
   @Mock private DistributedStorageAdmin admin1;
   @Mock private DistributedStorageAdmin admin2;

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -26,9 +26,9 @@ public class MultiStorageTest {
 
   protected static final String NAMESPACE1 = "test_ns1";
   protected static final String NAMESPACE2 = "test_ns2";
-  protected static final String TABLE1 = "tbl1";
-  protected static final String TABLE2 = "tbl2";
-  protected static final String TABLE3 = "tbl3";
+  protected static final String TABLE1 = "test_table1";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE3 = "test_table3";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -26,9 +26,9 @@ public class MultiStorageTest {
 
   protected static final String NAMESPACE1 = "test_ns1";
   protected static final String NAMESPACE2 = "test_ns2";
-  protected static final String TABLE1 = "test_table1";
-  protected static final String TABLE2 = "test_table2";
-  protected static final String TABLE3 = "test_table3";
+  protected static final String TABLE1 = "tbl1";
+  protected static final String TABLE2 = "tbl2";
+  protected static final String TABLE3 = "tbl3";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/ObjectStoragePartitionTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/ObjectStoragePartitionTest.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 
 public class ObjectStoragePartitionTest {
   private static final String NAMESPACE = "test_namespace";
-  private static final String TABLE = "tbl";
+  private static final String TABLE = "test_table";
   private static final String PARTITION_KEY_NAME = "pk";
   private static final String CLUSTERING_KEY_NAME = "ck";
   private static final String COLUMN_NAME_1 = "col1";

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/ObjectStoragePartitionTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/ObjectStoragePartitionTest.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 
 public class ObjectStoragePartitionTest {
   private static final String NAMESPACE = "test_namespace";
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   private static final String PARTITION_KEY_NAME = "pk";
   private static final String CLUSTERING_KEY_NAME = "ck";
   private static final String COLUMN_NAME_1 = "col1";

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/StreamingRecordIteratorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/StreamingRecordIteratorTest.java
@@ -22,7 +22,7 @@ import org.mockito.MockitoAnnotations;
 
 public class StreamingRecordIteratorTest {
   private static final String NAMESPACE = "test_namespace";
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   private static final String PARTITION_KEY_1 = "partition1";
   private static final String PARTITION_KEY_2 = "partition2";
   private static final String PARTITION_KEY_3 = "partition3";

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -40,7 +40,7 @@ import org.mockito.MockitoAnnotations;
 public abstract class ConsensusCommitAdminTestBase {
 
   private static final String NAMESPACE = "test_namespace";
-  private static final String TABLE = "tbl";
+  private static final String TABLE = "test_table";
 
   @Mock private DistributedStorageAdmin distributedStorageAdmin;
   @Mock private ConsensusCommitConfig config;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -40,7 +40,7 @@ import org.mockito.MockitoAnnotations;
 public abstract class ConsensusCommitAdminTestBase {
 
   private static final String NAMESPACE = "test_namespace";
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
 
   @Mock private DistributedStorageAdmin distributedStorageAdmin;
   @Mock private ConsensusCommitConfig config;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -201,6 +201,7 @@ public abstract class ConsensusCommitAdminTestBase {
             .addColumn(BALANCE, DataType.INT)
             .addPartitionKey(ACCOUNT_ID)
             .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
             .build();
 
     TableMetadata expected =
@@ -221,10 +222,63 @@ public abstract class ConsensusCommitAdminTestBase {
             .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
             .addPartitionKey(ACCOUNT_ID)
             .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .addSecondaryIndex(Attribute.BEFORE_PREFIX + BALANCE)
             .build();
 
     // Act
     admin.createTable(NAMESPACE, TABLE, tableMetadata);
+
+    // Assert
+    verify(distributedStorageAdmin).createTable(NAMESPACE, TABLE, expected, Collections.emptyMap());
+  }
+
+  @Test
+  public void
+      createTable_WithIndexEventuallyConsistentReadEnabled_shouldNotAddBeforeImageSecondaryIndex()
+          throws ExecutionException {
+    // Arrange
+    when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithFlag =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    // Act
+    adminWithFlag.createTable(NAMESPACE, TABLE, tableMetadata);
 
     // Assert
     verify(distributedStorageAdmin).createTable(NAMESPACE, TABLE, expected, Collections.emptyMap());
@@ -273,7 +327,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void createNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void createNamespace_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
 
     // Act
@@ -284,7 +339,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void dropTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void dropTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
 
     // Act
@@ -295,7 +350,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void dropNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void dropNamespace_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
 
     // Act
@@ -306,7 +361,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void truncateTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void truncateTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
 
     // Act
@@ -317,29 +372,103 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void createIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void createIndex_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("pk", DataType.INT)
+            .addColumn("col", DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + "col", DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey("pk")
+            .build();
+    when(distributedStorageAdmin.getTableMetadata("ns", "tbl")).thenReturn(tableMetadata);
 
     // Act
     admin.createIndex("ns", "tbl", "col", Collections.emptyMap());
 
     // Assert
     verify(distributedStorageAdmin).createIndex("ns", "tbl", "col", Collections.emptyMap());
+    verify(distributedStorageAdmin)
+        .createIndex("ns", "tbl", Attribute.BEFORE_PREFIX + "col", Collections.emptyMap());
   }
 
   @Test
-  public void dropIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void createIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotCreateBeforeImageIndex()
+      throws ExecutionException {
     // Arrange
+    when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithFlag =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    // Act
+    adminWithFlag.createIndex("ns", "tbl", "col", Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createIndex("ns", "tbl", "col", Collections.emptyMap());
+    verify(distributedStorageAdmin, never())
+        .createIndex("ns", "tbl", Attribute.BEFORE_PREFIX + "col", Collections.emptyMap());
+  }
+
+  @Test
+  public void dropIndex_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("pk", DataType.INT)
+            .addColumn("col", DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + "col", DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey("pk")
+            .build();
+    when(distributedStorageAdmin.getTableMetadata("ns", "tbl")).thenReturn(tableMetadata);
 
     // Act
     admin.dropIndex("ns", "tbl", "col");
 
     // Assert
     verify(distributedStorageAdmin).dropIndex("ns", "tbl", "col");
+    verify(distributedStorageAdmin).dropIndex("ns", "tbl", Attribute.BEFORE_PREFIX + "col", true);
   }
 
   @Test
-  public void getTableMetadata_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void dropIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotDropBeforeImageIndex()
+      throws ExecutionException {
+    // Arrange
+    when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithFlag =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    // Act
+    adminWithFlag.dropIndex("ns", "tbl", "col");
+
+    // Assert
+    verify(distributedStorageAdmin).dropIndex("ns", "tbl", "col");
+    verify(distributedStorageAdmin, never())
+        .dropIndex("ns", "tbl", Attribute.BEFORE_PREFIX + "col", true);
+  }
+
+  @Test
+  public void getTableMetadata_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -385,8 +514,9 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void getTableMetadata_WithIncludeMetadataEnabled_ShouldCallJdbcAdminProperly()
-      throws ExecutionException {
+  public void
+      getTableMetadata_WithIncludeMetadataEnabled_ShouldCallDistributedStorageAdminProperly()
+          throws ExecutionException {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -506,7 +636,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void namespaceExists_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void namespaceExists_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     when(distributedStorageAdmin.namespaceExists(any())).thenReturn(true);
 
@@ -533,6 +664,7 @@ public abstract class ConsensusCommitAdminTestBase {
             .addColumn(BALANCE, DataType.INT)
             .addPartitionKey(ACCOUNT_ID)
             .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
             .build();
 
     TableMetadata expected =
@@ -553,6 +685,8 @@ public abstract class ConsensusCommitAdminTestBase {
             .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
             .addPartitionKey(ACCOUNT_ID)
             .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .addSecondaryIndex(Attribute.BEFORE_PREFIX + BALANCE)
             .build();
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -564,7 +698,60 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void repairCoordinatorTables_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void
+      repairTable_WithIndexEventuallyConsistentReadEnabled_shouldNotAddBeforeImageSecondaryIndex()
+          throws ExecutionException {
+    // Arrange
+    when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithFlag =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    adminWithFlag.repairTable(NAMESPACE, TABLE, tableMetadata, options);
+
+    // Assert
+    verify(distributedStorageAdmin).repairTable(NAMESPACE, TABLE, expected, options);
+  }
+
+  @Test
+  public void repairCoordinatorTables_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -579,7 +766,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void addNewColumnToTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void addNewColumnToTable_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     String newColumn = "c2";
     TableMetadata tableMetadata =
@@ -607,7 +795,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void dropColumnFromTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void dropColumnFromTable_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     String targetColumn = "col2";
     TableMetadata tableMetadata =
@@ -630,7 +819,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void renameColumn_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void renameColumn_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
     String existingColumnName = "col2";
     String newColumnName = "col3";
@@ -659,7 +848,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void alterColumnType_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void alterColumnType_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     String columnName = "col2";
     DataType columnType = DataType.BIGINT;
@@ -683,7 +873,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void renameTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void renameTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
     String existingTableName = "tbl1";
     String newTableName = "tbl2";
@@ -735,7 +925,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void getNamespacesNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void getNamespacesNames_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
     Set<String> namespaces = ImmutableSet.of("n1", "n2", coordinatorNamespaceName);
     when(distributedStorageAdmin.getNamespaceNames()).thenReturn(namespaces);
@@ -749,7 +940,8 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void repairNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void repairNamespace_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
     // Arrange
 
     // Act
@@ -760,15 +952,74 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void upgrade_ShouldCallJdbcAdminProperly() throws ExecutionException {
+  public void upgrade_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
     // Act
     admin.upgrade(options);
 
-    // Arrange
+    // Assert
     verify(distributedStorageAdmin).upgrade(options);
+  }
+
+  @Test
+  public void upgrade_CoordinatorTableDoesNotExist_ShouldNotCallAddNewColumnToTable()
+      throws ExecutionException {
+    // Arrange
+    Map<String, String> options = Collections.emptyMap();
+    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
+        .thenReturn(null);
+
+    // Act
+    admin.upgrade(options);
+
+    // Assert
+    verify(distributedStorageAdmin).upgrade(options);
+    verify(distributedStorageAdmin, never())
+        .addNewColumnToTable(anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void upgrade_CoordinatorTableExistsWithAllColumns_ShouldNotCallAddNewColumnToTable()
+      throws ExecutionException {
+    // Arrange
+    Map<String, String> options = Collections.emptyMap();
+    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
+        .thenReturn(Coordinator.TABLE_METADATA);
+
+    // Act
+    admin.upgrade(options);
+
+    // Assert
+    verify(distributedStorageAdmin).upgrade(options);
+    verify(distributedStorageAdmin, never())
+        .addNewColumnToTable(anyString(), anyString(), anyString(), any());
+  }
+
+  @Test
+  public void upgrade_CoordinatorTableExistsButMissingChildIdsColumn_ShouldAddChildIdsColumn()
+      throws ExecutionException {
+    // Arrange
+    Map<String, String> options = Collections.emptyMap();
+    TableMetadata oldCoordinatorMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.CREATED_AT, DataType.BIGINT)
+            .addPartitionKey(Attribute.ID)
+            .build();
+    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
+        .thenReturn(oldCoordinatorMetadata);
+
+    // Act
+    admin.upgrade(options);
+
+    // Assert
+    verify(distributedStorageAdmin).upgrade(options);
+    verify(distributedStorageAdmin)
+        .addNewColumnToTable(
+            coordinatorNamespaceName, Coordinator.TABLE, Attribute.CHILD_IDS, DataType.TEXT);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -31,6 +31,7 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isOnePhaseCommitEnabled()).isFalse();
     assertThat(config.isParallelImplicitPreReadEnabled()).isTrue();
     assertThat(config.isIncludeMetadataEnabled()).isFalse();
+    assertThat(config.isIndexEventuallyConsistentReadEnabled()).isFalse();
   }
 
   @Test
@@ -207,5 +208,19 @@ public class ConsensusCommitConfigTest {
 
     // Assert
     assertThat(config.isIncludeMetadataEnabled()).isTrue();
+  }
+
+  @Test
+  public void
+      constructor_PropertiesWithIndexEventuallyConsistentReadEnabledGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ConsensusCommitConfig.INDEX_EVENTUALLY_CONSISTENT_READ_ENABLED, "true");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.isIndexEventuallyConsistentReadEnabled()).isTrue();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
@@ -683,11 +683,6 @@ public class ConsensusCommitOperationCheckerTest {
             .addSecondaryIndex("idx_col")
             .build();
     when(tableMetadata.getTableMetadata()).thenReturn(metadata);
-    TableMetadata mockTableMetadata = mock(TableMetadata.class);
-    when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
-    when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
-    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         Scan.newBuilder()

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
@@ -563,14 +563,14 @@ public class ConsensusCommitOperationCheckerTest {
   public void
       checkForScan_ScanAllWithConditionOnIndexedColumnInSerializable_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
-    when(tableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     // Mock the underlying TableMetadata
     TableMetadata mockTableMetadata = mock(TableMetadata.class);
     when(tableMetadata.getTableMetadata()).thenReturn(mockTableMetadata);
     when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
     when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         ScanAll.newBuilder()
@@ -591,14 +591,14 @@ public class ConsensusCommitOperationCheckerTest {
   public void
       checkForScan_ScanAllWithConditionOnNonIndexedColumnInSerializable_ShouldNotThrowException() {
     // Arrange
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
-    when(tableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     // Mock the underlying TableMetadata
     TableMetadata mockTableMetadata = mock(TableMetadata.class);
     when(tableMetadata.getTableMetadata()).thenReturn(mockTableMetadata);
     when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
     when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         ScanAll.newBuilder()
@@ -618,16 +618,15 @@ public class ConsensusCommitOperationCheckerTest {
   public void
       checkForScan_ScanAllWithConditionOnIndexedPartitionKeyColumnInSerializable_ShouldNotThrowException() {
     // Arrange
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
-    when(tableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     // Mock the underlying TableMetadata - indexed column is also a partition key
     TableMetadata mockTableMetadata = mock(TableMetadata.class);
     when(tableMetadata.getTableMetadata()).thenReturn(mockTableMetadata);
-    LinkedHashSet<String> partitionKeys = new LinkedHashSet<>();
-    partitionKeys.add("idx_col");
+    LinkedHashSet<String> partitionKeys = new LinkedHashSet<>(Collections.singletonList("idx_col"));
     when(mockTableMetadata.getPartitionKeyNames()).thenReturn(partitionKeys);
     when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         ScanAll.newBuilder()
@@ -647,16 +646,16 @@ public class ConsensusCommitOperationCheckerTest {
   public void
       checkForScan_ScanAllWithConditionOnIndexedClusteringKeyColumnInSerializable_ShouldNotThrowException() {
     // Arrange
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
-    when(tableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     // Mock the underlying TableMetadata - indexed column is also a clustering key
     TableMetadata mockTableMetadata = mock(TableMetadata.class);
     when(tableMetadata.getTableMetadata()).thenReturn(mockTableMetadata);
     when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
-    LinkedHashSet<String> clusteringKeys = new LinkedHashSet<>();
-    clusteringKeys.add("idx_col");
+    LinkedHashSet<String> clusteringKeys =
+        new LinkedHashSet<>(Collections.singletonList("idx_col"));
     when(mockTableMetadata.getClusteringKeyNames()).thenReturn(clusteringKeys);
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         ScanAll.newBuilder()
@@ -683,9 +682,12 @@ public class ConsensusCommitOperationCheckerTest {
             .addPartitionKey("pk")
             .addSecondaryIndex("idx_col")
             .build();
-    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
     when(tableMetadata.getTableMetadata()).thenReturn(metadata);
-    when(tableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
+    TableMetadata mockTableMetadata = mock(TableMetadata.class);
+    when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
+    when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
 
     Scan scan =
         Scan.newBuilder()

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
@@ -1615,4 +1615,266 @@ public class ConsensusCommitUtilsTest {
                 .consistency(Consistency.LINEARIZABLE)
                 .build());
   }
+
+  @Test
+  public void
+      buildTransactionTableMetadata_tableMetadataWithSecondaryIndexGiven_shouldAddBeforeImageSecondaryIndex() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .addSecondaryIndex(Attribute.BEFORE_PREFIX + BALANCE)
+            .build();
+
+    // Act
+    TableMetadata actual = ConsensusCommitUtils.buildTransactionTableMetadata(tableMetadata);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void
+      buildTransactionTableMetadata_WithIndexEventuallyConsistentReadEnabled_shouldNotAddBeforeImageSecondaryIndex() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    // Act
+    TableMetadata actual = ConsensusCommitUtils.buildTransactionTableMetadata(tableMetadata, true);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void
+      buildTransactionMetadataTableMetadata_tableMetadataWithSecondaryIndexGiven_shouldAddBeforeImageSecondaryIndex() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(Attribute.BEFORE_PREFIX + BALANCE)
+            .build();
+
+    // Act
+    TableMetadata actual =
+        ConsensusCommitUtils.buildTransactionMetadataTableMetadata(tableMetadata);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void
+      buildTransactionMetadataTableMetadata_WithIndexEventuallyConsistentReadEnabled_shouldNotAddBeforeImageSecondaryIndex() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BALANCE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+
+    // Act
+    TableMetadata actual =
+        ConsensusCommitUtils.buildTransactionMetadataTableMetadata(tableMetadata, true);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void createBeforeIndexScan_ScanWithIndex_shouldCreateScanWithBeforeIndexKey() {
+    // Arrange
+    Scan scanWithIndex =
+        Scan.newBuilder().namespace("ns").table("tbl").indexKey(Key.ofInt("col1", 10)).build();
+
+    // Act
+    Scan result = ConsensusCommitUtils.createBeforeIndexScan(scanWithIndex);
+
+    // Assert
+    assertThat(result)
+        .isEqualTo(
+            Scan.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .indexKey(Key.ofInt(Attribute.BEFORE_PREFIX + "col1", 10))
+                .consistency(Consistency.LINEARIZABLE)
+                .build());
+  }
+
+  @Test
+  public void createBeforeIndexScan_GetWithIndex_shouldCreateScanWithBeforeIndexKey() {
+    // Arrange
+    Get getWithIndex =
+        Get.newBuilder().namespace("ns").table("tbl").indexKey(Key.ofText("col1", "value")).build();
+
+    // Act
+    Scan result = ConsensusCommitUtils.createBeforeIndexScan(getWithIndex);
+
+    // Assert
+    assertThat(result)
+        .isEqualTo(
+            Scan.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .indexKey(Key.ofText(Attribute.BEFORE_PREFIX + "col1", "value"))
+                .consistency(Consistency.LINEARIZABLE)
+                .build());
+  }
+
+  @Test
+  public void
+      createBeforeIndexScanAll_ScanAllWithIndexedColumnCondition_shouldCreateScanAllWithBeforeImageConditions() {
+    // Arrange
+    TableMetadata metadata =
+        ConsensusCommitUtils.buildTransactionTableMetadata(
+            TableMetadata.newBuilder()
+                .addColumn("pk", DataType.INT)
+                .addColumn("col1", DataType.INT)
+                .addColumn("col2", DataType.TEXT)
+                .addPartitionKey("pk")
+                .addSecondaryIndex("col1")
+                .build());
+
+    ScanAll scanAll =
+        (ScanAll)
+            ScanAll.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .all()
+                .where(column("col1").isEqualToInt(10))
+                .build();
+
+    // Act
+    Scan result = ConsensusCommitUtils.createBeforeIndexScanAll(scanAll, metadata);
+
+    // Assert
+    assertThat(result)
+        .isEqualTo(
+            Scan.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .all()
+                .where(column(Attribute.BEFORE_PREFIX + "col1").isEqualToInt(10))
+                .consistency(Consistency.LINEARIZABLE)
+                .build());
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -3156,6 +3156,63 @@ public class CrudHandlerTest {
   }
 
   @Test
+  public void
+      read_GetWithIndexAndBeforeIndexRollbackCausesDifferentResult_ShouldUseKeyFromSecondResult()
+          throws Exception {
+    // Arrange
+    Get getWithIndex = prepareGetWithIndex();
+    Get getForStorage = toGetForStorageFrom(getWithIndex);
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // First get returns a committed result with partition key "text1"
+    TransactionResult committedResult1 =
+        prepareResult(ANY_TEXT_1, ANY_TEXT_2, TransactionState.COMMITTED);
+    // Second get returns a different committed result with partition key "text4"
+    TransactionResult committedResult2 =
+        prepareResult(ANY_TEXT_4, ANY_TEXT_5, TransactionState.COMMITTED);
+    when(storage.get(getForStorage))
+        .thenReturn(Optional.of(committedResult1))
+        .thenReturn(Optional.of(committedResult2));
+
+    // Before-index scan: first call finds a rolled-back record, second call finds nothing
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner1 = mock(Scanner.class);
+    when(beforeIndexScanner1.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner2 = mock(Scanner.class);
+    when(beforeIndexScanner2.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(expectedBeforeIndexScan))
+        .thenReturn(beforeIndexScanner1)
+        .thenReturn(beforeIndexScanner2);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act
+    handler.read(null, getWithIndex, context, TRANSACTION_TABLE_METADATA);
+
+    // Assert
+    // Verify key is created from the second result, not reusing the stale key from the first
+    Snapshot.Key expectedKey = new Snapshot.Key(getWithIndex, committedResult2, TABLE_METADATA);
+    verify(snapshot).putIntoReadSet(expectedKey, Optional.of(committedResult2));
+  }
+
+  @Test
   public void scan_ScanWithIndexAndBeforeIndexScanFindsRolledBackRecord_ShouldRetry()
       throws Exception {
     // Arrange

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -33,6 +33,7 @@ import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.io.Column;
@@ -90,6 +91,9 @@ public class CrudHandlerTest {
               .addSecondaryIndex(ANY_NAME_3)
               .build());
 
+  private static final TransactionTableMetadata TRANSACTION_TABLE_METADATA =
+      new TransactionTableMetadata(TABLE_METADATA);
+
   private CrudHandler handler;
   @Mock private DistributedStorage storage;
   @Mock private RecoveryExecutor recoveryExecutor;
@@ -110,14 +114,19 @@ public class CrudHandlerTest {
             recoveryExecutor,
             tableMetadataManager,
             false,
+            false,
             mutationConditionsValidator,
             parallelExecutor);
 
     // Arrange
     when(tableMetadataManager.getTransactionTableMetadata(any()))
-        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
+        .thenReturn(TRANSACTION_TABLE_METADATA);
     when(tableMetadataManager.getTransactionTableMetadata(any(), any()))
-        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
+        .thenReturn(TRANSACTION_TABLE_METADATA);
+
+    // Default mock for before-index scan to return an empty scanner
+    when(storage.scan(any(Scan.class))).thenReturn(scanner);
+    when(scanner.iterator()).thenReturn(Collections.emptyIterator());
   }
 
   private Get prepareGet() {
@@ -128,6 +137,14 @@ public class CrudHandlerTest {
         .table(ANY_TABLE_NAME)
         .partitionKey(partitionKey)
         .clusteringKey(clusteringKey)
+        .build();
+  }
+
+  private Get prepareGetWithIndex() {
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .indexKey(Key.ofText(ANY_NAME_3, ANY_TEXT_3))
         .build();
   }
 
@@ -150,6 +167,23 @@ public class CrudHandlerTest {
         .table(ANY_TABLE_NAME)
         .all()
         .where(column(ANY_NAME_4).isEqualToInt(ANY_INT_1))
+        .build();
+  }
+
+  private Scan prepareScanWithIndex() {
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .indexKey(Key.ofText(ANY_NAME_3, ANY_TEXT_3))
+        .build();
+  }
+
+  private Scan prepareExpectedBeforeIndexScan() {
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .indexKey(Key.ofText(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_TEXT_3))
+        .consistency(Consistency.LINEARIZABLE)
         .build();
   }
 
@@ -453,7 +487,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
@@ -507,7 +542,8 @@ public class CrudHandlerTest {
             transactionResult,
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     when(snapshot.mergeResult(key, Optional.of(recoveredResult), get.getConjunctions()))
         .thenReturn(Optional.of(expected));
@@ -564,7 +600,8 @@ public class CrudHandlerTest {
             transactionResult,
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_NOT_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     when(snapshot.mergeResult(key, Optional.of(recoveredResult), get.getConjunctions()))
         .thenReturn(Optional.of(expected));
@@ -981,7 +1018,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
@@ -1035,7 +1073,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.READ_COMMITTED, false, false);
@@ -1088,7 +1127,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_COMMITTED_RESULT_AND_NOT_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.READ_COMMITTED, true, false);
@@ -1409,7 +1449,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
@@ -1471,7 +1512,8 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
@@ -1633,7 +1675,7 @@ public class CrudHandlerTest {
             new TransactionResult(uncommittedResult1),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key1, Optional.empty(), recoveryFuture));
+        .thenReturn(new RecoveryExecutor.Result(key1, Optional.empty(), recoveryFuture, false));
     when(recoveryExecutor.execute(
             key2,
             scanWithLimit,
@@ -1641,7 +1683,8 @@ public class CrudHandlerTest {
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
         .thenReturn(
-            new RecoveryExecutor.Result(key2, Optional.of(recoveredResult1), recoveryFuture));
+            new RecoveryExecutor.Result(
+                key2, Optional.of(recoveredResult1), recoveryFuture, false));
     when(recoveryExecutor.execute(
             key3,
             scanWithLimit,
@@ -1649,7 +1692,8 @@ public class CrudHandlerTest {
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
         .thenReturn(
-            new RecoveryExecutor.Result(key3, Optional.of(recoveredResult2), recoveryFuture));
+            new RecoveryExecutor.Result(
+                key3, Optional.of(recoveredResult2), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
@@ -1942,7 +1986,7 @@ public class CrudHandlerTest {
     spied.put(put, context);
 
     // Assert
-    verify(spied).read(key, getForKey, context, TABLE_METADATA);
+    verify(spied).read(key, getForKey, context, TRANSACTION_TABLE_METADATA);
     verify(snapshot).getResult(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(put, result, ANY_ID_1);
     verify(snapshot).putIntoWriteSet(key, put);
@@ -2093,7 +2137,7 @@ public class CrudHandlerTest {
     spied.delete(delete, context);
 
     // Assert
-    verify(spied).read(key, getForKey, context, TABLE_METADATA);
+    verify(spied).read(key, getForKey, context, TRANSACTION_TABLE_METADATA);
     verify(snapshot).getResult(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(delete, null, ANY_ID_1);
     verify(snapshot).putIntoDeleteSet(key, delete);
@@ -2120,7 +2164,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage, never()).get(getForStorage);
@@ -2150,7 +2194,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2186,7 +2230,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2218,7 +2262,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2256,13 +2300,14 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2308,13 +2353,13 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, recoveredRecord, recoveryFuture));
+        .thenReturn(new RecoveryExecutor.Result(key, recoveredRecord, recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getForKey, context, TABLE_METADATA);
+    handler.readUnread(key, getForKey, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2372,13 +2417,14 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getWithConjunction, context, TABLE_METADATA);
+    handler.readUnread(key, getWithConjunction, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2435,13 +2481,14 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getWithConjunction, context, TABLE_METADATA);
+    handler.readUnread(key, getWithConjunction, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2474,7 +2521,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(null, getWithIndex, context, TABLE_METADATA);
+    handler.readUnread(null, getWithIndex, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2507,7 +2554,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(null, getWithIndex, context, TABLE_METADATA);
+    handler.readUnread(null, getWithIndex, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2551,13 +2598,14 @@ public class CrudHandlerTest {
             new TransactionResult(result),
             ANY_ID_1,
             RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
-        .thenReturn(new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture));
+        .thenReturn(
+            new RecoveryExecutor.Result(key, Optional.of(recoveredResult), recoveryFuture, false));
 
     TransactionContext context =
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.readUnread(key, getWithIndex, context, TABLE_METADATA);
+    handler.readUnread(key, getWithIndex, context, TRANSACTION_TABLE_METADATA);
 
     // Assert
     verify(storage).get(getForStorage);
@@ -2722,6 +2770,702 @@ public class CrudHandlerTest {
     verify(snapshot).putIntoGetSet(get4, Optional.of(new TransactionResult(result4)));
 
     assertThat(transactionIdCaptor.getValue()).isEqualTo(ANY_ID_1);
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_GetWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    Get get = prepareGetWithIndex();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(get, TRANSACTION_TABLE_METADATA)).isTrue();
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_GetWithPrimaryKey_ShouldReturnFalse() {
+    // Arrange
+    Get get = prepareGet();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(get, TRANSACTION_TABLE_METADATA)).isFalse();
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_ScanWithPartitionKey_ShouldReturnFalse() {
+    // Arrange
+    Scan scan = prepareScan();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(scan, TRANSACTION_TABLE_METADATA)).isFalse();
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_ScanWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    Scan scan = prepareScanWithIndex();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(scan, TRANSACTION_TABLE_METADATA)).isTrue();
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_ScanAllWithIndexedColumnCondition_ShouldReturnTrue() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+            .build();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(scan, TRANSACTION_TABLE_METADATA)).isTrue();
+  }
+
+  @Test
+  public void requiresBeforeIndexCheck_ScanAllWithNonIndexedColumnCondition_ShouldReturnFalse() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(column(ANY_NAME_4).isEqualToInt(ANY_INT_1))
+            .build();
+
+    // Act Assert
+    assertThat(handler.requiresBeforeIndexCheck(scan, TRANSACTION_TABLE_METADATA)).isFalse();
+  }
+
+  @Test
+  public void
+      requiresBeforeIndexCheck_IndexEventuallyConsistentReadEnabled_ShouldAlwaysReturnFalse() {
+    // Arrange
+    CrudHandler handlerWithEventuallyConsistentRead =
+        new CrudHandler(
+            storage,
+            recoveryExecutor,
+            tableMetadataManager,
+            false,
+            true,
+            mutationConditionsValidator,
+            parallelExecutor);
+    Get getWithIndex = prepareGetWithIndex();
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanAll =
+        ScanAll.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(column(ANY_NAME_3).isEqualToInt(ANY_INT_1))
+            .build();
+
+    // Act Assert
+    assertThat(
+            handlerWithEventuallyConsistentRead.requiresBeforeIndexCheck(
+                getWithIndex, TRANSACTION_TABLE_METADATA))
+        .isFalse();
+    assertThat(
+            handlerWithEventuallyConsistentRead.requiresBeforeIndexCheck(
+                scanWithIndex, TRANSACTION_TABLE_METADATA))
+        .isFalse();
+    assertThat(
+            handlerWithEventuallyConsistentRead.requiresBeforeIndexCheck(
+                scanAll, TRANSACTION_TABLE_METADATA))
+        .isFalse();
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RolledBackRecordFound_ShouldRecoverSynchronouslyAndReturnTrue()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryResult);
+
+    // Act
+    boolean result =
+        handler.checkAndRecoverBeforeIndexRecords(
+            scanWithIndex, context, TRANSACTION_TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+    verify(storage).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture).get();
+    assertThat(context.recoveryResults).isEmpty();
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RolledForwardRecordFound_ShouldTrackAsyncAndReturnFalse()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            false);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryResult);
+
+    // Act
+    boolean result =
+        handler.checkAndRecoverBeforeIndexRecords(
+            scanWithIndex, context, TRANSACTION_TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isFalse();
+    verify(storage).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture, never()).get();
+    assertThat(context.recoveryResults).hasSize(1);
+    assertThat(context.recoveryResults.get(0)).isSameAs(recoveryResult);
+  }
+
+  @Test
+  public void read_GetWithIndexAndBeforeIndexScanFindsRolledBackRecord_ShouldRetry()
+      throws Exception {
+    // Arrange
+    Get getWithIndex = prepareGetWithIndex();
+    Get getForStorage =
+        Get.newBuilder(getWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // First get returns a committed result
+    TransactionResult committedResult = prepareResult(TransactionState.COMMITTED);
+    when(storage.get(getForStorage)).thenReturn(Optional.of(committedResult));
+
+    // Before-index scan: first call finds a rolled-back record, second call finds nothing
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner1 = mock(Scanner.class);
+    when(beforeIndexScanner1.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner2 = mock(Scanner.class);
+    when(beforeIndexScanner2.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(expectedBeforeIndexScan))
+        .thenReturn(beforeIndexScanner1)
+        .thenReturn(beforeIndexScanner2);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act
+    handler.read(null, getWithIndex, context, TRANSACTION_TABLE_METADATA);
+
+    // Assert
+    verify(storage, times(2)).get(getForStorage);
+    verify(storage, times(2)).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture).get();
+  }
+
+  @Test
+  public void read_GetWithIndexAndBeforeIndexScanFindsRolledForwardRecord_ShouldNotRetry()
+      throws Exception {
+    // Arrange
+    Get getWithIndex = prepareGetWithIndex();
+    Get getForStorage =
+        Get.newBuilder(getWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Get returns a committed result
+    TransactionResult committedResult = prepareResult(TransactionState.COMMITTED);
+    when(storage.get(getForStorage)).thenReturn(Optional.of(committedResult));
+
+    // Before-index scan finds a rolled-forward record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            false);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act
+    handler.read(null, getWithIndex, context, TRANSACTION_TABLE_METADATA);
+
+    // Assert
+    verify(storage, times(1)).get(getForStorage);
+    verify(storage, times(1)).scan(expectedBeforeIndexScan);
+    verify(recoveryFuture, never()).get();
+  }
+
+  @Test
+  public void read_GetWithIndexAndRetryLimitExceeded_ShouldThrowCrudConflictException()
+      throws Exception {
+    // Arrange
+    Get getWithIndex = prepareGetWithIndex();
+    Get getForStorage =
+        Get.newBuilder(getWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    TransactionResult committedResult = prepareResult(TransactionState.COMMITTED);
+    when(storage.get(getForStorage)).thenReturn(Optional.of(committedResult));
+
+    // Before-index scan always finds a rolled-back record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner1 = mock(Scanner.class);
+    when(beforeIndexScanner1.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner2 = mock(Scanner.class);
+    when(beforeIndexScanner2.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner3 = mock(Scanner.class);
+    when(beforeIndexScanner3.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    when(storage.scan(expectedBeforeIndexScan))
+        .thenReturn(beforeIndexScanner1)
+        .thenReturn(beforeIndexScanner2)
+        .thenReturn(beforeIndexScanner3);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.read(null, getWithIndex, context, TRANSACTION_TABLE_METADATA))
+        .isInstanceOf(CrudConflictException.class);
+
+    verify(storage, times(3)).get(getForStorage);
+    verify(storage, times(3)).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor, times(3))
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture, times(3)).get();
+  }
+
+  @Test
+  public void scan_ScanWithIndexAndBeforeIndexScanFindsRolledBackRecord_ShouldRetry()
+      throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanForStorage =
+        Scan.newBuilder(scanWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Scan from storage returns empty results
+    Scanner storageScanner1 = mock(Scanner.class);
+    when(storageScanner1.iterator()).thenReturn(Collections.emptyIterator());
+    Scanner storageScanner2 = mock(Scanner.class);
+    when(storageScanner2.iterator()).thenReturn(Collections.emptyIterator());
+
+    // Before-index scan: first call finds a rolled-back record, second finds nothing
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner1 = mock(Scanner.class);
+    when(beforeIndexScanner1.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner2 = mock(Scanner.class);
+    when(beforeIndexScanner2.iterator()).thenReturn(Collections.emptyIterator());
+
+    when(storage.scan(scanForStorage)).thenReturn(storageScanner1).thenReturn(storageScanner2);
+    when(storage.scan(expectedBeforeIndexScan))
+        .thenReturn(beforeIndexScanner1)
+        .thenReturn(beforeIndexScanner2);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act
+    handler.scan(scanWithIndex, context);
+
+    // Assert
+    verify(storage, times(2)).scan(scanForStorage);
+    verify(storage, times(2)).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture).get();
+  }
+
+  @Test
+  public void scan_ScanWithIndexAndBeforeIndexScanFindsRolledForwardRecord_ShouldNotRetry()
+      throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanForStorage =
+        Scan.newBuilder(scanWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Scan from storage returns empty results
+    Scanner storageScanner = mock(Scanner.class);
+    when(storageScanner.iterator()).thenReturn(Collections.emptyIterator());
+
+    // Before-index scan finds a rolled-forward record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+
+    when(storage.scan(scanForStorage)).thenReturn(storageScanner);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            false);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act
+    handler.scan(scanWithIndex, context);
+
+    // Assert
+    verify(storage, times(1)).scan(scanForStorage);
+    verify(storage, times(1)).scan(expectedBeforeIndexScan);
+    verify(recoveryFuture, never()).get();
+  }
+
+  @Test
+  public void scan_ScanWithIndexAndRetryLimitExceeded_ShouldThrowCrudConflictException()
+      throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanForStorage =
+        Scan.newBuilder(scanWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Scan from storage returns empty results (3 times)
+    Scanner storageScanner1 = mock(Scanner.class);
+    when(storageScanner1.iterator()).thenReturn(Collections.emptyIterator());
+    Scanner storageScanner2 = mock(Scanner.class);
+    when(storageScanner2.iterator()).thenReturn(Collections.emptyIterator());
+    Scanner storageScanner3 = mock(Scanner.class);
+    when(storageScanner3.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(scanForStorage))
+        .thenReturn(storageScanner1)
+        .thenReturn(storageScanner2)
+        .thenReturn(storageScanner3);
+
+    // Before-index scan always finds a rolled-back record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner1 = mock(Scanner.class);
+    when(beforeIndexScanner1.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner2 = mock(Scanner.class);
+    when(beforeIndexScanner2.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    Scanner beforeIndexScanner3 = mock(Scanner.class);
+    when(beforeIndexScanner3.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+    when(storage.scan(expectedBeforeIndexScan))
+        .thenReturn(beforeIndexScanner1)
+        .thenReturn(beforeIndexScanner2)
+        .thenReturn(beforeIndexScanner3);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scanWithIndex, context))
+        .isInstanceOf(CrudConflictException.class);
+
+    verify(storage, times(3)).scan(scanForStorage);
+    verify(storage, times(3)).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor, times(3))
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture, times(3)).get();
+  }
+
+  @Test
+  public void
+      getScanner_CloseWithBeforeIndexScanFindsRolledBackRecord_ShouldThrowCrudConflictException()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanForStorage =
+        Scan.newBuilder(scanWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Storage scan returns empty results
+    Scanner storageScanner = mock(Scanner.class);
+    when(storageScanner.one()).thenReturn(Optional.empty());
+
+    // Before-index scan finds a rolled-back record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+
+    when(storage.scan(scanForStorage)).thenReturn(storageScanner);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            true);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner txScanner = handler.getScanner(scanWithIndex, context);
+    assertThat(txScanner.one()).isEmpty(); // drain the scanner
+    assertThatThrownBy(txScanner::close).isInstanceOf(CrudConflictException.class);
+
+    verify(storage).scan(scanForStorage);
+    verify(storage).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture).get();
+  }
+
+  @Test
+  public void getScanner_CloseWithBeforeIndexScanFindsRolledForwardRecord_ShouldCloseNormally()
+      throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan scanForStorage =
+        Scan.newBuilder(scanWithIndex)
+            .clearProjections()
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Storage scan returns empty results
+    Scanner storageScanner = mock(Scanner.class);
+    when(storageScanner.one()).thenReturn(Optional.empty());
+
+    // Before-index scan finds a rolled-forward record
+    TransactionResult preparedResult = prepareResult(TransactionState.PREPARED);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.<Result>singletonList(preparedResult).iterator());
+
+    when(storage.scan(scanForStorage)).thenReturn(storageScanner);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    @SuppressWarnings("unchecked")
+    Future<Void> recoveryFuture = mock(Future.class);
+    RecoveryExecutor.Result recoveryExecResult =
+        new RecoveryExecutor.Result(
+            new Snapshot.Key(expectedBeforeIndexScan, preparedResult, TABLE_METADATA),
+            Optional.of(preparedResult),
+            recoveryFuture,
+            false);
+    when(recoveryExecutor.execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER)))
+        .thenReturn(recoveryExecResult);
+
+    // Act - should close normally without throwing
+    TransactionCrudOperable.Scanner txScanner = handler.getScanner(scanWithIndex, context);
+    assertThat(txScanner.one()).isEmpty(); // drain the scanner
+    txScanner.close(); // should not throw
+
+    // Assert
+    verify(storage).scan(scanForStorage);
+    verify(storage).scan(expectedBeforeIndexScan);
+    verify(recoveryExecutor)
+        .execute(
+            any(Snapshot.Key.class),
+            eq(expectedBeforeIndexScan),
+            eq(preparedResult),
+            eq(ANY_ID_1),
+            eq(RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER));
+    verify(recoveryFuture, never()).get();
   }
 
   private List<Result> scanOrGetScanner(Scan scan, ScanType scanType, TransactionContext context)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -390,6 +390,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
@@ -417,6 +418,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
@@ -442,6 +444,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
@@ -469,6 +472,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
@@ -498,6 +502,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledForwardResult());
+    assertThat(result.rolledBack).isFalse();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
@@ -524,6 +529,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isNotPresent();
+    assertThat(result.rolledBack).isFalse();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
@@ -550,6 +556,7 @@ public class RecoveryExecutorTest {
         .hasCauseInstanceOf(CrudException.class);
 
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
     verify(recovery, never()).recover(any(), any(), any());
@@ -579,6 +586,7 @@ public class RecoveryExecutorTest {
         .hasCauseInstanceOf(UncommittedRecordException.class);
 
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
     verify(recovery, never()).recover(any(), any(), any());
@@ -607,6 +615,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
@@ -634,6 +643,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
@@ -659,6 +669,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
@@ -686,6 +697,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
@@ -715,6 +727,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
@@ -741,6 +754,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
     verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
@@ -766,6 +780,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
     verify(recovery, never()).recover(any(), any(), any());
@@ -792,6 +807,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
     verify(recovery, never()).recover(any(), any(), any());
@@ -818,6 +834,7 @@ public class RecoveryExecutorTest {
 
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
     verify(recovery, never()).recover(any(), any(), any());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
@@ -215,6 +215,77 @@ public class TransactionTableMetadataManagerTest {
     verify(admin).getTableMetadata("ns", "tbl");
   }
 
+  @Test
+  public void hasBeforeImageSecondaryIndex_ColumnWithBeforeImageSecondaryIndex_ShouldReturnTrue()
+      throws ExecutionException {
+    // Arrange
+    TableMetadata tableMetadataWithBeforeIndex =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(BRANCH, DataType.TEXT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + BRANCH, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BRANCH)
+            .addSecondaryIndex(Attribute.BEFORE_PREFIX + BRANCH)
+            .build();
+    when(admin.getTableMetadata(anyString(), anyString())).thenReturn(tableMetadataWithBeforeIndex);
+
+    TransactionTableMetadataManager tableMetadataManager =
+        new TransactionTableMetadataManager(admin, -1);
+
+    // Act
+    TransactionTableMetadata actual =
+        tableMetadataManager.getTransactionTableMetadata(
+            Get.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .partitionKey(Key.ofText("c1", "aaa"))
+                .build());
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.hasBeforeImageSecondaryIndex(BRANCH)).isTrue();
+    assertThat(actual.hasBeforeImageSecondaryIndex(BALANCE)).isFalse();
+  }
+
+  @Test
+  public void
+      hasBeforeImageSecondaryIndex_ColumnWithoutBeforeImageSecondaryIndex_ShouldReturnFalse()
+          throws ExecutionException {
+    // Arrange
+    TransactionTableMetadataManager tableMetadataManager =
+        new TransactionTableMetadataManager(admin, -1);
+
+    // Act
+    TransactionTableMetadata actual =
+        tableMetadataManager.getTransactionTableMetadata(
+            Get.newBuilder()
+                .namespace("ns")
+                .table("tbl")
+                .partitionKey(Key.ofText("c1", "aaa"))
+                .build());
+
+    // Assert
+    // BRANCH has a secondary index, but before_branch does not have a secondary index
+    assertThat(actual).isNotNull();
+    assertThat(actual.hasBeforeImageSecondaryIndex(BRANCH)).isFalse();
+    assertThat(actual.hasBeforeImageSecondaryIndex(BALANCE)).isFalse();
+  }
+
   private void assertTransactionMetadata(TransactionTableMetadata actual) {
     assertThat(actual).isNotNull();
     assertThat(actual.getTableMetadata()).isEqualTo(tableMetadata);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminCaseSensitivityIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminCaseSensitivityIntegrationTestBase.java
@@ -7,10 +7,10 @@ public abstract class DistributedStorageAdminCaseSensitivityIntegrationTestBase
   private static final String NAMESPACE1 = "Int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE2 = "Int_test_" + TEST_NAME + "2";
   private static final String NAMESPACE3 = "Int_test_" + TEST_NAME + "3";
-  private static final String TABLE1 = "Test_table1";
-  private static final String TABLE2 = "Test_table2";
-  private static final String TABLE3 = "Test_table3";
-  private static final String TABLE4 = "Test_table4";
+  private static final String TABLE1 = "Tbl1";
+  private static final String TABLE2 = "Tbl2";
+  private static final String TABLE3 = "Tbl3";
+  private static final String TABLE4 = "Tbl4";
   private static final String COL_NAME1 = "Column1";
   private static final String COL_NAME2 = "Column2";
   private static final String COL_NAME3 = "Column3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -44,10 +44,10 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
   private static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
-  private static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
-  private static final String TABLE4 = "test_table4";
+  private static final String TABLE1 = "tbl1";
+  private static final String TABLE2 = "tbl2";
+  private static final String TABLE3 = "tbl3";
+  private static final String TABLE4 = "tbl4";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminPermissionIntegrationTestBase.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 public abstract class DistributedStorageAdminPermissionIntegrationTestBase {
   protected static final String TEST_NAME = "storage_admin";
   protected static final String NAMESPACE = "test_" + TEST_NAME + "_1";
-  protected static final String TABLE = "test_table_1";
+  protected static final String TABLE = "tbl_1";
 
   private static final Logger logger =
       LoggerFactory.getLogger(DistributedStorageAdminPermissionIntegrationTestBase.class);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairIntegrationTestBase.java
@@ -26,7 +26,7 @@ public abstract class DistributedStorageAdminRepairIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_admin_repair";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCaseSensitivityIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCaseSensitivityIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class DistributedStorageCaseSensitivityIntegrationTestBase
 
   private static final String TEST_NAME = "storage_case";
   private static final String NAMESPACE = "Int_test_" + TEST_NAME;
-  private static final String TABLE = "Test_table";
+  private static final String TABLE = "Tbl";
   private static final String COL_NAME1 = "Column1";
   private static final String COL_NAME2 = "Column2";
   private static final String COL_NAME3 = "Column3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -49,7 +49,7 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_col_val";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String PARTITION_KEY = "pkey";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -56,7 +56,7 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_cond_mutation";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   private static final String PARTITION_KEY = "pkey";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -46,7 +46,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
   private static final String TEST_NAME = "storage";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
@@ -27,7 +27,7 @@ public abstract class DistributedStorageJapaneseIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_jp";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  private static final String TABLE = "tbl";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMutationAtomicityUnitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMutationAtomicityUnitIntegrationTestBase.java
@@ -29,8 +29,8 @@ public abstract class DistributedStorageMutationAtomicityUnitIntegrationTestBase
   protected static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
   protected static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
   protected static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
-  protected static final String TABLE1 = "test_table1";
-  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE1 = "tbl1";
+  protected static final String TABLE2 = "tbl2";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStoragePermissionIntegrationTestBase.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 public abstract class DistributedStoragePermissionIntegrationTestBase {
   protected static final String TEST_NAME = "storage";
   protected static final String NAMESPACE = "int_test_" + TEST_NAME;
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
 
   private static final Logger logger =
       LoggerFactory.getLogger(DistributedStoragePermissionIntegrationTestBase.class);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -41,10 +41,10 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       LoggerFactory.getLogger(DistributedTransactionAdminIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE1 = "test_table1";
-  protected static final String TABLE2 = "test_table2";
-  protected static final String TABLE3 = "test_table3";
-  protected static final String TABLE4 = "test_table4";
+  protected static final String TABLE1 = "tbl1";
+  protected static final String TABLE2 = "tbl2";
+  protected static final String TABLE3 = "tbl3";
+  protected static final String TABLE4 = "tbl4";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";
@@ -56,10 +56,10 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   protected static final String COL_NAME9 = "c9";
   protected static final String COL_NAME10 = "c10";
   protected static final String COL_NAME11 = "c11";
-  private static final String COL_NAME12 = "c12";
-  private static final String COL_NAME13 = "c13";
-  private static final String COL_NAME14 = "c14";
-  private static final String COL_NAME15 = "c15";
+  protected static final String COL_NAME12 = "c12";
+  protected static final String COL_NAME13 = "c13";
+  protected static final String COL_NAME14 = "c14";
+  protected static final String COL_NAME15 = "c15";
 
   protected static final TableMetadata TABLE_METADATA =
       TableMetadata.newBuilder()
@@ -517,9 +517,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   @Test
   public void createIndex_ForAllDataTypesWithExistingData_ShouldCreateIndexesCorrectly()
       throws Exception {
-    // Use a separate table name to avoid hitting the stale cache, which can cause test failure when
-    // executing DMLs
-    String table = "table_for_create_index";
+    String table = "tbl_for_create_idx";
 
     try {
       // Arrange
@@ -712,9 +710,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   @Test
   public void dropIndex_ForAllDataTypesWithExistingData_ShouldDropIndexCorrectly()
       throws Exception {
-    // Use a separate table name to avoid hitting the stale cache, which can cause test failure when
-    // executing DMLs
-    String table = "table_for_drop_index";
+    String table = "tbl_for_drop_idx";
 
     try {
       // Arrange

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairIntegrationTestBase.java
@@ -30,7 +30,7 @@ public abstract class DistributedTransactionAdminRepairIntegrationTestBase {
   protected static final String TEST_NAME = "tx_admin_repair";
   protected static final String NAMESPACE = "int_test_" + TEST_NAME;
 
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String COL_NAME1 = "c1";
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
@@ -38,8 +38,8 @@ public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBas
       LoggerFactory.getLogger(DistributedTransactionCrossPartitionScanIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_cpscan_tx_test_";
-  protected static final String TABLE = "test_table";
-  protected static final String TABLE_WITH_TEXT = "test_table_with_text";
+  protected static final String TABLE = "tbl";
+  protected static final String TABLE_WITH_TEXT = "tbl_with_text";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String ACCOUNT_NAME = "account_name";

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -66,7 +66,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
       LoggerFactory.getLogger(DistributedTransactionIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
@@ -38,8 +38,8 @@ public abstract class TwoPhaseCommitTransactionCrossPartitionScanIntegrationTest
       LoggerFactory.getLogger(TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_rscan_2pc_test_";
-  protected static final String TABLE_1 = "test_table1";
-  protected static final String TABLE_2 = "test_table2";
+  protected static final String TABLE_1 = "tbl1";
+  protected static final String TABLE_2 = "tbl2";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String ACCOUNT_NAME = "account_name";

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -66,8 +66,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       LoggerFactory.getLogger(TwoPhaseCommitTransactionIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE_1 = "test_table1";
-  protected static final String TABLE_2 = "test_table2";
+  protected static final String TABLE_1 = "tbl1";
+  protected static final String TABLE_2 = "tbl2";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -39,8 +39,8 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
       Paths.get("import_schema.json").toAbsolutePath();
 
   private static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE_1 = "test_table1";
-  protected static final String TABLE_2 = "test_table2";
+  protected static final String TABLE_1 = "tbl1";
+  protected static final String TABLE_2 = "tbl2";
 
   private DistributedStorageAdmin storageAdmin;
   private DistributedTransactionAdmin transactionAdmin;

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -33,7 +33,7 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
   private static final Logger logger =
       LoggerFactory.getLogger(SchemaLoaderImportIntegrationTestBase.class);
 
-  private static final String TEST_NAME = "schema_loader_import";
+  private static final String TEST_NAME = "sl_import";
   private static final Path CONFIG_FILE_PATH = Paths.get("config.properties").toAbsolutePath();
   private static final Path IMPORT_SCHEMA_FILE_PATH =
       Paths.get("import_schema.json").toAbsolutePath();

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportWithMetadataDecouplingIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class SchemaLoaderImportWithMetadataDecouplingIntegrationTestBas
 
   @Override
   protected String getTestName() {
-    return "schema_loader_import_decoupling";
+    return "sl_import_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -49,8 +49,8 @@ public abstract class SchemaLoaderIntegrationTestBase {
       Paths.get("altered_schema.json").toAbsolutePath();
 
   private static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE_1 = "test_table1";
-  protected static final String TABLE_2 = "test_table2";
+  protected static final String TABLE_1 = "tbl1";
+  protected static final String TABLE_2 = "tbl2";
 
   private DistributedStorageAdmin storageAdmin;
   private DistributedTransactionAdmin transactionAdmin;

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderWithMetadataDecouplingIntegrationTestBase.java
@@ -12,7 +12,7 @@ public abstract class SchemaLoaderWithMetadataDecouplingIntegrationTestBase
 
   @Override
   protected String getTestName() {
-    return "schema_loader_decoupling";
+    return "sl_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class ConsensusCommitAdminImportTableWithMetadataDecouplingInteg
 
   @Override
   protected String getTestName() {
-    return "tx_cc_import_decoupling";
+    return "tx_cc_import_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -57,7 +57,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
 
   private static final String TEST_NAME = "cc_import";
   private static final String NAMESPACE_BASE_NAME = "int_test_";
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String BALANCE = "balance";
   private static final int INITIAL_BALANCE = 1000;

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -261,8 +261,8 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
             .value(BigIntColumn.ofNull(Attribute.BEFORE_COMMITTED_AT))
             .build();
 
-    // When using Oracle with the SERIALIZABLE isolation level, a RetriableExecutionException may
-    // occur even without any conflicts. So, we retry the put operation in such a case.
+    // When using Oracle, a RetriableExecutionException may occur even without any conflicts. So, we
+    // retry the put operation in such a case.
     while (true) {
       try {
         originalStorage.put(put);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -138,6 +138,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
             recoveryExecutor,
             tableMetadataManager,
             consensusCommitConfig.isIncludeMetadataEnabled(),
+            consensusCommitConfig.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     CommitHandler commit = spy(createCommitHandler(tableMetadataManager, groupCommitter));
     manager =

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class ConsensusCommitImportTableWithMetadataDecouplingIntegratio
 
   @Override
   protected String getTestName() {
-    return "cc_import_decoupling";
+    return "cc_import_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -150,6 +150,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
             recoveryExecutor,
             tableMetadataManager,
             consensusCommitConfig.isIncludeMetadataEnabled(),
+            consensusCommitConfig.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     CommitHandler commit = spy(createCommitHandler(tableMetadataManager, groupCommitter));
     manager =

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -52,8 +52,8 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
 
   private static final String TEST_NAME = "cc_null";
   private static final String NAMESPACE_BASE_NAME = "int_test_";
-  private static final String TABLE_1 = "test_table1";
-  private static final String TABLE_2 = "test_table2";
+  private static final String TABLE_1 = "tbl1";
+  private static final String TABLE_2 = "tbl2";
   private static final String ACCOUNT_ID = "account_id";
   private static final String ACCOUNT_TYPE = "account_type";
   private static final String BALANCE = "balance";

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1336,7 +1336,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -1444,7 +1444,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws TransactionException, ExecutionException, CoordinatorException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -1576,10 +1576,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void
-      scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
-          Isolation isolation, boolean readOnly, CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
+  void scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
+      Isolation isolation, boolean readOnly, CommitType commitType)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
@@ -1700,7 +1699,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -1824,7 +1823,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -1932,7 +1931,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -2064,10 +2063,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
-          Isolation isolation, boolean readOnly, CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
+  void scan_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
+      Isolation isolation, boolean readOnly, CommitType commitType)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldBehaveCorrectly(
         scanAll, false, isolation, readOnly, commitType);
@@ -2176,7 +2174,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @MethodSource("isolationAndReadOnlyModeAndCommitType")
-  void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
+  void scan_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
       Isolation isolation, boolean readOnly, CommitType commitType)
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
@@ -2193,6 +2191,962 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldBehaveCorrectly(
         scanAll, true, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnResult(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.PREPARED,
+        current,
+        TransactionState.COMMITTED,
+        CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+
+    // Assert
+    // The before-index check finds the PREPARED record via before_BALANCE=INITIAL_BALANCE
+    // and rolls it forward. After roll-forward, the record has BALANCE=NEW_BALANCE,
+    // so Get with BALANCE=INITIAL_BALANCE returns empty
+    assertThat(result).isNotPresent();
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-forward)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.PREPARED,
+        current,
+        TransactionState.ABORTED,
+        CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+
+    // Assert
+    // The before-index check finds the PREPARED record via before_BALANCE=INITIAL_BALANCE
+    // and rolls it back. After roll-back, the record is restored to BALANCE=INITIAL_BALANCE,
+    // so Get returns it
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnResult(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            prepared_at,
+            null,
+            CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+
+    // Assert
+    // After abort (expired) and roll-back, the record is restored to BALANCE=INITIAL_BALANCE
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (abort due to expiry, then roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.PREPARED,
+        prepared_at,
+        null,
+        CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(UncommittedRecordException.class);
+
+    transaction.rollback();
+
+    // Recovery should not occur
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnEmpty(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.COMMITTED,
+        CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+
+    // Assert
+    // After roll-forward, the DELETED record is physically deleted, so Get returns empty
+    assertThat(result).isNotPresent();
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-forward = delete committed)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void get_GetWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.ABORTED,
+        CommitType.NORMAL_COMMIT);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+
+    // Assert
+    // After roll-back, the delete is undone and BALANCE=INITIAL_BALANCE is restored
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populateRecordsForBeforeIndexTest(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.PREPARED,
+        current,
+        TransactionState.COMMITTED);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    if (!useScanner) {
+      List<Result> results = transaction.scan(scan);
+
+      // Assert
+      // After roll-forward, the PREPARED record has BALANCE=NEW_BALANCE, so scanning for
+      // INITIAL_BALANCE returns only the 2 COMMITTED records
+      assertThat(results.size()).isEqualTo(2);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    } else {
+      List<Result> results;
+      try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+        results = scanner.all();
+      }
+
+      // After roll-forward, rolledBack=false, so no exception from close().
+      // The scanner returns 2 COMMITTED records.
+      assertThat(results.size()).isEqualTo(2);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-forward)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, true, isolation);
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populateRecordsForBeforeIndexTest(
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, current, TransactionState.ABORTED);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    if (!useScanner) {
+      List<Result> results = transaction.scan(scan);
+
+      // After roll-back, the PREPARED record is restored to BALANCE=INITIAL_BALANCE,
+      // so all 3 records match
+      assertThat(results.size()).isEqualTo(3);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    } else {
+      // For scanner, the before-index check at close() detects the rolled-back record
+      // and throws CrudConflictException
+      assertThatThrownBy(
+              () -> {
+                try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                  scanner.all();
+                }
+              })
+          .isInstanceOf(CrudConflictException.class);
+    }
+
+    if (!useScanner) {
+      transaction.commit();
+    } else {
+      transaction.rollback();
+    }
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void scan_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populateRecordsForBeforeIndexTest(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    if (!useScanner) {
+      List<Result> results = transaction.scan(scan);
+
+      // After abort (expired) and roll-back, all 3 records have BALANCE=INITIAL_BALANCE
+      assertThat(results.size()).isEqualTo(3);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    } else {
+      // For scanner, the before-index check at close() detects the rolled-back record
+      assertThatThrownBy(
+              () -> {
+                try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                  scanner.all();
+                }
+              })
+          .isInstanceOf(CrudConflictException.class);
+    }
+
+    if (!useScanner) {
+      transaction.commit();
+    } else {
+      transaction.rollback();
+    }
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (abort due to expiry, then roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis();
+    populateRecordsForBeforeIndexTest(
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    // The before-index check always uses RETURN_LATEST_RESULT_AND_RECOVER, which throws
+    // UncommittedRecordException for not-expired records regardless of isolation level
+    assertThatThrownBy(
+            () -> {
+              if (!useScanner) {
+                transaction.scan(scan);
+              } else {
+                try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                  scanner.all();
+                }
+              }
+            })
+        .isInstanceOf(UncommittedRecordException.class);
+
+    transaction.rollback();
+
+    // Recovery should not occur
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+        scan, true, isolation);
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populateRecordsForBeforeIndexTest(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.COMMITTED);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    if (!useScanner) {
+      List<Result> results = transaction.scan(scan);
+
+      // Assert
+      // After roll-forward, the DELETED record is physically deleted, so only 2 COMMITTED
+      // records remain
+      assertThat(results.size()).isEqualTo(2);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    } else {
+      List<Result> results;
+      try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+        results = scanner.all();
+      }
+
+      // After roll-forward (delete committed), rolledBack=false, so no exception from close().
+      assertThat(results.size()).isEqualTo(2);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-forward = delete committed)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+        scan, true, isolation);
+  }
+
+  private void
+      scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Scan scan, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long current = System.currentTimeMillis();
+    populateRecordsForBeforeIndexTest(
+        storage, namespace1, TABLE_1, TransactionState.DELETED, current, TransactionState.ABORTED);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    if (!useScanner) {
+      List<Result> results = transaction.scan(scan);
+
+      // After roll-back, the delete is undone and BALANCE=INITIAL_BALANCE is restored,
+      // so all 3 records match
+      assertThat(results.size()).isEqualTo(3);
+      for (Result r : results) {
+        assertThat(r.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+    } else {
+      // For scanner, the before-index check at close() detects the rolled-back record
+      assertThatThrownBy(
+              () -> {
+                try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                  scanner.all();
+                }
+              })
+          .isInstanceOf(CrudConflictException.class);
+    }
+
+    if (!useScanner) {
+      transaction.commit();
+    } else {
+      transaction.rollback();
+    }
+
+    waitForRecoveryCompletion(transaction);
+
+    // Recovery should occur (roll-back)
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void scan_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    if (isolation == Isolation.SERIALIZABLE) {
+      // skip for now
+      return;
+    }
+
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+        scan, true, isolation);
+  }
+
+  private String populateRecordsForBeforeIndexTest(
+      DistributedStorage storage,
+      String namespace,
+      String table,
+      TransactionState recordState,
+      long preparedAt,
+      TransactionState coordinatorState)
+      throws ExecutionException, CoordinatorException {
+    // (0,0): COMMITTED with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace, table, 0, 0, INITIAL_BALANCE);
+
+    // (0,2): COMMITTED with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace, table, 0, 2, INITIAL_BALANCE);
+
+    // (0,1): PREPARED/DELETED with BALANCE changed from INITIAL_BALANCE to NEW_BALANCE
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 1);
+
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, recordState.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, preparedAt)
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    if (coordinatorState == null) {
+      return ANY_ID_2;
+    }
+
+    coordinator.putState(new Coordinator.State(ANY_ID_2, coordinatorState));
+    return ANY_ID_2;
+  }
+
+  private void populateCommittedRecordWithBalance(
+      DistributedStorage storage,
+      String namespace,
+      String table,
+      int accountId,
+      int accountType,
+      int balance)
+      throws ExecutionException {
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, accountId))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, accountType))
+            .intValue(BALANCE, balance)
+            .textValue(Attribute.ID, ANY_ID_1)
+            .intValue(Attribute.STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.VERSION, 1)
+            .bigIntValue(Attribute.PREPARED_AT, 1)
+            .bigIntValue(Attribute.COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
   }
 
   @ParameterizedTest
@@ -8185,6 +9139,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     return gets;
   }
 
+  private Get prepareGetWithIndex(String namespace, String table, int balance) {
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .indexKey(Key.ofInt(BALANCE, balance))
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
   private Scan prepareScan(int id, int fromType, int toType, String namespace, String table) {
     Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
     return Scan.newBuilder()
@@ -8222,6 +9185,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .namespace(namespace)
         .table(table)
         .all()
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  private Scan prepareScanAllWithBalanceCondition(String namespace, String table, int balance) {
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .all()
+        .where(column(BALANCE).isEqualToInt(balance))
         .consistency(Consistency.LINEARIZABLE)
         .build();
   }
@@ -8294,6 +9267,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             recoveryExecutor,
             tableMetadataManager,
             consensusCommitConfig.isIncludeMetadataEnabled(),
+            consensusCommitConfig.isIndexEventuallyConsistentReadEnabled(),
             parallelExecutor);
     commit = spy(createCommitHandler(tableMetadataManager, groupCommitter, onePhaseCommitEnabled));
     return new ConsensusCommitManager(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -42,6 +42,7 @@ import com.scalar.db.common.DecoratedDistributedTransaction;
 import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
@@ -9104,7 +9105,17 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
             .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
             .build();
-    storage.put(put);
+
+    // When using Oracle, a RetriableExecutionException may occur even without any conflicts. So, we
+    // retry the put operation in such a case.
+    while (true) {
+      try {
+        storage.put(put);
+        break;
+      } catch (RetriableExecutionException e) {
+        // retry
+      }
+    }
 
     if (coordinatorState == null) {
       return ongoingTxId;

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -86,8 +86,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   private static final String TEST_NAME = "cc";
   private static final String NAMESPACE_BASE_NAME = "int_test_";
-  private static final String TABLE_1 = "test_table1";
-  private static final String TABLE_2 = "test_table2";
+  private static final String TABLE_1 = "tbl1";
+  private static final String TABLE_2 = "tbl2";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";
@@ -2195,8 +2195,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnResult(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnResult(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2236,7 +2238,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+  public void get_GetWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
       Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
@@ -2278,8 +2280,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnResult(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnResult(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2320,8 +2324,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2354,8 +2360,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnEmpty(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      get_GetWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnEmpty(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2393,7 +2401,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void get_GetWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
+  public void get_GetWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
       Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
@@ -2483,7 +2491,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2499,7 +2507,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2515,7 +2523,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2531,7 +2539,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2593,8 +2601,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void scan_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2607,7 +2617,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2623,7 +2633,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2639,7 +2649,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2701,7 +2711,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2717,7 +2727,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2733,7 +2743,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2749,7 +2759,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2799,8 +2809,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -2813,7 +2825,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2829,7 +2841,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2845,7 +2857,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2910,7 +2922,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2926,7 +2938,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2942,7 +2954,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -2958,7 +2970,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -3019,8 +3031,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void scan_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
-      Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
     if (isolation == Isolation.SERIALIZABLE) {
       // skip for now
       return;
@@ -3033,7 +3047,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -3049,7 +3063,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
@@ -3065,7 +3079,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @ParameterizedTest
   @EnumSource(Isolation.class)
-  void
+  public void
       getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTe
 
   @Override
   protected String getTestName() {
-    return "cc_decoupling";
+    return "cc_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -37,7 +37,7 @@ public abstract class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBa
 
   protected static final String TEST_NAME = "cc_inc_meta";
   protected static final String NAMESPACE = "int_test_" + TEST_NAME;
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMetadataDecouplingIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMetadataDecouplingIntegrationTestBase.java
@@ -8,7 +8,7 @@ public abstract class ConsensusCommitWithMetadataDecouplingIntegrationTestBase
 
   @Override
   protected String getTestName() {
-    return "tx_cc_decoupling";
+    return "tx_cc_dcpl";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -44,8 +44,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   private static final String TEST_NAME = "2pcc";
   private static final String NAMESPACE_1 = "int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE_2 = "int_test_" + TEST_NAME + "2";
-  private static final String TABLE_1 = "tx_test_table1";
-  private static final String TABLE_2 = "tx_test_table2";
+  private static final String TABLE_1 = "tx_tbl1";
+  private static final String TABLE_2 = "tx_tbl2";
   private static final String ACCOUNT_ID = "account_id";
   private static final String ACCOUNT_TYPE = "account_type";
   private static final String BALANCE = "balance";

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -37,7 +37,7 @@ public abstract class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrati
 
   protected static final String TEST_NAME = "2pcc_inc_meta";
   protected static final String NAMESPACE = "int_test_" + TEST_NAME;
-  protected static final String TABLE = "test_table";
+  protected static final String TABLE = "tbl";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";


### PR DESCRIPTION
## Description

In Consensus Commit, `Get`/`Scan` operations using secondary indexes can miss records that are in PREPARED or DELETED state when the indexed column value has been changed. For example, if a record's `indexed_column` is being updated from 10 to 20 (PREPARED state), a query for `indexed_column = 10` will not find the record because the storage layer looks up the current column value, which no longer matches the committed value. For details on this issue, see https://github.com/scalar-labs/scalardb/pull/3133.

This PR fixes this issue by introducing before-image secondary indexes (`before_<col>`) and using them in `CrudHandler` to detect and recover such records, ensuring correctness for index-based reads.

### Algorithm

When an index-based `Get` or `Scan` is executed (e.g., `BALANCE = 10`), the following steps are performed:

1. **Normal index lookup**: The storage layer returns records where the current `BALANCE` value is 10.
2. **Before-image index check**: An additional scan is performed on `before_BALANCE = 10` to find PREPARED/DELETED records whose committed (before-image) value matches the query but whose current value does not.
3. **Recovery and retry**: If such records are found, recovery is executed for each record:
   - If the record is **rolled back** (the before-image value is restored), the record now matches the original query again, so the original operation is **retried**.
   - If the record is **rolled forward** (the new value is committed), the record's committed value no longer matches the query, so **no retry is needed**.

### Example

Consider three records with `BALANCE = 10`:

| ID | BALANCE | State |
|--------|---------|-------|
| 0 | 10 | COMMITTED |
| 1 | 20 (before: 10) | PREPARED |
| 2 | 10 | COMMITTED |

A Scan with `BALANCE = 10` returns only `record0` and `record2` from the normal index lookup because `record1` has `BALANCE = 20` in its current value. The before-image index check then scans `before_BALANCE = 10` and finds `record1` in PREPARED state.

- If `record1` is rolled back: `BALANCE` reverts to 10. The operation is retried and now returns all three records.
- If `record1` is rolled forward: `BALANCE` is committed as 20. The operation does not need a retry and correctly returns `record0` and `record2`.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3133

## Changes made

### Before-image secondary index schema

- In `ConsensusCommitUtils.buildTransactionTableMetadata()` and `buildTransactionMetadataTableMetadata()`, a `before_<col>` secondary index is now automatically created for each user-defined secondary index on a non-primary-key column.
- Added `hasBeforeImageSecondaryIndex(String columnName)` to `TransactionTableMetadata` to check whether a column has a corresponding before-image index at runtime.

### `CrudHandler` before-index check and recovery

- For `Index Get`, `Index Scan`, and `ScanAll` (with indexed column conditions), when a before-image secondary index exists, an additional scan on `before_<col>` is performed to find PREPARED/DELETED records whose committed values match the original query.
- When such records are found, recovery is executed. If the recovery results in a rollback (the before-image value is restored), the original operation is retried (up to `MAX_BEFORE_INDEX_CHECK_RETRIES`). If it results in a roll-forward, no retry is needed.
- In `ConsensusCommitStorageScanner.close()`, a before-index check is performed; if PREPARED/DELETED records needing recovery are found, a `CrudConflictException` is thrown to prompt a transaction-level retry.

### RecoveryExecutor.Result enhancement

- Added `rolledBack` field to `RecoveryExecutor.Result` to distinguish rollback from roll-forward outcomes, enabling `CrudHandler` to decide whether a retry is necessary.

### ConsensusCommitAdmin updates

- `createIndex()` and `dropIndex()` now automatically create/drop the corresponding `before_<col>` index when the before-image column exists.

### Helper methods in ConsensusCommitUtils

- `createBeforeIndexScan(Selection)`: Creates a `ScanWithIndex` using the `before_<col>` index key.
- `createBeforeIndexScanAll(ScanAll, TableMetadata)`: Creates a `ScanAll` with before-image column conditions.
- `requiresBeforeIndexCheck(Selection, TransactionTableMetadata):` Determines whether a before-index check is needed for a given operation.
- `warnIfBeforeImageIndexesAreMissing(DistributedStorageAdmin, ConsensusCommitConfig)`: Checks all tables at startup and logs a warning for tables with secondary indexes but missing before-image indexes.

### Startup warning for missing before-image indexes

- At startup, `ConsensusCommitManager` and `TwoPhaseConsensusCommitManager` check all transaction tables for missing before-image indexes and log a warning suggesting repairTable(). This check is only performed when the isolation level is SNAPSHOT or READ_COMMITTED and index eventual consistent read is disabled, as these are the configurations where missing before-image indexes can cause records to be missed.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

### Backward compatibility

Tables created before this change will not have `before_<col>` secondary indexes. In that case, `hasBeforeImageSecondaryIndex()` returns false and the before-index check is skipped entirely, preserving existing behavior. Running `repairTable()` on existing tables will automatically add the `before_<col> `indexes. At startup, a warning is logged for tables missing before-image indexes to guide users.

### SERIALIZABLE support

This PR doesn’t include SERIALIZABLE support. I’ll create a separate PR to handle it.

## Release notes

Fixed a correctness issue in index-based `Get`, `Scan`, and `ScanAll` operations in Consensus Commit where records whose indexed column was being concurrently updated by another transaction could be missed. ScalarDB now maintains a companion before-image secondary index for each user-defined secondary index on a non-primary-key column and uses it to recover PREPARED/DELETED records during index reads.

When upgrading from an earlier version, you must run `repairTable()` on each existing table to create the companion before-image secondary indexes that the new check requires. Until `repairTable()` is run, ScalarDB logs a warning at startup and index-based reads fall back to the pre-check behavior, which may miss records whose indexed column is being concurrently updated. A new configuration option `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` (default `false`) is available to opt out of the new check; this is a backward-compatibility option and is not recommended for new workloads.
