### PR TITLE
Replace MySQL Connector/J with MariaDB Connector/J to resolve licensing issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.42.4'
         hikariCpVersion = '4.0.3'
-        mysqlDriverVersion = '9.6.0'
         postgresqlDriverVersion = '42.7.10'
         oracleDriverVersion = '23.26.1.0.0'
         sqlserverDriverVersion = '12.8.2.jre8'

--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -164,7 +164,7 @@ jdbc:
         GRANT INSERT ON *.* TO 'test'@'%%';
         GRANT UPDATE ON *.* TO 'test'@'%%';
         GRANT DELETE ON *.* TO 'test'@'%%';"
-    run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:mysql://localhost:3306/ -Dscalardb.jdbc.username=test -Dscalardb.jdbc.password=test
+    run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:mysql://localhost:3306/?sslMode=REQUIRED -Dscalardb.jdbc.username=test -Dscalardb.jdbc.password=test
 
   - label: oracle_%VERSION%
     display_name: Oracle %VERSION%

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -179,7 +179,6 @@ dependencies {
     testImplementation 'software.amazon.awssdk:iam'
     testImplementation 'software.amazon.awssdk:iam-policy-builder'
     implementation "com.zaxxer:HikariCP:${hikariCpVersion}"
-    implementation "com.mysql:mysql-connector-j:${mysqlDriverVersion}"
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCaseSensitivityIntegrationTest.java
@@ -1,23 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageCaseSensitivityIntegrationTestBase;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.Key;
-import com.scalar.db.service.StorageFactory;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Test;
 
 public class JdbcDatabaseCaseSensitivityIntegrationTest
     extends DistributedStorageCaseSensitivityIntegrationTestBase {
@@ -40,114 +25,5 @@ public class JdbcDatabaseCaseSensitivityIntegrationTest
     } else {
       return super.getLargeDataSizeInBytes();
     }
-  }
-
-  @Test
-  public void get_InStreamingMode_ShouldRetrieveSingleResult() throws ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-      int cKey = 1;
-      int value = 2;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-              .intValue(getColumnName3(), value)
-              .build());
-
-      // Act
-      Optional<Result> result =
-          storage.get(
-              Get.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-                  .build());
-
-      // Assert
-      assertThat(result.isPresent()).isTrue();
-      assertThat(result.get().getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(result.get().getInt(getColumnName4())).isEqualTo(cKey);
-      assertThat(result.get().getInt(getColumnName3())).isEqualTo(value);
-    }
-  }
-
-  @Test
-  public void scan_InStreamingMode_ShouldRetrieveResults() throws IOException, ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 0))
-              .intValue(getColumnName3(), 1)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 1))
-              .intValue(getColumnName3(), 2)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 2))
-              .intValue(getColumnName3(), 3)
-              .build());
-
-      // Act
-      Scanner scanner =
-          storage.scan(
-              Scan.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .build());
-      List<Result> results = scanner.all();
-      scanner.close();
-
-      // Assert
-      assertThat(results).hasSize(3);
-      assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(0);
-      assertThat(results.get(0).getInt(getColumnName3())).isEqualTo(1);
-
-      assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(1);
-      assertThat(results.get(1).getInt(getColumnName3())).isEqualTo(2);
-
-      assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(2);
-      assertThat(results.get(2).getInt(getColumnName3())).isEqualTo(3);
-    }
-  }
-
-  private DistributedStorage getStorageInStreamingMode() {
-    Properties properties = JdbcEnv.getProperties(getTestName());
-    properties.setProperty(DatabaseConfig.SCAN_FETCH_SIZE, Integer.toString(Integer.MIN_VALUE));
-    return StorageFactory.create(properties).getStorage();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
@@ -1,23 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageIntegrationTestBase;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.Key;
-import com.scalar.db.service.StorageFactory;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Test;
 
 public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTestBase {
 
@@ -39,114 +24,5 @@ public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTe
     } else {
       return super.getLargeDataSizeInBytes();
     }
-  }
-
-  @Test
-  public void get_InStreamingMode_ShouldRetrieveSingleResult() throws ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-      int cKey = 1;
-      int value = 2;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-              .intValue(getColumnName3(), value)
-              .build());
-
-      // Act
-      Optional<Result> result =
-          storage.get(
-              Get.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-                  .build());
-
-      // Assert
-      assertThat(result.isPresent()).isTrue();
-      assertThat(result.get().getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(result.get().getInt(getColumnName4())).isEqualTo(cKey);
-      assertThat(result.get().getInt(getColumnName3())).isEqualTo(value);
-    }
-  }
-
-  @Test
-  public void scan_InStreamingMode_ShouldRetrieveResults() throws IOException, ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 0))
-              .intValue(getColumnName3(), 1)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 1))
-              .intValue(getColumnName3(), 2)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 2))
-              .intValue(getColumnName3(), 3)
-              .build());
-
-      // Act
-      Scanner scanner =
-          storage.scan(
-              Scan.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .build());
-      List<Result> results = scanner.all();
-      scanner.close();
-
-      // Assert
-      assertThat(results).hasSize(3);
-      assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(0);
-      assertThat(results.get(0).getInt(getColumnName3())).isEqualTo(1);
-
-      assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(1);
-      assertThat(results.get(1).getInt(getColumnName3())).isEqualTo(2);
-
-      assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(2);
-      assertThat(results.get(2).getInt(getColumnName3())).isEqualTo(3);
-    }
-  }
-
-  private DistributedStorage getStorageInStreamingMode() {
-    Properties properties = JdbcEnv.getProperties(getTestName());
-    properties.setProperty(DatabaseConfig.SCAN_FETCH_SIZE, Integer.toString(Integer.MIN_VALUE));
-    return StorageFactory.create(properties).getStorage();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseWithReservedKeywordIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseWithReservedKeywordIntegrationTest.java
@@ -1,23 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageWithReservedKeywordIntegrationTestBase;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.Key;
-import com.scalar.db.service.StorageFactory;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Test;
 
 public class JdbcDatabaseWithReservedKeywordIntegrationTest
     extends DistributedStorageWithReservedKeywordIntegrationTestBase {
@@ -82,114 +67,5 @@ public class JdbcDatabaseWithReservedKeywordIntegrationTest
     } else {
       return super.getLargeDataSizeInBytes();
     }
-  }
-
-  @Test
-  public void get_InStreamingMode_ShouldRetrieveSingleResult() throws ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-      int cKey = 1;
-      int value = 2;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-              .intValue(getColumnName3(), value)
-              .build());
-
-      // Act
-      Optional<Result> result =
-          storage.get(
-              Get.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .clusteringKey(Key.ofInt(getColumnName4(), cKey))
-                  .build());
-
-      // Assert
-      assertThat(result.isPresent()).isTrue();
-      assertThat(result.get().getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(result.get().getInt(getColumnName4())).isEqualTo(cKey);
-      assertThat(result.get().getInt(getColumnName3())).isEqualTo(value);
-    }
-  }
-
-  @Test
-  public void scan_InStreamingMode_ShouldRetrieveResults() throws IOException, ExecutionException {
-    if (!JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isMariaDB(rdbEngine)) {
-      // MySQL is the only RDB engine that supports streaming mode
-      return;
-    }
-
-    try (DistributedStorage storage = getStorageInStreamingMode()) {
-      // Arrange
-      int pKey = 0;
-
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 0))
-              .intValue(getColumnName3(), 1)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 1))
-              .intValue(getColumnName3(), 2)
-              .build());
-      storage.put(
-          Put.newBuilder()
-              .namespace(namespace)
-              .table(getTableName())
-              .partitionKey(Key.ofInt(getColumnName1(), pKey))
-              .clusteringKey(Key.ofInt(getColumnName4(), 2))
-              .intValue(getColumnName3(), 3)
-              .build());
-
-      // Act
-      Scanner scanner =
-          storage.scan(
-              Scan.newBuilder()
-                  .namespace(namespace)
-                  .table(getTableName())
-                  .partitionKey(Key.ofInt(getColumnName1(), pKey))
-                  .build());
-      List<Result> results = scanner.all();
-      scanner.close();
-
-      // Assert
-      assertThat(results).hasSize(3);
-      assertThat(results.get(0).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(0).getInt(getColumnName4())).isEqualTo(0);
-      assertThat(results.get(0).getInt(getColumnName3())).isEqualTo(1);
-
-      assertThat(results.get(1).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(1).getInt(getColumnName4())).isEqualTo(1);
-      assertThat(results.get(1).getInt(getColumnName3())).isEqualTo(2);
-
-      assertThat(results.get(2).getInt(getColumnName1())).isEqualTo(pKey);
-      assertThat(results.get(2).getInt(getColumnName4())).isEqualTo(2);
-      assertThat(results.get(2).getInt(getColumnName3())).isEqualTo(3);
-    }
-  }
-
-  private DistributedStorage getStorageInStreamingMode() {
-    Properties properties = JdbcEnv.getProperties(getTestName());
-    properties.setProperty(DatabaseConfig.SCAN_FETCH_SIZE, Integer.toString(Integer.MIN_VALUE));
-    return StorageFactory.create(properties).getStorage();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -78,7 +78,7 @@ public final class JdbcUtils {
      */
     hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
 
-    hikariConfig.setJdbcUrl(config.getJdbcUrl());
+    hikariConfig.setJdbcUrl(rdbEngine.adjustJdbcUrl(config.getJdbcUrl()));
     config.getUsername().ifPresent(hikariConfig::setUsername);
     config.getPassword().ifPresent(hikariConfig::setPassword);
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
@@ -1,44 +1,9 @@
 package com.scalar.db.storage.jdbc;
 
-import com.scalar.db.io.DataType;
-import java.sql.Connection;
-import java.sql.JDBCType;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.Map;
-import javax.annotation.Nullable;
-
 class RdbEngineMariaDB extends RdbEngineMysql {
-  @Override
-  public String getDriverClassName() {
-    return org.mariadb.jdbc.Driver.class.getName();
-  }
 
   @Override
-  DataType getDataTypeForScalarDbInternal(
-      JDBCType type,
-      String typeName,
-      int columnSize,
-      int digits,
-      String columnDescription,
-      @Nullable DataType overrideDataType) {
-    if (type == JDBCType.BOOLEAN) {
-      // MariaDB JDBC driver maps TINYINT(1) type as a BOOLEAN JDBC type which differs from the
-      // MySQL driver which maps it to a BIT type.
-      return DataType.BOOLEAN;
-    } else {
-      return super.getDataTypeForScalarDbInternal(
-          type, typeName, columnSize, digits, columnDescription, overrideDataType);
-    }
-  }
-
-  @Override
-  public Map<String, String> getConnectionProperties(JdbcConfig config) {
-    return Collections.emptyMap();
-  }
-
-  @Override
-  public void setConnectionToReadOnly(Connection connection, boolean readOnly) throws SQLException {
-    connection.setReadOnly(readOnly);
+  public String adjustJdbcUrl(String jdbcUrl) {
+    return jdbcUrl;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -367,8 +367,8 @@ class RdbEngineMysql extends AbstractRdbEngine {
         return DataType.DATE;
       case TIME:
         return DataType.TIME;
-      // Both MySQL TIMESTAMP and DATETIME data types are mapped to the TIMESTAMP JDBC type
       case TIMESTAMP:
+        // Both MySQL TIMESTAMP and DATETIME data types are mapped to the TIMESTAMP JDBC type
         if (overrideDataType == DataType.TIMESTAMPTZ || typeName.equalsIgnoreCase("TIMESTAMP")) {
           return DataType.TIMESTAMPTZ;
         }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -367,7 +367,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
         return DataType.DATE;
       case TIME:
         return DataType.TIME;
-        // Both MySQL TIMESTAMP and DATETIME data types are mapped to the TIMESTAMP JDBC type
+      // Both MySQL TIMESTAMP and DATETIME data types are mapped to the TIMESTAMP JDBC type
       case TIMESTAMP:
         if (overrideDataType == DataType.TIMESTAMPTZ || typeName.equalsIgnoreCase("TIMESTAMP")) {
           return DataType.TIMESTAMPTZ;
@@ -485,6 +485,10 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public String adjustJdbcUrl(String jdbcUrl) {
+    // MariaDB Connector/J checks for "permitMysqlScheme" in the JDBC URL during URL parsing before
+    // any connection properties are applied. If the URL starts with "jdbc:mysql:" and doesn't
+    // contain "permitMysqlScheme", the driver rejects the URL entirely. That's why we need to embed
+    // it directly in the JDBC URL rather than using getConnectionProperties().
     if (jdbcUrl.contains("permitMysqlScheme")) {
       return jdbcUrl;
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -20,8 +20,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -288,6 +286,8 @@ class RdbEngineMysql extends AbstractRdbEngine {
       String columnDescription,
       @Nullable DataType overrideDataType) {
     switch (type) {
+      case BOOLEAN:
+        return DataType.BOOLEAN;
       case BIT:
         if (columnSize != 1) {
           throw new IllegalArgumentException(
@@ -422,7 +422,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public String getDriverClassName() {
-    return com.mysql.cj.jdbc.Driver.class.getName();
+    return org.mariadb.jdbc.Driver.class.getName();
   }
 
   @Override
@@ -484,20 +484,15 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
-  public Map<String, String> getConnectionProperties(JdbcConfig config) {
-    if (config.getDatabaseConfig().getScanFetchSize() == Integer.MIN_VALUE) {
-      // If the scan fetch size is set to Integer.MIN_VALUE, use the streaming mode.
-      return Collections.emptyMap();
+  public String adjustJdbcUrl(String jdbcUrl) {
+    if (jdbcUrl.contains("permitMysqlScheme")) {
+      return jdbcUrl;
     }
-
-    // Otherwise, use the cursor fetch mode.
-    return Collections.singletonMap("useCursorFetch", "true");
-  }
-
-  @Override
-  public void setConnectionToReadOnly(Connection connection, boolean readOnly) throws SQLException {
-    // Observed performance degradation when using read-only connections in MySQL. So we do not
-    // set the read-only mode for MySQL connections.
+    if (jdbcUrl.contains("?")) {
+      return jdbcUrl + "&permitMysqlScheme";
+    } else {
+      return jdbcUrl + "?permitMysqlScheme";
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -488,11 +488,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
     if (jdbcUrl.contains("permitMysqlScheme")) {
       return jdbcUrl;
     }
-    if (jdbcUrl.contains("?")) {
-      return jdbcUrl + "&permitMysqlScheme";
-    } else {
-      return jdbcUrl + "?permitMysqlScheme";
-    }
+    return jdbcUrl + (jdbcUrl.contains("?") ? "&" : "?") + "permitMysqlScheme=true";
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -258,6 +258,16 @@ public interface RdbEngineStrategy {
     return Collections.emptyMap();
   }
 
+  /**
+   * Adjust the JDBC URL for the underlying database if needed.
+   *
+   * @param jdbcUrl the original JDBC URL
+   * @return the adjusted JDBC URL
+   */
+  default String adjustJdbcUrl(String jdbcUrl) {
+    return jdbcUrl;
+  }
+
   RdbEngineTimeTypeStrategy<?, ?, ?, ?> getTimeTypeStrategy();
 
   default String getProjectionsSqlForSelectQuery(TableMetadata metadata, List<String> projections) {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.mysql.cj.jdbc.exceptions.CommunicationsException;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
@@ -50,6 +49,7 @@ import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -332,7 +332,7 @@ public class JdbcAdminTest {
             .addSecondaryIndex("c4")
             .build();
     assertThat(actualMetadata).isEqualTo(expectedMetadata);
-    if (rdbEngine == RdbEngine.MYSQL || rdbEngine == RdbEngine.SQLITE) {
+    if (rdbEngine == RdbEngine.SQLITE) {
       verify(connection, never()).setReadOnly(anyBoolean());
     } else {
       verify(connection).setReadOnly(true);
@@ -1646,7 +1646,7 @@ public class JdbcAdminTest {
       createMetadataTableIfNotExists_WithInternalDbError_forMysql_shouldThrowInternalDbError()
           throws SQLException {
     createTableMetadataTableIfNotExists_WithInternalDbError_forX_shouldThrowInternalDbError(
-        RdbEngine.MYSQL, new CommunicationsException("", null));
+        RdbEngine.MYSQL, new SQLNonTransientConnectionException(""));
   }
 
   @Test
@@ -2599,7 +2599,7 @@ public class JdbcAdminTest {
     Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
 
     // Assert
-    if (rdbEngine == RdbEngine.MYSQL || rdbEngine == RdbEngine.SQLITE) {
+    if (rdbEngine == RdbEngine.SQLITE) {
       verify(connection, never()).setReadOnly(anyBoolean());
     } else {
       verify(connection).setReadOnly(true);
@@ -2800,7 +2800,7 @@ public class JdbcAdminTest {
     // Assert
     assertThat(admin.namespaceExists(namespace)).isTrue();
 
-    if (rdbEngine == RdbEngine.MYSQL || rdbEngine == RdbEngine.SQLITE) {
+    if (rdbEngine == RdbEngine.SQLITE) {
       verify(connection, never()).setReadOnly(anyBoolean());
     } else {
       verify(connection).setReadOnly(true);
@@ -4616,7 +4616,7 @@ public class JdbcAdminTest {
     Set<String> actualNamespaceNames = admin.getNamespaceNames();
 
     // Assert
-    if (rdbEngine == RdbEngine.MYSQL || rdbEngine == RdbEngine.SQLITE) {
+    if (rdbEngine == RdbEngine.SQLITE) {
       verify(connection, never()).setReadOnly(anyBoolean());
     } else {
       verify(connection).setReadOnly(true);
@@ -4696,11 +4696,7 @@ public class JdbcAdminTest {
         .execute(expectedCheckTableExistStatement);
     assertThat(actual.getPartitionKeyNames()).hasSameElementsAs(ImmutableSet.of("pk1", "pk2"));
     assertThat(actual.getColumnDataTypes()).containsExactlyEntriesOf(expectedColumns);
-    if (rdbEngine == RdbEngine.MYSQL) {
-      verify(connection, never()).setReadOnly(anyBoolean());
-    } else {
-      verify(connection).setReadOnly(true);
-    }
+    verify(connection).setReadOnly(true);
     verify(rdbEngineStrategy)
         .getDataTypeForScalarDb(
             any(JDBCType.class),

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -48,7 +48,7 @@ public class JdbcUtilsTest {
     when(rdbEngine.getDriverClassName()).thenReturn("org.mariadb.jdbc.Driver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
     when(rdbEngine.adjustJdbcUrl("jdbc:mysql://localhost:3306/"))
-        .thenReturn("jdbc:mysql://localhost:3306/?permitMysqlScheme");
+        .thenReturn("jdbc:mysql://localhost:3306/?permitMysqlScheme=true");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
@@ -72,7 +72,7 @@ public class JdbcUtilsTest {
     assertThat(hikariConfig).isNotNull();
     assertThat(hikariConfig.getDriverClassName()).isEqualTo("org.mariadb.jdbc.Driver");
     assertThat(hikariConfig.getJdbcUrl())
-        .isEqualTo("jdbc:mysql://localhost:3306/?permitMysqlScheme");
+        .isEqualTo("jdbc:mysql://localhost:3306/?permitMysqlScheme=true");
     assertThat(hikariConfig.getUsername()).isEqualTo("root");
     assertThat(hikariConfig.getPassword()).isEqualTo("mysql");
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -45,8 +45,10 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.CONNECTION_POOL_KEEPALIVE_TIME_MILLIS, "60000");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    when(rdbEngine.getDriverClassName()).thenReturn("com.mysql.cj.jdbc.Driver");
+    when(rdbEngine.getDriverClassName()).thenReturn("org.mariadb.jdbc.Driver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl("jdbc:mysql://localhost:3306/"))
+        .thenReturn("jdbc:mysql://localhost:3306/?permitMysqlScheme");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
@@ -68,8 +70,9 @@ public class JdbcUtilsTest {
     // Assert
     HikariConfig hikariConfig = capturedConfig.get();
     assertThat(hikariConfig).isNotNull();
-    assertThat(hikariConfig.getDriverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
-    assertThat(hikariConfig.getJdbcUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("org.mariadb.jdbc.Driver");
+    assertThat(hikariConfig.getJdbcUrl())
+        .isEqualTo("jdbc:mysql://localhost:3306/?permitMysqlScheme");
     assertThat(hikariConfig.getUsername()).isEqualTo("root");
     assertThat(hikariConfig.getPassword()).isEqualTo("mysql");
 
@@ -101,6 +104,8 @@ public class JdbcUtilsTest {
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("org.postgresql.Driver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl("jdbc:postgresql://localhost:5432/"))
+        .thenReturn("jdbc:postgresql://localhost:5432/");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
@@ -151,6 +156,9 @@ public class JdbcUtilsTest {
     when(rdbEngine.getDriverClassName()).thenReturn("com.microsoft.sqlserver.jdbc.SQLServerDriver");
     when(rdbEngine.getConnectionProperties(config))
         .thenReturn(ImmutableMap.of("prop1", "prop1Value", "prop2", "prop2Value"));
+    when(rdbEngine.adjustJdbcUrl(
+            "jdbc:sqlserver://localhost:5432;prop1=prop1Value;prop3=prop3Value"))
+        .thenReturn("jdbc:sqlserver://localhost:5432;prop1=prop1Value;prop3=prop3Value");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
@@ -199,6 +207,8 @@ public class JdbcUtilsTest {
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("oracle.jdbc.driver.OracleDriver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl("jdbc:oracle:thin:@localhost:1521/XEPDB1"))
+        .thenReturn("jdbc:oracle:thin:@localhost:1521/XEPDB1");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 
@@ -255,6 +265,8 @@ public class JdbcUtilsTest {
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     when(rdbEngine.getDriverClassName()).thenReturn("com.microsoft.sqlserver.jdbc.SQLServerDriver");
     when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl("jdbc:sqlserver://localhost:1433"))
+        .thenReturn("jdbc:sqlserver://localhost:1433");
 
     AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
@@ -1,0 +1,36 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RdbEngineMysqlTest {
+
+  private RdbEngineMysql rdbEngineMysql;
+
+  @BeforeEach
+  void setUp() {
+    rdbEngineMysql = new RdbEngineMysql();
+  }
+
+  @Test
+  void adjustJdbcUrl_WithNoParams_ShouldAppendPermitMysqlScheme() {
+    String result = rdbEngineMysql.adjustJdbcUrl("jdbc:mysql://localhost:3306/");
+    assertThat(result).isEqualTo("jdbc:mysql://localhost:3306/?permitMysqlScheme=true");
+  }
+
+  @Test
+  void adjustJdbcUrl_WithExistingParams_ShouldAppendPermitMysqlScheme() {
+    String result = rdbEngineMysql.adjustJdbcUrl("jdbc:mysql://localhost:3306/?sslMode=REQUIRED");
+    assertThat(result)
+        .isEqualTo("jdbc:mysql://localhost:3306/?sslMode=REQUIRED&permitMysqlScheme=true");
+  }
+
+  @Test
+  void adjustJdbcUrl_WithPermitMysqlSchemeAlreadyPresent_ShouldReturnAsIs() {
+    String url = "jdbc:mysql://localhost:3306/?permitMysqlScheme=true";
+    String result = rdbEngineMysql.adjustJdbcUrl(url);
+    assertThat(result).isEqualTo(url);
+  }
+}


### PR DESCRIPTION
## Description

MySQL Connector/J Community is licensed under GPLv2 (with Universal FOSS Exception), which poses licensing concerns for the project. This PR replaces it with MariaDB Connector/J (LGPL 2.1), which natively supports `jdbc:mysql://` URLs with the `permitMysqlScheme` parameter. After this change, MariaDB Connector/J is the sole JDBC driver for MySQL, MariaDB, and TiDB connections.

### Migration notes for users

When using `jdbc:mysql://` URLs with MariaDB Connector/J, the following differences from MySQL Connector/J should be noted:

- **`permitMysqlScheme` parameter**: ScalarDB automatically appends this to `jdbc:mysql://` URLs, so no user action is needed.
- **SSL**: MariaDB Connector/J does not enable SSL by default (unlike MySQL Connector/J). If connecting to MySQL 8.0+ with `caching_sha2_password` authentication without SSL, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to the JDBC URL.
- **Streaming mode**: `setFetchSize(Integer.MIN_VALUE)` is not supported by MariaDB Connector/J. Use `setFetchSize(1)` instead for row-by-row streaming.

## Related issues and/or PRs

N/A

## Changes made

- Remove the `com.mysql:mysql-connector-j` dependency and `mysqlDriverVersion` property from the Gradle build files
- Change the JDBC driver class in `RdbEngineMysql` from `com.mysql.cj.jdbc.Driver` to `org.mariadb.jdbc.Driver`
- Add `adjustJdbcUrl()` method to `RdbEngineStrategy` interface. `RdbEngineMysql` overrides it to append `permitMysqlScheme` to `jdbc:mysql://` URLs, which is required by MariaDB Connector/J to accept MySQL URL scheme
- Remove the `useCursorFetch` connection property from `RdbEngineMysql`, which is specific to MySQL Connector/J. MariaDB Connector/J handles fetch size natively via client-side streaming
- Add `JDBCType.BOOLEAN` case to `RdbEngineMysql.getDataTypeForScalarDbInternal()` since MariaDB Connector/J reports `TINYINT(1)` as `BOOLEAN` instead of `BIT`
- Update `RdbEngineMariaDB` to override `adjustJdbcUrl()` to pass through the URL unchanged (no `permitMysqlScheme` needed for `jdbc:mariadb://` URLs)
- Replace MySQL Connector/J specific `CommunicationsException` with standard JDBC `SQLNonTransientConnectionException` in tests
- Update driver class name references and `adjustJdbcUrl` mocks in test assertions
- Add `sslMode=REQUIRED` to MySQL CI JDBC URL to handle `caching_sha2_password` authentication without `allowPublicKeyRetrieval`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Replaced MySQL Connector/J with MariaDB Connector/J to resolve GPLv2 licensing concerns. MariaDB Connector/J is now the sole JDBC driver for MySQL, MariaDB, and TiDB connections.

Note for MySQL users: SSL is no longer enabled by default. If you connect to MySQL 8.0+ with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL.

No action is required for the `jdbc:mysql://` URL scheme — ScalarDB automatically appends `permitMysqlScheme` for compatibility.
