### PR TITLE
Add AuthenticationMethod support to AuthAdmin for OIDC integration

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -47,7 +47,7 @@ public interface AuthAdmin {
 
   /**
    * Creates a user with the given username, password, authentication methods and user options. If
-   * the password is null, the user is created without a password. If the authentication methods is
+   * the password is null, the user is created without a password. If the authentication methods are
    * null, the default authentication methods are used.
    *
    * @param username the username
@@ -70,7 +70,7 @@ public interface AuthAdmin {
   /**
    * Alters a user with the given username, password, authentication methods and user options. If
    * the password is null, the password is not changed. If empty, the password is deleted. If the
-   * authentication methods is null, the authentication methods are not changed.
+   * authentication methods are null, the authentication methods are not changed.
    *
    * @param username the username
    * @param password the password. If null, the password is not changed. If empty, the password is

--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -48,7 +48,7 @@ public interface AuthAdmin {
       @Nullable Set<AuthenticationMethod> authenticationMethods,
       UserOption... userOptions)
       throws ExecutionException {
-    createUser(username, password, userOptions);
+    throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
   }
 
   /**
@@ -87,7 +87,7 @@ public interface AuthAdmin {
       @Nullable Set<AuthenticationMethod> authenticationMethods,
       UserOption... userOptions)
       throws ExecutionException {
-    alterUser(username, password, userOptions);
+    throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
   }
 
   /**
@@ -475,9 +475,7 @@ public interface AuthAdmin {
      *
      * @return the authentication methods
      */
-    default Set<AuthenticationMethod> getAuthenticationMethods() {
-      return Collections.emptySet();
-    }
+    Set<AuthenticationMethod> getAuthenticationMethods();
   }
 
   /** Represents a role, including its granted roles. */

--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -2,6 +2,7 @@ package com.scalar.db.api;
 
 import com.scalar.db.common.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -42,6 +43,51 @@ public interface AuthAdmin {
   default void alterUser(String username, @Nullable String password, UserOption... userOptions)
       throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
+  }
+
+  /**
+   * Creates a user with the given username, password, authentication methods and user options. If
+   * the password is null, the user is created without a password. If the authentication methods is
+   * null, the default authentication methods are used.
+   *
+   * @param username the username
+   * @param password the password. If null, the user is created without a password
+   * @param authenticationMethods the authentication methods. If null, the default authentication
+   *     methods are used
+   * @param userOptions the user options
+   * @throws IllegalArgumentException if the user already exists
+   * @throws ExecutionException if the operation fails
+   */
+  default void createUser(
+      String username,
+      @Nullable String password,
+      @Nullable Set<AuthenticationMethod> authenticationMethods,
+      UserOption... userOptions)
+      throws ExecutionException {
+    createUser(username, password, userOptions);
+  }
+
+  /**
+   * Alters a user with the given username, password, authentication methods and user options. If
+   * the password is null, the password is not changed. If empty, the password is deleted. If the
+   * authentication methods is null, the authentication methods are not changed.
+   *
+   * @param username the username
+   * @param password the password. If null, the password is not changed. If empty, the password is
+   *     deleted
+   * @param authenticationMethods the authentication methods. If null, the authentication methods
+   *     are not changed
+   * @param userOptions the user options
+   * @throws IllegalArgumentException if the user does not exist
+   * @throws ExecutionException if the operation fails
+   */
+  default void alterUser(
+      String username,
+      @Nullable String password,
+      @Nullable Set<AuthenticationMethod> authenticationMethods,
+      UserOption... userOptions)
+      throws ExecutionException {
+    alterUser(username, password, userOptions);
   }
 
   /**
@@ -423,6 +469,15 @@ public interface AuthAdmin {
      * @return whether the user is a superuser
      */
     boolean isSuperuser();
+
+    /**
+     * Returns the authentication methods associated with the user.
+     *
+     * @return the authentication methods
+     */
+    default Set<AuthenticationMethod> getAuthenticationMethods() {
+      return Collections.emptySet();
+    }
   }
 
   /** Represents a role, including its granted roles. */
@@ -488,6 +543,15 @@ public interface AuthAdmin {
      * @return whether admin option is granted for this role grant
      */
     boolean hasAdminOption();
+  }
+
+  /** The authentication methods. */
+  enum AuthenticationMethod {
+    /** Password-based authentication. */
+    PASSWORD,
+
+    /** OpenID Connect (OIDC) authentication. */
+    OIDC,
   }
 
   /** The user options. */

--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -30,22 +30,6 @@ public interface AuthAdmin {
   }
 
   /**
-   * Alters a user with the given username, password and user options. If the password is null, the
-   * password is not changed. If empty, the password is deleted.
-   *
-   * @param username the username
-   * @param password the password. If null, the password is not changed. If empty, the password is
-   *     deleted
-   * @param userOptions the user options
-   * @throws IllegalArgumentException if the user does not exist
-   * @throws ExecutionException if the operation fails
-   */
-  default void alterUser(String username, @Nullable String password, UserOption... userOptions)
-      throws ExecutionException {
-    throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
-  }
-
-  /**
    * Creates a user with the given username, password, authentication methods and user options. If
    * the password is null, the user is created without a password. If the authentication methods are
    * null, the default authentication methods are used.
@@ -65,6 +49,22 @@ public interface AuthAdmin {
       UserOption... userOptions)
       throws ExecutionException {
     createUser(username, password, userOptions);
+  }
+
+  /**
+   * Alters a user with the given username, password and user options. If the password is null, the
+   * password is not changed. If empty, the password is deleted.
+   *
+   * @param username the username
+   * @param password the password. If null, the password is not changed. If empty, the password is
+   *     deleted
+   * @param userOptions the user options
+   * @throws IllegalArgumentException if the user does not exist
+   * @throws ExecutionException if the operation fails
+   */
+  default void alterUser(String username, @Nullable String password, UserOption... userOptions)
+      throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -2,7 +2,6 @@ package com.scalar.db.api;
 
 import com.scalar.db.common.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -320,12 +320,6 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
-  public void alterUser(String username, @Nullable String password, UserOption... userOptions)
-      throws ExecutionException {
-    distributedTransactionAdmin.alterUser(username, password, userOptions);
-  }
-
-  @Override
   public void createUser(
       String username,
       @Nullable String password,
@@ -333,6 +327,12 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
       UserOption... userOptions)
       throws ExecutionException {
     distributedTransactionAdmin.createUser(username, password, authenticationMethods, userOptions);
+  }
+
+  @Override
+  public void alterUser(String username, @Nullable String password, UserOption... userOptions)
+      throws ExecutionException {
+    distributedTransactionAdmin.alterUser(username, password, userOptions);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -326,6 +326,26 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
+  public void createUser(
+      String username,
+      @Nullable String password,
+      @Nullable Set<AuthenticationMethod> authenticationMethods,
+      UserOption... userOptions)
+      throws ExecutionException {
+    distributedTransactionAdmin.createUser(username, password, authenticationMethods, userOptions);
+  }
+
+  @Override
+  public void alterUser(
+      String username,
+      @Nullable String password,
+      @Nullable Set<AuthenticationMethod> authenticationMethods,
+      UserOption... userOptions)
+      throws ExecutionException {
+    distributedTransactionAdmin.alterUser(username, password, authenticationMethods, userOptions);
+  }
+
+  @Override
   public void dropUser(String username) throws ExecutionException {
     distributedTransactionAdmin.dropUser(username);
   }


### PR DESCRIPTION
## Description

This PR adds `AuthenticationMethod` enum and authentication-method-aware `createUser`/`alterUser` overloads to the `AuthAdmin` interface, enabling OIDC authentication support in ScalarDB Cluster.

This change moves the temporary types (`TentativeAuthAdmin`, `TentativeDecoratedDistributedAdmin`, `TentativeDistributedTransactionAdmin`) introduced in scalar-labs/scalardb-cluster#1590 into ScalarDB Core, so those workaround classes can be removed.

## Related issues and/or PRs

- scalar-labs/scalardb-cluster#1570
- scalar-labs/scalardb-cluster#1590

## Changes made

- **`AuthAdmin`**:
  - Added `AuthenticationMethod` enum (`PASSWORD`, `OIDC`).
  - Added `getAuthenticationMethods()` default method to `User` sub-interface.
  - Added overloaded `createUser()` and `alterUser()` with `@Nullable Set<AuthenticationMethod>` parameter. Default implementations delegate to the existing methods, preserving backward compatibility.
- **`DecoratedDistributedTransactionAdmin`**:
  - Added delegation for the new `createUser`/`alterUser` overloads.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added `AuthenticationMethod` enum and authentication-method-aware user management APIs to `AuthAdmin` to support OIDC authentication.