### PR TITLE
Fix shadow jar being published to GitHub Packages

### DIFF
--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -85,9 +85,7 @@ task docker(type: Exec) {
 }
 
 // for publishing (not to publish the fat jar)
-if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
+if (project.gradle.startParameter.taskNames.any { it.tokenize(':').last().startsWith('publish') }) {
     shadowJar.enabled = false
 }
 

--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -84,11 +84,10 @@ task docker(type: Exec) {
     commandLine 'docker', 'build', "--tag=ghcr.io/scalar-labs/scalardb-data-loader-cli:${project.version}", "."
 }
 
-// for archiving and uploading to maven central
+// for publishing (not to publish the fat jar)
 if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
         project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
         project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
-    // not to publish the fat jar to maven central
     shadowJar.enabled = false
 }
 

--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -86,7 +86,8 @@ task docker(type: Exec) {
 
 // for archiving and uploading to maven central
 if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') }) {
+        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
+        project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
     // not to publish the fat jar to maven central
     shadowJar.enabled = false
 }

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -93,11 +93,10 @@ spotbugsTest.reports {
 }
 spotbugsTest.excludeFilter = file("${project.rootDir}/gradle/spotbugs-exclude.xml")
 
-// for archiving and uploading to maven central
+// for publishing (not to publish the fat jar)
 if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
         project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
         project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
-    // not to publish the fat jar to maven central
     shadowJar.enabled = false
 }
 

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -95,7 +95,8 @@ spotbugsTest.excludeFilter = file("${project.rootDir}/gradle/spotbugs-exclude.xm
 
 // for archiving and uploading to maven central
 if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') }) {
+        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
+        project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
     // not to publish the fat jar to maven central
     shadowJar.enabled = false
 }

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -94,9 +94,7 @@ spotbugsTest.reports {
 spotbugsTest.excludeFilter = file("${project.rootDir}/gradle/spotbugs-exclude.xml")
 
 // for publishing (not to publish the fat jar)
-if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') } ||
-        project.gradle.startParameter.taskNames.any { it.endsWith('publishAllPublicationsToGitHubPackagesRepository') }) {
+if (project.gradle.startParameter.taskNames.any { it.tokenize(':').last().startsWith('publish') }) {
     shadowJar.enabled = false
 }
 


### PR DESCRIPTION
## Description

The condition to disable `shadowJar` during publishing did not match the `publishAllPublicationsToGitHubPackagesRepository` task used by the feature snapshot workflow (#3431), causing the fat jar to be published instead of the thin jar. This resulted in dependency version mismatch issues for downstream consumers.

## Related issues and/or PRs

- #3431

## Changes made

- Replaced the brittle `endsWith` checks with a generic `it.tokenize(':').last().startsWith('publish')` to match all publish tasks in `schema-loader/build.gradle` and `data-loader/cli/build.gradle`
- Updated comments to reflect broader publishing scope

## Additional notes (optional)

N/A

## Release notes

N/A
