### PR TITLE
Backport to branch(3.16) : Fix before-image index validation to exclude primary key columns and fix RuntimeException handling

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -830,13 +830,13 @@ public enum CoreError implements ScalarDbError {
       ""),
   CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_RECORDS(
       Category.CONCURRENCY_ERROR, "0026", "A conflict occurred when committing records", "", ""),
-  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED(
+  CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED(
       Category.CONCURRENCY_ERROR,
       "0028",
       "Before-image index recovery retry limit exceeded. Transaction ID: %s",
       "",
       ""),
-  CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER(
+  CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_NEEDED_IN_SCANNER(
       Category.CONCURRENCY_ERROR,
       "0029",
       "Records that need recovery were found during the before-image index check when closing the scanner. Transaction ID: %s",

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -89,7 +89,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         new ConsensusCommitOperationChecker(
             tableMetadataManager, config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   protected ConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -121,7 +121,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         new ConsensusCommitOperationChecker(
             tableMetadataManager, config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -651,7 +651,7 @@ public final class ConsensusCommitUtils {
    * @param admin a distributed storage admin
    * @param config a consensus commit config
    */
-  static void warnIfBeforeImageIndexesAreMissing(
+  static void warnIfBeforeIndexesAreMissing(
       DistributedStorageAdmin admin, ConsensusCommitConfig config) {
     if (config.getIsolation() == Isolation.SERIALIZABLE
         || config.isIndexEventuallyConsistentReadEnabled()) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -175,8 +175,8 @@ public class CrudHandler {
       if (beforeIndexCheckRequired && checkAndRecoverBeforeIndexRecords(get, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
-                  .buildMessage(context.transactionId),
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED.buildMessage(
+                  context.transactionId),
               context.transactionId);
         }
         continue;
@@ -272,16 +272,14 @@ public class CrudHandler {
           }
         }
       } catch (RuntimeException e) {
-        Exception exception;
         if (e.getCause() instanceof ExecutionException) {
-          exception = (ExecutionException) e.getCause();
-        } else {
-          exception = e;
+          ExecutionException cause = (ExecutionException) e.getCause();
+          throw new CrudException(
+              CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
+              cause,
+              context.transactionId);
         }
-        throw new CrudException(
-            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
-            exception,
-            context.transactionId);
+        throw e;
       } catch (IOException e) {
         logger.warn("Failed to close the scanner. Transaction ID: {}", context.transactionId, e);
       }
@@ -293,8 +291,8 @@ public class CrudHandler {
           && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
         if (i >= MAX_BEFORE_INDEX_CHECK_RETRIES - 1) {
           throw new CrudConflictException(
-              CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED
-                  .buildMessage(context.transactionId),
+              CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_RETRY_LIMIT_EXCEEDED.buildMessage(
+                  context.transactionId),
               context.transactionId);
         }
         continue;
@@ -619,10 +617,10 @@ public class CrudHandler {
    * <p>If the before-image index does not exist (e.g., for tables created before the before-image
    * index check feature was introduced), the check is skipped. In SNAPSHOT and READ_COMMITTED
    * isolation, this means index-based reads may return eventually consistent results, which is a
-   * known limitation (a warning is logged at startup via {@code
-   * warnIfBeforeImageIndexesAreMissing}). In SERIALIZABLE isolation, this case does not occur
-   * because {@link ConsensusCommitOperationChecker} rejects index-based operations on tables
-   * without before-image indexes.
+   * known limitation (a warning is logged at startup via {@code warnIfBeforeIndexesAreMissing}). In
+   * SERIALIZABLE isolation, this case does not occur because {@link
+   * ConsensusCommitOperationChecker} rejects index-based operations on tables without before-image
+   * indexes.
    *
    * @param selection the selection operation
    * @param metadata the transaction table metadata
@@ -720,16 +718,14 @@ public class CrudHandler {
         }
       }
     } catch (RuntimeException e) {
-      Exception exception;
       if (e.getCause() instanceof ExecutionException) {
-        exception = (ExecutionException) e.getCause();
-      } else {
-        exception = e;
+        ExecutionException cause = (ExecutionException) e.getCause();
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
+            cause,
+            context.transactionId);
       }
-      throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
-          exception,
-          context.transactionId);
+      throw e;
     } catch (ExecutionException e) {
       throw new CrudException(
           CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
@@ -864,7 +860,7 @@ public class CrudHandler {
       if (requiresBeforeIndexCheck(scan, txMetadata)
           && checkAndRecoverBeforeIndexRecords(scan, context, txMetadata)) {
         throw new CrudConflictException(
-            CoreError.CONSENSUS_COMMIT_BEFORE_IMAGE_INDEX_RECOVERY_NEEDED_IN_SCANNER.buildMessage(
+            CoreError.CONSENSUS_COMMIT_BEFORE_INDEX_RECOVERY_NEEDED_IN_SCANNER.buildMessage(
                 context.transactionId),
             context.transactionId);
       }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -823,7 +823,7 @@ public class Snapshot {
   private void validateBeforeIndex(
       DistributedStorage storage, Selection selection, TransactionTableMetadata txMetadata)
       throws ExecutionException, ValidationConflictException {
-    if (!isIndexBasedOperation(selection, txMetadata.getTableMetadata())) {
+    if (!requiresBeforeIndexValidation(selection, txMetadata.getTableMetadata())) {
       return;
     }
 
@@ -859,26 +859,36 @@ public class Snapshot {
   }
 
   /**
-   * Checks if the given selection is an index-based operation that requires before-image index
-   * validation. This includes Get with index, Scan with index, and ScanAll with conditions on
-   * indexed columns.
+   * Checks if the given selection requires before-image index validation. This is true when the
+   * selection is an index-based operation (Get with index, Scan with index, or ScanAll with
+   * conditions on indexed columns) and the index column is a non-primary-key column.
+   *
+   * <p>Primary key columns (partition keys and clustering keys) are excluded because they are
+   * immutable and do not have corresponding before-image columns, so before-image index validation
+   * is not needed for them.
    *
    * <p>For ScanAll, whether the underlying storage actually uses the index depends on the storage
-   * implementation. However, this method considers ScanAll with conditions on indexed columns as an
-   * index-based operation regardless.
+   * implementation. However, this method considers ScanAll with conditions on indexed columns as
+   * requiring before-image index validation regardless.
    *
    * @param selection the selection operation to check
    * @param metadata the table metadata
-   * @return true if the selection is an index-based operation
+   * @return true if the selection requires before-image index validation
    */
-  private boolean isIndexBasedOperation(Selection selection, TableMetadata metadata) {
+  @VisibleForTesting
+  boolean requiresBeforeIndexValidation(Selection selection, TableMetadata metadata) {
     if (ScalarDbUtils.isSecondaryIndexSpecified(selection, metadata)) {
-      return true;
+      String indexColumnName = selection.getPartitionKey().getColumns().get(0).getName();
+      return !metadata.getPartitionKeyNames().contains(indexColumnName)
+          && !metadata.getClusteringKeyNames().contains(indexColumnName);
     }
     if (selection instanceof ScanAll) {
       for (Selection.Conjunction conjunction : selection.getConjunctions()) {
         for (ConditionalExpression condition : conjunction.getConditions()) {
-          if (metadata.getSecondaryIndexNames().contains(condition.getColumn().getName())) {
+          String columnName = condition.getColumn().getName();
+          if (metadata.getSecondaryIndexNames().contains(columnName)
+              && !metadata.getPartitionKeyNames().contains(columnName)
+              && !metadata.getClusteringKeyNames().contains(columnName)) {
             return true;
           }
         }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -97,7 +97,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         new ConsensusCommitOperationChecker(
             tableMetadataManager, config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   public TwoPhaseConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -134,7 +134,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         new ConsensusCommitOperationChecker(
             tableMetadataManager, config.isIncludeMetadataEnabled());
 
-    ConsensusCommitUtils.warnIfBeforeImageIndexesAreMissing(admin, config);
+    ConsensusCommitUtils.warnIfBeforeIndexesAreMissing(admin, config);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -449,7 +449,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void createIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotCreateBeforeImageIndex()
+  public void createIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotCreateBeforeIndex()
       throws ExecutionException {
     // Arrange
     when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);
@@ -496,7 +496,7 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void dropIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotDropBeforeImageIndex()
+  public void dropIndex_WithIndexEventuallyConsistentReadEnabled_ShouldNotDropBeforeIndex()
       throws ExecutionException {
     // Arrange
     when(config.isIndexEventuallyConsistentReadEnabled()).thenReturn(true);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationCheckerTest.java
@@ -328,7 +328,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForGet_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForGet_WithSecondaryIndexInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
     TableMetadata metadata =
         TableMetadata.newBuilder()
@@ -512,7 +512,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForScan_WithSecondaryIndexInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForScan_WithSecondaryIndexInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
     TableMetadata metadata =
         TableMetadata.newBuilder()
@@ -674,7 +674,7 @@ public class ConsensusCommitOperationCheckerTest {
 
   @Test
   public void
-      checkForScan_ScanAllWithConditionOnIndexedColumnInSerializableAndBeforeImageIndexExists_ShouldNotThrowException() {
+      checkForScan_ScanAllWithConditionOnIndexedColumnInSerializableAndBeforeIndexExists_ShouldNotThrowException() {
     // Arrange
 
     // Mock the underlying TableMetadata

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -1743,8 +1743,34 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void scan_RuntimeExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
-      throws ExecutionException, IOException {
+  public void
+      scan_RuntimeExceptionWithExecutionExceptionCauseThrownByIteratorHasNext_ShouldThrowCrudException()
+          throws ExecutionException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    ExecutionException executionException = mock(ExecutionException.class);
+    RuntimeException runtimeException = new RuntimeException(executionException);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    when(scanner.iterator()).thenReturn(iterator);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan, context))
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      scan_RuntimeExceptionWithoutExecutionExceptionCauseThrownByIteratorHasNext_ShouldThrowRuntimeException()
+          throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
@@ -1758,9 +1784,7 @@ public class CrudHandlerTest {
         new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.scan(scan, context))
-        .isInstanceOf(CrudException.class)
-        .hasCause(runtimeException);
+    assertThatThrownBy(() -> handler.scan(scan, context)).isSameAs(runtimeException);
 
     verify(scanner).close();
   }
@@ -2973,6 +2997,60 @@ public class CrudHandlerTest {
     verify(recoveryFuture, never()).get();
     assertThat(context.recoveryResults).hasSize(1);
     assertThat(context.recoveryResults.get(0)).isSameAs(recoveryResult);
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RuntimeExceptionWithExecutionExceptionCauseThrown_ShouldThrowCrudException()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    ExecutionException executionException = mock(ExecutionException.class);
+    RuntimeException runtimeException = new RuntimeException(executionException);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(iterator);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                handler.checkAndRecoverBeforeIndexRecords(
+                    scanWithIndex, context, TRANSACTION_TABLE_METADATA))
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+  }
+
+  @Test
+  public void
+      checkAndRecoverBeforeIndexRecords_RuntimeExceptionWithoutExecutionExceptionCauseThrown_ShouldThrowRuntimeException()
+          throws Exception {
+    // Arrange
+    Scan scanWithIndex = prepareScanWithIndex();
+    Scan expectedBeforeIndexScan = prepareExpectedBeforeIndexScan();
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    RuntimeException runtimeException = mock(RuntimeException.class);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    Scanner beforeIndexScanner = mock(Scanner.class);
+    when(beforeIndexScanner.iterator()).thenReturn(iterator);
+    when(storage.scan(expectedBeforeIndexScan)).thenReturn(beforeIndexScanner);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                handler.checkAndRecoverBeforeIndexRecords(
+                    scanWithIndex, context, TRANSACTION_TABLE_METADATA))
+        .isSameAs(runtimeException);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -94,6 +94,20 @@ public class SnapshotTest {
               .addSecondaryIndex(ANY_NAME_4)
               .build());
 
+  // Table metadata where the partition key is also a secondary index
+  private static final TableMetadata TABLE_METADATA_WITH_PK_INDEX =
+      ConsensusCommitUtils.buildTransactionTableMetadata(
+          TableMetadata.newBuilder()
+              .addColumn(ANY_NAME_1, DataType.TEXT)
+              .addColumn(ANY_NAME_2, DataType.TEXT)
+              .addColumn(ANY_NAME_3, DataType.TEXT)
+              .addColumn(ANY_NAME_4, DataType.TEXT)
+              .addPartitionKey(ANY_NAME_1)
+              .addClusteringKey(ANY_NAME_2)
+              .addSecondaryIndex(ANY_NAME_1)
+              .addSecondaryIndex(ANY_NAME_4)
+              .build());
+
   private Snapshot snapshot;
   private ConcurrentMap<Snapshot.Key, Optional<TransactionResult>> readSet;
   private ConcurrentMap<Get, Optional<TransactionResult>> getSet;
@@ -2516,5 +2530,121 @@ public class SnapshotTest {
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void requiresBeforeIndexValidation_GetWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get = prepareGetWithIndex();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void requiresBeforeIndexValidation_ScanWithSecondaryIndex_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scan = prepareScanWithIndex();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(scan, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void requiresBeforeIndexValidation_GetWithPartitionKeyIndex_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .indexKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .build();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA_WITH_PK_INDEX);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void requiresBeforeIndexValidation_GetWithPartitionKey_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Get get = prepareGet();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(get, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void requiresBeforeIndexValidation_ScanAllWithSecondaryIndexCondition_ShouldReturnTrue() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_4))
+            .build();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void
+      requiresBeforeIndexValidation_ScanAllWithPartitionKeyIndexCondition_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_1).isEqualToText(ANY_TEXT_1))
+            .build();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA_WITH_PK_INDEX);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void
+      requiresBeforeIndexValidation_ScanAllWithNonIndexedColumnCondition_ShouldReturnFalse() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+            .build();
+
+    // Act
+    boolean result = snapshot.requiresBeforeIndexValidation(scanAll, TABLE_METADATA);
+
+    // Assert
+    assertThat(result).isFalse();
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3487
- **Commit to backport:** f7a818b6eebb1d1c7eec7610b0212b2812f27d95

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-3487 &&
git cherry-pick --no-rerere-autoupdate -m1 f7a818b6eebb1d1c7eec7610b0212b2812f27d95
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!