### PR TITLE
Backport to branch(3.16) : Support SERIALIZABLE isolation for index-based operations with before-image index validation

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -699,19 +699,22 @@ public enum CoreError implements ScalarDbError {
   CONSENSUS_COMMIT_INDEX_GET_NOT_ALLOWED_IN_SERIALIZABLE(
       Category.USER_ERROR,
       "0260",
-      "Get operations by using an index is not allowed in the SERIALIZABLE isolation level",
+      "Get operations using a secondary index are not allowed in the SERIALIZABLE isolation level without before-image indexes. "
+          + "Run repairTable() to create before-image indexes for the table, which will enable index-based Get operations in the SERIALIZABLE isolation level",
       "",
       ""),
   CONSENSUS_COMMIT_INDEX_SCAN_NOT_ALLOWED_IN_SERIALIZABLE(
       Category.USER_ERROR,
       "0261",
-      "Scan operations by using an index is not allowed in the SERIALIZABLE isolation level",
+      "Scan operations using a secondary index are not allowed in the SERIALIZABLE isolation level without before-image indexes. "
+          + "Run repairTable() to create before-image indexes for the table, which will enable index-based Scan operations in the SERIALIZABLE isolation level",
       "",
       ""),
   CONSENSUS_COMMIT_CONDITION_ON_INDEXED_COLUMNS_NOT_ALLOWED_IN_CROSS_PARTITION_SCAN_IN_SERIALIZABLE(
       Category.USER_ERROR,
       "0262",
-      "Conditions on indexed columns in cross-partition scan operations are not allowed in the SERIALIZABLE isolation level",
+      "Conditions on indexed columns in cross-partition scan operations are not allowed in the SERIALIZABLE isolation level without before-image indexes. "
+          + "Run repairTable() to create before-image indexes for the table, which will enable conditions on indexed columns in cross-partition scan operations in the SERIALIZABLE isolation level",
       "",
       ""),
   TABLE_METADATA_BUILD_ERROR_SECONDARY_INDEX_COLUMN_DEFINITION_NOT_SPECIFIED(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationChecker.java
@@ -83,7 +83,8 @@ public class ConsensusCommitOperationChecker {
         // If the index column is part of the primary key, it's allowed
         String indexKeyColumnName = get.getPartitionKey().getColumns().get(0).getName();
         if (!tableMetadata.getPartitionKeyNames().contains(indexKeyColumnName)
-            && !tableMetadata.getClusteringKeyNames().contains(indexKeyColumnName)) {
+            && !tableMetadata.getClusteringKeyNames().contains(indexKeyColumnName)
+            && !metadata.hasBeforeImageSecondaryIndex(indexKeyColumnName)) {
           throw new IllegalArgumentException(
               CoreError.CONSENSUS_COMMIT_INDEX_GET_NOT_ALLOWED_IN_SERIALIZABLE.buildMessage());
         }
@@ -148,7 +149,8 @@ public class ConsensusCommitOperationChecker {
         // If the index column is part of the primary key, it's allowed
         String indexKeyColumnName = scan.getPartitionKey().getColumns().get(0).getName();
         if (!tableMetadata.getPartitionKeyNames().contains(indexKeyColumnName)
-            && !tableMetadata.getClusteringKeyNames().contains(indexKeyColumnName)) {
+            && !tableMetadata.getClusteringKeyNames().contains(indexKeyColumnName)
+            && !metadata.hasBeforeImageSecondaryIndex(indexKeyColumnName)) {
           throw new IllegalArgumentException(
               CoreError.CONSENSUS_COMMIT_INDEX_SCAN_NOT_ALLOWED_IN_SERIALIZABLE.buildMessage());
         }
@@ -162,7 +164,8 @@ public class ConsensusCommitOperationChecker {
             // If the column is an indexed column but is part of the primary key, it's allowed
             if (tableMetadata.getSecondaryIndexNames().contains(column)
                 && !tableMetadata.getPartitionKeyNames().contains(column)
-                && !tableMetadata.getClusteringKeyNames().contains(column)) {
+                && !tableMetadata.getClusteringKeyNames().contains(column)
+                && !metadata.hasBeforeImageSecondaryIndex(column)) {
               throw new IllegalArgumentException(
                   CoreError
                       .CONSENSUS_COMMIT_CONDITION_ON_INDEXED_COLUMNS_NOT_ALLOWED_IN_CROSS_PARTITION_SCAN_IN_SERIALIZABLE

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -727,8 +727,7 @@ public class CrudHandler {
         exception = e;
       }
       throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
-              exception.getMessage()),
+          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
           exception,
           context.transactionId);
     } catch (ExecutionException e) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -609,8 +609,20 @@ public class CrudHandler {
   }
 
   /**
-   * Returns whether the given selection requires a before-image index check. This is true when the
-   * selection uses a secondary index that has a corresponding before-image secondary index.
+   * Returns whether the given selection requires a before-image index check.
+   *
+   * <p>For index-based selections (Get with index, Scan with index), this returns true when the
+   * index column has a corresponding before-image secondary index. For ScanAll, this returns true
+   * when any conjunction condition is on a column that has both a secondary index and a
+   * corresponding before-image secondary index.
+   *
+   * <p>If the before-image index does not exist (e.g., for tables created before the before-image
+   * index check feature was introduced), the check is skipped. In SNAPSHOT and READ_COMMITTED
+   * isolation, this means index-based reads may return eventually consistent results, which is a
+   * known limitation (a warning is logged at startup via {@code
+   * warnIfBeforeImageIndexesAreMissing}). In SERIALIZABLE isolation, this case does not occur
+   * because {@link ConsensusCommitOperationChecker} rejects index-based operations on tables
+   * without before-image indexes.
    *
    * @param selection the selection operation
    * @param metadata the transaction table metadata
@@ -623,11 +635,11 @@ public class CrudHandler {
     }
 
     if (selection instanceof ScanAll) {
-      // For ScanAll, check if any conjunction condition is on a column that has a before-image
-      // secondary index
       for (Selection.Conjunction conjunction : selection.getConjunctions()) {
         for (ConditionalExpression condition : conjunction.getConditions()) {
-          if (metadata.hasBeforeImageSecondaryIndex(condition.getColumn().getName())) {
+          String columnName = condition.getColumn().getName();
+          if (metadata.getTableMetadata().getSecondaryIndexNames().contains(columnName)
+              && metadata.hasBeforeImageSecondaryIndex(columnName)) {
             return true;
           }
         }
@@ -707,6 +719,18 @@ public class CrudHandler {
           }
         }
       }
+    } catch (RuntimeException e) {
+      Exception exception;
+      if (e.getCause() instanceof ExecutionException) {
+        exception = (ExecutionException) e.getCause();
+      } else {
+        exception = e;
+      }
+      throw new CrudException(
+          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
+              exception.getMessage()),
+          exception,
+          context.transactionId);
     } catch (ExecutionException e) {
       throw new CrudException(
           CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -2,13 +2,13 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitOperationAttributes.isImplicitPreReadEnabled;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitOperationAttributes.isInsertModeEnabled;
-import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Iterators;
 import com.scalar.db.api.ConditionSetBuilder;
+import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
@@ -20,6 +20,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.api.Selection;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
@@ -532,22 +533,43 @@ public class Snapshot {
 
     // Scan set is re-validated to check if there is no anti-dependency
     for (Map.Entry<Scan, LinkedHashMap<Key, TransactionResult>> entry : scanSet.entrySet()) {
-      tasks.add(() -> validateScanResults(storage, entry.getKey(), entry.getValue(), false));
+      tasks.add(
+          () -> {
+            TransactionTableMetadata txMetadata = getTransactionTableMetadata(entry.getKey());
+            validateScanResults(
+                storage, entry.getKey(), entry.getValue(), false, txMetadata.getTableMetadata());
+            validateBeforeIndex(storage, entry.getKey(), txMetadata);
+          });
     }
 
     // Scanner set is re-validated to check if there is no anti-dependency
     for (ScannerInfo scannerInfo : scannerSet) {
-      tasks.add(() -> validateScanResults(storage, scannerInfo.scan, scannerInfo.results, true));
+      tasks.add(
+          () -> {
+            TransactionTableMetadata txMetadata = getTransactionTableMetadata(scannerInfo.scan);
+            validateScanResults(
+                storage,
+                scannerInfo.scan,
+                scannerInfo.results,
+                true,
+                txMetadata.getTableMetadata());
+            validateBeforeIndex(storage, scannerInfo.scan, txMetadata);
+          });
     }
 
     // Get set is re-validated to check if there is no anti-dependency
     for (Map.Entry<Get, Optional<TransactionResult>> entry : getSet.entrySet()) {
       Get get = entry.getKey();
-      TableMetadata metadata = getTableMetadata(get);
+      TransactionTableMetadata txMetadata = getTransactionTableMetadata(get);
+      TableMetadata metadata = txMetadata.getTableMetadata();
 
       if (ScalarDbUtils.isSecondaryIndexSpecified(get, metadata)) {
         // For Get with index
-        tasks.add(() -> validateGetWithIndexResult(storage, get, entry.getValue(), metadata));
+        tasks.add(
+            () -> {
+              validateGetWithIndexResult(storage, get, entry.getValue(), metadata);
+              validateBeforeIndex(storage, get, txMetadata);
+            });
       } else {
         // For other Get
 
@@ -582,6 +604,7 @@ public class Snapshot {
    * @param results the results of the scan
    * @param notFullyScannedScanner if this is a validation for a scanner that has not been fully
    *     scanned
+   * @param metadata the table metadata for the scanned table
    * @throws ExecutionException if a storage operation fails
    * @throws ValidationConflictException if the scan results are changed by another transaction
    */
@@ -589,13 +612,11 @@ public class Snapshot {
       DistributedStorage storage,
       Scan scan,
       LinkedHashMap<Key, TransactionResult> results,
-      boolean notFullyScannedScanner)
+      boolean notFullyScannedScanner,
+      TableMetadata metadata)
       throws ExecutionException, ValidationConflictException {
-    Scanner scanner = null;
-    try {
-      TableMetadata metadata = getTableMetadata(scan);
-
-      scanner = storage.scan(ConsensusCommitUtils.prepareScanForStorage(scan, metadata));
+    try (Scanner scanner =
+        storage.scan(ConsensusCommitUtils.prepareScanForStorage(scan, metadata))) {
 
       // Initialize the iterator for the latest scan results
       Optional<Result> latestResult = getNextResult(scanner, scan);
@@ -694,14 +715,8 @@ public class Snapshot {
           throwExceptionDueToAntiDependency();
         }
       }
-    } finally {
-      if (scanner != null) {
-        try {
-          scanner.close();
-        } catch (IOException e) {
-          logger.warn("Failed to close the scanner. Transaction ID: {}", id, e);
-        }
-      }
+    } catch (IOException e) {
+      logger.warn("Failed to close the scanner. Transaction ID: {}", id, e);
     }
   }
 
@@ -752,7 +767,7 @@ public class Snapshot {
     originalResult.ifPresent(r -> results.put(new Snapshot.Key(scanWithIndex, r, metadata), r));
 
     // Validate the result to check if there is no anti-dependency
-    validateScanResults(storage, scanWithIndex, results, false);
+    validateScanResults(storage, scanWithIndex, results, false, metadata);
   }
 
   private void validateGetResult(
@@ -782,10 +797,99 @@ public class Snapshot {
     }
   }
 
-  private TableMetadata getTableMetadata(Operation operation) throws ExecutionException {
-    TransactionTableMetadata transactionTableMetadata =
-        getTransactionTableMetadata(tableMetadataManager, operation);
-    return transactionTableMetadata.getTableMetadata();
+  /**
+   * Validates that there are no uncommitted records on the before-image index that could cause
+   * phantom reads.
+   *
+   * <p>This is needed because when another transaction updates a record's indexed column (e.g.,
+   * from 10 to 20) and is in PREPARED/DELETED state, the regular index scan (e.g., index_col=10)
+   * won't find that record since its current value is 20. However, the record's committed
+   * (before-image) value is still 10. Without this check, a phantom could go undetected: a record
+   * committed with index_col=10 but updated to 20 by another PREPARED transaction would be
+   * invisible to both the original scan and the validation re-scan.
+   *
+   * <p>This method is only called in the SERIALIZABLE extra-read validation phase. In SERIALIZABLE,
+   * {@link ConsensusCommitOperationChecker} rejects index-based operations on tables without
+   * before-image indexes, so the existence of before-image indexes is guaranteed when this method
+   * is called. Therefore, this method only needs to check whether the selection is an index-based
+   * operation (Get with index, Scan with index, or ScanAll with indexed column conditions), without
+   * checking for the existence of before-image indexes.
+   *
+   * @param storage a distributed storage
+   * @param selection the original selection operation (Get with index, ScanWithIndex, or ScanAll)
+   * @throws ExecutionException if a storage operation fails
+   * @throws ValidationConflictException if uncommitted records are found on the before-image index
+   */
+  private void validateBeforeIndex(
+      DistributedStorage storage, Selection selection, TransactionTableMetadata txMetadata)
+      throws ExecutionException, ValidationConflictException {
+    if (!isIndexBasedOperation(selection, txMetadata.getTableMetadata())) {
+      return;
+    }
+
+    Scan beforeIndexScan;
+    if (selection instanceof ScanAll) {
+      beforeIndexScan =
+          ConsensusCommitUtils.createBeforeIndexScanAll(
+              (ScanAll) selection, txMetadata.getTableMetadata());
+    } else {
+      beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(selection);
+    }
+
+    try (Scanner scanner = storage.scan(beforeIndexScan)) {
+      for (Result result : scanner) {
+        TransactionResult txResult = new TransactionResult(result);
+        // Conservatively fail if any uncommitted record from another transaction is found on the
+        // before-image index. This may cause false positives (e.g., when the record will be
+        // rolled forward and its committed index value won't actually match the scan condition),
+        // but it guarantees correctness. On retry, the record should be committed, so the retry
+        // will succeed.
+        if (!txResult.isCommitted() && !id.equals(txResult.getId())) {
+          throwExceptionDueToAntiDependency();
+        }
+      }
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ExecutionException) {
+        throw (ExecutionException) e.getCause();
+      }
+      throw e;
+    } catch (IOException e) {
+      logger.warn("Failed to close the scanner. Transaction ID: {}", id, e);
+    }
+  }
+
+  /**
+   * Checks if the given selection is an index-based operation that requires before-image index
+   * validation. This includes Get with index, Scan with index, and ScanAll with conditions on
+   * indexed columns.
+   *
+   * <p>For ScanAll, whether the underlying storage actually uses the index depends on the storage
+   * implementation. However, this method considers ScanAll with conditions on indexed columns as an
+   * index-based operation regardless.
+   *
+   * @param selection the selection operation to check
+   * @param metadata the table metadata
+   * @return true if the selection is an index-based operation
+   */
+  private boolean isIndexBasedOperation(Selection selection, TableMetadata metadata) {
+    if (ScalarDbUtils.isSecondaryIndexSpecified(selection, metadata)) {
+      return true;
+    }
+    if (selection instanceof ScanAll) {
+      for (Selection.Conjunction conjunction : selection.getConjunctions()) {
+        for (ConditionalExpression condition : conjunction.getConditions()) {
+          if (metadata.getSecondaryIndexNames().contains(condition.getColumn().getName())) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private TransactionTableMetadata getTransactionTableMetadata(Operation operation)
+      throws ExecutionException {
+    return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, operation);
   }
 
   private boolean isChanged(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
@@ -327,6 +327,28 @@ public class ConsensusCommitOperationCheckerTest {
   }
 
   @Test
+  public void
+      checkForGet_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn("pk", DataType.INT)
+            .addColumn("idx", DataType.INT)
+            .addPartitionKey("pk")
+            .addSecondaryIndex("idx")
+            .build();
+    when(tableMetadata.getTableMetadata()).thenReturn(metadata);
+    when(tableMetadata.hasBeforeImageSecondaryIndex("idx")).thenReturn(true);
+
+    Get get = Get.newBuilder().namespace("ns").table("tbl").indexKey(Key.ofInt("idx", 100)).build();
+    TransactionContext context =
+        new TransactionContext("txId", null, Isolation.SERIALIZABLE, false, false);
+
+    // Act Assert
+    assertThatCode(() -> checker.check(get, context)).doesNotThrowAnyException();
+  }
+
+  @Test
   public void checkForGet_ValidGet_ShouldNotThrowException() {
     // Arrange
     Get get =
@@ -490,6 +512,29 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
+      checkForScan_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn("pk", DataType.INT)
+            .addColumn("idx", DataType.INT)
+            .addPartitionKey("pk")
+            .addSecondaryIndex("idx")
+            .build();
+    when(tableMetadata.getTableMetadata()).thenReturn(metadata);
+    when(tableMetadata.hasBeforeImageSecondaryIndex("idx")).thenReturn(true);
+
+    Scan scan =
+        Scan.newBuilder().namespace("ns").table("tbl").indexKey(Key.ofInt("idx", 100)).build();
+    TransactionContext context =
+        new TransactionContext("txId", null, Isolation.SERIALIZABLE, false, false);
+
+    // Act Assert
+    assertThatCode(() -> checker.check(scan, context)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
       checkForScan_ScanAllWithConditionOnIndexedColumnInSerializable_ShouldThrowIllegalArgumentException() {
     // Arrange
 
@@ -618,6 +663,34 @@ public class ConsensusCommitOperationCheckerTest {
             .namespace("ns")
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 1))
+            .where(ConditionBuilder.column("idx_col").isEqualToInt(100))
+            .build();
+    TransactionContext context =
+        new TransactionContext("txId", null, Isolation.SERIALIZABLE, false, false);
+
+    // Act Assert
+    assertThatCode(() -> checker.check(scan, context)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      checkForScan_ScanAllWithConditionOnIndexedColumnInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+    // Arrange
+
+    // Mock the underlying TableMetadata
+    TableMetadata mockTableMetadata = mock(TableMetadata.class);
+    when(tableMetadata.getTableMetadata()).thenReturn(mockTableMetadata);
+    when(mockTableMetadata.getPartitionKeyNames()).thenReturn(new LinkedHashSet<>());
+    when(mockTableMetadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
+    Set<String> secondaryIndexNames = new LinkedHashSet<>(Collections.singletonList("idx_col"));
+    when(mockTableMetadata.getSecondaryIndexNames()).thenReturn(secondaryIndexNames);
+    when(tableMetadata.hasBeforeImageSecondaryIndex("idx_col")).thenReturn(true);
+
+    Scan scan =
+        ScanAll.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .all()
             .where(ConditionBuilder.column("idx_col").isEqualToInt(100))
             .build();
     TransactionContext context =

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -27,6 +27,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
@@ -1056,6 +1057,12 @@ public class SnapshotTest {
     when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
+    // Mock the before-image index scan
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(getWithIndex);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
     // Act Assert
     assertThatCode(() -> snapshot.toSerializable(storage)).doesNotThrowAnyException();
 
@@ -1112,6 +1119,12 @@ public class SnapshotTest {
         .thenReturn(Optional.of(result2))
         .thenReturn(Optional.empty());
     when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Mock the before-image index scan
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(getWithIndex);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
 
     // Act Assert
     assertThatCode(() -> snapshot.toSerializable(storage)).doesNotThrowAnyException();
@@ -1695,6 +1708,12 @@ public class SnapshotTest {
 
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
+    // Mock the before-image index scan
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(scan);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
     // Act Assert
     assertThatCode(() -> snapshot.toSerializable(storage)).doesNotThrowAnyException();
 
@@ -1729,6 +1748,12 @@ public class SnapshotTest {
         Scan.newBuilder(scan).limit(0).consistency(Consistency.LINEARIZABLE).build();
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
+    // Mock the before-image index scan
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(scan);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
     // Act Assert
     assertThatCode(() -> snapshot.toSerializable(storage)).doesNotThrowAnyException();
 
@@ -1760,6 +1785,129 @@ public class SnapshotTest {
 
     // Assert
     verify(storage).scan(scanForStorage);
+  }
+
+  @Test
+  public void
+      toSerializable_GetSetWithGetWithIndex_WhenBeforeIndexHasUncommittedRecordFromOtherTransaction_ShouldThrowValidationConflictException()
+          throws ExecutionException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get getWithIndex = prepareGetWithIndex();
+    TransactionResult txResult = prepareResult(ANY_ID + "x");
+    snapshot.putIntoGetSet(getWithIndex, Optional.of(txResult));
+    DistributedStorage storage = mock(DistributedStorage.class);
+    Scan scanForStorage =
+        Scan.newBuilder(prepareScanWithIndex()).consistency(Consistency.LINEARIZABLE).build();
+
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.one()).thenReturn(Optional.of(txResult)).thenReturn(Optional.empty());
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Mock the before-image index scan returning a PREPARED record from another transaction
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(getWithIndex);
+    ImmutableMap<String, Column<?>> preparedColumns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_3))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_1))
+            .put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3))
+            .put(ANY_NAME_4, TextColumn.of(ANY_NAME_4, ANY_TEXT_4))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID + "other"))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, TransactionState.PREPARED.get()))
+            .build();
+    TransactionResult preparedResult =
+        new TransactionResult(new ResultImpl(preparedColumns, TABLE_METADATA));
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.singletonList((Result) preparedResult).iterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.toSerializable(storage))
+        .isInstanceOf(ValidationConflictException.class);
+  }
+
+  @Test
+  public void
+      toSerializable_ScanWithIndexInScanSet_WhenBeforeIndexHasUncommittedRecordFromOtherTransaction_ShouldThrowValidationConflictException()
+          throws ExecutionException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scan = prepareScanWithIndex();
+    TransactionResult result1 = prepareResult(ANY_ID + "x", ANY_TEXT_1, ANY_TEXT_1);
+    Snapshot.Key key1 = new Snapshot.Key(scan, result1, TABLE_METADATA);
+    snapshot.putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key1, result1)));
+
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.one()).thenReturn(Optional.of(result1)).thenReturn(Optional.empty());
+
+    DistributedStorage storage = mock(DistributedStorage.class);
+    Scan scanForStorage =
+        Scan.newBuilder(scan).limit(0).consistency(Consistency.LINEARIZABLE).build();
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Mock the before-image index scan returning a PREPARED record from another transaction
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(scan);
+    ImmutableMap<String, Column<?>> preparedColumns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_3))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_1))
+            .put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3))
+            .put(ANY_NAME_4, TextColumn.of(ANY_NAME_4, ANY_TEXT_4))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID + "other"))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, TransactionState.PREPARED.get()))
+            .build();
+    TransactionResult preparedResult =
+        new TransactionResult(new ResultImpl(preparedColumns, TABLE_METADATA));
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.singletonList((Result) preparedResult).iterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.toSerializable(storage))
+        .isInstanceOf(ValidationConflictException.class);
+  }
+
+  @Test
+  public void
+      toSerializable_ScanWithIndexInScannerSet_WhenBeforeIndexHasUncommittedRecordFromOtherTransaction_ShouldThrowValidationConflictException()
+          throws ExecutionException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scan = prepareScanWithIndex();
+    TransactionResult result1 = prepareResult(ANY_ID + "x", ANY_TEXT_1, ANY_TEXT_1);
+    Snapshot.Key key1 = new Snapshot.Key(scan, result1, TABLE_METADATA);
+    snapshot.putIntoScannerSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key1, result1)));
+
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.one()).thenReturn(Optional.of(result1)).thenReturn(Optional.empty());
+
+    DistributedStorage storage = mock(DistributedStorage.class);
+    Scan scanForStorage = Scan.newBuilder(scan).consistency(Consistency.LINEARIZABLE).build();
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Mock the before-image index scan returning a PREPARED record from another transaction
+    Scan beforeIndexScan = ConsensusCommitUtils.createBeforeIndexScan(scan);
+    ImmutableMap<String, Column<?>> preparedColumns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_3))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_1))
+            .put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3))
+            .put(ANY_NAME_4, TextColumn.of(ANY_NAME_4, ANY_TEXT_4))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID + "other"))
+            .put(Attribute.STATE, IntColumn.of(Attribute.STATE, TransactionState.PREPARED.get()))
+            .build();
+    TransactionResult preparedResult =
+        new TransactionResult(new ResultImpl(preparedColumns, TABLE_METADATA));
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator())
+        .thenReturn(Collections.singletonList((Result) preparedResult).iterator());
+    when(storage.scan(beforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.toSerializable(storage))
+        .isInstanceOf(ValidationConflictException.class);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -63,6 +63,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -2401,11 +2402,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       get_GetWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnResult(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -2442,11 +2438,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   @EnumSource(Isolation.class)
   public void get_GetWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
       Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -2486,11 +2477,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnResult(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
@@ -2530,11 +2516,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       get_GetWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long prepared_at = System.currentTimeMillis();
@@ -2566,11 +2547,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       get_GetWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnEmpty(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -2605,11 +2581,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   @EnumSource(Isolation.class)
   public void get_GetWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnResult(
       Isolation isolation) throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -2697,11 +2668,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, false, isolation);
@@ -2713,11 +2679,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, true, isolation);
@@ -2729,11 +2690,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, false, isolation);
@@ -2745,11 +2701,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, true, isolation);
@@ -2807,11 +2758,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, false, isolation);
@@ -2823,11 +2769,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, true, isolation);
@@ -2839,11 +2780,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, false, isolation);
@@ -2855,11 +2791,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, true, isolation);
@@ -2917,11 +2848,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
         scan, false, isolation);
@@ -2933,11 +2859,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
         scan, true, isolation);
@@ -2949,11 +2870,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
         scan, false, isolation);
@@ -2965,11 +2881,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortAndReturnAllRecords(
         scan, true, isolation);
@@ -3015,11 +2926,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
         scan, false, isolation);
@@ -3031,11 +2937,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
         scan, true, isolation);
@@ -3047,11 +2948,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
         scan, false, isolation);
@@ -3063,11 +2959,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowException(
         scan, true, isolation);
@@ -3128,11 +3019,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, false, isolation);
@@ -3144,11 +3030,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, true, isolation);
@@ -3160,11 +3041,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, false, isolation);
@@ -3176,11 +3052,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
         scan, true, isolation);
@@ -3237,11 +3108,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, false, isolation);
@@ -3253,11 +3119,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanWithIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, true, isolation);
@@ -3269,11 +3130,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, false, isolation);
@@ -3285,11 +3141,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
-    if (isolation == Isolation.SERIALIZABLE) {
-      // skip for now
-      return;
-    }
-
     Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
     scan_ScanWithBeforeIndexForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
         scan, true, isolation);
@@ -5412,17 +5263,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> transaction.scan(scan));
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
 
     // Assert
-    if (isolation == Isolation.SERIALIZABLE) {
-      // Index scans are not allowed in SERIALIZABLE isolation
-      assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
-      transaction.rollback();
-    } else {
-      assertThat(thrown).doesNotThrowAnyException();
-      transaction.commit();
-    }
+    // The put record has SOME_COLUMN="aaa", which does not satisfy SOME_COLUMN > "aaa"
+    assertThat(results).isEmpty();
   }
 
   @ParameterizedTest
@@ -6619,8 +6465,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scan_ScanWithIndexGiven_WithSerializable_ShouldThrowIllegalArgumentException()
-      throws TransactionException {
+  public void scan_ScanWithIndexGiven_WithSerializable_ShouldScan() throws TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
     manager.mutate(
@@ -6661,23 +6506,30 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                 .intValue(BALANCE, INITIAL_BALANCE)
                 .build()));
 
-    // Act Assert
+    // Act
     DistributedTransaction transaction = manager.begin();
-    // Index scans are not allowed in SERIALIZABLE isolation
-    assertThatThrownBy(
-            () ->
-                transaction.scan(
-                    Scan.newBuilder()
-                        .namespace(namespace1)
-                        .table(TABLE_1)
-                        .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
-                        .build()))
-        .isInstanceOf(IllegalArgumentException.class);
+    List<Result> results =
+        transaction.scan(
+            Scan.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
+                .build());
+    transaction.commit();
+
+    // Assert
+    assertThat(results).hasSize(5);
+    Set<Integer> accountIds = new HashSet<>();
+    for (Result result : results) {
+      assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+      assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      accountIds.add(result.getInt(ACCOUNT_ID));
+    }
+    assertThat(accountIds).containsExactlyInAnyOrder(0, 1, 2, 3, 4);
   }
 
   @Test
-  public void get_GetWithIndexGiven_WithSerializable_ShouldThrowIllegalArgumentException()
-      throws TransactionException {
+  public void get_GetWithIndexGiven_WithSerializable_ShouldGet() throws TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
     manager.insert(
@@ -6689,19 +6541,22 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .intValue(BALANCE, INITIAL_BALANCE)
             .build());
 
-    // Act Assert
+    // Act
     DistributedTransaction transaction = manager.begin();
+    Optional<Result> result =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
+                .build());
+    transaction.commit();
 
-    // Index gets are not allowed in SERIALIZABLE isolation
-    assertThatThrownBy(
-            () ->
-                transaction.get(
-                    Get.newBuilder()
-                        .namespace(namespace1)
-                        .table(TABLE_1)
-                        .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
-                        .build()))
-        .isInstanceOf(IllegalArgumentException.class);
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
   }
 
   @Test
@@ -9159,6 +9014,220 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .isEqualTo(TransactionState.ABORTED);
     assertThat(coordinator.getState(failingTxn2.getId()).get().getState())
         .isEqualTo(TransactionState.ABORTED);
+  }
+
+  @Test
+  public void
+      commit_GetWithIndexInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException()
+          throws ExecutionException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
+
+    // Start a SERIALIZABLE transaction and get with index
+    DistributedTransaction transaction = manager.begin();
+    Get get = prepareGetWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    Optional<Result> result = transaction.get(get);
+    assertThat(result).isEmpty();
+
+    // After the read, insert a PREPARED record (0,0) via DistributedStorage
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    // Act Assert
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      commit_ScanWithIndexInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException()
+          throws ExecutionException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
+
+    // Create committed records (0,0) and (0,2) with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 0, INITIAL_BALANCE);
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 2, INITIAL_BALANCE);
+
+    // Start a SERIALIZABLE transaction and scan with index
+    DistributedTransaction transaction = manager.begin();
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    List<Result> results = transaction.scan(scan);
+    assertThat(results.size()).isEqualTo(2);
+
+    // After the read, insert a PREPARED record (0,1) via DistributedStorage
+    // This simulates another transaction that changed BALANCE from INITIAL_BALANCE to NEW_BALANCE
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    // Act Assert
+    // toSerializable should detect the PREPARED record via before-image index and throw
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      commit_ScanAllWithIndexConditionInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException()
+          throws ExecutionException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
+
+    // Create committed records (0,0) and (0,2) with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 0, INITIAL_BALANCE);
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 2, INITIAL_BALANCE);
+
+    // Start a SERIALIZABLE transaction and scan all with balance condition
+    DistributedTransaction transaction = manager.begin();
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    List<Result> results = transaction.scan(scan);
+    assertThat(results.size()).isEqualTo(2);
+
+    // After the read, insert a PREPARED record (0,1) via DistributedStorage
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    // Act Assert
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      commit_GetScannerWithIndexInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException()
+          throws ExecutionException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
+
+    // Create committed records (0,0) and (0,2) with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 0, INITIAL_BALANCE);
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 2, INITIAL_BALANCE);
+
+    // Start a SERIALIZABLE transaction and scan with index via getScanner
+    DistributedTransaction transaction = manager.begin();
+    Scan scan = prepareScanWithIndex(namespace1, TABLE_1, INITIAL_BALANCE);
+    List<Result> results;
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      results = scanner.all();
+    }
+    assertThat(results.size()).isEqualTo(2);
+
+    // After the read, insert a PREPARED record (0,1) via DistributedStorage
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    // Act Assert
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      commit_GetScannerWithScanAllIndexConditionInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException()
+          throws ExecutionException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SERIALIZABLE);
+
+    // Create committed records (0,0) and (0,2) with BALANCE=INITIAL_BALANCE
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 0, INITIAL_BALANCE);
+    populateCommittedRecordWithBalance(storage, namespace1, TABLE_1, 0, 2, INITIAL_BALANCE);
+
+    // Start a SERIALIZABLE transaction and scan all with balance condition via getScanner
+    DistributedTransaction transaction = manager.begin();
+    Scan scan = prepareScanAllWithBalanceCondition(namespace1, TABLE_1, INITIAL_BALANCE);
+    List<Result> results;
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      results = scanner.all();
+    }
+    assertThat(results.size()).isEqualTo(2);
+
+    // After the read, insert a PREPARED record (0,1) via DistributedStorage
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+            .intValue(BALANCE, NEW_BALANCE)
+            .textValue(Attribute.ID, ANY_ID_2)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INITIAL_BALANCE)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    storage.put(put);
+
+    // Act Assert
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
   }
 
   private DistributedTransaction prepareTransfer(


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3463
- **Commit to backport:** e657e81e1d90fac9fb1d66f4cecc8c20463cdac4

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-3463 &&
git cherry-pick --no-rerere-autoupdate -m1 e657e81e1d90fac9fb1d66f4cecc8c20463cdac4
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!