### PR TITLE
Fix before-image index validation to exclude primary key columns and fix RuntimeException handling

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1180,13 +1180,13 @@ public enum CoreError implements ScalarDbError {
       "A transaction conflict occurred in the mutation. Details: %s",
       "",
       ""),
-  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED(
+  CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED(
       Category.CONCURRENCY_ERROR,
       "0028",
       "Before-image index recovery retry limit exceeded. Transaction ID: %s",
       "",
       ""),
-  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER(
+  CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_NEEDED_IN_SCANNER(
       Category.CONCURRENCY_ERROR,
       "0029",
       "Records that need recovery were found during the before-image index check when closing the scanner. Transaction ID: %s",

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -98,7 +98,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   protected ConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -136,7 +136,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -707,7 +707,7 @@ public final class ConsensusCommitUtils {
    * @param admin a distributed storage admin
    * @param config a consensus commit config
    */
-  static void warnIfBeforeImageIndexesAreMissing(
+  static void warnIfBeforeIndexesAreMissing(
       DistributedStorageAdmin admin, ConsensusCommitConfig config) {
     if (config.getIsolation() == Isolation.SERIALIZABLE
         || config.isIndexEventuallyConsistentReadEnabled()) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -175,7 +175,7 @@ public class CrudHandler {
       if (beforeIndexCheckRequired && checkAndRecoverBeforeIndexRecords(get, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
                   .buildMessage(context.transactionId),
               context.transactionId);
         }
@@ -292,7 +292,7 @@ public class CrudHandler {
           && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
                   .buildMessage(context.transactionId),
               context.transactionId);
         }
@@ -621,7 +621,7 @@ public class CrudHandler {
    * index check feature was introduced), the check is skipped. In SNAPSHOT and READ_COMMITTED
    * isolation, this means index-based reads may return eventually consistent results, which is a
    * known limitation (a warning is logged at startup via {@code
-   * warnIfBeforeImageIndexesAreMissing}). In SERIALIZABLE isolation, this case does not occur
+   * warnIfBeforeIndexesAreMissing}). In SERIALIZABLE isolation, this case does not occur
    * because {@link ConsensusCommitOperationChecker} rejects index-based operations on tables
    * without before-image indexes.
    *
@@ -866,7 +866,7 @@ public class CrudHandler {
       if (requiresBeforeIndexCheck(scan, txMetadata)
           && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
         throw new CrudConflictException(
-            CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER.buildMessage(
+            CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_NEEDED_IN_SCANNER.buildMessage(
                 context.transactionId),
             context.transactionId);
       }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -272,17 +272,15 @@ public class CrudHandler {
           }
         }
       } catch (RuntimeException e) {
-        Exception exception;
         if (e.getCause() instanceof ExecutionException) {
-          exception = (ExecutionException) e.getCause();
-        } else {
-          exception = e;
+          ExecutionException cause = (ExecutionException) e.getCause();
+          throw new CrudException(
+              CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
+                  cause.getMessage()),
+              cause,
+              context.transactionId);
         }
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
-                exception.getMessage()),
-            exception,
-            context.transactionId);
+        throw e;
       } catch (IOException e) {
         logger.warn("Failed to close the scanner. Transaction ID: {}", context.transactionId, e);
       }
@@ -723,17 +721,15 @@ public class CrudHandler {
         }
       }
     } catch (RuntimeException e) {
-      Exception exception;
       if (e.getCause() instanceof ExecutionException) {
-        exception = (ExecutionException) e.getCause();
-      } else {
-        exception = e;
+        ExecutionException cause = (ExecutionException) e.getCause();
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
+                cause.getMessage()),
+            cause,
+            context.transactionId);
       }
-      throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(
-              exception.getMessage()),
-          exception,
-          context.transactionId);
+      throw e;
     } catch (ExecutionException e) {
       throw new CrudException(
           CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -175,8 +175,8 @@ public class CrudHandler {
       if (beforeIndexCheckRequired && checkAndRecoverBeforeIndexRecords(get, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
-                  .buildMessage(context.transactionId),
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED.buildMessage(
+                  context.transactionId),
               context.transactionId);
         }
         continue;
@@ -292,8 +292,8 @@ public class CrudHandler {
           && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
-                  .buildMessage(context.transactionId),
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED.buildMessage(
+                  context.transactionId),
               context.transactionId);
         }
         continue;
@@ -620,10 +620,10 @@ public class CrudHandler {
    * <p>If the before-image index does not exist (e.g., for tables created before the before-image
    * index check feature was introduced), the check is skipped. In SNAPSHOT and READ_COMMITTED
    * isolation, this means index-based reads may return eventually consistent results, which is a
-   * known limitation (a warning is logged at startup via {@code
-   * warnIfBeforeIndexesAreMissing}). In SERIALIZABLE isolation, this case does not occur
-   * because {@link ConsensusCommitOperationChecker} rejects index-based operations on tables
-   * without before-image indexes.
+   * known limitation (a warning is logged at startup via {@code warnIfBeforeIndexesAreMissing}). In
+   * SERIALIZABLE isolation, this case does not occur because {@link
+   * ConsensusCommitOperationChecker} rejects index-based operations on tables without before-image
+   * indexes.
    *
    * @param selection the selection operation
    * @param metadata the transaction table metadata

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -891,6 +891,10 @@ public class Snapshot {
    * validation. This includes Get with index, Scan with index, and ScanAll with conditions on
    * indexed columns.
    *
+   * <p>Primary key columns (partition keys and clustering keys) are excluded because they are
+   * immutable and do not have corresponding before-image columns, so before-image index validation
+   * is not needed for them.
+   *
    * <p>For ScanAll, whether the underlying storage actually uses the index depends on the storage
    * implementation. However, this method considers ScanAll with conditions on indexed columns as an
    * index-based operation regardless.
@@ -899,14 +903,20 @@ public class Snapshot {
    * @param metadata the table metadata
    * @return true if the selection is an index-based operation
    */
-  private boolean isIndexBasedOperation(Selection selection, TableMetadata metadata) {
+  @VisibleForTesting
+  boolean isIndexBasedOperation(Selection selection, TableMetadata metadata) {
     if (ScalarDbUtils.isSecondaryIndexSpecified(selection, metadata)) {
-      return true;
+      String indexColumnName = selection.getPartitionKey().getColumns().get(0).getName();
+      return !metadata.getPartitionKeyNames().contains(indexColumnName)
+          && !metadata.getClusteringKeyNames().contains(indexColumnName);
     }
     if (selection instanceof ScanAll) {
       for (Selection.Conjunction conjunction : selection.getConjunctions()) {
         for (ConditionalExpression condition : conjunction.getConditions()) {
-          if (metadata.getSecondaryIndexNames().contains(condition.getColumn().getName())) {
+          String columnName = condition.getColumn().getName();
+          if (metadata.getSecondaryIndexNames().contains(columnName)
+              && !metadata.getPartitionKeyNames().contains(columnName)
+              && !metadata.getClusteringKeyNames().contains(columnName)) {
             return true;
           }
         }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -851,7 +851,7 @@ public class Snapshot {
   private void validateBeforeIndex(
       DistributedStorage storage, Selection selection, TransactionTableMetadata txMetadata)
       throws ExecutionException, ValidationConflictException {
-    if (!isIndexBasedOperation(selection, txMetadata.getTableMetadata())) {
+    if (!requiresBeforeIndexValidation(selection, txMetadata.getTableMetadata())) {
       return;
     }
 
@@ -887,24 +887,24 @@ public class Snapshot {
   }
 
   /**
-   * Checks if the given selection is an index-based operation that requires before-image index
-   * validation. This includes Get with index, Scan with index, and ScanAll with conditions on
-   * indexed columns.
+   * Checks if the given selection requires before-image index validation. This is true when the
+   * selection is an index-based operation (Get with index, Scan with index, or ScanAll with
+   * conditions on indexed columns) and the index column is a non-primary-key column.
    *
    * <p>Primary key columns (partition keys and clustering keys) are excluded because they are
    * immutable and do not have corresponding before-image columns, so before-image index validation
    * is not needed for them.
    *
    * <p>For ScanAll, whether the underlying storage actually uses the index depends on the storage
-   * implementation. However, this method considers ScanAll with conditions on indexed columns as an
-   * index-based operation regardless.
+   * implementation. However, this method considers ScanAll with conditions on indexed columns as
+   * requiring before-image index validation regardless.
    *
    * @param selection the selection operation to check
    * @param metadata the table metadata
-   * @return true if the selection is an index-based operation
+   * @return true if the selection requires before-image index validation
    */
   @VisibleForTesting
-  boolean isIndexBasedOperation(Selection selection, TableMetadata metadata) {
+  boolean requiresBeforeIndexValidation(Selection selection, TableMetadata metadata) {
     if (ScalarDbUtils.isSecondaryIndexSpecified(selection, metadata)) {
       String indexColumnName = selection.getPartitionKey().getColumns().get(0).getName();
       return !metadata.getPartitionKeyNames().contains(indexColumnName)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -106,7 +106,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   public TwoPhaseConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -149,7 +149,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
             storageInfoProvider,
             config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -403,7 +403,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void createIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotCreateBeforeImageIndex()
+  public void createIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotCreateBeforeIndex()
       throws ExecutionException {
     // Arrange
     when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
@@ -450,7 +450,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void dropIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotDropBeforeImageIndex()
+  public void dropIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotDropBeforeIndex()
       throws ExecutionException {
     // Arrange
     when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
@@ -396,7 +396,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForGet_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForGet_WithSecondaryIndexInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
     TableMetadata metadata =
         TableMetadata.newBuilder()
@@ -583,7 +583,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForScan_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForScan_WithSecondaryIndexInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
     TableMetadata metadata =
         TableMetadata.newBuilder()
@@ -745,7 +745,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForScan_ScanAllWithConditionOnIndexedColumnInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForScan_ScanAllWithConditionOnIndexedColumnInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
 
     // Mock the underlying TableMetadata

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -1747,8 +1747,34 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void scan_RuntimeExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
-      throws ExecutionException, IOException {
+  public void
+      scan_RuntimeExceptionWithExecutionExceptionCauseThrownByIteratorHasNext_ShouldThrowCrudException()
+          throws ExecutionException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    ExecutionException executionException = mock(ExecutionException.class);
+    RuntimeException runtimeException = new RuntimeException(executionException);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    when(scanner.iterator()).thenReturn(iterator);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan, context))
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      scan_RuntimeExceptionWithoutExecutionExceptionCauseThrownByIteratorHasNext_ShouldThrowRuntimeException()
+          throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
@@ -1762,9 +1788,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.scan(scan, context))
-        .isInstanceOf(CrudException.class)
-        .hasCause(runtimeException);
+    assertThatThrownBy(() -> handler.scan(scan, context)).isSameAs(runtimeException);
 
     verify(scanner).close();
   }
@@ -2977,6 +3001,60 @@ public class CrudHandlerTest {
     verify(recoveryFuture, never()).get();
     assertThat(context.recoveryResults).hasSize(1);
     assertThat(context.recoveryResults.get(0)).isSameAs(recoveryResult);
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RuntimeExceptionWithExecutionExceptionCauseThrown_ShouldThrowCrudException()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    ExecutionException executionException = mock(ExecutionException.class);
+    RuntimeException runtimeException = new RuntimeException(executionException);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(iterator);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                handler.checkAndRecoverBeforeIndexRecords(
+                    scanWithIndex, context, TRANSACTION_TABLE_METADATA))
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RuntimeExceptionWithoutExecutionExceptionCauseThrown_ShouldThrowRuntimeException()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    RuntimeException runtimeException = mock(RuntimeException.class);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(iterator);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                handler.checkAndRecoverBeforeIndexRecords(
+                    scanWithIndex, context, TRANSACTION_TABLE_METADATA))
+        .isSameAs(runtimeException);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -2620,33 +2620,33 @@ public class SnapshotTest {
   }
 
   @Test
-  public void isIndexBasedOperation_GetWithSecondaryIndex_ShouldReturnTrue() {
+  public void requiresBeforeIndexValidation_GetWithSecondaryIndex_ShouldReturnTrue() {
     // Arrange
     snapshot = prepareSnapshot();
     Get get = prepareGetWithIndex();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA);
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA);
 
     // Assert
     assertThat(result).isTrue();
   }
 
   @Test
-  public void isIndexBasedOperation_ScanWithSecondaryIndex_ShouldReturnTrue() {
+  public void requiresBeforeIndexValidation_ScanWithSecondaryIndex_ShouldReturnTrue() {
     // Arrange
     snapshot = prepareSnapshot();
     Scan scan = prepareScanWithIndex();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(scan, TABLE_METADATA);
+    boolean result = snapshot.requiresBeforeIndexValidation(scan, TABLE_METADATA);
 
     // Assert
     assertThat(result).isTrue();
   }
 
   @Test
-  public void isIndexBasedOperation_GetWithPartitionKeyIndex_ShouldReturnFalse() {
+  public void requiresBeforeIndexValidation_GetWithPartitionKeyIndex_ShouldReturnFalse() {
     // Arrange
     snapshot = prepareSnapshot();
     Get get =
@@ -2657,27 +2657,28 @@ public class SnapshotTest {
             .build();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA_WITH_PK_INDEX);
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA_WITH_PK_INDEX);
 
     // Assert
     assertThat(result).isFalse();
   }
 
   @Test
-  public void isIndexBasedOperation_GetWithPartitionKey_ShouldReturnFalse() {
+  public void requiresBeforeIndexValidation_GetWithPartitionKey_ShouldReturnFalse() {
     // Arrange
     snapshot = prepareSnapshot();
     Get get = prepareGet();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA);
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA);
 
     // Assert
     assertThat(result).isFalse();
   }
 
   @Test
-  public void isIndexBasedOperation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
+  public void
+      requiresBeforeIndexValidation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
     // Arrange
     snapshot = prepareSnapshot();
     Scan scanAll =
@@ -2689,14 +2690,15 @@ public class SnapshotTest {
             .build();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA);
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA);
 
     // Assert
     assertThat(result).isTrue();
   }
 
   @Test
-  public void isIndexBasedOperation_ScanAllWithPartitionKeyIndexCondition_ShouldReturnFalse() {
+  public void
+      requiresBeforeIndexValidation_ScanAllWithPartitionKeyIndexCondition_ShouldReturnFalse() {
     // Arrange
     snapshot = prepareSnapshot();
     Scan scanAll =
@@ -2708,14 +2710,16 @@ public class SnapshotTest {
             .build();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
+    boolean result =
+        snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
 
     // Assert
     assertThat(result).isFalse();
   }
 
   @Test
-  public void isIndexBasedOperation_ScanAllWithNonIndexedColumnCondition_ShouldReturnFalse() {
+  public void
+      requiresBeforeIndexValidation_ScanAllWithNonIndexedColumnCondition_ShouldReturnFalse() {
     // Arrange
     snapshot = prepareSnapshot();
     Scan scanAll =
@@ -2727,7 +2731,7 @@ public class SnapshotTest {
             .build();
 
     // Act
-    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA);
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA);
 
     // Assert
     assertThat(result).isFalse();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -90,6 +90,20 @@ public class SnapshotTest {
               .addSecondaryIndex(ANY_NAME_4)
               .build());
 
+  // Table metadata where the partition key is also a secondary index
+  private static final TableMetadata TABLE_METADATA_WITH_PK_INDEX =
+      ConsensusCommitUtils.buildTransactionTableMetadata(
+          TableMetadata.newBuilder()
+              .addColumn(ANY_NAME_1, DataType.TEXT)
+              .addColumn(ANY_NAME_2, DataType.TEXT)
+              .addColumn(ANY_NAME_3, DataType.TEXT)
+              .addColumn(ANY_NAME_4, DataType.TEXT)
+              .addPartitionKey(ANY_NAME_1)
+              .addClusteringKey(ANY_NAME_2)
+              .addSecondaryIndex(ANY_NAME_1)
+              .addSecondaryIndex(ANY_NAME_4)
+              .build());
+
   private Snapshot snapshot;
   private ConcurrentMap<Snapshot.Key, Optional<TransactionResult>> readSet;
   private ConcurrentMap<Get, Optional<TransactionResult>> getSet;
@@ -2603,5 +2617,119 @@ public class SnapshotTest {
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void isIndexBasedOperation_GetWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get = prepareGetWithIndex();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isIndexBasedOperation_ScanWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scan = prepareScanWithIndex();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(scan, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isIndexBasedOperation_GetWithPartitionKeyIndex_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .indexKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .build();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA_WITH_PK_INDEX);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isIndexBasedOperation_GetWithPartitionKey_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get = prepareGet();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(get, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isIndexBasedOperation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_4))
+            .build();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isIndexBasedOperation_ScanAllWithPartitionKeyIndexCondition_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_1).isEqualToText(ANY_TEXT_1))
+            .build();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isIndexBasedOperation_ScanAllWithNonIndexedColumnCondition_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+            .build();
+
+    // Act
+    boolean result = snapshot.isIndexBasedOperation(scanAll, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isFalse();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -2677,8 +2677,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void
-      requiresBeforeIndexValidation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
+  public void requiresBeforeIndexValidation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
     // Arrange
     snapshot = prepareSnapshot();
     Scan scanAll =
@@ -2710,8 +2709,7 @@ public class SnapshotTest {
             .build();
 
     // Act
-    boolean result =
-        snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
 
     // Assert
     assertThat(result).isFalse();


### PR DESCRIPTION
## Description

This PR fixes issues found in the review comments of the backport PRs (#3483, #3484, #3485) for #3463.

1. `isIndexBasedOperation` in `Snapshot` did not exclude primary key columns (partition keys and clustering keys). Since primary key columns are immutable and do not have corresponding before-image columns, before-image index validation is not needed for them. Including them could cause errors when `validateBeforeIndex` attempts to scan non-existent `before_*` columns.
2. The `RuntimeException` handling in `CrudHandler` wrapped all `RuntimeExceptions` into `CrudException`, which could mask programming errors (e.g., NPE) as storage scanning failures. This has been fixed to only wrap `RuntimeException`s whose cause is `ExecutionException`, consistent with the handling in `Snapshot.validateBeforeIndex`.

Additionally, this PR includes the following improvement:

3. Identifiers (method names, constant names, test method names) inconsistently used `BeforeImageIndex` and `BeforeIndex`. This has been unified to `BeforeIndex`.

## Related issues and/or PRs

- #3483
- #3484
- #3485

## Changes made

- Fixed `isIndexBasedOperation` in `Snapshot` to exclude primary key columns from before-image index validation, and renamed it to `requiresBeforeIndexValidation` to better reflect its purpose.
- Updated the Javadoc of `requiresBeforeIndexValidation` to document the primary key exclusion.
- Fixed `RuntimeException` handling in `CrudHandler.scanFromBeforeIndex` and `CrudHandler.checkAndRecoverBeforeIndexRecords` to rethrow `RuntimeExceptions` that do not wrap `ExecutionException`.
- Unified `BeforeImageIndex` to `BeforeIndex` in identifiers across `CoreError`, `ConsensusCommitUtils`, `ConsensusCommitManager`, `TwoPhaseConsensusCommitManager`, `CrudHandler`, and related test classes.
- Added unit tests for `requiresBeforeIndexValidation`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A