### PR TITLE
Backport to branch(3.17) : Shorten JDBC index names exceeding 63 characters using SHA-256 hash

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -695,4 +695,132 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   protected boolean isIndexOnBlobColumnSupported() {
     return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
   }
+
+  @Test
+  @DisabledIf("isDb2")
+  public void dropIndex_WithLongIndexNameCreatedByOldNaming_ShouldDropIndexByFallback()
+      throws Exception {
+    // Use a long column name that causes the index name to exceed the max length
+    // The column name is chosen so that the original index name
+    // (index_{namespace}_{table}_{column}) is exactly 64 characters, which exceeds the 63-character
+    // limit to trigger shortening but is still within MySQL's 64-character limit.
+    String longColumn = "long_column_name_for_testing1";
+    JdbcAdminTestUtils testUtils = (JdbcAdminTestUtils) getAdminTestUtils(getTestName());
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata tableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(longColumn, DataType.INT)
+              .addPartitionKey(getColumnName1())
+              .addSecondaryIndex(longColumn)
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), tableMetadata, options);
+
+      // Replace the shortened index with the old (long) naming convention
+      String shortenedIndexName = JdbcAdmin.getIndexName(getNamespace1(), getTable4(), longColumn);
+      String originalIndexName =
+          String.join("_", "index", getNamespace1(), getTable4(), longColumn);
+      assertThat(originalIndexName.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH + 1);
+      testUtils.dropIndex(getNamespace1(), getTable4(), shortenedIndexName);
+      testUtils.createIndex(getNamespace1(), getTable4(), longColumn, originalIndexName);
+
+      // Act Assert - dropIndex should succeed via fallback
+      assertThatCode(() -> admin.dropIndex(getNamespace1(), getTable4(), longColumn))
+          .doesNotThrowAnyException();
+      assertThat(admin.indexExists(getNamespace1(), getTable4(), longColumn)).isFalse();
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+      testUtils.close();
+    }
+  }
+
+  @Test
+  @DisabledIf("isDb2")
+  public void renameTable_WithLongIndexNameCreatedByOldNaming_ShouldRenameIndexByFallback()
+      throws Exception {
+    // The column name is chosen so that the original index name
+    // (index_{namespace}_{table}_{column}) is exactly 64 characters, which exceeds the 63-character
+    // limit to trigger shortening but is still within MySQL's 64-character limit.
+    String longColumn = "long_column_name_for_testing1";
+    String newTableName = "new" + getTable4();
+    JdbcAdminTestUtils testUtils = (JdbcAdminTestUtils) getAdminTestUtils(getTestName());
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata tableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(longColumn, DataType.INT)
+              .addPartitionKey(getColumnName1())
+              .addSecondaryIndex(longColumn)
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), tableMetadata, options);
+
+      // Replace the shortened index with the old (long) naming convention
+      String shortenedIndexName = JdbcAdmin.getIndexName(getNamespace1(), getTable4(), longColumn);
+      String originalIndexName =
+          String.join("_", "index", getNamespace1(), getTable4(), longColumn);
+      assertThat(originalIndexName.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH + 1);
+      testUtils.dropIndex(getNamespace1(), getTable4(), shortenedIndexName);
+      testUtils.createIndex(getNamespace1(), getTable4(), longColumn, originalIndexName);
+
+      // Act Assert - renameTable should succeed via fallback
+      assertThatCode(() -> admin.renameTable(getNamespace1(), getTable4(), newTableName))
+          .doesNotThrowAnyException();
+      assertThat(admin.tableExists(getNamespace1(), newTableName)).isTrue();
+      assertThat(admin.indexExists(getNamespace1(), newTableName, longColumn)).isTrue();
+
+      // Verify the renamed index can be dropped
+      assertThatCode(() -> admin.dropIndex(getNamespace1(), newTableName, longColumn))
+          .doesNotThrowAnyException();
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+      admin.dropTable(getNamespace1(), newTableName, true);
+      testUtils.close();
+    }
+  }
+
+  @Test
+  @DisabledIf("isDb2")
+  public void renameColumn_WithLongIndexNameCreatedByOldNaming_ShouldRenameIndexByFallback()
+      throws Exception {
+    // The column name is chosen so that the original index name
+    // (index_{namespace}_{table}_{column}) is exactly 64 characters, which exceeds the 63-character
+    // limit to trigger shortening but is still within MySQL's 64-character limit.
+    String longColumn = "long_column_name_for_testing1";
+    String newColumnName = "new_col";
+    JdbcAdminTestUtils testUtils = (JdbcAdminTestUtils) getAdminTestUtils(getTestName());
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata tableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(longColumn, DataType.INT)
+              .addPartitionKey(getColumnName1())
+              .addSecondaryIndex(longColumn)
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), tableMetadata, options);
+
+      // Replace the shortened index with the old (long) naming convention
+      String shortenedIndexName = JdbcAdmin.getIndexName(getNamespace1(), getTable4(), longColumn);
+      String originalIndexName =
+          String.join("_", "index", getNamespace1(), getTable4(), longColumn);
+      assertThat(originalIndexName.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH + 1);
+      testUtils.dropIndex(getNamespace1(), getTable4(), shortenedIndexName);
+      testUtils.createIndex(getNamespace1(), getTable4(), longColumn, originalIndexName);
+
+      // Act Assert - renameColumn should succeed via fallback
+      assertThatCode(
+              () -> admin.renameColumn(getNamespace1(), getTable4(), longColumn, newColumnName))
+          .doesNotThrowAnyException();
+      assertThat(admin.indexExists(getNamespace1(), getTable4(), newColumnName)).isTrue();
+      assertThat(admin.indexExists(getNamespace1(), getTable4(), longColumn)).isFalse();
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+      testUtils.close();
+    }
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -73,6 +73,34 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
     execute(deleteMetadataStatement);
   }
 
+  /**
+   * Creates an index with the specified index name.
+   *
+   * @param namespace the namespace of the table
+   * @param table the table name
+   * @param column the column name to create the index on
+   * @param indexName the index name to use
+   * @throws SQLException if a database error occurs
+   */
+  public void createIndex(String namespace, String table, String column, String indexName)
+      throws SQLException {
+    String sql = rdbEngine.createIndexSql(namespace, table, indexName, column);
+    execute(sql);
+  }
+
+  /**
+   * Drops an index with the specified index name.
+   *
+   * @param namespace the namespace of the table
+   * @param table the table name
+   * @param indexName the index name to drop
+   * @throws SQLException if a database error occurs
+   */
+  public void dropIndex(String namespace, String table, String indexName) throws SQLException {
+    String sql = rdbEngine.dropIndexSql(namespace, table, indexName);
+    execute(sql);
+  }
+
   private void execute(String sql) throws SQLException {
     withConnection(
         dataSource,

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.storage.jdbc.JdbcUtils.getJdbcType;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -961,6 +962,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
               tableMetadataBuilder.renameSecondaryIndex(oldColumnName, newColumnName);
             }
             TableMetadata updatedTableMetadata = tableMetadataBuilder.build();
+
             String renameColumnStatement =
                 rdbEngine.renameColumnSql(
                     namespace,
@@ -968,14 +970,13 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                     oldColumnName,
                     newColumnName,
                     getVendorDbColumnType(updatedTableMetadata, newColumnName));
-
             execute(connection, renameColumnStatement, requiresExplicitCommit);
+
             if (currentTableMetadata.getSecondaryIndexNames().contains(oldColumnName)) {
-              String oldIndexName = getIndexName(namespace, table, oldColumnName);
-              String newIndexName = getIndexName(namespace, table, newColumnName);
               renameIndexInternal(
-                  connection, namespace, table, newColumnName, oldIndexName, newIndexName);
+                  connection, namespace, table, oldColumnName, table, newColumnName);
             }
+
             addTableMetadata(connection, namespace, table, updatedTableMetadata, false, true);
           });
     } catch (SQLException e) {
@@ -1040,22 +1041,23 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             TableMetadata tableMetadata =
                 tableMetadataService.getTableMetadata(connection, namespace, oldTableName);
             assert tableMetadata != null;
+
             String renameTableStatement =
                 rdbEngine.renameTableSql(namespace, oldTableName, newTableName);
-
             execute(connection, renameTableStatement, requiresExplicitCommit);
+
             tableMetadataService.deleteTableMetadata(connection, namespace, oldTableName, false);
+
             for (String indexedColumnName : tableMetadata.getSecondaryIndexNames()) {
-              String oldIndexName = getIndexName(namespace, oldTableName, indexedColumnName);
-              String newIndexName = getIndexName(namespace, newTableName, indexedColumnName);
               renameIndexInternal(
                   connection,
                   namespace,
-                  newTableName,
+                  oldTableName,
                   indexedColumnName,
-                  oldIndexName,
-                  newIndexName);
+                  newTableName,
+                  indexedColumnName);
             }
+
             addTableMetadata(connection, namespace, newTableName, tableMetadata, false, false);
           });
     } catch (SQLException e) {
@@ -1070,13 +1072,32 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   private void renameIndexInternal(
       Connection connection,
       String schema,
-      String table,
-      String column,
-      String oldIndexName,
-      String newIndexName)
+      String oldTable,
+      String oldColumn,
+      String newTable,
+      String newColumn)
       throws SQLException {
-    String[] sqls = rdbEngine.renameIndexSqls(schema, table, column, oldIndexName, newIndexName);
-    execute(connection, sqls, requiresExplicitCommit);
+    String oldIndexName = getIndexName(schema, oldTable, oldColumn);
+    String newIndexName = getIndexName(schema, newTable, newColumn);
+    String[] sqls =
+        rdbEngine.renameIndexSqls(schema, newTable, newColumn, oldIndexName, newIndexName);
+    try {
+      execute(connection, sqls, requiresExplicitCommit);
+    } catch (SQLException e) {
+      if (!rdbEngine.isUndefinedIndexError(e)) {
+        throw e;
+      }
+      // Fallback: the index may have been created with the original long name before the shortening
+      // logic was introduced. Some databases (e.g., PostgreSQL) silently truncate long index names,
+      // so retrying with the original long name allows the database to match the truncated name.
+      String originalIndexName = getFullIndexName(schema, oldTable, oldColumn);
+      if (originalIndexName.equals(oldIndexName)) {
+        throw e;
+      }
+      String[] fallbackSqls =
+          rdbEngine.renameIndexSqls(schema, newTable, newColumn, originalIndexName, newIndexName);
+      execute(connection, fallbackSqls, requiresExplicitCommit);
+    }
   }
 
   @VisibleForTesting
@@ -1106,10 +1127,31 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws SQLException {
     String indexName = getIndexName(schema, table, indexedColumn);
     String sql = rdbEngine.dropIndexSql(schema, table, indexName);
-    execute(connection, sql, requiresExplicitCommit);
+    try {
+      execute(connection, sql, requiresExplicitCommit);
+    } catch (SQLException e) {
+      if (!rdbEngine.isUndefinedIndexError(e)) {
+        throw e;
+      }
+      // Fallback: the index may have been created with the original long name before the shortening
+      // logic was introduced. Some databases (e.g., PostgreSQL) silently truncate long index names,
+      // so retrying with the original long name allows the database to match the truncated name.
+      String originalIndexName = getFullIndexName(schema, table, indexedColumn);
+      if (originalIndexName.equals(indexName)) {
+        throw e;
+      }
+      String fallbackSql = rdbEngine.dropIndexSql(schema, table, originalIndexName);
+      execute(connection, fallbackSql, requiresExplicitCommit);
+    }
   }
 
-  private String getIndexName(String schema, String table, String indexedColumn) {
+  @VisibleForTesting
+  static String getIndexName(String schema, String table, String indexedColumn) {
+    return shortenIndexNameIfNeeded(
+        getFullIndexName(schema, table, indexedColumn), INDEX_NAME_PREFIX + "_");
+  }
+
+  private static String getFullIndexName(String schema, String table, String indexedColumn) {
     return String.join("_", INDEX_NAME_PREFIX, schema, table, indexedColumn);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,6 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.SQLException;
@@ -8,6 +10,12 @@ import java.util.Map.Entry;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
+
+  // The maximum index name length is set to 63 to match the shortest limit among supported
+  // databases (PostgreSQL). Other databases have higher limits (e.g., MySQL: 64, Oracle: 128,
+  // SQL Server: 128).
+  @VisibleForTesting static final int MAX_INDEX_NAME_LENGTH = 63;
+
   private JdbcUtils() {}
 
   public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
@@ -166,6 +174,25 @@ public final class JdbcUtils {
         }
     }
     return type;
+  }
+
+  /**
+   * Shortens the given index name using a SHA-256 hash if it exceeds the maximum index name length.
+   * Returns the original name if it is within the limit. The shortened name is composed of the
+   * given prefix followed by a 32-character hex hash.
+   *
+   * @param name the full index name to check and potentially shorten
+   * @param prefix the prefix to preserve in the shortened name (e.g., "index_")
+   * @return the original name if within the limit, or a shortened name using a hash
+   */
+  public static String shortenIndexNameIfNeeded(String name, String prefix) {
+    if (name.length() <= MAX_INDEX_NAME_LENGTH) {
+      return name;
+    }
+    // Shorten using SHA-256 hash truncated to 32 hex characters (128 bits)
+    String hash =
+        Hashing.sha256().hashString(name, StandardCharsets.UTF_8).toString().substring(0, 32);
+    return prefix + hash;
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -43,7 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class RdbEngineDb2 extends AbstractRdbEngine {
-  private static final Logger logger = LoggerFactory.getLogger(RdbEngineMysql.class);
+  private static final Logger logger = LoggerFactory.getLogger(RdbEngineDb2.class);
+  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final RdbEngineTimeTypeDb2 timeTypeEngine;
   private final String keyColumnSize;
 
@@ -209,7 +210,10 @@ class RdbEngineDb2 extends AbstractRdbEngine {
       // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
-              + enclose(getFullTableName(schema, table) + "_clustering_order_idx")
+              + enclose(
+                  shortenIndexNameIfNeeded(
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX))
               + " ON "
               + encloseFullTableName(schema, table)
               + " ("
@@ -318,6 +322,12 @@ class RdbEngineDb2 extends AbstractRdbEngine {
           + " TO "
           + enclose(newIndexName)
     };
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // SQL error code -204: name IS AN UNDEFINED NAME
+    return e.getErrorCode() == -204;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -194,6 +194,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1050; Symbol: ER_TABLE_EXISTS_ERROR; SQLSTATE: 42S01
     // Message: Table '%s' already exists
     return e.getErrorCode() == 1050;
@@ -204,14 +205,16 @@ class RdbEngineMysql extends AbstractRdbEngine {
     if (e.getSQLState() == null) {
       return false;
     }
+
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1022; Symbol: ER_DUP_KEY; SQLSTATE: 23000
     // Message: Can't write; duplicate key in table '%s'
-    // etc... See: <https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html>
     return e.getSQLState().equals("23000");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1049; Symbol: ER_BAD_DB_ERROR; SQLSTATE: 42000
     // Message: Unknown database '%s'
 
@@ -223,6 +226,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public boolean isConflict(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1213; Symbol: ER_LOCK_DEADLOCK; SQLSTATE: 40001
     // Message: Deadlock found when trying to get lock; try restarting transaction
 
@@ -230,6 +234,18 @@ class RdbEngineMysql extends AbstractRdbEngine {
     // Message: Lock wait timeout exceeded; try restarting transaction
 
     return e.getErrorCode() == 1213 || e.getErrorCode() == 1205;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+    // Error number: 1091; Symbol: ER_CANT_DROP_FIELD_OR_KEY; SQLSTATE: 42000
+    // Message: Can't DROP '%s'; check that column/key exists
+
+    // Error number: 1176; Symbol: ER_KEY_NOT_FOUND; SQLSTATE: 42000
+    // Message: Key '%s' doesn't exist in table '%s'
+
+    return e.getErrorCode() == 1091 || e.getErrorCode() == 1176;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.ConditionalExpression;
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 class RdbEngineOracle extends AbstractRdbEngine {
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineOracle.class);
+  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final String keyColumnSize;
   private final RdbEngineTimeTypeOracle timeTypeEngine;
 
@@ -95,7 +96,10 @@ class RdbEngineOracle extends AbstractRdbEngine {
       // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
-              + enclose(getFullTableName(schema, table) + "_clustering_order_idx")
+              + enclose(
+                  shortenIndexNameIfNeeded(
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX))
               + " ON "
               + encloseFullTableName(schema, table)
               + " ("
@@ -238,6 +242,12 @@ class RdbEngineOracle extends AbstractRdbEngine {
     // ORA-00060: deadlock detected while waiting for resource
     // ORA-08176: consistent read failure; rollback data not available
     return e.getErrorCode() == 8177 || e.getErrorCode() == 60 || e.getErrorCode() == 8176;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // ORA-01418: specified index does not exist
+    return e.getErrorCode() == 1418;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 class RdbEnginePostgresql extends AbstractRdbEngine {
   private static final Logger logger = LoggerFactory.getLogger(RdbEnginePostgresql.class);
+  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final RdbEngineTimeTypePostgresql timeTypeEngine;
 
   public RdbEnginePostgresql() {
@@ -71,7 +72,10 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
       sqls.add(
           "CREATE UNIQUE INDEX "
               + (ifNotExists ? "IF NOT EXISTS " : "")
-              + enclose(getFullTableName(schema, table) + "_clustering_order_idx")
+              + enclose(
+                  shortenIndexNameIfNeeded(
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX))
               + " ON "
               + encloseFullTableName(schema, table)
               + " ("
@@ -195,6 +199,16 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
     // 40001: serialization_failure
     // 40P01: deadlock_detected
     return e.getSQLState().equals("40001") || e.getSQLState().equals("40P01");
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
+    // 42704: undefined_object (DROP INDEX returns this)
+    // 42P01: undefined_table (ALTER INDEX RENAME returns this, as indexes are relations)
+    return e.getSQLState().equals("42704") || e.getSQLState().equals("42P01");
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -175,7 +175,8 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
-    // 2714: There is already an object named '%.*ls' in the database.
+    // Error code: 2714
+    // Message: There is already an object named '%.*ls' in the database.
     return e.getErrorCode() == 2714;
   }
 
@@ -184,21 +185,38 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
     if (e.getSQLState() == null) {
       return false;
     }
-    // 23000: Integrity constraint violation
+
+    // SQL state: 23000
+    // Message: Integrity constraint violation
     return e.getSQLState().equals("23000");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
-    // 208: Invalid object name '%.*ls'.
+    // Error code: 208
+    // Message: Invalid object name '%.*ls'.
     return e.getErrorCode() == 208;
   }
 
   @Override
   public boolean isConflict(SQLException e) {
-    // 1205: Transaction (Process ID %d) was deadlocked on %.*ls resources with another process and
-    // has been chosen as the deadlock victim. Rerun the transaction.
+    // Error code: 1205
+    // Message: Transaction (Process ID %d) was deadlocked on %.*ls resources with another process
+    // and has been chosen as the deadlock victim. Rerun the transaction.
     return e.getErrorCode() == 1205;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // Error code: 3701
+    // Message: Cannot drop the index '%.*ls', because it does not exist or you do not have
+    // permission.
+
+    // Error code: 15248
+    // Message: Either the parameter @objname is ambiguous or the claimed @objtype (INDEX) is wrong.
+    // (Returned by sp_rename when the index does not exist)
+
+    return e.getErrorCode() == 3701 || e.getErrorCode() == 15248;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -91,6 +91,15 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // Error code: SQLITE_ERROR (1)
+    // Message: no such index: XXX
+    return e.getErrorCode() == 1
+        && e.getMessage() != null
+        && e.getMessage().contains("no such index");
+  }
+
+  @Override
   public boolean isDuplicateIndexError(SQLException e) {
     // Since the "IF NOT EXISTS" syntax is used to create an index, we always return false
     return false;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -201,6 +201,8 @@ public interface RdbEngineStrategy {
     return likeExpression.getEscape();
   }
 
+  boolean isUndefinedIndexError(SQLException e);
+
   boolean isDuplicateIndexError(SQLException e);
 
   String tryAddIfNotExistsToCreateIndexSql(String createIndexSql);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -579,7 +579,7 @@ public class JdbcAdminTest {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.POSTGRESQL,
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c5\" INT,\"c2\" BIGINT,\"c4\" BYTEA,\"c6\" DOUBLE PRECISION,\"c7\" REAL,\"c8\" DATE,\"c9\" TIME,\"c10\" TIMESTAMP,\"c11\" TIMESTAMP WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -599,7 +599,7 @@ public class JdbcAdminTest {
         RdbEngine.ORACLE,
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" BLOB,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -613,7 +613,7 @@ public class JdbcAdminTest {
         new RdbEngineOracle(config),
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" BLOB,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -633,7 +633,7 @@ public class JdbcAdminTest {
     createTableInternal_ForX_CreateTableAndIndexes(
         new RdbEngineDb2(config),
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(64) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3), PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -645,7 +645,7 @@ public class JdbcAdminTest {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.DB2,
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3), PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -718,7 +718,7 @@ public class JdbcAdminTest {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.POSTGRESQL,
         "CREATE TABLE IF NOT EXISTS \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c5\" INT,\"c2\" BIGINT,\"c4\" BYTEA,\"c6\" DOUBLE PRECISION,\"c7\" REAL,\"c8\" DATE,\"c9\" TIME,\"c10\" TIMESTAMP,\"c11\" TIMESTAMP WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
-        "CREATE UNIQUE INDEX IF NOT EXISTS \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX IF NOT EXISTS \"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX IF NOT EXISTS \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -740,7 +740,7 @@ public class JdbcAdminTest {
         RdbEngine.ORACLE,
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c5\" NUMBER(10),\"c2\" NUMBER(16),\"c4\" BLOB,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c5\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -761,7 +761,7 @@ public class JdbcAdminTest {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.DB2,
         "CREATE TABLE IF NOT EXISTS \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN NOT NULL,\"c1\" VARCHAR(128) NOT NULL,\"c5\" INT NOT NULL,\"c2\" BIGINT,\"c4\" BLOB(2G),\"c6\" DOUBLE,\"c7\" REAL,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3), PRIMARY KEY (\"c3\",\"c1\",\"c5\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c5\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c5\" ON \"my_ns\".\"foo_table\" (\"c5\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
   }
@@ -3418,6 +3418,47 @@ public class JdbcAdminTest {
   }
 
   @Test
+  public void dropIndex_WithLongIndexNameAndUndefinedIndexError_ShouldFallbackToOriginalName()
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "my_tbl";
+    String longColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
+
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                "c1", DataType.BOOLEAN.toString(), "PARTITION", null, false),
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                longColumn, DataType.BOOLEAN.toString(), null, null, true));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+
+    Statement statement = mock(Statement.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+
+    // The first execute (with shortened index name) throws undefined index error,
+    // the second execute (with original long name) and the metadata update succeed
+    String shortenedIndexName = JdbcAdmin.getIndexName(namespace, table, longColumn);
+    String shortenedDropSql = "DROP INDEX \"" + namespace + "\".\"" + shortenedIndexName + "\"";
+    String originalName = String.join("_", "index", namespace, table, longColumn);
+    String fallbackDropSql = "DROP INDEX \"" + namespace + "\".\"" + originalName + "\"";
+    PSQLException undefinedIndexError = new PSQLException("undefined", PSQLState.UNDEFINED_OBJECT);
+    when(statement.execute(shortenedDropSql)).thenThrow(undefinedIndexError);
+    when(statement.execute(fallbackDropSql)).thenReturn(false);
+
+    // Act
+    admin.dropIndex(namespace, table, longColumn);
+
+    // Assert
+    verify(statement).execute(shortenedDropSql);
+    verify(statement).execute(fallbackDropSql);
+  }
+
+  @Test
   public void dropIndex_VirtualTableWithColumnInLeftSourceTable_ShouldDropIndexOnLeftSourceTable()
       throws Exception {
     // Arrange
@@ -4112,6 +4153,64 @@ public class JdbcAdminTest {
   }
 
   @Test
+  public void renameColumn_WithLongIndexNameAndUndefinedIndexError_ShouldFallbackToOriginalName()
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "my_tbl";
+    String oldColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
+    String newColumn = "new_col";
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
+
+    // Mock table metadata with a secondary index on the long column
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                "c1", DataType.BOOLEAN.toString(), "PARTITION", null, false),
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                oldColumn, DataType.BOOLEAN.toString(), null, null, true));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+
+    Statement statement = mock(Statement.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+
+    // The rename index with the current name throws undefined index error
+    String oldIndexName = JdbcAdmin.getIndexName(namespace, table, oldColumn);
+    String newIndexName = JdbcAdmin.getIndexName(namespace, table, newColumn);
+    String renameSql =
+        "ALTER INDEX \""
+            + namespace
+            + "\".\""
+            + oldIndexName
+            + "\" RENAME TO \""
+            + newIndexName
+            + "\"";
+    String originalOldIndexName = String.join("_", "index", namespace, table, oldColumn);
+    String fallbackRenameSql =
+        "ALTER INDEX \""
+            + namespace
+            + "\".\""
+            + originalOldIndexName
+            + "\" RENAME TO \""
+            + newIndexName
+            + "\"";
+
+    PSQLException undefinedIndexError = new PSQLException("undefined", PSQLState.UNDEFINED_TABLE);
+    when(statement.execute(renameSql)).thenThrow(undefinedIndexError);
+    when(statement.execute(fallbackRenameSql)).thenReturn(false);
+
+    // Act
+    admin.renameColumn(namespace, table, oldColumn, newColumn);
+
+    // Assert
+    verify(statement).execute(renameSql);
+    verify(statement).execute(fallbackRenameSql);
+  }
+
+  @Test
   public void alterColumnType_ForMysql_ShouldWorkProperly()
       throws SQLException, ExecutionException {
     alterColumnType_ForX_ShouldWorkProperly(
@@ -4436,6 +4535,64 @@ public class JdbcAdminTest {
         verify(expectedStatements.get(i)).execute(expectedSqlStatements[i]);
       }
     }
+  }
+
+  @Test
+  public void renameTable_WithLongIndexNameAndUndefinedIndexError_ShouldFallbackToOriginalName()
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String oldTable = "my_tbl";
+    String newTable = "my_new_tbl";
+    String longColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
+
+    // Mock table metadata with a secondary index on the long column
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                "c1", DataType.BOOLEAN.toString(), "PARTITION", null, false),
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                longColumn, DataType.BOOLEAN.toString(), null, null, true));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+
+    Statement statement = mock(Statement.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+
+    // The rename index with the current name throws undefined index error
+    String oldIndexName = JdbcAdmin.getIndexName(namespace, oldTable, longColumn);
+    String newIndexName = JdbcAdmin.getIndexName(namespace, newTable, longColumn);
+    String renameSql =
+        "ALTER INDEX \""
+            + namespace
+            + "\".\""
+            + oldIndexName
+            + "\" RENAME TO \""
+            + newIndexName
+            + "\"";
+    String originalOldIndexName = String.join("_", "index", namespace, oldTable, longColumn);
+    String fallbackRenameSql =
+        "ALTER INDEX \""
+            + namespace
+            + "\".\""
+            + originalOldIndexName
+            + "\" RENAME TO \""
+            + newIndexName
+            + "\"";
+
+    PSQLException undefinedIndexError = new PSQLException("undefined", PSQLState.UNDEFINED_TABLE);
+    when(statement.execute(renameSql)).thenThrow(undefinedIndexError);
+    when(statement.execute(fallbackRenameSql)).thenReturn(false);
+
+    // Act
+    admin.renameTable(namespace, oldTable, newTable);
+
+    // Assert
+    verify(statement).execute(renameSql);
+    verify(statement).execute(fallbackRenameSql);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -242,4 +242,85 @@ public class JdbcUtilsTest {
 
     adminDataSource.close();
   }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithShortName_ShouldReturnOriginalName() {
+    // Arrange
+    String name = "index_ns_tbl_col";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result).isEqualTo(name);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExactlyAtMaxLength_ShouldReturnOriginalName() {
+    // Arrange
+    String prefix = "index_";
+    int paddingLength = JdbcUtils.MAX_INDEX_NAME_LENGTH - prefix.length();
+    String padding = String.join("", Collections.nCopies(paddingLength, "c"));
+    String name = prefix + padding;
+    assertThat(name.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH); // sanity check
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, prefix);
+
+    // Assert
+    assertThat(result).isEqualTo(name);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExceedingMaxLength_ShouldReturnShortenedName() {
+    // Arrange
+    String name = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result).startsWith("index_");
+    assertThat(result.length()).isLessThanOrEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExceedingMaxLength_ShouldPreservePrefix() {
+    // Arrange
+    String name = "index_clustering_order_my_long_namespace_my_long_table_name_exceeding_limit";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_clustering_order_");
+
+    // Assert
+    assertThat(result).startsWith("index_clustering_order_");
+    assertThat(result.length()).isLessThanOrEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithSameInput_ShouldReturnConsistentResult() {
+    // Arrange
+    String name = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit";
+
+    // Act
+    String result1 = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+    String result2 = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result1).isEqualTo(result2);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithDifferentInputs_ShouldReturnDifferentResults() {
+    // Arrange
+    String name1 = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit_1";
+    String name2 = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit_2";
+
+    // Act
+    String result1 = JdbcUtils.shortenIndexNameIfNeeded(name1, "index_");
+    String result2 = JdbcUtils.shortenIndexNameIfNeeded(name2, "index_");
+
+    // Assert
+    assertThat(result1).isNotEqualTo(result2);
+  }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3481
- **Commit to backport:** 49f1eeebf7c1f9943e85772a2da6f1e05b3bcd99

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.17-pull-3481 &&
git cherry-pick --no-rerere-autoupdate -m1 49f1eeebf7c1f9943e85772a2da6f1e05b3bcd99
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!