### PR TITLE
Make table metadata addition atomic

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
@@ -50,17 +50,38 @@ public class TableMetadataService {
     if (createMetadataTable) {
       createTableMetadataTableIfNotExists(connection);
     }
-    if (overwriteMetadata) {
-      // Delete the metadata for the table before we add them
-      execute(
-          connection, getDeleteTableMetadataStatement(namespace, table), requiresExplicitCommit);
-    }
-    LinkedHashSet<String> orderedColumns = new LinkedHashSet<>(metadata.getPartitionKeyNames());
-    orderedColumns.addAll(metadata.getClusteringKeyNames());
-    orderedColumns.addAll(metadata.getColumnNames());
-    int ordinalPosition = 1;
-    for (String column : orderedColumns) {
-      insertMetadataColumn(namespace, table, metadata, connection, ordinalPosition++, column);
+
+    boolean originalAutoCommit = connection.getAutoCommit();
+    try {
+      if (originalAutoCommit) {
+        connection.setAutoCommit(false);
+      }
+
+      if (overwriteMetadata) {
+        // Delete the metadata for the table before we add them
+        execute(connection, getDeleteTableMetadataStatement(namespace, table), false);
+      }
+
+      LinkedHashSet<String> orderedColumns = new LinkedHashSet<>(metadata.getPartitionKeyNames());
+      orderedColumns.addAll(metadata.getClusteringKeyNames());
+      orderedColumns.addAll(metadata.getColumnNames());
+      int ordinalPosition = 1;
+      for (String column : orderedColumns) {
+        insertMetadataColumn(namespace, table, metadata, connection, ordinalPosition++, column);
+      }
+
+      connection.commit();
+    } catch (SQLException e) {
+      try {
+        connection.rollback();
+      } catch (SQLException rollbackEx) {
+        e.addSuppressed(rollbackEx);
+      }
+      throw e;
+    } finally {
+      if (originalAutoCommit) {
+        connection.setAutoCommit(true);
+      }
     }
   }
 
@@ -131,7 +152,7 @@ public class TableMetadataService {
             metadata.getClusteringOrder(column),
             metadata.getSecondaryIndexNames().contains(column),
             ordinalPosition);
-    execute(connection, insertStatement, requiresExplicitCommit);
+    execute(connection, insertStatement, false);
   }
 
   private String getInsertStatement(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
@@ -52,6 +52,7 @@ public class TableMetadataService {
     }
 
     boolean originalAutoCommit = connection.getAutoCommit();
+    SQLException primaryException = null;
     try {
       if (originalAutoCommit) {
         connection.setAutoCommit(false);
@@ -72,6 +73,7 @@ public class TableMetadataService {
 
       connection.commit();
     } catch (SQLException e) {
+      primaryException = e;
       try {
         connection.rollback();
       } catch (SQLException rollbackEx) {
@@ -80,7 +82,15 @@ public class TableMetadataService {
       throw e;
     } finally {
       if (originalAutoCommit) {
-        connection.setAutoCommit(true);
+        try {
+          connection.setAutoCommit(true);
+        } catch (SQLException e) {
+          if (primaryException != null) {
+            primaryException.addSuppressed(e);
+          } else {
+            throw e;
+          }
+        }
       }
     }
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
@@ -39,6 +39,9 @@ public class TableMetadataService {
     this.requiresExplicitCommit = requiresExplicitCommit;
   }
 
+  // This method manages its own transaction (commit/rollback) to ensure the DELETE and all INSERTs
+  // are applied atomically, unlike other methods that rely on per-statement commits via
+  // requiresExplicitCommit.
   void addTableMetadata(
       Connection connection,
       String namespace,

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -959,6 +959,39 @@ public class JdbcAdminTest {
   }
 
   @Test
+  public void addTableMetadata_WhenInsertFails_ShouldRollback() throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.BIGINT)
+            .build();
+
+    Statement deleteStatement = mock(Statement.class);
+    Statement insertStatement1 = mock(Statement.class);
+    Statement insertStatement2 = mock(Statement.class);
+    when(connection.createStatement())
+        .thenReturn(deleteStatement, insertStatement1, insertStatement2);
+    when(insertStatement2.execute(anyString())).thenThrow(new SQLException("insert failed"));
+    when(connection.getAutoCommit()).thenReturn(true);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.MYSQL);
+
+    // Act & Assert
+    assertThatThrownBy(
+            () -> admin.addTableMetadata(connection, namespace, table, metadata, false, true))
+        .isInstanceOf(SQLException.class)
+        .hasMessage("insert failed");
+    verify(connection).rollback();
+    verify(connection, never()).commit();
+    verify(connection).setAutoCommit(true);
+  }
+
+  @Test
   public void addTableMetadata_OverwriteMetadataForMysql_ShouldWorkProperly() throws Exception {
     addTableMetadata_overwriteMetadataForX_ShouldWorkProperly(
         RdbEngine.MYSQL,

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -1046,6 +1046,7 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).commit();
   }
 
   @Test
@@ -1234,6 +1235,7 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).commit();
   }
 
   @Test
@@ -1531,6 +1533,7 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).commit();
   }
 
   @ParameterizedTest

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -925,6 +925,40 @@ public class JdbcAdminTest {
   }
 
   @Test
+  public void addTableMetadata_WhenAutoCommitIsFalse_ShouldCommitWithoutTogglingAutoCommit()
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.BIGINT)
+            .build();
+
+    List<Statement> mockedStatements = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      mockedStatements.add(mock(Statement.class));
+    }
+    when(connection.createStatement())
+        .thenReturn(
+            mockedStatements.get(0),
+            mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
+    when(connection.getAutoCommit()).thenReturn(false);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.MYSQL);
+
+    // Act
+    admin.addTableMetadata(connection, namespace, table, metadata, false, true);
+
+    // Assert
+    verify(connection, never()).setAutoCommit(anyBoolean());
+    verify(connection).commit();
+  }
+
+  @Test
   public void addTableMetadata_OverwriteMetadataForMysql_ShouldWorkProperly() throws Exception {
     addTableMetadata_overwriteMetadataForX_ShouldWorkProperly(
         RdbEngine.MYSQL,
@@ -1035,6 +1069,7 @@ public class JdbcAdminTest {
         .thenReturn(
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
+    when(connection.getAutoCommit()).thenReturn(true);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -1046,7 +1081,9 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).setAutoCommit(false);
     verify(connection).commit();
+    verify(connection).setAutoCommit(true);
   }
 
   @Test
@@ -1224,6 +1261,7 @@ public class JdbcAdminTest {
         .thenReturn(
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
+    when(connection.getAutoCommit()).thenReturn(true);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -1235,7 +1273,9 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).setAutoCommit(false);
     verify(connection).commit();
+    verify(connection).setAutoCommit(true);
   }
 
   @Test
@@ -1522,6 +1562,7 @@ public class JdbcAdminTest {
         .thenReturn(
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
+    when(connection.getAutoCommit()).thenReturn(true);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -1533,7 +1574,9 @@ public class JdbcAdminTest {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+    verify(connection).setAutoCommit(false);
     verify(connection).commit();
+    verify(connection).setAutoCommit(true);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

This PR makes metadata addition in DDLs more robust.

`TableMetadataService.addTableMetadata` previously committed each SQL statement (DELETE and per-column INSERTs) individually. If a failure occurred mid-way, the table metadata could be left in an incomplete state. We can use `repairTable` in such a case, but it would be more robust if these metadata writes were executed atomically. This PR wraps the DELETE and all INSERTs in a single transaction to ensure atomicity.

## Related issues and/or PRs

N/A

## Changes made

- Wrap the DELETE and all INSERT operations in `TableMetadataService.addTableMetadata` in a single transaction with explicit commit and rollback on failure.
- Add `verify(connection).commit()` assertions to existing `TableMetadataService.addTableMetadata` unit tests.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Updated `Admin` to make multiple metadata writes atomic.