### PR TITLE
Backport to branch(3.15) : Shorten JDBC index names exceeding 63 characters using SHA-256 hash

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -1,9 +1,15 @@
 package com.scalar.db.storage.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
 import com.scalar.db.util.AdminTestUtils;
+import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -105,5 +111,44 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   @DisabledIf("isSqlite")
   public void createTable_ForNonExistingNamespace_ShouldThrowIllegalArgumentException() {
     super.createTable_ForNonExistingNamespace_ShouldThrowIllegalArgumentException();
+  }
+
+  @Test
+  public void dropIndex_WithLongIndexNameCreatedByOldNaming_ShouldDropIndexByFallback()
+      throws Exception {
+    // Use a long column name that causes the index name to exceed the max length
+    // The column name is chosen so that the original index name
+    // (index_{namespace}_{table}_{column}) is exactly 64 characters, which exceeds the 63-character
+    // limit to trigger shortening but is still within MySQL's 64-character limit.
+    String longColumn = "long_column_name_for_testing1";
+    JdbcAdminTestUtils testUtils = (JdbcAdminTestUtils) getAdminTestUtils(getTestName());
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata tableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(longColumn, DataType.INT)
+              .addPartitionKey(getColumnName1())
+              .addSecondaryIndex(longColumn)
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), tableMetadata, options);
+
+      // Replace the shortened index with the old (long) naming convention
+      String shortenedIndexName = JdbcAdmin.getIndexName(getNamespace1(), getTable4(), longColumn);
+      String originalIndexName =
+          String.join("_", "index", getNamespace1(), getTable4(), longColumn);
+      assertThat(originalIndexName.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH + 1);
+      testUtils.dropIndex(getNamespace1(), getTable4(), shortenedIndexName);
+      testUtils.createIndex(getNamespace1(), getTable4(), longColumn, originalIndexName);
+
+      // Act Assert - dropIndex should succeed via fallback
+      assertThatCode(() -> admin.dropIndex(getNamespace1(), getTable4(), longColumn))
+          .doesNotThrowAnyException();
+      assertThat(admin.indexExists(getNamespace1(), getTable4(), longColumn)).isFalse();
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+      testUtils.close();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -72,6 +72,34 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
     }
   }
 
+  /**
+   * Creates an index with the specified index name.
+   *
+   * @param namespace the namespace of the table
+   * @param table the table name
+   * @param column the column name to create the index on
+   * @param indexName the index name to use
+   * @throws SQLException if a database error occurs
+   */
+  public void createIndex(String namespace, String table, String column, String indexName)
+      throws SQLException {
+    String sql = rdbEngine.createIndexSql(namespace, table, indexName, column);
+    execute(sql);
+  }
+
+  /**
+   * Drops an index with the specified index name.
+   *
+   * @param namespace the namespace of the table
+   * @param table the table name
+   * @param indexName the index name to drop
+   * @throws SQLException if a database error occurs
+   */
+  public void dropIndex(String namespace, String table, String indexName) throws SQLException {
+    String sql = rdbEngine.dropIndexSql(namespace, table, indexName);
+    execute(sql);
+  }
+
   private void execute(String sql) throws SQLException {
     try (Connection connection = dataSource.getConnection()) {
       JdbcAdmin.execute(connection, sql);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.storage.jdbc.JdbcUtils.getJdbcType;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -863,10 +864,31 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws SQLException {
     String indexName = getIndexName(schema, table, indexedColumn);
     String sql = rdbEngine.dropIndexSql(schema, table, indexName);
-    execute(connection, sql);
+    try {
+      execute(connection, sql);
+    } catch (SQLException e) {
+      if (!rdbEngine.isUndefinedIndexError(e)) {
+        throw e;
+      }
+      // Fallback: the index may have been created with the original long name before the shortening
+      // logic was introduced. Some databases (e.g., PostgreSQL) silently truncate long index names,
+      // so retrying with the original long name allows the database to match the truncated name.
+      String originalIndexName = getFullIndexName(schema, table, indexedColumn);
+      if (originalIndexName.equals(indexName)) {
+        throw e;
+      }
+      String fallbackSql = rdbEngine.dropIndexSql(schema, table, originalIndexName);
+      execute(connection, fallbackSql);
+    }
   }
 
-  private String getIndexName(String schema, String table, String indexedColumn) {
+  @VisibleForTesting
+  static String getIndexName(String schema, String table, String indexedColumn) {
+    return shortenIndexNameIfNeeded(
+        getFullIndexName(schema, table, indexedColumn), INDEX_NAME_PREFIX + "_");
+  }
+
+  private static String getFullIndexName(String schema, String table, String indexedColumn) {
     return String.join("_", INDEX_NAME_PREFIX, schema, table, indexedColumn);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,12 +1,20 @@
 package com.scalar.db.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.JDBCType;
 import java.util.Map.Entry;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
+
+  // The maximum index name length is set to 63 to match the shortest limit among supported
+  // databases (PostgreSQL). Other databases have higher limits (e.g., MySQL: 64, Oracle: 128,
+  // SQL Server: 128).
+  @VisibleForTesting static final int MAX_INDEX_NAME_LENGTH = 63;
+
   private JdbcUtils() {}
 
   public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
@@ -142,5 +150,24 @@ public final class JdbcUtils {
         }
     }
     return type;
+  }
+
+  /**
+   * Shortens the given index name using a SHA-256 hash if it exceeds the maximum index name length.
+   * Returns the original name if it is within the limit. The shortened name is composed of the
+   * given prefix followed by a 32-character hex hash.
+   *
+   * @param name the full index name to check and potentially shorten
+   * @param prefix the prefix to preserve in the shortened name (e.g., "index_")
+   * @return the original name if within the limit, or a shortened name using a hash
+   */
+  public static String shortenIndexNameIfNeeded(String name, String prefix) {
+    if (name.length() <= MAX_INDEX_NAME_LENGTH) {
+      return name;
+    }
+    // Shorten using SHA-256 hash truncated to 32 hex characters (128 bits)
+    String hash =
+        Hashing.sha256().hashString(name, StandardCharsets.UTF_8).toString().substring(0, 32);
+    return prefix + hash;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -154,6 +154,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1050; Symbol: ER_TABLE_EXISTS_ERROR; SQLSTATE: 42S01
     // Message: Table '%s' already exists
     return e.getErrorCode() == 1050;
@@ -164,14 +165,16 @@ class RdbEngineMysql extends AbstractRdbEngine {
     if (e.getSQLState() == null) {
       return false;
     }
+
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1022; Symbol: ER_DUP_KEY; SQLSTATE: 23000
     // Message: Can't write; duplicate key in table '%s'
-    // etc... See: <https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html>
     return e.getSQLState().equals("23000");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1049; Symbol: ER_BAD_DB_ERROR; SQLSTATE: 42000
     // Message: Unknown database '%s'
 
@@ -183,6 +186,7 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public boolean isConflict(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     // Error number: 1213; Symbol: ER_LOCK_DEADLOCK; SQLSTATE: 40001
     // Message: Deadlock found when trying to get lock; try restarting transaction
 
@@ -190,6 +194,18 @@ class RdbEngineMysql extends AbstractRdbEngine {
     // Message: Lock wait timeout exceeded; try restarting transaction
 
     return e.getErrorCode() == 1213 || e.getErrorCode() == 1205;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+    // Error number: 1091; Symbol: ER_CANT_DROP_FIELD_OR_KEY; SQLSTATE: 42000
+    // Message: Can't DROP '%s'; check that column/key exists
+
+    // Error number: 1176; Symbol: ER_KEY_NOT_FOUND; SQLSTATE: 42000
+    // Message: Key '%s' doesn't exist in table '%s'
+
+    return e.getErrorCode() == 1091 || e.getErrorCode() == 1176;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.LikeExpression;
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 public class RdbEngineOracle extends AbstractRdbEngine {
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineOracle.class);
+  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final String keyColumnSize;
   private final RdbEngineTimeTypeOracle timeTypeEngine;
 
@@ -76,7 +77,10 @@ public class RdbEngineOracle extends AbstractRdbEngine {
       // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
-              + enclose(getFullTableName(schema, table) + "_clustering_order_idx")
+              + enclose(
+                  shortenIndexNameIfNeeded(
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX))
               + " ON "
               + encloseFullTableName(schema, table)
               + " ("
@@ -208,6 +212,12 @@ public class RdbEngineOracle extends AbstractRdbEngine {
     // ORA-08177: can't serialize access for this transaction
     // ORA-00060: deadlock detected while waiting for resource
     return e.getErrorCode() == 8177 || e.getErrorCode() == 60;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // ORA-01418: specified index does not exist
+    return e.getErrorCode() == 1418;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.error.CoreError;
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 class RdbEnginePostgresql extends AbstractRdbEngine {
   private static final Logger logger = LoggerFactory.getLogger(RdbEnginePostgresql.class);
+  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final RdbEngineTimeTypePostgresql timeTypeEngine;
 
   public RdbEnginePostgresql() {
@@ -60,7 +61,10 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
       // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
-              + enclose(getFullTableName(schema, table) + "_clustering_order_idx")
+              + enclose(
+                  shortenIndexNameIfNeeded(
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                      CLUSTERING_ORDER_INDEX_NAME_PREFIX))
               + " ON "
               + encloseFullTableName(schema, table)
               + " ("
@@ -171,6 +175,16 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
     // 40001: serialization_failure
     // 40P01: deadlock_detected
     return e.getSQLState().equals("40001") || e.getSQLState().equals("40P01");
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
+    // 42704: undefined_object (DROP INDEX returns this)
+    // 42P01: undefined_table (ALTER INDEX RENAME returns this, as indexes are relations)
+    return e.getSQLState().equals("42704") || e.getSQLState().equals("42P01");
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -124,7 +124,8 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
-    // 2714: There is already an object named '%.*ls' in the database.
+    // Error code: 2714
+    // Message: There is already an object named '%.*ls' in the database.
     return e.getErrorCode() == 2714;
   }
 
@@ -133,21 +134,38 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
     if (e.getSQLState() == null) {
       return false;
     }
-    // 23000: Integrity constraint violation
+
+    // SQL state: 23000
+    // Message: Integrity constraint violation
     return e.getSQLState().equals("23000");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
-    // 208: Invalid object name '%.*ls'.
+    // Error code: 208
+    // Message: Invalid object name '%.*ls'.
     return e.getErrorCode() == 208;
   }
 
   @Override
   public boolean isConflict(SQLException e) {
-    // 1205: Transaction (Process ID %d) was deadlocked on %.*ls resources with another process and
-    // has been chosen as the deadlock victim. Rerun the transaction.
+    // Error code: 1205
+    // Message: Transaction (Process ID %d) was deadlocked on %.*ls resources with another process
+    // and has been chosen as the deadlock victim. Rerun the transaction.
     return e.getErrorCode() == 1205;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // Error code: 3701
+    // Message: Cannot drop the index '%.*ls', because it does not exist or you do not have
+    // permission.
+
+    // Error code: 15248
+    // Message: Either the parameter @objname is ambiguous or the claimed @objtype (INDEX) is wrong.
+    // (Returned by sp_rename when the index does not exist)
+
+    return e.getErrorCode() == 3701 || e.getErrorCode() == 15248;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -84,6 +84,15 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    // Error code: SQLITE_ERROR (1)
+    // Message: no such index: XXX
+    return e.getErrorCode() == 1
+        && e.getMessage() != null
+        && e.getMessage().contains("no such index");
+  }
+
+  @Override
   public String getDataTypeForEngine(DataType scalarDbDataType) {
     switch (scalarDbDataType) {
       case BOOLEAN:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -150,6 +150,8 @@ public interface RdbEngineStrategy {
     return likeExpression.getEscape();
   }
 
+  boolean isUndefinedIndexError(SQLException e);
+
   default @Nullable String getCatalogName(String namespace) {
     return null;
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -808,7 +808,7 @@ public abstract class JdbcAdminTestBase {
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL,\"c8\" DATE,\"c9\" TIME,\"c10\" TIMESTAMP,\"c11\" TIMESTAMP WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
@@ -914,7 +914,7 @@ public abstract class JdbcAdminTestBase {
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(128),\"c4\" RAW(128),\"c2\" NUMBER(16),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT,\"c8\" DATE,\"c9\" TIMESTAMP(6),\"c10\" TIMESTAMP(3),\"c11\" TIMESTAMP(3) WITH TIME ZONE, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
+        "CREATE UNIQUE INDEX \"index_clustering_order_my_ns_foo_table\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
         "CREATE INDEX \"my_ns\".\"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
@@ -2054,6 +2054,49 @@ public abstract class JdbcAdminTestBase {
     assertThat(captor.getAllValues().get(0)).isEqualTo(expectedDropIndexStatement);
     assertThat(captor.getAllValues().get(1)).isEqualTo(expectedAlterColumnStatement);
     assertThat(captor.getAllValues().get(2)).isEqualTo(expectedUpdateTableMetadataStatement);
+  }
+
+  @Test
+  public void dropIndex_WithLongIndexNameAndUndefinedIndexError_ShouldFallbackToOriginalName()
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "my_tbl";
+    String longColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
+
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet resultSet =
+        mockResultSet(
+            Arrays.asList(
+                new GetColumnsResultSetMocker.Row(
+                    "c1", DataType.BOOLEAN.toString(), "PARTITION", null, false),
+                new GetColumnsResultSetMocker.Row(
+                    longColumn, DataType.BOOLEAN.toString(), null, null, true)));
+    when(selectStatement.executeQuery()).thenReturn(resultSet);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
+
+    Statement statement = mock(Statement.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+
+    // The first execute (with shortened index name) throws undefined index error,
+    // the second execute (with original long name) and the metadata update succeed
+    String shortenedIndexName = JdbcAdmin.getIndexName(namespace, table, longColumn);
+    String shortenedDropSql = "DROP INDEX \"" + namespace + "\".\"" + shortenedIndexName + "\"";
+    String originalName = String.join("_", "index", namespace, table, longColumn);
+    String fallbackDropSql = "DROP INDEX \"" + namespace + "\".\"" + originalName + "\"";
+    PSQLException undefinedIndexError = new PSQLException("undefined", PSQLState.UNDEFINED_OBJECT);
+    when(statement.execute(shortenedDropSql)).thenThrow(undefinedIndexError);
+    when(statement.execute(fallbackDropSql)).thenReturn(false);
+
+    // Act
+    admin.dropIndex(namespace, table, longColumn);
+
+    // Assert
+    verify(statement).execute(shortenedDropSql);
+    verify(statement).execute(fallbackDropSql);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -230,4 +230,85 @@ public class JdbcUtilsTest {
 
     adminDataSource.close();
   }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithShortName_ShouldReturnOriginalName() {
+    // Arrange
+    String name = "index_ns_tbl_col";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result).isEqualTo(name);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExactlyAtMaxLength_ShouldReturnOriginalName() {
+    // Arrange
+    String prefix = "index_";
+    int paddingLength = JdbcUtils.MAX_INDEX_NAME_LENGTH - prefix.length();
+    String padding = String.join("", Collections.nCopies(paddingLength, "c"));
+    String name = prefix + padding;
+    assertThat(name.length()).isEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH); // sanity check
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, prefix);
+
+    // Assert
+    assertThat(result).isEqualTo(name);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExceedingMaxLength_ShouldReturnShortenedName() {
+    // Arrange
+    String name = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result).startsWith("index_");
+    assertThat(result.length()).isLessThanOrEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithNameExceedingMaxLength_ShouldPreservePrefix() {
+    // Arrange
+    String name = "index_clustering_order_my_long_namespace_my_long_table_name_exceeding_limit";
+
+    // Act
+    String result = JdbcUtils.shortenIndexNameIfNeeded(name, "index_clustering_order_");
+
+    // Assert
+    assertThat(result).startsWith("index_clustering_order_");
+    assertThat(result.length()).isLessThanOrEqualTo(JdbcUtils.MAX_INDEX_NAME_LENGTH);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithSameInput_ShouldReturnConsistentResult() {
+    // Arrange
+    String name = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit";
+
+    // Act
+    String result1 = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+    String result2 = JdbcUtils.shortenIndexNameIfNeeded(name, "index_");
+
+    // Assert
+    assertThat(result1).isEqualTo(result2);
+  }
+
+  @Test
+  public void shortenIndexNameIfNeeded_WithDifferentInputs_ShouldReturnDifferentResults() {
+    // Arrange
+    String name1 = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit_1";
+    String name2 = "index_my_namespace_my_table_a_very_long_column_name_that_exceeds_the_limit_2";
+
+    // Act
+    String result1 = JdbcUtils.shortenIndexNameIfNeeded(name1, "index_");
+    String result2 = JdbcUtils.shortenIndexNameIfNeeded(name2, "index_");
+
+    // Assert
+    assertThat(result1).isNotEqualTo(result2);
+  }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -58,7 +58,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   private static final String COL_NAME14 = "c14";
   private static final String COL_NAME15 = "c15";
   private StorageFactory storageFactory;
-  private DistributedStorageAdmin admin;
+  protected DistributedStorageAdmin admin;
   private String systemNamespaceName;
   private String namespace1;
   private String namespace2;

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -38,10 +38,10 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
   private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
   private static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
-  private static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
-  private static final String TABLE4 = "test_table4";
+  private static final String TABLE1 = "tbl1";
+  private static final String TABLE2 = "tbl2";
+  private static final String TABLE3 = "tbl3";
+  private static final String TABLE4 = "tbl4";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3481
- **Commit to backport:** 49f1eeebf7c1f9943e85772a2da6f1e05b3bcd99

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.15-pull-3481 &&
git cherry-pick --no-rerere-autoupdate -m1 49f1eeebf7c1f9943e85772a2da6f1e05b3bcd99
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!