### PR TITLE
Support Google Spanner

### DIFF
--- a/.github/workflows/spanner-adapter-check.yaml
+++ b/.github/workflows/spanner-adapter-check.yaml
@@ -1,0 +1,336 @@
+# Do not include Spanner integration test in the CI because some tests require more than 2 hours
+# to complete.
+name: CI for Spanner Adapter
+run-name: "CI for Spanner Adapter : JDK ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }} (${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      INT_TEST_JAVA_RUNTIME_VERSION:
+        description: JDK version used to run the integration test
+        type: choice
+        default: '8'
+        options:
+          - '8'
+          - '11'
+          - '17'
+          - '21'
+      INT_TEST_JAVA_RUNTIME_VENDOR:
+        description: Vendor of the JDK used to run the integration test
+        type: choice
+        default: 'temurin'
+        options:
+          - 'corretto'
+          - 'microsoft'
+          - 'oracle'
+          - 'temurin'
+
+env:
+  ARTIFACT_SUFFIX: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}_${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
+  INT_TEST_JAVA_RUNTIME_VERSION: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}
+  INT_TEST_JAVA_RUNTIME_VENDOR: ${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
+  SPANNER_JDBC_URL: "jdbc:cloudspanner://localhost:9010/projects/emulator-project/instances/test-instance/databases/test-db;autoConfigEmulator=true;dialect=POSTGRESQL"
+
+# Group commit only applies to **.ConsensusCommit** tests.
+# Groups without ConsensusCommit tests have group_commit_tests are skipped in the group_commit
+# flavor via the job-level `if` condition.
+
+jobs:
+  spanner-integration-test:
+    name: "${{ matrix.test_group.name }} (${{ matrix.group_commit_enabled == 'true' && 'group_commit' || 'default' }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group_commit_enabled:
+          - 'false'
+          - 'true'
+        test_group:
+          - name: ConsensusCommitSpecific
+            label: spanner_cc_specific
+            tests: "ConsensusCommitSpecificIntegrationTestWithJdbcDatabase"
+
+          - name: ConsensusCommitSpecific (highest isolation)
+            label: spanner_cc_specific_highest
+            tests: "ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation"
+
+          - name: ConsensusCommitSpecific (metadata decoupling)
+            label: spanner_cc_specific_md
+            tests: "ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase"
+
+          - name: MultipleClusteringKeyScan
+            label: spanner_multi_ck_scan
+            tests: "JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner"
+
+          - name: ConditionalMutation
+            label: spanner_cond_mutation
+            tests: "JdbcDatabaseConditionalMutationIntegrationTestWithSpanner"
+
+          - name: "Admin & Import"
+            label: spanner_group1
+            tests: >-
+              ConsensusCommitAdminIntegrationTestWithJdbcDatabase
+              ConsensusCommitAdminRepairIntegrationTestWithJdbcDatabase
+              ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
+              ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase
+              ConsensusCommitImportTableIntegrationTestWithJdbcDatabase
+              ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase
+              JdbcAdminImportTableIntegrationTest
+              JdbcAdminRepairIntegrationTest
+              JdbcSchemaLoaderImportIntegrationTest
+              JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
+              JdbcAdminIntegrationTest
+              JdbcTransactionAdminIntegrationTest
+
+          - name: "Core JDBC"
+            label: spanner_group2
+            tests: >-
+              JdbcDatabaseIntegrationTest
+              JdbcDatabaseColumnValueIntegrationTest
+              JdbcDatabaseCrossPartitionScanIntegrationTest
+              JdbcDatabaseSingleClusteringKeyScanIntegrationTest
+              JdbcDatabaseSinglePartitionKeyIntegrationTest
+              JdbcDatabaseMultiplePartitionKeyIntegrationTest
+              JdbcDatabaseSecondaryIndexIntegrationTest
+
+          - name: "Schema & i18n"
+            label: spanner_group3
+            tests: >-
+              JdbcDatabaseJapaneseIntegrationTest
+              JdbcDatabaseCaseSensitivityIntegrationTest
+              JdbcDatabaseWithReservedKeywordIntegrationTest
+              JdbcDatabaseVirtualTablesIntegrationTest
+              JdbcDatabaseMutationAtomicityUnitIntegrationTest
+              JdbcAdminCaseSensitivityIntegrationTest
+              JdbcSchemaLoaderIntegrationTest
+              JdbcSchemaLoaderWithMetadataDecouplingIntegrationTest
+
+          - name: "CC base & TwoPhase & SingleCrud & JDBC transaction"
+            label: spanner_group4
+            tests: >-
+              ConsensusCommitIntegrationTestWithJdbcDatabase
+              ConsensusCommitIntegrationTestWithJdbcDatabaseInHighestIsolation
+              ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
+              ConsensusCommitNullMetadataIntegrationTestWithJdbcDatabase
+              ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase
+              ConsensusCommitWithMetadataDecouplingIntegrationTestWithJdbcDatabase
+              TwoPhaseConsensusCommitIntegrationTestWithJdbcDatabase
+              TwoPhaseConsensusCommitSpecificIntegrationTestWithJdbcDatabase
+              TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
+              TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase
+              SingleCrudOperationTransactionIntegrationTestWithJdbcDatabase
+              SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
+              JdbcTransactionCrossPartitionScanIntegrationTest
+              JdbcTransactionIntegrationTest
+
+        # Skip the group_commit flavor for test groups that contain no group commit tests —
+        exclude:
+          - group_commit_enabled: 'true'
+            test_group:
+              label: spanner_multi_ck_scan
+          - group_commit_enabled: 'true'
+            test_group:
+              label: spanner_cond_mutation
+          - group_commit_enabled: 'true'
+            test_group:
+              label: spanner_group2
+          - group_commit_enabled: 'true'
+            test_group:
+              label: spanner_group3
+
+    steps:
+      - name: Check if job should run
+        id: should-run
+        run: |
+          # For group_commit flavor, filter tests to only ConsensusCommit* classes
+          # Skip entirely if no ConsensusCommit tests exist in this group
+          if [ "${{ matrix.group_commit_enabled }}" = "true" ]; then
+            CC_TESTS=""
+            for test_class in ${{ matrix.test_group.tests }}; do
+              case "${test_class}" in ConsensusCommit*) CC_TESTS="${CC_TESTS} ${test_class}" ;; esac
+            done
+            if [ -z "${CC_TESTS}" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Skipping: no ConsensusCommit tests in this group"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.should-run.outputs.skip == 'false'
+
+      # Use the binary emulator instead of Docker image for a slight performance gain
+      - name: Install Spanner emulator
+        if: steps.should-run.outputs.skip == 'false'
+        run: |
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
+            | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+          curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+            | sudo tee /usr/share/keyrings/cloud.google.asc > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq google-cloud-cli-spanner-emulator
+
+      - name: Start Spanner emulator
+        if: steps.should-run.outputs.skip == 'false'
+        run: |
+          EMULATOR_DIR=/usr/lib/google-cloud-sdk/bin/cloud_spanner_emulator
+          ${EMULATOR_DIR}/gateway_main \
+            --hostname 0.0.0.0 \
+            --grpc_port 9010 \
+            --http_port 9020 \
+            --grpc_binary ${EMULATOR_DIR}/emulator_main \
+            &
+
+      - name: Wait for Spanner emulator to be ready
+        if: steps.should-run.outputs.skip == 'false'
+        run: |
+          SECONDS=0
+          until curl -sf http://localhost:9020/v1/projects/emulator-project/instances > /dev/null 2>&1; do
+            if (( SECONDS > 60 )); then
+              echo "Timeout: Spanner emulator failed to start within 60 seconds"
+              exit 1
+            fi
+            echo "Waiting for Spanner emulator..."
+            sleep 2
+          done
+          echo "Spanner emulator is ready"
+
+      - name: Set up JDK 8
+        if: steps.should-run.outputs.skip == 'false'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        id: setup-int-test-jdk
+        if: ${{ steps.should-run.outputs.skip == 'false' && env.INT_TEST_JAVA_RUNTIME_VENDOR != 'oracle' }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ steps.should-run.outputs.skip == 'false' && steps.setup-int-test-jdk.outcome == 'skipped' }}
+        run: |
+          echo ${{ secrets.OCR_TOKEN }} | docker login container-registry.oracle.com -u ${{ secrets.OCR_USERNAME }} --password-stdin
+          container_id=$(docker create "container-registry.oracle.com/java/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}")
+          docker cp -L "$container_id:/usr/java/default" /usr/lib/jvm/oracle-jdk && docker rm "$container_id"
+
+      - name: Setup Gradle
+        if: steps.should-run.outputs.skip == 'false'
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run integration test
+        if: steps.should-run.outputs.skip == 'false'
+        id: run-integration-test
+        env:
+          ORG_GRADLE_PROJECT_javaVersion: '8'
+          ORG_GRADLE_PROJECT_javaVendor: 'temurin'
+          ORG_GRADLE_PROJECT_integrationTestJavaRuntimeVersion: "${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}"
+          ORG_GRADLE_PROJECT_integrationTestJavaRuntimeVendor: "${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}"
+        run: |
+          # Build the --tests arguments; for group_commit, filter to ConsensusCommit* only
+          # (prefix match — must match the should-run guard above so TwoPhase* classes are excluded)
+          TESTS_ARGS=""
+          for test_class in ${{ matrix.test_group.tests }}; do
+            if [ "${{ matrix.group_commit_enabled }}" = "true" ]; then
+              case "${test_class}" in ConsensusCommit*) ;; *) continue ;; esac
+            fi
+            TESTS_ARGS="${TESTS_ARGS} --tests ${test_class}"
+          done
+
+          # Group commit options
+          GROUP_COMMIT_OPTS=""
+          if [ "${{ matrix.group_commit_enabled }}" = "true" ]; then
+            GROUP_COMMIT_OPTS="-Dscalardb.consensus_commit.coordinator.group_commit.enabled=true -Dscalardb.consensus_commit.coordinator.group_commit.old_group_abort_timeout_millis=15000"
+          fi
+
+          ./gradlew core:integrationTestJdbc \
+            "-Dscalardb.jdbc.url=${{ env.SPANNER_JDBC_URL }}" "-Dscalardb.jdbc.username=" "-Dscalardb.jdbc.password=" \
+            ${GROUP_COMMIT_OPTS} \
+            ${TESTS_ARGS}
+
+      - name: Upload binary test results
+        if: ${{ always() && steps.should-run.outputs.skip == 'false' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: internal_test-results_${{ matrix.test_group.label }}_${{ matrix.group_commit_enabled == 'true' && 'group_commit' || 'default' }}
+          path: core/build/test-results/integrationTestJdbc/
+
+      - name: Upload HTML test report
+        if: ${{ always() && steps.should-run.outputs.skip == 'false' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.run-integration-test.outcome == 'success' && 'success' || 'failure' }}_${{ matrix.test_group.label }}_${{ matrix.group_commit_enabled == 'true' && 'group_commit' || 'default' }}_report_${{ env.ARTIFACT_SUFFIX }}
+          path: core/build/reports/tests/
+
+  aggregate-report:
+    if: always()
+    name: "Aggregate report (${{ matrix.flavor }})"
+    runs-on: ubuntu-latest
+    needs:
+      - spanner-integration-test
+    strategy:
+      matrix:
+        flavor:
+          - default
+          - group_commit
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Download all ${{ matrix.flavor }} test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: internal_test-results_*_${{ matrix.flavor }}
+          path: downloaded-results/
+
+      - name: Generate aggregated HTML report
+        id: aggregate-report
+        run: |
+          # Create an init script that registers an aggregate TestReport task
+          cat > /tmp/aggregate-init.gradle << 'EOF'
+          import org.gradle.api.tasks.testing.TestReport
+
+          rootProject {
+              tasks.register('aggregateTestReport', TestReport) {
+                  destinationDirectory = layout.buildDirectory.dir('reports/tests/aggregated')
+                  def resultsDir = file("${rootDir}/downloaded-results")
+                  resultsDir.eachDirRecurse { dir ->
+                      if (dir.name == 'binary') {
+                          testResults.from(dir)
+                      }
+                  }
+              }
+          }
+          EOF
+
+          ./gradlew -I /tmp/aggregate-init.gradle aggregateTestReport
+
+      - name: Upload aggregated HTML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spanner_ci_${{ matrix.flavor }}_report_${{ env.ARTIFACT_SUFFIX }}_run_#${{ github.run_attempt }}
+          path: build/reports/tests/aggregated/
+
+      - name: Delete per-job binary and HTML report artifacts
+        if: steps.aggregate-report.outcome == 'success'
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: |
+            internal_test-results_*_${{ matrix.flavor }}
+            *_${{ matrix.flavor }}_report_${{ env.ARTIFACT_SUFFIX }}
+          failOnError: false

--- a/.github/workflows/spanner-adapter-check.yaml
+++ b/.github/workflows/spanner-adapter-check.yaml
@@ -292,7 +292,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Download all ${{ matrix.flavor }} test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: internal_test-results_*_${{ matrix.flavor }}
           path: downloaded-results/

--- a/.github/workflows/spanner-adapter-check.yaml
+++ b/.github/workflows/spanner-adapter-check.yaml
@@ -29,7 +29,7 @@ env:
   ARTIFACT_SUFFIX: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}_${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
   INT_TEST_JAVA_RUNTIME_VERSION: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}
   INT_TEST_JAVA_RUNTIME_VENDOR: ${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
-  SPANNER_JDBC_URL: "jdbc:cloudspanner://localhost:9010/projects/emulator-project/instances/test-instance/databases/test-db;autoConfigEmulator=true"
+  SPANNER_JDBC_URL: "jdbc:cloudspanner://localhost:9010/projects/emulator-project/instances/test-instance/databases/test-db;autoConfigEmulator=true;dialect=POSTGRESQL"
 
 # Group commit only applies to **.ConsensusCommit** tests.
 # Groups without ConsensusCommit tests have group_commit_tests are skipped in the group_commit

--- a/.github/workflows/spanner-adapter-check.yaml
+++ b/.github/workflows/spanner-adapter-check.yaml
@@ -29,7 +29,7 @@ env:
   ARTIFACT_SUFFIX: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}_${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
   INT_TEST_JAVA_RUNTIME_VERSION: ${{ inputs.INT_TEST_JAVA_RUNTIME_VERSION || '8' }}
   INT_TEST_JAVA_RUNTIME_VENDOR: ${{ inputs.INT_TEST_JAVA_RUNTIME_VENDOR || 'temurin' }}
-  SPANNER_JDBC_URL: "jdbc:cloudspanner://localhost:9010/projects/emulator-project/instances/test-instance/databases/test-db;autoConfigEmulator=true;dialect=POSTGRESQL"
+  SPANNER_JDBC_URL: "jdbc:cloudspanner://localhost:9010/projects/emulator-project/instances/test-instance/databases/test-db;autoConfigEmulator=true"
 
 # Group commit only applies to **.ConsensusCommit** tests.
 # Groups without ConsensusCommit tests have group_commit_tests are skipped in the group_commit

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ subprojects {
         mariadDbDriverVersion = '3.5.8'
         alloyDbJdbcConnectorVersion = '1.3.0'
         googleCloudStorageVersion = '2.67.0'
-        spannerDriverVersion='2.38.0'
+        spannerDriverVersion = '2.38.0'
         picocliVersion = '4.7.7'
         commonsTextVersion = '1.15.0'
         caffeineVersion = '2.9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ subprojects {
         mariadDbDriverVersion = '3.5.8'
         alloyDbJdbcConnectorVersion = '1.3.0'
         googleCloudStorageVersion = '2.67.0'
+        spannerDriverVersion='2.38.0'
         picocliVersion = '4.7.7'
         commonsTextVersion = '1.15.0'
         caffeineVersion = '2.9.3'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -195,6 +195,9 @@ dependencies {
     implementation("com.google.cloud:google-cloud-storage:${googleCloudStorageVersion}") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+        implementation("com.google.cloud:google-cloud-spanner-jdbc:${spannerDriverVersion}") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     implementation "org.apache.commons:commons-text:${commonsTextVersion}"
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     testImplementation platform("org.junit:junit-bom:${junitVersion}")

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     implementation("com.google.cloud:google-cloud-storage:${googleCloudStorageVersion}") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
-        implementation("com.google.cloud:google-cloud-spanner-jdbc:${spannerDriverVersion}") {
+    implementation("com.google.cloud:google-cloud-spanner-jdbc:${spannerDriverVersion}") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     implementation "org.apache.commons:commons-text:${commonsTextVersion}"

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -74,8 +74,23 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isTidb() {
     return JdbcTestUtils.isTidb(rdbEngine);
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameKeyAndIndexColumnNotSupported() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isIndexOnFloatColumnNotSupported() {
+    return JdbcEnv.isSpanner();
   }
 
   @SuppressWarnings("unused")
@@ -83,17 +98,20 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     return JdbcTestUtils.isDb2(rdbEngine)
         || JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine)
         || isTidb();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcTestUtils.isOracle(rdbEngine) || JdbcTestUtils.isSqlite(rdbEngine);
+    return JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly()
       throws ExecutionException {
     super.renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly();
@@ -101,7 +119,7 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly()
       throws ExecutionException {
     super.renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly();
@@ -495,8 +513,147 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     }
   }
 
+  @Test
+  @EnabledIf("isSpanner")
+  public void renameColumn_Spanner_ForAnyColumn_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addClusteringKey(COL_NAME2)
+              .addSecondaryIndex(COL_NAME3)
+              .build();
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME1, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME2, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME3, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME4, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    super.renameColumn_ShouldRenameColumnCorrectly();
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ShouldAlterColumnTypesCorrectlyIfSupported()
+          throws ExecutionException, TransactionException {
+    // Only BLOB to TEXT alteration is supported
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.BLOB)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+      InsertBuilder.Buildable insert =
+          Insert.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt("c1", 1))
+              .clusteringKey(Key.ofInt("c2", 2))
+              .intValue("c3", 1)
+              .bigIntValue("c4", 2L)
+              .floatValue("c5", 3.0f)
+              .doubleValue("c6", 4.0d)
+              .textValue("c7", "5")
+              .blobValue("c8", "6".getBytes(StandardCharsets.UTF_8))
+              .dateValue("c9", LocalDate.now(ZoneId.of("UTC")))
+              .timeValue("c10", LocalTime.now(ZoneId.of("UTC")))
+              .timestampValue("c11", LocalDateTime.now(ZoneOffset.UTC))
+              .timestampTZValue("c12", Instant.now());
+
+      transactionalInsert(insert.build());
+
+      // Act Assert
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c3", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c4", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c5", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c6", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c7", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c8", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c9", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c10", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c11", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c12", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.TEXT)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4)).isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
   @Override
   protected boolean isIndexOnBlobColumnSupported() {
     return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+  }
+
+  @Override
+  protected boolean isIndexOnFloatColumnSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  @Override
+  protected boolean isRenameTableSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
@@ -1,7 +1,10 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
     extends ConsensusCommitCrossPartitionScanIntegrationTestBase {
@@ -9,5 +12,20 @@ public class ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProps(String testName) {
     return ConsensusCommitJdbcEnv.getProperties(testName);
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord()
+          throws TransactionException {
+    super
+        .scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitImportTableIntegrationTestWithJdbcDatabase.java
@@ -39,7 +39,7 @@ public class ConsensusCommitImportTableIntegrationTestWithJdbcDatabase
 
   @Override
   protected Key createPartitionKey(int id) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       return Key.ofBigInt(ACCOUNT_ID, id);
     }
     return super.createPartitionKey(id);
@@ -47,7 +47,7 @@ public class ConsensusCommitImportTableIntegrationTestWithJdbcDatabase
 
   @Override
   protected Column<?> createBalanceColumn(int balance) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       return BigIntColumn.of(BALANCE, balance);
     }
     return super.createBalanceColumn(balance);
@@ -55,7 +55,7 @@ public class ConsensusCommitImportTableIntegrationTestWithJdbcDatabase
 
   @Override
   protected int getBalance(Result result) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       assertThat(result.getColumns()).containsKey(BALANCE);
       assertThat(result.getColumns().get(BALANCE).hasNullValue()).isFalse();
       return (int) result.getColumns().get(BALANCE).getBigIntValue();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
@@ -39,7 +39,7 @@ public class ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWith
 
   @Override
   protected Key createPartitionKey(int id) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       return Key.ofBigInt(ACCOUNT_ID, id);
     }
     return super.createPartitionKey(id);
@@ -47,7 +47,7 @@ public class ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWith
 
   @Override
   protected Column<?> createBalanceColumn(int balance) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       return BigIntColumn.of(BALANCE, balance);
     }
     return super.createBalanceColumn(balance);
@@ -55,7 +55,7 @@ public class ConsensusCommitImportTableWithMetadataDecouplingIntegrationTestWith
 
   @Override
   protected int getBalance(Result result) {
-    if (JdbcEnv.isOracle()) {
+    if (JdbcEnv.isOracle() || JdbcEnv.isSpanner()) {
       assertThat(result.getColumns()).containsKey(BALANCE);
       assertThat(result.getColumns().get(BALANCE).hasNullValue()).isFalse();
       return (int) result.getColumns().get(BALANCE).getBigIntValue();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
@@ -1,7 +1,16 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.CoordinatorException;
+import com.scalar.db.transaction.consensuscommit.Isolation;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabase
     extends ConsensusCommitSpecificIntegrationTestBase {
@@ -9,5 +18,88 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProperties(String testName) {
     return ConsensusCommitJdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws TransactionException, CoordinatorException, ExecutionException {
+    super
+        .getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  protected Stream<Arguments> provideIsolation() {
+    // Skip SERIALIZABLE for the Spanner emulator
+    // The Spanner Emulator randomizes query results without ORDER BY (cross-partition scan or
+    // scan-by-index), which breaks the order-dependent serializability verification in
+    // Snapshot.validateScanResults() and causes the test to fail. Real Spanner preserves ordering,
+    // so we only need to skip SERIALIZABLE on the emulator.
+    return Arrays.stream(Isolation.values())
+        .filter(i -> !(JdbcEnv.isSpannerEmulator() && i == Isolation.SERIALIZABLE))
+        .map(Arguments::of);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
@@ -1,8 +1,17 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.CoordinatorException;
+import com.scalar.db.transaction.consensuscommit.Isolation;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation
     extends ConsensusCommitSpecificIntegrationTestBase {
@@ -19,5 +28,88 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsol
         JdbcTestUtils.getIsolationLevel(rdbEngine.getHighestIsolationLevel()).name());
 
     return properties;
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws TransactionException, CoordinatorException, ExecutionException {
+    super
+        .getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  protected Stream<Arguments> provideIsolation() {
+    // Skip SERIALIZABLE for the Spanner emulator
+    // The Spanner Emulator randomizes query results without ORDER BY (cross-partition scan or
+    // scan-by-index), which breaks the order-dependent serializability verification in
+    // Snapshot.validateScanResults() and causes the test to fail. Real Spanner preserves ordering,
+    // so we only need to skip SERIALIZABLE on the emulator.
+    return Arrays.stream(com.scalar.db.transaction.consensuscommit.Isolation.values())
+        .filter(i -> !(JdbcEnv.isSpannerEmulator() && i == Isolation.SERIALIZABLE))
+        .map(Arguments::of);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
@@ -1,8 +1,17 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.CoordinatorException;
+import com.scalar.db.transaction.consensuscommit.Isolation;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase
     extends ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestBase {
@@ -21,5 +30,88 @@ public class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdb
             .name());
 
     return properties;
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws TransactionException, CoordinatorException, ExecutionException {
+    super
+        .getScanner_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForDeletedWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnCommittedRecords(
+            isolation);
+  }
+
+  @Override
+  @ParameterizedTest
+  @MethodSource("provideIsolation")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          com.scalar.db.transaction.consensuscommit.Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    super
+        .scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+            isolation);
+  }
+
+  protected Stream<Arguments> provideIsolation() {
+    // Skip SERIALIZABLE for the Spanner emulator
+    // The Spanner Emulator randomizes query results without ORDER BY (cross-partition scan or
+    // scan-by-index), which breaks the order-dependent serializability verification in
+    // Snapshot.validateScanResults() and causes the test to fail. Real Spanner preserves ordering,
+    // so we only need to skip SERIALIZABLE on the emulator.
+    return Arrays.stream(com.scalar.db.transaction.consensuscommit.Isolation.values())
+        .filter(i -> !(JdbcEnv.isSpannerEmulator() && i == Isolation.SERIALIZABLE))
+        .map(Arguments::of);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminCaseSensitivityIntegrationTest.java
@@ -77,16 +77,29 @@ public class JdbcAdminCaseSensitivityIntegrationTest
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameKeyAndIndexColumnNotSupported() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isColumnTypeConversionToTextNotFullySupported() {
     return JdbcTestUtils.isDb2(rdbEngine)
         || JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine)
         || isTidb();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcTestUtils.isOracle(rdbEngine) || JdbcTestUtils.isSqlite(rdbEngine);
+    return JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Test
@@ -97,7 +110,7 @@ public class JdbcAdminCaseSensitivityIntegrationTest
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly()
       throws ExecutionException {
     super.renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly();
@@ -105,10 +118,17 @@ public class JdbcAdminCaseSensitivityIntegrationTest
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly()
       throws ExecutionException {
     super.renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    super.renameColumn_ShouldRenameColumnCorrectly();
   }
 
   @Test
@@ -144,6 +164,51 @@ public class JdbcAdminCaseSensitivityIntegrationTest
               () ->
                   admin.renameColumn(
                       getNamespace1(), getTable4(), getColumnName3(), getColumnName4()))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+    }
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void renameColumn_Spanner_ForAnyColumn_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.TEXT)
+              .addColumn(getColumnName4(), DataType.TEXT)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2())
+              .addSecondaryIndex(getColumnName3())
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), currentTableMetadata, options);
+
+      // Act Assert
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName1(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName2(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName3(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName4(), getColumnName5()))
           .isInstanceOf(UnsupportedOperationException.class);
     } finally {
       admin.dropTable(getNamespace1(), getTable4(), true);
@@ -507,6 +572,130 @@ public class JdbcAdminCaseSensitivityIntegrationTest
   }
 
   @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ShouldAlterColumnTypesCorrectlyIfSupported()
+          throws ExecutionException {
+    // Only BLOB to TEXT alteration is supported
+    try (DistributedStorage storage = storageFactory.getStorage()) {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.INT)
+              .addColumn(getColumnName4(), DataType.BIGINT)
+              .addColumn(getColumnName5(), DataType.FLOAT)
+              .addColumn(getColumnName6(), DataType.DOUBLE)
+              .addColumn(getColumnName7(), DataType.TEXT)
+              .addColumn(getColumnName8(), DataType.BLOB)
+              .addColumn(getColumnName9(), DataType.DATE)
+              .addColumn(getColumnName10(), DataType.TIME)
+              .addColumn(getColumnName11(), DataType.TIMESTAMP)
+              .addColumn(getColumnName12(), DataType.TIMESTAMPTZ)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2(), Scan.Ordering.Order.ASC)
+              .build();
+
+      admin.createTable(getNamespace1(), getTable4(), currentTableMetadata, options);
+      PutBuilder.Buildable put =
+          Put.newBuilder()
+              .namespace(getNamespace1())
+              .table(getTable4())
+              .partitionKey(Key.ofInt(getColumnName1(), 1))
+              .clusteringKey(Key.ofInt(getColumnName2(), 2))
+              .intValue(getColumnName3(), 1)
+              .bigIntValue(getColumnName4(), 2L)
+              .floatValue(getColumnName5(), 3.0f)
+              .doubleValue(getColumnName6(), 4.0d)
+              .textValue(getColumnName7(), "5")
+              .blobValue(getColumnName8(), "6".getBytes(StandardCharsets.UTF_8))
+              .dateValue(getColumnName9(), LocalDate.now(ZoneId.of("UTC")))
+              .timeValue(getColumnName10(), LocalTime.now(ZoneId.of("UTC")))
+              .timestampValue(getColumnName11(), LocalDateTime.now(ZoneOffset.UTC))
+              .timestampTZValue(getColumnName12(), Instant.now());
+
+      storage.put(put.build());
+      storage.close();
+
+      // Act Assert
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName3(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName4(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName5(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName6(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName7(), DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName8(), DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName9(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName10(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName11(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName12(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.INT)
+              .addColumn(getColumnName4(), DataType.BIGINT)
+              .addColumn(getColumnName5(), DataType.FLOAT)
+              .addColumn(getColumnName6(), DataType.DOUBLE)
+              .addColumn(getColumnName7(), DataType.TEXT)
+              .addColumn(getColumnName8(), DataType.TEXT)
+              .addColumn(getColumnName9(), DataType.DATE)
+              .addColumn(getColumnName10(), DataType.TIME)
+              .addColumn(getColumnName11(), DataType.TIMESTAMP)
+              .addColumn(getColumnName12(), DataType.TIMESTAMPTZ)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2(), Scan.Ordering.Order.ASC)
+              .build();
+      assertThat(admin.getTableMetadata(getNamespace1(), getTable4()))
+          .isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+    }
+  }
+
+  @Test
   @Override
   @DisabledIf("isWideningColumnTypeConversionNotFullySupported")
   public void alterColumnType_WideningConversion_ShouldAlterColumnTypesCorrectly()
@@ -617,6 +806,18 @@ public class JdbcAdminCaseSensitivityIntegrationTest
 
   @Override
   protected boolean isIndexOnBlobColumnSupported() {
-    return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+    return !(JdbcTestUtils.isDb2(rdbEngine)
+        || JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine));
+  }
+
+  @Override
+  protected boolean isIndexOnFloatColumnSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  @Override
+  protected boolean isRenameTableSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
@@ -94,17 +94,23 @@ public class JdbcAdminImportTableIntegrationTest
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isColumnTypeConversionToTextNotFullySupported() {
     return JdbcEnv.isDb2()
         || JdbcEnv.isSqlServer()
         || JdbcEnv.isOracle()
         || JdbcEnv.isSqlite()
-        || isTidb();
+        || isTidb()
+        || JdbcEnv.isSpanner();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcEnv.isOracle() || JdbcEnv.isSqlite();
+    return JdbcEnv.isOracle() || JdbcEnv.isSqlite() || JdbcEnv.isSpanner();
   }
 
   @Test
@@ -267,6 +273,54 @@ public class JdbcAdminImportTableIntegrationTest
           if (!metadata.getPartitionKeyNames().contains(column)
               && !metadata.getClusteringKeyNames().contains(column)) {
             if (metadata.getColumnDataType(column).equals(DataType.BLOB)) {
+              continue;
+            }
+            assertThat(newMetadata.getColumnDataType(column)).isEqualTo(DataType.TEXT);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ForImportedTable_ShouldAlterColumnTypesCorrectly()
+          throws Exception {
+    // Arrange
+    testDataList.addAll(createExistingDatabaseWithAllDataTypes());
+    for (TestData testData : testDataList) {
+      if (testData.isImportableTable()) {
+        admin.importTable(
+            getNamespace(),
+            testData.getTableName(),
+            Collections.emptyMap(),
+            testData.getOverrideColumnsType());
+      }
+    }
+
+    for (TestData testData : testDataList) {
+      if (testData.isImportableTable()) {
+        // Act
+        TableMetadata metadata = testData.getTableMetadata();
+        for (String column : metadata.getColumnNames()) {
+          if (!metadata.getPartitionKeyNames().contains(column)
+              && !metadata.getClusteringKeyNames().contains(column)) {
+            if (!metadata.getColumnDataType(column).equals(DataType.BLOB)) {
+              // For Spanner, only BLOB to TEXT alteration is supported
+              continue;
+            }
+            admin.alterColumnType(getNamespace(), testData.getTableName(), column, DataType.TEXT);
+          }
+        }
+
+        // Assert
+        TableMetadata newMetadata = admin.getTableMetadata(getNamespace(), testData.getTableName());
+        assertThat(newMetadata).isNotNull();
+        for (String column : metadata.getColumnNames()) {
+          if (!metadata.getPartitionKeyNames().contains(column)
+              && !metadata.getClusteringKeyNames().contains(column)) {
+            if (!metadata.getColumnDataType(column).equals(DataType.BLOB)) {
               continue;
             }
             assertThat(newMetadata.getColumnDataType(column)).isEqualTo(DataType.TEXT);

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -118,6 +118,8 @@ public class JdbcAdminImportTestUtils {
           "geography");
   static final List<String> UNSUPPORTED_DATA_TYPES_DB2 =
       Arrays.asList("DECIMAL", "DECFLOAT", "XML");
+  static final List<String> UNSUPPORTED_DATA_TYPES_SPANNER =
+      Arrays.asList("int[]", "jsonb", "decimal", "uuid");
 
   private final RdbEngineStrategy rdbEngine;
   private final int majorVersion;
@@ -137,6 +139,8 @@ public class JdbcAdminImportTestUtils {
     execute(rdbEngine.createSchemaSqls(namespace));
     if (JdbcTestUtils.isMysql(rdbEngine)) {
       return createExistingMysqlDatabaseWithAllDataTypes(namespace);
+    } else if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return createExistingSpannerDatabaseWithAllDataTypes(namespace);
     } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       return createExistingPostgresDatabaseWithAllDataTypes(namespace);
     } else if (JdbcTestUtils.isOracle(rdbEngine)) {
@@ -587,6 +591,50 @@ public class JdbcAdminImportTestUtils {
         .build();
   }
 
+  private LinkedHashMap<String, String> prepareColumnsForSpanner() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "bigint");
+    columns.put("pk2", "bigint");
+    columns.put("col01", "boolean");
+    columns.put("col02", "bytea");
+    columns.put("col03", "date");
+    columns.put("col04", "real");
+    columns.put("col05", "double precision");
+    columns.put("col06", "int");
+    columns.put("col07", "bigint");
+    columns.put("col08", "timestamp with time zone"); // override to TIME
+    columns.put("col09", "timestamp with time zone"); // override to TIMESTAMP
+    columns.put("col10", "timestamp with time zone");
+    columns.put("col11", "text");
+    columns.put("col12", "varchar(64)");
+    return columns;
+  }
+
+  private Map<String, DataType> prepareOverrideColumnsTypeForSpanner() {
+    return ImmutableMap.of("col08", DataType.TIME, "col09", DataType.TIMESTAMP);
+  }
+
+  private TableMetadata prepareTableMetadataForSpanner() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.BIGINT)
+        .addColumn("pk2", DataType.BIGINT)
+        .addColumn("col01", DataType.BOOLEAN)
+        .addColumn("col02", DataType.BLOB)
+        .addColumn("col03", DataType.DATE)
+        .addColumn("col04", DataType.FLOAT)
+        .addColumn("col05", DataType.DOUBLE)
+        .addColumn("col06", DataType.BIGINT)
+        .addColumn("col07", DataType.BIGINT)
+        .addColumn("col08", DataType.TIME)
+        .addColumn("col09", DataType.TIMESTAMP)
+        .addColumn("col10", DataType.TIMESTAMPTZ)
+        .addColumn("col11", DataType.TEXT)
+        .addColumn("col12", DataType.TEXT)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
   private Map<String, Column<?>> prepareInsertColumnsForDb2(TableMetadata metadata) {
     List<Column<?>> customColumns =
         ImmutableList.of(TimeColumn.of("col24", LocalTime.of(11, 8, 35)));
@@ -607,7 +655,9 @@ public class JdbcAdminImportTestUtils {
 
   private String prepareCreateNonImportableTableSql(String namespace, String table, String type) {
     LinkedHashMap<String, String> columns = new LinkedHashMap<>();
-    columns.put("pk", "CHAR(8) NOT NULL");
+    // All storages beside Spanner support CHAR(n)
+    String pkType = JdbcTestUtils.isSpanner(rdbEngine) ? "VARCHAR(8) NOT NULL" : "CHAR(8) NOT NULL";
+    columns.put("pk", pkType);
     columns.put("col", type);
     return prepareCreateTableSql(
         namespace, table, columns, new LinkedHashSet<>(Collections.singletonList("pk")));
@@ -880,6 +930,32 @@ public class JdbcAdminImportTestUtils {
     return ImmutableList.copyOf(data);
   }
 
+  private List<TestData> createExistingSpannerDatabaseWithAllDataTypes(String namespace)
+      throws SQLException {
+    List<JdbcTestData> data = new ArrayList<>();
+
+    TableMetadata tableMetadata = prepareTableMetadataForSpanner();
+    String sql =
+        prepareCreateTableSql(
+            namespace,
+            SUPPORTED_TABLE_NAME,
+            prepareColumnsForSpanner(),
+            tableMetadata.getPartitionKeyNames());
+    data.add(
+        JdbcTestData.createImportableTable(
+            SUPPORTED_TABLE_NAME,
+            sql,
+            tableMetadata,
+            prepareOverrideColumnsTypeForSpanner(),
+            prepareInsertColumnsWithGenericValues(tableMetadata)));
+
+    data.addAll(prepareCreateNonImportableTableSql(namespace, UNSUPPORTED_DATA_TYPES_SPANNER));
+
+    executeCreateTableSql(data);
+
+    return ImmutableList.copyOf(data);
+  }
+
   private ImmutableList<String> getIntCompatibleColumnNamesOnExistingDb2Database(String table) {
     if (table.equals(SUPPORTED_TABLE_NAME)) {
       return ImmutableList.of("col01", "col02");
@@ -998,6 +1074,15 @@ public class JdbcAdminImportTestUtils {
           .put("DOUBLE", DataType.DOUBLE)
           .put("CHAR(8)", DataType.TEXT)
           .put("VARCHAR(512)", DataType.TEXT)
+          .build();
+    } else if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return ImmutableMap.<String, DataType>builder()
+          .put("boolean", DataType.BOOLEAN)
+          .put("double precision", DataType.DOUBLE)
+          .put("int", DataType.BIGINT)
+          .put("bigint", DataType.BIGINT)
+          .put("text", DataType.TEXT)
+          .put("varchar(512)", DataType.TEXT)
           .build();
     } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       return ImmutableMap.<String, DataType>builder()

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -78,27 +78,58 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameKeyAndIndexColumnNotSupported() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameTableNotSupported() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isIndexOnFloatColumnNotSupported() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isColumnTypeConversionToTextNotFullySupported() {
     return JdbcTestUtils.isDb2(rdbEngine)
         || JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine)
         || isTidb();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcTestUtils.isOracle(rdbEngine) || JdbcTestUtils.isSqlite(rdbEngine);
+    return JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  private boolean isDb2OrSpanner() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
   }
 
   @Test
   @Override
   @DisabledIf("isSqlite")
   public void
-      dropNamespace_ForNamespaceWithNonScalarDBManagedTables_ShouldThrowIllegalArgumentException() {}
+      dropNamespace_ForNamespaceWithNonScalarDBManagedTables_ShouldThrowIllegalArgumentException()
+          throws Exception {
+    super
+        .dropNamespace_ForNamespaceWithNonScalarDBManagedTables_ShouldThrowIllegalArgumentException();
+  }
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly()
       throws ExecutionException {
     super.renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly();
@@ -106,7 +137,7 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly()
       throws ExecutionException {
     super.renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly();
@@ -149,6 +180,55 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
     } finally {
       admin.dropTable(getNamespace1(), getTable4(), true);
     }
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void renameColumn_Spanner_ForAnyColumn_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.TEXT)
+              .addColumn(getColumnName4(), DataType.TEXT)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2())
+              .addSecondaryIndex(getColumnName3())
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), currentTableMetadata, options);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName1(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName2(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName3(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.renameColumn(
+                      getNamespace1(), getTable4(), getColumnName4(), getColumnName5()))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+    }
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    super.renameColumn_ShouldRenameColumnCorrectly();
   }
 
   @Test
@@ -508,6 +588,130 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   }
 
   @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ShouldAlterColumnTypesCorrectlyIfSupported()
+          throws ExecutionException {
+    // Only BLOB to TEXT alteration is supported
+    try (DistributedStorage storage = storageFactory.getStorage()) {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.INT)
+              .addColumn(getColumnName4(), DataType.BIGINT)
+              .addColumn(getColumnName5(), DataType.FLOAT)
+              .addColumn(getColumnName6(), DataType.DOUBLE)
+              .addColumn(getColumnName7(), DataType.TEXT)
+              .addColumn(getColumnName8(), DataType.BLOB)
+              .addColumn(getColumnName9(), DataType.DATE)
+              .addColumn(getColumnName10(), DataType.TIME)
+              .addColumn(getColumnName11(), DataType.TIMESTAMP)
+              .addColumn(getColumnName12(), DataType.TIMESTAMPTZ)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2(), Scan.Ordering.Order.ASC)
+              .build();
+
+      admin.createTable(getNamespace1(), getTable4(), currentTableMetadata, options);
+      PutBuilder.Buildable put =
+          Put.newBuilder()
+              .namespace(getNamespace1())
+              .table(getTable4())
+              .partitionKey(Key.ofInt(getColumnName1(), 1))
+              .clusteringKey(Key.ofInt(getColumnName2(), 2))
+              .intValue(getColumnName3(), 1)
+              .bigIntValue(getColumnName4(), 2L)
+              .floatValue(getColumnName5(), 3.0f)
+              .doubleValue(getColumnName6(), 4.0d)
+              .textValue(getColumnName7(), "5")
+              .blobValue(getColumnName8(), "6".getBytes(StandardCharsets.UTF_8))
+              .dateValue(getColumnName9(), LocalDate.now(ZoneId.of("UTC")))
+              .timeValue(getColumnName10(), LocalTime.now(ZoneId.of("UTC")))
+              .timestampValue(getColumnName11(), LocalDateTime.now(ZoneOffset.UTC))
+              .timestampTZValue(getColumnName12(), Instant.now());
+
+      storage.put(put.build());
+      storage.close();
+
+      // Act Assert
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName3(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName4(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName5(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName6(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName7(), DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName8(), DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName9(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName10(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName11(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName12(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.INT)
+              .addColumn(getColumnName4(), DataType.BIGINT)
+              .addColumn(getColumnName5(), DataType.FLOAT)
+              .addColumn(getColumnName6(), DataType.DOUBLE)
+              .addColumn(getColumnName7(), DataType.TEXT)
+              .addColumn(getColumnName8(), DataType.TEXT)
+              .addColumn(getColumnName9(), DataType.DATE)
+              .addColumn(getColumnName10(), DataType.TIME)
+              .addColumn(getColumnName11(), DataType.TIMESTAMP)
+              .addColumn(getColumnName12(), DataType.TIMESTAMPTZ)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2(), Scan.Ordering.Order.ASC)
+              .build();
+      assertThat(admin.getTableMetadata(getNamespace1(), getTable4()))
+          .isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+    }
+  }
+
+  @Test
   @Override
   @DisabledIf("isWideningColumnTypeConversionNotFullySupported")
   public void alterColumnType_WideningConversion_ShouldAlterColumnTypesCorrectly()
@@ -615,9 +819,46 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
     }
   }
 
+  @Test
+  @EnabledIf("isSpanner")
+  public void alterColumnType_Spanner_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(getColumnName1(), DataType.INT)
+              .addColumn(getColumnName2(), DataType.INT)
+              .addColumn(getColumnName3(), DataType.INT)
+              .addPartitionKey(getColumnName1())
+              .addClusteringKey(getColumnName2(), Scan.Ordering.Order.ASC)
+              .build();
+      admin.createTable(getNamespace1(), getTable4(), currentTableMetadata, options);
+      assertThatCode(
+              () ->
+                  admin.alterColumnType(
+                      getNamespace1(), getTable4(), getColumnName3(), DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(getNamespace1(), getTable4(), true);
+    }
+  }
+
   @Override
   protected boolean isIndexOnBlobColumnSupported() {
-    return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+    return !(JdbcTestUtils.isDb2(rdbEngine)
+        || JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine));
+  }
+
+  @Override
+  protected boolean isIndexOnFloatColumnSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  @Override
+  protected boolean isRenameTableSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Test
@@ -661,7 +902,7 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   }
 
   @Test
-  @DisabledIf("isDb2")
+  @DisabledIf("isDb2OrSpanner")
   public void renameTable_WithLongIndexNameCreatedByOldNaming_ShouldRenameIndexByFallback()
       throws Exception {
     // The column name is chosen so that the original index name
@@ -707,7 +948,7 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   }
 
   @Test
-  @DisabledIf("isDb2")
+  @DisabledIf("isDb2OrSpanner")
   public void renameColumn_WithLongIndexNameCreatedByOldNaming_ShouldRenameIndexByFallback()
       throws Exception {
     // The column name is chosen so that the original index name

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -113,6 +113,7 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
         || JdbcTestUtils.isSpanner(rdbEngine);
   }
 
+  @SuppressWarnings("unused")
   private boolean isDb2OrSpanner() {
     return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -140,8 +140,40 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
 
   @Override
   public void dropTable(String namespace, String table) throws Exception {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      dropAllIndexesForTable(namespace, table);
+    }
     String dropTableStatement = "DROP TABLE " + rdbEngine.encloseFullTableName(namespace, table);
     execute(dropTableStatement);
+  }
+
+  private void dropAllIndexesForTable(String namespace, String table) throws SQLException {
+    // Spanner requires all indexes to be dropped before dropping a table.
+    withConnection(
+        dataSource,
+        requiresExplicitCommit,
+        connection -> {
+          java.util.List<String> indexNames = new java.util.ArrayList<>();
+          executeQuery(
+              connection,
+              "SELECT index_name FROM information_schema.indexes"
+                  + " WHERE table_schema = ? AND table_name = ? AND index_type = 'INDEX'",
+              requiresExplicitCommit,
+              ps -> {
+                ps.setString(1, namespace);
+                ps.setString(2, table);
+              },
+              rs -> {
+                while (rs.next()) {
+                  indexNames.add(rs.getString(1));
+                }
+                return null;
+              });
+          for (String indexName : indexNames) {
+            String dropIndexSql = rdbEngine.dropIndexSql(namespace, table, indexName);
+            JdbcAdmin.execute(connection, dropIndexSql, requiresExplicitCommit);
+          }
+        });
   }
 
   @Override
@@ -152,7 +184,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   @Override
   public boolean namespaceExists(String namespace) throws SQLException {
     String sql;
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isMysql(rdbEngine) || JdbcTestUtils.isSpanner(rdbEngine)) {
       sql = "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?";
     } else if (JdbcTestUtils.isOracle(rdbEngine)) {
       sql = "SELECT 1 FROM all_users WHERE username = ?";

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
@@ -125,6 +125,10 @@ public class JdbcDatabaseColumnValueIntegrationTest
       // A BLOB column is mapped to SQLServer `varbinary(8000)` which accepts a maximum size of
       // 8,000 bytes.
       args.add(Arguments.of(8_000, "8 KB"));
+    } else if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      // Spanner maximum size for the column of a record is 10MB and the maximum size for a query is
+      // also 10MB
+      args.add(Arguments.of(10_000_000, "10 MB"));
     } else {
       return super.provideLargeBlobSizes();
     }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
@@ -7,7 +7,13 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.condition.DisabledIf;
 
+/**
+ * For the Spanner emulator test, see {@link
+ * JdbcDatabaseConditionalMutationIntegrationTestWithSpanner}
+ */
+@DisabledIf("com.scalar.db.storage.jdbc.JdbcEnv#isSpannerEmulator")
 public class JdbcDatabaseConditionalMutationIntegrationTest
     extends DistributedStorageConditionalMutationIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTestWithSpanner.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTestWithSpanner.java
@@ -1,0 +1,126 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spanner-emulator specific conditional mutation integration test that works around the emulator
+ * limitation to reduce the test execution to about 2 hours; the emulator only allows one read-write
+ * transaction or schema change at a time.
+ *
+ * <p>This class is only enabled when running against the Spanner emulator. It overrides {@link
+ * #createStorageAdmin} and {@link #createStorage} to return thread-dispatching proxies that route
+ * each executor thread to its own Spanner database (test-db-1..test-db-N).
+ */
+@EnabledIf("com.scalar.db.storage.jdbc.JdbcEnv#isSpannerEmulator")
+public class JdbcDatabaseConditionalMutationIntegrationTestWithSpanner
+    extends JdbcDatabaseConditionalMutationIntegrationTest {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(JdbcDatabaseConditionalMutationIntegrationTestWithSpanner.class);
+
+  private final List<DistributedStorage> perThreadStorages = new ArrayList<>();
+  private final List<DistributedStorageAdmin> perThreadAdmins = new ArrayList<>();
+  private final AtomicInteger threadIndex = new AtomicInteger(0);
+  private ThreadLocal<Integer> threadId;
+
+  @Override
+  protected int getThreadNum() {
+    // Optimized for a standard Github action runner
+    return 18;
+  }
+
+  @Override
+  protected void initialize(String testName) throws Exception {
+
+    threadId = ThreadLocal.withInitial(() -> threadIndex.getAndIncrement() % getThreadNum());
+
+    String baseUrl = System.getProperty("scalardb.jdbc.url");
+    logger.debug("Initializing {} per-thread databases for Spanner emulator", getThreadNum());
+    for (int i = 0; i < getThreadNum(); i++) {
+      // Each thread gets assigned its own database: test-db-1..test-db-N.
+      // The Spanner emulator automatically creates database when the JDBC property
+      // `autoConfigEmulator=true`is set, so we don't need to create the database explicitly
+      String threadUrl = baseUrl.replaceFirst("/databases/[^;/]+", "/databases/test-db-" + i);
+      logger.info("Thread {}: {}", i, threadUrl);
+      Properties props = JdbcEnv.getProperties(testName);
+      props.setProperty(DatabaseConfig.CONTACT_POINTS, threadUrl);
+      StorageFactory factory = StorageFactory.create(props);
+      perThreadAdmins.add(factory.getStorageAdmin());
+      perThreadStorages.add(factory.getStorage());
+    }
+  }
+
+  @Override
+  protected DistributedStorageAdmin createStorageAdmin(StorageFactory factory) {
+    return createAdminProxy();
+  }
+
+  @Override
+  protected DistributedStorage createStorage(StorageFactory factory) {
+    return createStorageProxy();
+  }
+
+  private DistributedStorage createStorageProxy() {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          // Intercept close() to close all per-thread instances
+          if ("close".equals(method.getName()) && (args == null || args.length == 0)) {
+            for (DistributedStorage s : perThreadStorages) {
+              s.close();
+            }
+            return null;
+          }
+          int idx = threadId.get();
+          logger.debug(
+              "Storage.{}() dispatched to db-{} on thread {}",
+              method.getName(),
+              idx,
+              Thread.currentThread().getName());
+          try {
+            return method.invoke(perThreadStorages.get(idx), args);
+          } catch (java.lang.reflect.InvocationTargetException e) {
+            throw e.getCause();
+          }
+        };
+    return (DistributedStorage)
+        Proxy.newProxyInstance(
+            DistributedStorage.class.getClassLoader(),
+            new Class<?>[] {DistributedStorage.class},
+            handler);
+  }
+
+  private DistributedStorageAdmin createAdminProxy() {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          // Broadcast all admin operations to every per-thread database
+          Object result = null;
+          int i = 0;
+          for (DistributedStorageAdmin a : perThreadAdmins) {
+            try {
+              logger.debug("Admin.{}() dispatched to db-{}", method.getName(), i++);
+              result = method.invoke(a, args);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+              throw e.getCause();
+            }
+          }
+          return result;
+        };
+    return (DistributedStorageAdmin)
+        Proxy.newProxyInstance(
+            DistributedStorageAdmin.class.getClassLoader(),
+            new Class<?>[] {DistributedStorageAdmin.class},
+            handler);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
@@ -45,7 +45,7 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine) || JdbcEnv.isSpannerEmulator()) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -67,9 +67,9 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
       return Stream.of(
           Arguments.of(allColumnNames.subList(0, allColumnNames.size() / 2)),
           Arguments.of(allColumnNames.subList(allColumnNames.size() / 2, allColumnNames.size())));
-    } else if (JdbcTestUtils.isDb2(rdbEngine)) {
-      // Db2 requires an even smaller number of conditions to be able to process the query so we
-      // split the conditions into 3 parts
+    } else if (JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isSpanner(rdbEngine)) {
+      // Db2 and Spanner require an even smaller number of conditions to be able to process the
+      // query so we split the conditions into 3 parts
       Collections.shuffle(allColumnNames, random.get());
       return Stream.of(
           Arguments.of(allColumnNames.subList(0, allColumnNames.size() / 3)),
@@ -83,11 +83,18 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
 
   @Override
   protected boolean isOrderingOnBlobColumnSupported() {
-    return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+    return !(JdbcTestUtils.isDb2(rdbEngine)
+        || JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine));
   }
 
   @Override
   protected boolean isConditionOnBlobColumnSupported() {
     return !JdbcTestUtils.isOracle(rdbEngine);
+  }
+
+  @Override
+  protected boolean isLikeExpressionWithCustomEscapeCharSupported() {
+    return !JdbcEnv.isSpanner();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
@@ -10,7 +10,13 @@ import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.condition.DisabledIf;
 
+/**
+ * For the Spanner emulator test, see {@link
+ * JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner}
+ */
+@DisabledIf("com.scalar.db.storage.jdbc.JdbcEnv#isSpannerEmulator")
 public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
     extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
 
@@ -26,7 +32,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    if (JdbcTestUtils.isOracle(rdbEngine)) {
+    if (JdbcTestUtils.isOracle(rdbEngine) || JdbcEnv.isSpannerEmulator()) {
       return 1;
     }
     return super.getThreadNum();
@@ -34,7 +40,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine) || JdbcEnv.isSpannerEmulator()) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -95,6 +101,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
   protected List<DataType> getDataTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // BLOB type cannot be used as a clustering key in Db2
+    // FLOAT type cannot be used as clustering key column in Spanner
     return JdbcTestUtils.filterDataTypes(
         super.getDataTypes(),
         rdbEngine,
@@ -102,6 +109,8 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
             RdbEngineOracle.class,
             ImmutableList.of(DataType.TIMESTAMPTZ, DataType.BLOB),
             RdbEngineDb2.class,
-            ImmutableList.of(DataType.BLOB)));
+            ImmutableList.of(DataType.BLOB),
+            RdbEngineSpanner.class,
+            ImmutableList.of(DataType.FLOAT)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner.java
@@ -1,0 +1,140 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spanner-emulator specific multiple clustering key scan test that works around the emulator
+ * limitation to reduce the test execution to about 2 hours; the emulator only allows one read-write
+ * transaction or schema change at a time.
+ *
+ * <p>This class is only enabled when running against the Spanner emulator. It overrides {@link
+ * #createStorageAdmin} and {@link #createStorage} to return thread-dispatching proxies that route
+ * each executor thread to its own Spanner database (test-db-1..test-db-N).
+ */
+@EnabledIf("com.scalar.db.storage.jdbc.JdbcEnv#isSpannerEmulator")
+public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner
+    extends JdbcDatabaseMultipleClusteringKeyScanIntegrationTest {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(
+          JdbcDatabaseMultipleClusteringKeyScanIntegrationTestWithSpanner.class);
+  private final List<DistributedStorage> perThreadStorages = new ArrayList<>();
+  private final List<DistributedStorageAdmin> perThreadAdmins = new ArrayList<>();
+  private final AtomicInteger threadIndex = new AtomicInteger(0);
+  private ThreadLocal<Integer> threadId;
+
+  @Override
+  protected int getThreadNum() {
+    // Optimized for a standard Github action runner
+    return 4;
+  }
+
+  @Override
+  protected void initialize(String testName) throws Exception {
+    threadId = ThreadLocal.withInitial(() -> threadIndex.getAndIncrement() % getThreadNum());
+
+    String baseUrl = System.getProperty("scalardb.jdbc.url");
+    logger.info("Initializing {} per-thread Spanner databases", getThreadNum());
+    for (int i = 0; i < getThreadNum(); i++) {
+      // Each thread gets assigned its own database: test-db-1..test-db-N.
+      //  The Spanner emulator automatically creates database when the JDBC property
+      //  `autoConfigEmulator=true`is set, so we don't need to create the database explicitly
+      String threadUrl = baseUrl.replaceFirst("/databases/[^;/]+", "/databases/test-db-" + (i + 1));
+      logger.info("Thread {}: {}", i, threadUrl);
+      Properties props = JdbcEnv.getProperties(testName);
+      props.setProperty(DatabaseConfig.CONTACT_POINTS, threadUrl);
+      StorageFactory factory = StorageFactory.create(props);
+      perThreadAdmins.add(factory.getStorageAdmin());
+      perThreadStorages.add(factory.getStorage());
+    }
+  }
+
+  @Override
+  protected DistributedStorageAdmin createStorageAdmin(StorageFactory factory) {
+    return createAdminProxy();
+  }
+
+  @Override
+  protected DistributedStorage createStorage(StorageFactory factory) {
+    return createStorageProxy();
+  }
+
+  private DistributedStorage createStorageProxy() {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          // Intercept close() to close all per-thread instances
+          if ("close".equals(method.getName()) && (args == null || args.length == 0)) {
+            for (DistributedStorage s : perThreadStorages) {
+              s.close();
+            }
+            return null;
+          }
+          int idx = threadId.get();
+          logger.debug(
+              "Storage.{}() dispatched to db-{} on thread {}",
+              method.getName(),
+              idx,
+              Thread.currentThread().getName());
+          try {
+            return method.invoke(perThreadStorages.get(idx), args);
+          } catch (java.lang.reflect.InvocationTargetException e) {
+            throw e.getCause();
+          }
+        };
+    return (DistributedStorage)
+        Proxy.newProxyInstance(
+            DistributedStorage.class.getClassLoader(),
+            new Class<?>[] {DistributedStorage.class},
+            handler);
+  }
+
+  private DistributedStorageAdmin createAdminProxy() {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          // Per-thread dispatch: truncateTable only clears data in the calling thread's database,
+          // since only that thread wrote there via the storage proxy.
+          if ("truncateTable".equals(method.getName())) {
+            int idx = threadId.get();
+            logger.debug(
+                "Admin.truncateTable() dispatched to db-{} on thread {}",
+                idx,
+                Thread.currentThread().getName());
+            try {
+              return method.invoke(perThreadAdmins.get(idx), args);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+              throw e.getCause();
+            }
+          }
+          // Broadcast all other admin operations to every per-thread database so the schema stays
+          // consistent across all databases.
+          Object result = null;
+          int i = 0;
+          for (DistributedStorageAdmin a : perThreadAdmins) {
+            try {
+              logger.debug("Admin.{}() dispatched to db-{}", method.getName(), i++);
+              result = method.invoke(a, args);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+              throw e.getCause();
+            }
+          }
+          return result;
+        };
+    return (DistributedStorageAdmin)
+        Proxy.newProxyInstance(
+            DistributedStorageAdmin.class.getClassLoader(),
+            new Class<?>[] {DistributedStorageAdmin.class},
+            handler);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
@@ -34,7 +34,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine) || JdbcEnv.isSpannerEmulator()) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -89,6 +89,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // FLOAT and DOUBLE types cannot be used as partition key in Yugabyte
     // BLOB type cannot be used as a partition key in Db2
+    // FLOAT type cannot be used as partition key in Spanner
     return JdbcTestUtils.filterDataTypes(
         super.getDataTypes(),
         rdbEngine,
@@ -98,6 +99,8 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
             RdbEngineYugabyte.class,
             ImmutableList.of(DataType.FLOAT, DataType.DOUBLE),
             RdbEngineDb2.class,
-            ImmutableList.of(DataType.BLOB)));
+            ImmutableList.of(DataType.BLOB),
+            RdbEngineSpanner.class,
+            ImmutableList.of(DataType.FLOAT)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
@@ -76,7 +76,8 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
 
   @Override
   protected Set<DataType> getSecondaryIndexTypes() {
-    // BLOB type cannot be used as a secondary index in Db2
+    // BLOB type cannot be used as a secondary index in Db2, Oracle.
+    // FLOAT type cannot be used as a secondary index in Spanner.
     return Sets.newHashSet(
         JdbcTestUtils.filterDataTypes(
             Arrays.asList(DataType.values()),
@@ -85,6 +86,8 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
                 RdbEngineDb2.class,
                 ImmutableList.of(DataType.BLOB),
                 RdbEngineOracle.class,
-                ImmutableList.of(DataType.BLOB))));
+                ImmutableList.of(DataType.BLOB),
+                RdbEngineSpanner.class,
+                ImmutableList.of(DataType.FLOAT))));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
@@ -71,6 +71,7 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
   protected List<DataType> getClusteringKeyTypes() {
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // BLOB type cannot be used as a clustering key in Db2
+    // FLOAT type cannot be used as a clustering key in Spanner
     return JdbcTestUtils.filterDataTypes(
         super.getClusteringKeyTypes(),
         rdbEngine,
@@ -78,6 +79,8 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
             RdbEngineOracle.class,
             ImmutableList.of(DataType.TIMESTAMPTZ, DataType.BLOB),
             RdbEngineDb2.class,
-            ImmutableList.of(DataType.BLOB)));
+            ImmutableList.of(DataType.BLOB),
+            RdbEngineSpanner.class,
+            ImmutableList.of(DataType.FLOAT)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
@@ -72,6 +72,7 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
     // TIMESTAMP WITH TIME ZONE type cannot be used as a primary key in Oracle
     // FLOAT and DOUBLE types cannot be used as partition key in Yugabyte
     // BLOB type cannot be used as a partition key in Db2
+    // FLOAT type cannot be used as partition key in Spanner
     return JdbcTestUtils.filterDataTypes(
         super.getPartitionKeyTypes(),
         rdbEngine,
@@ -81,6 +82,8 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
             RdbEngineYugabyte.class,
             ImmutableList.of(DataType.FLOAT, DataType.DOUBLE),
             RdbEngineDb2.class,
-            ImmutableList.of(DataType.BLOB)));
+            ImmutableList.of(DataType.BLOB),
+            RdbEngineSpanner.class,
+            ImmutableList.of(DataType.FLOAT)));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -25,8 +25,12 @@ public final class JdbcEnv {
 
     Properties properties = new Properties();
     properties.setProperty(DatabaseConfig.CONTACT_POINTS, jdbcUrl);
-    properties.setProperty(DatabaseConfig.USERNAME, username);
-    properties.setProperty(DatabaseConfig.PASSWORD, password);
+    if (!username.isEmpty()) {
+      properties.setProperty(DatabaseConfig.USERNAME, username);
+    }
+    if (!password.isEmpty()) {
+      properties.setProperty(DatabaseConfig.PASSWORD, password);
+    }
     properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
     properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN, "true");
     properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_FILTERING, "true");
@@ -74,5 +78,14 @@ public final class JdbcEnv {
 
   public static boolean isDb2() {
     return System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL).startsWith("jdbc:db2:");
+  }
+
+  public static boolean isSpanner() {
+    return System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL).startsWith("jdbc:cloudspanner:");
+  }
+
+  public static boolean isSpannerEmulator() {
+    return isSpanner()
+        && System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL).contains("autoConfigEmulator");
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -38,7 +38,21 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   protected void createImportableTable(String namespace, String table) throws Exception {
     String sql;
 
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      sql =
+          "CREATE TABLE "
+              + rdbEngine.encloseFullTableName(namespace, table)
+              + "("
+              + rdbEngine.enclose("pk")
+              + " VARCHAR(8),"
+              + rdbEngine.enclose("col1")
+              + " VARCHAR(8),"
+              + rdbEngine.enclose("col2")
+              + " TIMESTAMP WITH TIME ZONE,"
+              + "PRIMARY KEY("
+              + rdbEngine.enclose("pk")
+              + "))";
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       sql =
           "CREATE TABLE "
               + rdbEngine.encloseFullTableName(namespace, table)
@@ -103,7 +117,9 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   protected Map<String, DataType> getImportableTableOverrideColumnsType() {
     // col1 type override confirms overriding with the default data type mapping does not fail
     // col2 really performs a type override
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIME);
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMPTZ);
     } else if (JdbcTestUtils.isOracle(rdbEngine)) {
       return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMP);
@@ -123,7 +139,11 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     metadata.addColumn("pk", DataType.TEXT);
     metadata.addColumn("col1", DataType.TEXT);
 
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return metadata
+          .addColumn("col2", hasTypeOverride ? DataType.TIME : DataType.TIMESTAMPTZ)
+          .build();
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       return metadata
           .addColumn("col2", hasTypeOverride ? DataType.TIMESTAMPTZ : DataType.TIMESTAMP)
           .build();
@@ -146,7 +166,9 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   @Override
   protected void createNonImportableTable(String namespace, String table) throws Exception {
     String nonImportableDataType;
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      nonImportableDataType = "NUMERIC";
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       nonImportableDataType = "YEAR";
     } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       nonImportableDataType = "INTERVAL";
@@ -159,12 +181,15 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     } else {
       throw new AssertionError();
     }
+    String pkType = JdbcTestUtils.isSpanner(rdbEngine) ? "VARCHAR(8) NOT NULL" : "CHAR(8) NOT NULL";
     testUtils.execute(
         "CREATE TABLE "
             + rdbEngine.encloseFullTableName(namespace, table)
             + "("
             + rdbEngine.enclose("pk")
-            + " CHAR(8) NOT NULL,"
+            + " "
+            + pkType
+            + ","
             + rdbEngine.enclose("col")
             + " "
             + nonImportableDataType

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest.java
@@ -47,7 +47,21 @@ public class JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
   protected void createImportableTable(String namespace, String table) throws Exception {
     String sql;
 
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      sql =
+          "CREATE TABLE "
+              + rdbEngine.encloseFullTableName(namespace, table)
+              + "("
+              + rdbEngine.enclose("pk")
+              + " VARCHAR(8),"
+              + rdbEngine.enclose("col1")
+              + " VARCHAR(8),"
+              + rdbEngine.enclose("col2")
+              + " TIMESTAMP WITH TIME ZONE,"
+              + "PRIMARY KEY("
+              + rdbEngine.enclose("pk")
+              + "))";
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       sql =
           "CREATE TABLE "
               + rdbEngine.encloseFullTableName(namespace, table)
@@ -112,7 +126,9 @@ public class JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
   protected Map<String, DataType> getImportableTableOverrideColumnsType() {
     // col1 type override confirms overriding with the default data type mapping does not fail
     // col2 really performs a type override
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIME);
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMPTZ);
     } else if (JdbcTestUtils.isOracle(rdbEngine)) {
       return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMP);
@@ -132,7 +148,11 @@ public class JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
     metadata.addColumn("pk", DataType.TEXT);
     metadata.addColumn("col1", DataType.TEXT);
 
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      return metadata
+          .addColumn("col2", hasTypeOverride ? DataType.TIME : DataType.TIMESTAMPTZ)
+          .build();
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       return metadata
           .addColumn("col2", hasTypeOverride ? DataType.TIMESTAMPTZ : DataType.TIMESTAMP)
           .build();
@@ -155,7 +175,9 @@ public class JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
   @Override
   protected void createNonImportableTable(String namespace, String table) throws Exception {
     String nonImportableDataType;
-    if (JdbcTestUtils.isMysql(rdbEngine)) {
+    if (JdbcTestUtils.isSpanner(rdbEngine)) {
+      nonImportableDataType = "NUMERIC";
+    } else if (JdbcTestUtils.isMysql(rdbEngine)) {
       nonImportableDataType = "YEAR";
     } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       nonImportableDataType = "INTERVAL";
@@ -168,12 +190,15 @@ public class JdbcSchemaLoaderImportWithMetadataDecouplingIntegrationTest
     } else {
       throw new AssertionError();
     }
+    String pkType = JdbcTestUtils.isSpanner(rdbEngine) ? "VARCHAR(8) NOT NULL" : "CHAR(8) NOT NULL";
     testUtils.execute(
         "CREATE TABLE "
             + rdbEngine.encloseFullTableName(namespace, table)
             + "("
             + rdbEngine.enclose("pk")
-            + " CHAR(8) NOT NULL,"
+            + " "
+            + pkType
+            + ","
             + rdbEngine.enclose("col")
             + " "
             + nonImportableDataType

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcTestUtils.java
@@ -95,6 +95,10 @@ public final class JdbcTestUtils {
     return rdbEngine instanceof RdbEngineTidb;
   }
 
+  public static boolean isSpanner(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineSpanner;
+  }
+
   /**
    * Filters the data types based on the RDB engine and the excluded data types.
    *

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
@@ -79,21 +79,39 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameKeyAndIndexColumnNotSupported() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isIndexOnFloatColumnNotSupported() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isColumnTypeConversionToTextNotFullySupported() {
     return JdbcTestUtils.isDb2(rdbEngine)
         || JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine)
         || isTidb();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcTestUtils.isOracle(rdbEngine) || JdbcTestUtils.isSqlite(rdbEngine);
+    return JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly()
       throws ExecutionException {
     super.renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly();
@@ -101,10 +119,17 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly()
       throws ExecutionException {
     super.renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    super.renameColumn_ShouldRenameColumnCorrectly();
   }
 
   @Test
@@ -126,6 +151,33 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
       admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
 
       // Act Assert
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME1, COL_NAME4))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME2, COL_NAME4))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME3, COL_NAME4))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void renameColumn_Spanner_ForAnyColumn_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addClusteringKey(COL_NAME2)
+              .addSecondaryIndex(COL_NAME3)
+              .build();
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
       assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME1, COL_NAME4))
           .isInstanceOf(UnsupportedOperationException.class);
       assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME2, COL_NAME4))
@@ -495,8 +547,112 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
     }
   }
 
+  @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ShouldAlterColumnTypesCorrectlyIfSupported()
+          throws ExecutionException, TransactionException {
+    // Only BLOB to TEXT alteration is supported
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.BLOB)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+      InsertBuilder.Buildable insert =
+          Insert.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt("c1", 1))
+              .clusteringKey(Key.ofInt("c2", 2))
+              .intValue("c3", 1)
+              .bigIntValue("c4", 2L)
+              .floatValue("c5", 3.0f)
+              .doubleValue("c6", 4.0d)
+              .textValue("c7", "5")
+              .blobValue("c8", "6".getBytes(StandardCharsets.UTF_8))
+              .dateValue("c9", LocalDate.now(ZoneId.of("UTC")))
+              .timeValue("c10", LocalTime.now(ZoneId.of("UTC")))
+              .timestampValue("c11", LocalDateTime.now(ZoneOffset.UTC))
+              .timestampTZValue("c12", Instant.now());
+
+      transactionalInsert(insert.build());
+
+      // Act Assert
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c3", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c4", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c5", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c6", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c7", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c8", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c9", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c10", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c11", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c12", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.TEXT)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4)).isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
   @Override
   protected boolean isIndexOnBlobColumnSupported() {
-    return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+    return !(JdbcTestUtils.isDb2(rdbEngine)
+        || JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine));
+  }
+
+  @Override
+  protected boolean isIndexOnFloatColumnSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  @Override
+  protected boolean isRenameTableSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
@@ -1,7 +1,10 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
     extends TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase {
@@ -9,5 +12,20 @@ public class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDat
   @Override
   protected Properties getProps1(String testName) {
     return ConsensusCommitJdbcEnv.getProperties(testName);
+  }
+
+  @Test
+  @DisabledIf("isSpanner")
+  @Override
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecords()
+          throws TransactionException {
+    super
+        .scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecords();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -152,21 +152,34 @@ public class JdbcTransactionAdminIntegrationTest
   }
 
   @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isRenameKeyAndIndexColumnNotSupported() {
+    return JdbcEnv.isDb2() || JdbcEnv.isSpanner();
+  }
+
+  @SuppressWarnings("unused")
   private boolean isColumnTypeConversionToTextNotFullySupported() {
     return JdbcTestUtils.isDb2(rdbEngine)
         || JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine)
         || isTidb();
   }
 
   @SuppressWarnings("unused")
   private boolean isWideningColumnTypeConversionNotFullySupported() {
-    return JdbcTestUtils.isOracle(rdbEngine) || JdbcTestUtils.isSqlite(rdbEngine);
+    return JdbcTestUtils.isOracle(rdbEngine)
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly()
       throws ExecutionException {
     super.renameColumn_ForPrimaryKeyColumn_ShouldRenameColumnCorrectly();
@@ -174,10 +187,16 @@ public class JdbcTransactionAdminIntegrationTest
 
   @Test
   @Override
-  @DisabledIf("isDb2")
+  @DisabledIf("isRenameKeyAndIndexColumnNotSupported")
   public void renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly()
       throws ExecutionException {
     super.renameColumn_ForIndexKeyColumn_ShouldRenameColumnAndIndexCorrectly();
+  }
+
+  @Override
+  @DisabledIf("isSpanner")
+  public void renameColumn_ShouldRenameColumnCorrectly() throws ExecutionException {
+    super.renameColumn_ShouldRenameColumnCorrectly();
   }
 
   @Test
@@ -204,6 +223,36 @@ public class JdbcTransactionAdminIntegrationTest
       assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME2, COL_NAME4))
           .isInstanceOf(UnsupportedOperationException.class);
       assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME3, COL_NAME4))
+          .isInstanceOf(UnsupportedOperationException.class);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  @EnabledIf("isSpanner")
+  public void renameColumn_Spanner_ForAnyColumn_ShouldThrowUnsupportedOperationException()
+      throws ExecutionException {
+    try {
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addClusteringKey(COL_NAME2)
+              .addSecondaryIndex(COL_NAME3)
+              .build();
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME1, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME2, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME3, COL_NAME5))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.renameColumn(namespace1, TABLE4, COL_NAME4, COL_NAME5))
           .isInstanceOf(UnsupportedOperationException.class);
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
@@ -568,9 +617,111 @@ public class JdbcTransactionAdminIntegrationTest
     }
   }
 
+  @Test
+  @EnabledIf("isSpanner")
+  public void
+      alterColumnType_Spanner_AlterColumnTypeFromEachExistingDataTypeToText_ShouldAlterColumnTypesCorrectlyIfSupported()
+          throws ExecutionException, TransactionException {
+    // Only BLOB to TEXT alteration is supported
+    try {
+      // Arrange
+      Map<String, String> options = getCreationOptions();
+      TableMetadata currentTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.BLOB)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+
+      admin.createTable(namespace1, TABLE4, currentTableMetadata, options);
+      InsertBuilder.Buildable insert =
+          Insert.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt("c1", 1))
+              .clusteringKey(Key.ofInt("c2", 2))
+              .intValue("c3", 1)
+              .bigIntValue("c4", 2L)
+              .floatValue("c5", 3.0f)
+              .doubleValue("c6", 4.0d)
+              .textValue("c7", "5")
+              .blobValue("c8", "6".getBytes(StandardCharsets.UTF_8))
+              .dateValue("c9", LocalDate.now(ZoneId.of("UTC")))
+              .timeValue("c10", LocalTime.now(ZoneId.of("UTC")))
+              .timestampValue("c11", LocalDateTime.now(ZoneOffset.UTC))
+              .timestampTZValue("c12", Instant.now());
+
+      transactionalInsert(insert.build());
+
+      // Act Assert
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c3", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c4", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c5", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c6", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c7", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c8", DataType.TEXT))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c9", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c10", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c11", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatCode(() -> admin.alterColumnType(namespace1, TABLE4, "c12", DataType.TEXT))
+          .isInstanceOf(UnsupportedOperationException.class);
+
+      TableMetadata expectedTableMetadata =
+          TableMetadata.newBuilder()
+              .addColumn("c1", DataType.INT)
+              .addColumn("c2", DataType.INT)
+              .addColumn("c3", DataType.INT)
+              .addColumn("c4", DataType.BIGINT)
+              .addColumn("c5", DataType.FLOAT)
+              .addColumn("c6", DataType.DOUBLE)
+              .addColumn("c7", DataType.TEXT)
+              .addColumn("c8", DataType.TEXT)
+              .addColumn("c9", DataType.DATE)
+              .addColumn("c10", DataType.TIME)
+              .addColumn("c11", DataType.TIMESTAMP)
+              .addColumn("c12", DataType.TIMESTAMPTZ)
+              .addPartitionKey("c1")
+              .addClusteringKey("c2", Scan.Ordering.Order.ASC)
+              .build();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4)).isEqualTo(expectedTableMetadata);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
   @Override
   protected boolean isIndexOnBlobColumnSupported() {
     return !(JdbcTestUtils.isDb2(rdbEngine) || JdbcTestUtils.isOracle(rdbEngine));
+  }
+
+  @Override
+  protected boolean isIndexOnFloatColumnSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
+  }
+
+  @Override
+  protected boolean isRenameTableSupported() {
+    return !JdbcTestUtils.isSpanner(rdbEngine);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionCrossPartitionScanIntegrationTest.java
@@ -2,9 +2,12 @@ package com.scalar.db.transaction.jdbc;
 
 import com.scalar.db.api.DistributedTransactionCrossPartitionScanIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class JdbcTransactionCrossPartitionScanIntegrationTest
     extends DistributedTransactionCrossPartitionScanIntegrationTestBase {
@@ -20,5 +23,20 @@ public class JdbcTransactionCrossPartitionScanIntegrationTest
     properties.putAll(JdbcEnv.getProperties(testName));
     properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, JdbcConfig.TRANSACTION_MANAGER_NAME);
     return properties;
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord()
+          throws TransactionException {
+    super
+        .scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
   }
 }

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
@@ -189,7 +189,7 @@ public class AttributePropagatingDistributedTransactionManager
       return super.batch(this.<Operation>mergeAttributesForEach(operations));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "ReferenceEquality"})
     private <T extends Operation> List<T> mergeAttributesForEach(List<? extends T> operations) {
       // Allocates a new list only when some element actually needs merging. Returns the original
       // list (same reference) when every element is forwarded unchanged so a common case of "no tx

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1053,6 +1053,24 @@ public enum CoreError implements ScalarDbError {
       "This column value is out of range for BigInt in Object Storage. Value: %s",
       "",
       ""),
+  JDBC_SPANNER_RENAME_COLUMN_NOT_SUPPORTED(
+      Category.USER_ERROR, "0283", "Spanner does not support renaming columns", "", ""),
+  JDBC_SPANNER_UNSUPPORTED_COLUMN_TYPE_CONVERSION(
+      Category.USER_ERROR,
+      "0284",
+      "Spanner does not support column type conversion expect from BLOB to TEXT. Conversion: from %s to %s",
+      "",
+      ""),
+  JDBC_SPANNER_RENAME_TABLE_NOT_SUPPORTED(
+      Category.USER_ERROR, "0285", "Spanner does not support renaming tables", "", ""),
+  JDBC_SPANNER_LIKE_ESCAPE_CHARACTER_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0286",
+      "Spanner use by default '\\' as escape character and it cannot be configured or disabled. Escape character: '%s'",
+      "",
+      ""),
+  JDBC_SPANNER_SERVICE_ACCOUNT_KEY_LOAD_FAILED(
+      Category.USER_ERROR, "0287", "Failed to load the service account key for Spanner.", "", ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1058,7 +1058,7 @@ public enum CoreError implements ScalarDbError {
   JDBC_SPANNER_UNSUPPORTED_COLUMN_TYPE_CONVERSION(
       Category.USER_ERROR,
       "0284",
-      "Spanner does not support column type conversion expect from BLOB to TEXT. Conversion: from %s to %s",
+      "Spanner does not support column type conversion except from BLOB to TEXT. Conversion: from %s to %s",
       "",
       ""),
   JDBC_SPANNER_RENAME_TABLE_NOT_SUPPORTED(
@@ -1066,11 +1066,17 @@ public enum CoreError implements ScalarDbError {
   JDBC_SPANNER_LIKE_ESCAPE_CHARACTER_NOT_SUPPORTED(
       Category.USER_ERROR,
       "0286",
-      "Spanner use by default '\\' as escape character and it cannot be configured or disabled. Escape character: '%s'",
+      "Spanner uses '\\' as the default LIKE escape character and it cannot be configured or disabled. Escape character: '%s'",
       "",
       ""),
   JDBC_SPANNER_SERVICE_ACCOUNT_KEY_LOAD_FAILED(
-      Category.USER_ERROR, "0287", "Failed to load the service account key for Spanner.", "", ""),
+      Category.USER_ERROR, "0287", "Failed to load the service account key for Spanner", "", ""),
+  JDBC_SPANNER_CREDENTIALS_ALREADY_REGISTERED(
+      Category.USER_ERROR,
+      "0288",
+      "Different Spanner credentials are already registered in this JVM. ScalarDB's Spanner adapter supports only one set of Spanner credentials per JVM",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1071,10 +1071,10 @@ public enum CoreError implements ScalarDbError {
       ""),
   JDBC_SPANNER_SERVICE_ACCOUNT_KEY_LOAD_FAILED(
       Category.USER_ERROR, "0287", "Failed to load the service account key for Spanner", "", ""),
-  JDBC_SPANNER_CREDENTIALS_ALREADY_REGISTERED(
+  JDBC_SPANNER_CREDENTIALS_LIMIT_EXCEEDED(
       Category.USER_ERROR,
       "0288",
-      "Different Spanner credentials are already registered in this JVM. ScalarDB's Spanner adapter supports only one set of Spanner credentials per JVM",
+      "All %d Spanner credential slots are already in use. ScalarDB's Spanner adapter supports up to that many distinct sets of Spanner credentials per JVM",
       "",
       ""),
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -315,8 +315,9 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   private void dropTableInternal(Connection connection, String schema, String table)
       throws SQLException {
-    TableMetadata metadata = tableMetadataService.getTableMetadata(connection, schema, table);
-    String[] dropTableStatements = rdbEngine.dropTableSql(metadata, schema, table);
+    TableMetadata tableMetadata = tableMetadataService.getTableMetadata(connection, schema, table);
+    assert tableMetadata != null;
+    String[] dropTableStatements = rdbEngine.dropTableSql(tableMetadata, schema, table);
     execute(connection, dropTableStatements, requiresExplicitCommit);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -315,8 +315,9 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   private void dropTableInternal(Connection connection, String schema, String table)
       throws SQLException {
-    String dropTableStatement = "DROP TABLE " + encloseFullTableName(schema, table);
-    execute(connection, dropTableStatement, requiresExplicitCommit);
+    TableMetadata metadata = tableMetadataService.getTableMetadata(connection, schema, table);
+    String[] dropTableStatements = rdbEngine.dropTableSql(metadata, schema, table);
+    execute(connection, dropTableStatements, requiresExplicitCommit);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -317,8 +317,12 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws SQLException {
     TableMetadata tableMetadata = tableMetadataService.getTableMetadata(connection, schema, table);
     assert tableMetadata != null;
-    String[] dropTableStatements = rdbEngine.dropTableSql(tableMetadata, schema, table);
-    execute(connection, dropTableStatements, requiresExplicitCommit);
+    execute(
+        connection,
+        rdbEngine.dropTableInternalSqlsBeforeDropTable(schema, table, tableMetadata),
+        requiresExplicitCommit);
+    execute(
+        connection, "DROP TABLE " + encloseFullTableName(schema, table), requiresExplicitCommit);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -74,6 +74,8 @@ public class JdbcConfig {
       PREFIX + "oracle.time_column.default_date_component";
   public static final String DB2_TIME_COLUMN_DEFAULT_DATE_COMPONENT =
       PREFIX + "db2.time_column.default_date_component";
+  public static final String SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT =
+      PREFIX + "spanner.time_column.default_date_component";
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 20;
   public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 200;
 
@@ -118,6 +120,11 @@ public class JdbcConfig {
   // is 1970-01-01.
   public static final String DEFAULT_DB2_TIME_COLUMN_DEFAULT_DATE_COMPONENT = "1970-01-01";
 
+  // In Spanner PostgreSQL, there is no native TIME type, so TIME values are stored as TIMESTAMPTZ
+  // with a fixed date component for ease of comparison and sorting. The default date component is
+  // 1970-01-01.
+  public static final String DEFAULT_SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT = "1970-01-01";
+
   private final DatabaseConfig databaseConfig;
 
   private final String jdbcUrl;
@@ -155,6 +162,7 @@ public class JdbcConfig {
 
   private final LocalDate oracleTimeColumnDefaultDateComponent;
   private final LocalDate db2TimeColumnDefaultDateComponent;
+  private final LocalDate spannerTimeColumnDefaultDateComponent;
 
   public JdbcConfig(DatabaseConfig databaseConfig) {
     this.databaseConfig = databaseConfig;
@@ -307,6 +315,15 @@ public class JdbcConfig {
     assert db2TimeColumnDefaultDateComponentString != null;
     db2TimeColumnDefaultDateComponent =
         LocalDate.parse(db2TimeColumnDefaultDateComponentString, DateTimeFormatter.ISO_LOCAL_DATE);
+    String spannerTimeColumnDefaultDateComponentString =
+        getString(
+            databaseConfig.getProperties(),
+            SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT,
+            DEFAULT_SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT);
+    assert spannerTimeColumnDefaultDateComponentString != null;
+    spannerTimeColumnDefaultDateComponent =
+        LocalDate.parse(
+            spannerTimeColumnDefaultDateComponentString, DateTimeFormatter.ISO_LOCAL_DATE);
 
     if (databaseConfig.getProperties().containsKey(TABLE_METADATA_SCHEMA)) {
       logger.warn(
@@ -438,5 +455,9 @@ public class JdbcConfig {
 
   public LocalDate getDb2TimeColumnDefaultDateComponent() {
     return db2TimeColumnDefaultDateComponent;
+  }
+
+  public LocalDate getSpannerTimeColumnDefaultDateComponent() {
+    return spannerTimeColumnDefaultDateComponent;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -87,8 +87,7 @@ public final class JdbcUtils {
     hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
 
     hikariConfig.setJdbcUrl(rdbEngine.adjustJdbcUrl(config.getJdbcUrl()));
-    config.getUsername().ifPresent(hikariConfig::setUsername);
-    config.getPassword().ifPresent(hikariConfig::setPassword);
+    rdbEngine.setConnectionCredentials(config, hikariConfig);
 
     if (transactional) {
       hikariConfig.setAutoCommit(false);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -443,6 +443,9 @@ class RdbEngineDb2 extends AbstractRdbEngine {
 
   @Override
   public DateColumn parseDateColumn(ResultSet resultSet, String columnName) throws SQLException {
+    // Reading the column directly as a `LocalDate` returns a value offset by 10 days for dates
+    // around the Julian-to-Gregorian calendar transition (October 1582). Read it as a String and
+    // parse manually to preserve the original date.
     String dateStr = resultSet.getString(columnName);
     if (dateStr == null) {
       return DateColumn.ofNull(columnName);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
@@ -30,6 +30,8 @@ public final class RdbEngineFactory {
       return new RdbEngineMariaDB();
     } else if (jdbcUrl.startsWith("jdbc:db2:")) {
       return new RdbEngineDb2(config);
+    } else if (jdbcUrl.startsWith("jdbc:cloudspanner:")) {
+      return new RdbEngineSpanner(config);
     } else {
       throw new IllegalArgumentException(
           CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED.buildMessage(jdbcUrl));

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -14,10 +14,6 @@ import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -27,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 class RdbEnginePostgresql extends AbstractRdbEngine {
   private static final Logger logger = LoggerFactory.getLogger(RdbEnginePostgresql.class);
-  private static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
+  protected static final String CLUSTERING_ORDER_INDEX_NAME_PREFIX = "index_clustering_order_";
   private final RdbEngineTimeTypePostgresql timeTypeEngine;
 
   public RdbEnginePostgresql() {
@@ -405,8 +401,7 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
   }
 
   @Override
-  public RdbEngineTimeTypeStrategy<LocalDate, LocalTime, LocalDateTime, OffsetDateTime>
-      getTimeTypeStrategy() {
+  public RdbEngineTimeTypeStrategy<?, ?, ?, ?> getTimeTypeStrategy() {
     return timeTypeEngine;
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -4,6 +4,7 @@ import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.rpc.Code;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
@@ -27,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 class RdbEngineSpanner extends RdbEnginePostgresql {
@@ -272,11 +274,14 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
       // no-arg constructor, so the credentials are passed through a static registry rather than
       // through the connection property itself. This avoids putting the service-account key into
       // a HikariConfig data-source property (which would surface in Hikari diagnostic logs)
-      SpannerCredentialsProvider.register(credentials);
-      // Setting a system property is required by the driver to use this authentication mode
+      // The raw service-account JSON bytes are the stable identity of these credentials and let
+      // SpannerCredentialsProvider dedup repeated registrations without depending on
+      // Credentials.equals (which is unreliable across implementations).
+      String credentialsProviderClassName =
+          SpannerCredentialsProvider.register(credentials, credentialsBytes);
+      // The driver requires setting this system property to use this authentication mode
       System.setProperty("ENABLE_CREDENTIALS_PROVIDER", "true");
-      connectionConfig.addDataSourceProperty(
-          "credentialsProvider", SpannerCredentialsProvider.class.getName());
+      connectionConfig.addDataSourceProperty("credentialsProvider", credentialsProviderClassName);
     }
   }
 
@@ -303,5 +308,10 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   @Override
   public boolean requiresExplicitDropIndexBeforeDropColumn() {
     return true;
+  }
+
+  @Override
+  public Map<String, String> getConnectionProperties(JdbcConfig config) {
+    return ImmutableMap.of("dialect", "POSTGRESQL");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -232,6 +232,9 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
 
   @Override
   public DateColumn parseDateColumn(ResultSet resultSet, String columnName) throws SQLException {
+    // Reading the column directly as a `LocalDate` returns a value offset by 10 days for dates
+    // around the Julian-to-Gregorian calendar transition (October 1582). Read it as a String and
+    // parse manually to preserve the original date.
     String dateStr = resultSet.getString(columnName);
     if (dateStr == null) {
       return DateColumn.ofNull(columnName);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -310,8 +310,4 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
     return true;
   }
 
-  @Override
-  public Map<String, String> getConnectionProperties(JdbcConfig config) {
-    return ImmutableMap.of("dialect", "POSTGRESQL");
-  }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -285,27 +285,27 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   }
 
   @Override
-  public String[] dropTableSql(TableMetadata metadata, String schema, String table) {
-    List<String> sqls = new ArrayList<>();
-    // Index needs to be explicitly dropped before dropping the table
-    for (String index : metadata.getSecondaryIndexNames()) {
-      String indexName = JdbcAdmin.getIndexName(schema, table, index);
-      sqls.add(dropIndexSql(schema, table, indexName));
-    }
-    if (JdbcAdmin.hasDifferentClusteringOrders(metadata)) {
-      String indexName =
-          shortenIndexNameIfNeeded(
-              CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
-              CLUSTERING_ORDER_INDEX_NAME_PREFIX);
-      sqls.add(dropIndexSql(schema, table, indexName));
-    }
-    sqls.add("DROP TABLE " + encloseFullTableName(schema, table));
-
-    return sqls.toArray(new String[0]);
+  public boolean requiresExplicitDropIndexBeforeDropColumn() {
+    return true;
   }
 
   @Override
-  public boolean requiresExplicitDropIndexBeforeDropColumn() {
-    return true;
+  public String[] dropTableInternalSqlsBeforeDropTable(
+      String schema, String table, TableMetadata metadata) {
+    // Indexes must be dropped explicitly before dropping the table.
+    List<String> sqls = new ArrayList<>();
+    for (String index : metadata.getSecondaryIndexNames()) {
+      sqls.add(dropIndexSql(schema, table, JdbcAdmin.getIndexName(schema, table, index)));
+    }
+    if (JdbcAdmin.hasDifferentClusteringOrders(metadata)) {
+      sqls.add(
+          dropIndexSql(
+              schema,
+              table,
+              shortenIndexNameIfNeeded(
+                  CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+                  CLUSTERING_ORDER_INDEX_NAME_PREFIX)));
+    }
+    return sqls.toArray(new String[0]);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -1,0 +1,297 @@
+package com.scalar.db.storage.jdbc;
+
+import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.rpc.Code;
+import com.scalar.db.api.LikeExpression;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.DateColumn;
+import com.scalar.db.io.TimeColumn;
+import com.scalar.db.io.TimestampColumn;
+import com.scalar.db.storage.jdbc.query.InsertOnConflictDoUpdateQuery;
+import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import com.zaxxer.hikari.HikariConfig;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import javax.annotation.Nullable;
+
+class RdbEngineSpanner extends RdbEnginePostgresql {
+
+  private final RdbEngineTimeTypeSpanner timeTypeEngine;
+
+  RdbEngineSpanner(JdbcConfig config) {
+    timeTypeEngine = new RdbEngineTimeTypeSpanner(config);
+  }
+
+  @VisibleForTesting
+  RdbEngineSpanner() {
+    timeTypeEngine = null;
+  }
+
+  @Override
+  public String getDriverClassName() {
+    return "com.google.cloud.spanner.jdbc.JdbcDriver";
+  }
+
+  @Override
+  public String getDataTypeForEngine(DataType scalarDbDataType) {
+    switch (scalarDbDataType) {
+      case INT:
+      case BIGINT:
+        // Spanner has no traditional integer type coded on 4 bytes. "int" type is an alias for a
+        // bigint coded on 8 bytes.
+        return "bigint";
+      case BLOB:
+        return "bytea";
+      case BOOLEAN:
+        return "boolean";
+      case FLOAT:
+        return "real";
+      case DOUBLE:
+        return "double precision";
+      case TEXT:
+        return "text";
+      case DATE:
+        return "date";
+      case TIME:
+      case TIMESTAMP:
+      case TIMESTAMPTZ:
+        return "timestamp with time zone";
+      default:
+        return super.getDataTypeForEngine(scalarDbDataType);
+    }
+  }
+
+  @Override
+  public String getDataTypeForKey(DataType dataType) {
+    // No specific handling for key data type is required
+    return null;
+  }
+
+  @Override
+  public int getSqlTypes(DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return Types.BIGINT;
+      case TIME:
+      case TIMESTAMP:
+        return Types.TIMESTAMP_WITH_TIMEZONE;
+      default:
+        return super.getSqlTypes(dataType);
+    }
+  }
+
+  @Override
+  public String truncateTableSql(String namespace, String table) {
+    return "DELETE FROM " + encloseFullTableName(namespace, table) + " WHERE TRUE";
+  }
+
+  @Override
+  public boolean isDuplicateTableError(SQLException e) {
+    // Since the "IF NOT EXISTS" syntax is used to create a table, we always return false
+    return false;
+  }
+
+  @Override
+  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+    // Since the "IF NOT EXISTS" syntax is used to create a schema, we always return false
+    return false;
+  }
+
+  @Override
+  public boolean isDuplicateKeyError(SQLException e) {
+    return e.getErrorCode() == Code.ALREADY_EXISTS_VALUE;
+  }
+
+  @Override
+  public boolean isUndefinedTableError(SQLException e) {
+    return e.getErrorCode() == Code.INVALID_ARGUMENT_VALUE;
+  }
+
+  @Override
+  public boolean isUndefinedIndexError(SQLException e) {
+    return e.getErrorCode() == Code.NOT_FOUND_VALUE;
+  }
+
+  @Override
+  public boolean isConflict(SQLException e) {
+    return e.getErrorCode() == Code.ABORTED_VALUE;
+  }
+
+  @Override
+  public void throwIfRenameColumnNotSupported(String columnName, TableMetadata tableMetadata) {
+    throw new UnsupportedOperationException(
+        CoreError.JDBC_SPANNER_RENAME_COLUMN_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public void throwIfAlterColumnTypeNotSupported(DataType from, DataType to) {
+    if (!(from == DataType.BLOB && to == DataType.TEXT)) {
+      throw new UnsupportedOperationException(
+          CoreError.JDBC_SPANNER_UNSUPPORTED_COLUMN_TYPE_CONVERSION.buildMessage(
+              from.toString(), to.toString()));
+    }
+  }
+
+  @Override
+  public String renameTableSql(String namespace, String oldTableName, String newTableName) {
+    // Renaming a table is supported but is quite limited since it relocates it to the `public`
+    // schema instead of keeping it in the original schema. Because of this limitation, we can't
+    // support it.
+    throw new UnsupportedOperationException(
+        CoreError.JDBC_SPANNER_RENAME_TABLE_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public RdbEngineTimeTypeStrategy<LocalDate, OffsetDateTime, OffsetDateTime, OffsetDateTime>
+      getTimeTypeStrategy() {
+    return timeTypeEngine;
+  }
+
+  @Override
+  public TimeColumn parseTimeColumn(ResultSet resultSet, String columnName) throws SQLException {
+    OffsetDateTime odt = resultSet.getObject(columnName, OffsetDateTime.class);
+    if (odt == null) {
+      return TimeColumn.ofNull(columnName);
+    }
+    return TimeColumn.ofStrict(columnName, odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalTime());
+  }
+
+  @Override
+  public TimestampColumn parseTimestampColumn(ResultSet resultSet, String columnName)
+      throws SQLException {
+    OffsetDateTime odt = resultSet.getObject(columnName, OffsetDateTime.class);
+    if (odt == null) {
+      return TimestampColumn.ofNull(columnName);
+    }
+    return TimestampColumn.ofStrict(
+        columnName, odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime());
+  }
+
+  @Override
+  DataType getDataTypeForScalarDbInternal(
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      @Nullable DataType overrideDataType) {
+    switch (type) {
+      case BOOLEAN:
+        return DataType.BOOLEAN;
+      case BIGINT:
+        return DataType.BIGINT;
+      case REAL:
+        return DataType.FLOAT;
+      case DOUBLE:
+        return DataType.DOUBLE;
+      case NVARCHAR:
+        if (typeName.equalsIgnoreCase("jsonb")) {
+          throw new IllegalArgumentException(
+              CoreError.JDBC_IMPORT_DATA_TYPE_NOT_SUPPORTED.buildMessage(
+                  typeName, columnDescription));
+        }
+        return DataType.TEXT;
+      case BINARY:
+        return DataType.BLOB;
+      case DATE:
+        return DataType.DATE;
+      case TIMESTAMP:
+        if (overrideDataType == DataType.TIME) {
+          return DataType.TIME;
+        }
+        if (overrideDataType == DataType.TIMESTAMP) {
+          return DataType.TIMESTAMP;
+        }
+        return DataType.TIMESTAMPTZ;
+      default:
+        throw new IllegalArgumentException(
+            CoreError.JDBC_IMPORT_DATA_TYPE_NOT_SUPPORTED.buildMessage(
+                typeName, columnDescription));
+    }
+  }
+
+  @Override
+  public UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder) {
+    return new InsertOnConflictDoUpdateQuery(builder, true);
+  }
+
+  @Override
+  public DateColumn parseDateColumn(ResultSet resultSet, String columnName) throws SQLException {
+    String dateStr = resultSet.getString(columnName);
+    if (dateStr == null) {
+      return DateColumn.ofNull(columnName);
+    } else {
+      LocalDate date = RdbEngineTimeTypeSpanner.DATE_FORMATTER.parse(dateStr, LocalDate::from);
+      return DateColumn.of(columnName, date);
+    }
+  }
+
+  @Override
+  public String getEscape(LikeExpression likeExpression) {
+    if (likeExpression.getEscape().isEmpty() || !likeExpression.getEscape().equals("\\")) {
+      throw new UnsupportedOperationException(
+          CoreError.JDBC_SPANNER_LIKE_ESCAPE_CHARACTER_NOT_SUPPORTED.buildMessage(
+              likeExpression.getEscape()));
+    }
+    return null;
+  }
+
+  @Override
+  public void setConnectionCredentials(JdbcConfig config, HikariConfig connectionConfig) {
+    if (config.getPassword().isPresent()) {
+      byte[] credentials = config.getPassword().get().getBytes(StandardCharsets.UTF_8);
+      try (ByteArrayInputStream keyStream = new ByteArrayInputStream(credentials)) {
+        // Validate the credentials
+        ServiceAccountCredentials.fromStream(keyStream);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(
+            CoreError.JDBC_SPANNER_SERVICE_ACCOUNT_KEY_LOAD_FAILED.buildMessage(), e);
+      }
+      String encodedCredentials = Base64.getEncoder().encodeToString(credentials);
+      // Setting this system property is required to use encoded credentials authentication
+      System.setProperty("ENABLE_ENCODED_CREDENTIALS", "true");
+      connectionConfig.addDataSourceProperty("encodedcredentials", encodedCredentials);
+    }
+  }
+
+  @Override
+  public String[] dropTableSql(TableMetadata metadata, String schema, String table) {
+    List<String> sqls = new ArrayList<>();
+    // Index needs to be explicitly dropped before dropping the table
+    for (String index : metadata.getSecondaryIndexNames()) {
+      String indexName = JdbcAdmin.getIndexName(schema, table, index);
+      sqls.add(dropIndexSql(schema, table, indexName));
+    }
+    if (JdbcAdmin.hasDifferentClusteringOrders(metadata)) {
+      String indexName =
+          shortenIndexNameIfNeeded(
+              CLUSTERING_ORDER_INDEX_NAME_PREFIX + schema + "_" + table,
+              CLUSTERING_ORDER_INDEX_NAME_PREFIX);
+      sqls.add(dropIndexSql(schema, table, indexName));
+    }
+    sqls.add("DROP TABLE " + encloseFullTableName(schema, table));
+
+    return sqls.toArray(new String[0]);
+  }
+
+  @Override
+  public boolean requiresExplicitDropIndexBeforeDropColumn() {
+    return true;
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -2,7 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
-import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.rpc.Code;
 import com.scalar.db.api.LikeExpression;
@@ -26,7 +26,6 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -244,7 +243,7 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
 
   @Override
   public String getEscape(LikeExpression likeExpression) {
-    if (likeExpression.getEscape().isEmpty() || !likeExpression.getEscape().equals("\\")) {
+    if (!likeExpression.getEscape().equals("\\")) {
       throw new UnsupportedOperationException(
           CoreError.JDBC_SPANNER_LIKE_ESCAPE_CHARACTER_NOT_SUPPORTED.buildMessage(
               likeExpression.getEscape()));
@@ -255,18 +254,26 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   @Override
   public void setConnectionCredentials(JdbcConfig config, HikariConfig connectionConfig) {
     if (config.getPassword().isPresent()) {
-      byte[] credentials = config.getPassword().get().getBytes(StandardCharsets.UTF_8);
-      try (ByteArrayInputStream keyStream = new ByteArrayInputStream(credentials)) {
-        // Validate the credentials
-        ServiceAccountCredentials.fromStream(keyStream);
+      // The password contains the credentials in the format of a Google Cloud service account key
+      // in JSON format
+      // The username is never used
+      byte[] credentialsBytes = config.getPassword().get().getBytes(StandardCharsets.UTF_8);
+      GoogleCredentials credentials;
+      try (ByteArrayInputStream keyStream = new ByteArrayInputStream(credentialsBytes)) {
+        credentials = GoogleCredentials.fromStream(keyStream);
       } catch (IOException e) {
         throw new IllegalArgumentException(
             CoreError.JDBC_SPANNER_SERVICE_ACCOUNT_KEY_LOAD_FAILED.buildMessage(), e);
       }
-      String encodedCredentials = Base64.getEncoder().encodeToString(credentials);
-      // Setting this system property is required to use encoded credentials authentication
-      System.setProperty("ENABLE_ENCODED_CREDENTIALS", "true");
-      connectionConfig.addDataSourceProperty("encodedcredentials", encodedCredentials);
+      // The driver instantiates the credentialsProvider class reflectively via a
+      // no-arg constructor, so the credentials are passed through a static registry rather than
+      // through the connection property itself. This avoids putting the service-account key into
+      // a HikariConfig data-source property (which would surface in Hikari diagnostic logs)
+      SpannerCredentialsProvider.register(credentials);
+      // Setting a system property is required by the driver to use this authentication mode
+      System.setProperty("ENABLE_CREDENTIALS_PROVIDER", "true");
+      connectionConfig.addDataSourceProperty(
+          "credentialsProvider", SpannerCredentialsProvider.class.getName());
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -3,8 +3,8 @@ package com.scalar.db.storage.jdbc;
 import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.jdbc.JdbcDriver;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.rpc.Code;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
@@ -28,7 +28,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 class RdbEngineSpanner extends RdbEnginePostgresql {
@@ -46,7 +45,7 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
 
   @Override
   public String getDriverClassName() {
-    return "com.google.cloud.spanner.jdbc.JdbcDriver";
+    return JdbcDriver.class.getName();
   }
 
   @Override
@@ -309,5 +308,4 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   public boolean requiresExplicitDropIndexBeforeDropColumn() {
     return true;
   }
-
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -395,7 +395,8 @@ public interface RdbEngineStrategy {
     config.getPassword().ifPresent(connectionConfig::setPassword);
   }
 
-  default String[] dropTableSql(TableMetadata metadata, String schema, String table) {
-    return new String[] {"DROP TABLE " + encloseFullTableName(schema, table)};
+  default String[] dropTableInternalSqlsBeforeDropTable(
+      String schema, String table, TableMetadata metadata) {
+    return new String[] {};
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -12,6 +12,7 @@ import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import com.zaxxer.hikari.HikariConfig;
 import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
@@ -380,5 +381,21 @@ public interface RdbEngineStrategy {
    */
   default int getHighestIsolationLevel() {
     return Connection.TRANSACTION_SERIALIZABLE;
+  }
+
+  /**
+   * Configure the credentials
+   *
+   * @param config the JdbcConfig object containing the connection credentials, such as username and
+   *     password
+   * @param connectionConfig the HikariConfig object where the connection credentials will be set
+   */
+  default void setConnectionCredentials(JdbcConfig config, HikariConfig connectionConfig) {
+    config.getUsername().ifPresent(connectionConfig::setUsername);
+    config.getPassword().ifPresent(connectionConfig::setPassword);
+  }
+
+  default String[] dropTableSql(TableMetadata metadata, String schema, String table) {
+    return new String[] {"DROP TABLE " + encloseFullTableName(schema, table)};
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpanner.java
@@ -1,0 +1,61 @@
+package com.scalar.db.storage.jdbc;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+
+class RdbEngineTimeTypeSpanner
+    implements RdbEngineTimeTypeStrategy<
+        LocalDate, OffsetDateTime, OffsetDateTime, OffsetDateTime> {
+  /**
+   * A formatter for a Spanner DATE literal. The format is "YYYY-MM-DD". For example, "2020-03-04".
+   */
+  public static final DateTimeFormatter DATE_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendValue(YEAR, 4, 4, SignStyle.NEVER)
+          .appendLiteral('-')
+          .appendValue(MONTH_OF_YEAR, 2)
+          .appendLiteral('-')
+          .appendValue(DAY_OF_MONTH, 2)
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.STRICT)
+          .withChronology(IsoChronology.INSTANCE);
+
+  private final JdbcConfig config;
+
+  public RdbEngineTimeTypeSpanner(JdbcConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public LocalDate convert(LocalDate date) {
+    return date;
+  }
+
+  @Override
+  public OffsetDateTime convert(LocalTime time) {
+    return OffsetDateTime.of(
+        config.getSpannerTimeColumnDefaultDateComponent(), time, ZoneOffset.UTC);
+  }
+
+  @Override
+  public OffsetDateTime convert(LocalDateTime timestamp) {
+    return timestamp.atOffset(ZoneOffset.UTC);
+  }
+
+  @Override
+  public OffsetDateTime convert(OffsetDateTime timestampTZ) {
+    return timestampTZ;
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/SpannerCredentialsProvider.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/SpannerCredentialsProvider.java
@@ -1,0 +1,60 @@
+package com.scalar.db.storage.jdbc;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.common.CoreError;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Exposes Spanner service-account credentials to the Google Cloud Spanner JDBC driver via the
+ * {@code credentialsProvider} connection property.
+ *
+ * <p>The Spanner JDBC driver instantiates this class reflectively through its no-arg constructor,
+ * so credentials cannot be passed through the constructor. They are registered statically by {@link
+ * RdbEngineSpanner#setConnectionCredentials} before the connection pool is initialized. Only one
+ * set of Spanner credentials per JVM is supported; attempting to register a different credential
+ * fails fast rather than silently overwriting the existing one.
+ */
+public class SpannerCredentialsProvider implements CredentialsProvider {
+
+  private static final AtomicReference<Credentials> CREDENTIALS = new AtomicReference<>();
+
+  static void register(Credentials credentials) {
+    Objects.requireNonNull(credentials);
+    Credentials existing = CREDENTIALS.get();
+    if (existing == null) {
+      if (!CREDENTIALS.compareAndSet(null, credentials)) {
+        // Lost the race — fall through to the equality check against the winner
+        existing = CREDENTIALS.get();
+      } else {
+        return;
+      }
+    }
+    if (!existing.equals(credentials)) {
+      throw new IllegalStateException(
+          CoreError.JDBC_SPANNER_CREDENTIALS_ALREADY_REGISTERED.buildMessage());
+    }
+  }
+
+  @VisibleForTesting
+  static void clear() {
+    CREDENTIALS.set(null);
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public SpannerCredentialsProvider() {}
+
+  @Override
+  public Credentials getCredentials() {
+    Credentials credentials = CREDENTIALS.get();
+    if (credentials == null) {
+      throw new IllegalStateException(
+          "Spanner credentials have not been registered. "
+              + SpannerCredentialsProvider.class.getName()
+              + " is intended to be used only by ScalarDB's Spanner JDBC adapter");
+    }
+    return credentials;
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/SpannerCredentialsProvider.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/SpannerCredentialsProvider.java
@@ -4,57 +4,174 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.common.CoreError;
+import java.security.MessageDigest;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * Exposes Spanner service-account credentials to the Google Cloud Spanner JDBC driver via the
  * {@code credentialsProvider} connection property.
  *
- * <p>The Spanner JDBC driver instantiates this class reflectively through its no-arg constructor,
- * so credentials cannot be passed through the constructor. They are registered statically by {@link
- * RdbEngineSpanner#setConnectionCredentials} before the connection pool is initialized. Only one
- * set of Spanner credentials per JVM is supported; attempting to register a different credential
- * fails fast rather than silently overwriting the existing one.
+ * <p>The Spanner JDBC driver instantiates the configured class reflectively through its no-arg
+ * constructor, so credentials cannot be passed through the constructor. They are registered
+ * statically by {@link RdbEngineSpanner#setConnectionCredentials} before the connection pool is
+ * initialized. To allow the same JVM to use multiple Spanner data sources with different
+ * credentials, this class declares {@value #MAX_CREDENTIALS} concrete slot subclasses; each
+ * registered credential is bound to its own slot subclass and Hikari is pointed at that subclass's
+ * fully qualified name.
  */
-public class SpannerCredentialsProvider implements CredentialsProvider {
+public abstract class SpannerCredentialsProvider implements CredentialsProvider {
 
-  private static final AtomicReference<Credentials> CREDENTIALS = new AtomicReference<>();
+  static final int MAX_CREDENTIALS = 5;
 
-  static void register(Credentials credentials) {
+  private static final AtomicReference<Slot>[] SLOTS = newSlotArray();
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static AtomicReference<Slot>[] newSlotArray() {
+    AtomicReference[] slots = new AtomicReference[MAX_CREDENTIALS];
+    for (int i = 0; i < MAX_CREDENTIALS; i++) {
+      slots[i] = new AtomicReference<>();
+    }
+    return (AtomicReference<Slot>[]) slots;
+  }
+
+  /**
+   * Claims (or reuses) a slot for the given credentials and returns the fully qualified class name
+   * of the slot subclass that should be used as the {@code credentialsProvider} connection property
+   * value.
+   *
+   * <p>If a previously registered slot has the same {@code identityKey}, that slot's class name is
+   * returned (idempotent). Otherwise the first empty slot is claimed.
+   *
+   * @param credentials the parsed credentials object handed back to the JDBC driver
+   * @param identityKey caller-supplied bytes that uniquely identify these credentials (the raw
+   *     service-account JSON).
+   * @throws IllegalStateException when all {@value #MAX_CREDENTIALS} slots are occupied with
+   *     distinct identity keys.
+   */
+  static String register(Credentials credentials, byte[] identityKey) {
     Objects.requireNonNull(credentials);
-    Credentials existing = CREDENTIALS.get();
-    if (existing == null) {
-      if (!CREDENTIALS.compareAndSet(null, credentials)) {
-        // Lost the race — fall through to the equality check against the winner
-        existing = CREDENTIALS.get();
-      } else {
-        return;
+    Objects.requireNonNull(identityKey);
+    // Reuse the slot if these exact identity bytes are already registered.
+    for (int i = 0; i < MAX_CREDENTIALS; i++) {
+      Slot existing = SLOTS[i].get();
+      if (existing != null && MessageDigest.isEqual(existing.identityKey, identityKey)) {
+        return slotClassName(i);
       }
     }
-    if (!existing.equals(credentials)) {
-      throw new IllegalStateException(
-          CoreError.JDBC_SPANNER_CREDENTIALS_ALREADY_REGISTERED.buildMessage());
+    // Otherwise claim the first empty slot.
+    Slot newSlot = new Slot(credentials, identityKey.clone());
+    for (int i = 0; i < MAX_CREDENTIALS; i++) {
+      if (SLOTS[i].compareAndSet(null, newSlot)) {
+        return slotClassName(i);
+      }
+      // Lost the compare-and-swap race — if the winner has matching identity bytes, reuse this
+      // slot.
+      Slot existing = SLOTS[i].get();
+      if (existing != null && MessageDigest.isEqual(existing.identityKey, identityKey)) {
+        return slotClassName(i);
+      }
     }
+    throw new IllegalStateException(
+        CoreError.JDBC_SPANNER_CREDENTIALS_LIMIT_EXCEEDED.buildMessage(MAX_CREDENTIALS));
   }
 
   @VisibleForTesting
   static void clear() {
-    CREDENTIALS.set(null);
+    for (AtomicReference<Slot> slot : SLOTS) {
+      slot.set(null);
+    }
   }
 
-  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
-  public SpannerCredentialsProvider() {}
+  private static String slotClassName(int index) {
+    switch (index) {
+      case 0:
+        return Slot0.class.getName();
+      case 1:
+        return Slot1.class.getName();
+      case 2:
+        return Slot2.class.getName();
+      case 3:
+        return Slot3.class.getName();
+      case 4:
+        return Slot4.class.getName();
+      default:
+        throw new IllegalStateException("Unexpected slot index: " + index);
+    }
+  }
+
+  abstract int slot();
 
   @Override
   public Credentials getCredentials() {
-    Credentials credentials = CREDENTIALS.get();
-    if (credentials == null) {
+    @Nullable Slot s = SLOTS[slot()].get();
+    if (s == null) {
       throw new IllegalStateException(
           "Spanner credentials have not been registered. "
-              + SpannerCredentialsProvider.class.getName()
+              + getClass().getName()
               + " is intended to be used only by ScalarDB's Spanner JDBC adapter");
     }
-    return credentials;
+    return s.credentials;
+  }
+
+  private static final class Slot {
+    final Credentials credentials;
+    final byte[] identityKey;
+
+    Slot(Credentials credentials, byte[] identityKey) {
+      this.credentials = credentials;
+      this.identityKey = identityKey;
+    }
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public static final class Slot0 extends SpannerCredentialsProvider {
+    public Slot0() {}
+
+    @Override
+    int slot() {
+      return 0;
+    }
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public static final class Slot1 extends SpannerCredentialsProvider {
+    public Slot1() {}
+
+    @Override
+    int slot() {
+      return 1;
+    }
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public static final class Slot2 extends SpannerCredentialsProvider {
+    public Slot2() {}
+
+    @Override
+    int slot() {
+      return 2;
+    }
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public static final class Slot3 extends SpannerCredentialsProvider {
+    public Slot3() {}
+
+    @Override
+    int slot() {
+      return 3;
+    }
+  }
+
+  /** Required by the Spanner JDBC driver, which instantiates this class reflectively. */
+  public static final class Slot4 extends SpannerCredentialsProvider {
+    public Slot4() {}
+
+    @Override
+    int slot() {
+      return 4;
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/InsertOnConflictDoUpdateQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/InsertOnConflictDoUpdateQuery.java
@@ -14,6 +14,15 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * An UPSERT query using {@code INSERT ... ON CONFLICT (pk) DO UPDATE SET ...}.
+ *
+ * <p>The SET-clause format depends on the backend. Standard PostgreSQL and SQLite accept bind
+ * parameters ({@code SET col=?}), while Spanner PostgreSQL rejects that form and requires the
+ * {@code excluded} table alias ({@code SET col=excluded.col}). Pass {@code useExcludedAlias=true}
+ * to produce the Spanner-compatible form, which also skips the second bind pass since the SET
+ * clause no longer contains placeholders.
+ */
 @ThreadSafe
 public class InsertOnConflictDoUpdateQuery implements UpsertQuery {
 
@@ -24,9 +33,15 @@ public class InsertOnConflictDoUpdateQuery implements UpsertQuery {
   private final Key partitionKey;
   private final Optional<Key> clusteringKey;
   private final Map<String, Column<?>> columns;
+  private final boolean useExcludedAlias;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public InsertOnConflictDoUpdateQuery(Builder builder) {
+    this(builder, false);
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public InsertOnConflictDoUpdateQuery(Builder builder, boolean useExcludedAlias) {
     rdbEngine = builder.rdbEngine;
     schema = builder.schema;
     table = builder.table;
@@ -34,6 +49,7 @@ public class InsertOnConflictDoUpdateQuery implements UpsertQuery {
     partitionKey = builder.partitionKey;
     clusteringKey = builder.clusteringKey;
     columns = builder.columns;
+    this.useExcludedAlias = useExcludedAlias;
   }
 
   @Override
@@ -72,7 +88,11 @@ public class InsertOnConflictDoUpdateQuery implements UpsertQuery {
       sql.append("UPDATE SET ")
           .append(
               columns.keySet().stream()
-                  .map(n -> rdbEngine.enclose(n) + "=?")
+                  .map(
+                      n ->
+                          useExcludedAlias
+                              ? rdbEngine.enclose(n) + "=excluded." + rdbEngine.enclose(n)
+                              : rdbEngine.enclose(n) + "=?")
                   .collect(Collectors.joining(",")));
     } else {
       sql.append("NOTHING");
@@ -102,10 +122,14 @@ public class InsertOnConflictDoUpdateQuery implements UpsertQuery {
       binder.throwSQLExceptionIfOccurred();
     }
 
-    // For ON DUPLICATE KEY UPDATE
-    for (Column<?> column : columns.values()) {
-      column.accept(binder);
-      binder.throwSQLExceptionIfOccurred();
+    if (!useExcludedAlias) {
+      // Second bind pass for the "SET col=?" placeholders in the ON CONFLICT DO UPDATE clause.
+      // When useExcludedAlias is true, the SET clause uses excluded.col references with no
+      // placeholders, so this pass is skipped.
+      for (Column<?> column : columns.values()) {
+        column.accept(binder);
+        binder.throwSQLExceptionIfOccurred();
+      }
     }
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.rpc.Code;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
@@ -83,23 +84,17 @@ public class JdbcAdminTest {
   private static final String NAMESPACE = "namespace";
   private static final String TABLE = "table";
   private static final ImmutableMap<RdbEngine, RdbEngineStrategy> RDB_ENGINES =
-      ImmutableMap.of(
-          RdbEngine.MYSQL,
-          new RdbEngineMysql(),
-          RdbEngine.ORACLE,
-          new RdbEngineOracle(),
-          RdbEngine.POSTGRESQL,
-          new RdbEnginePostgresql(),
-          RdbEngine.SQL_SERVER,
-          new RdbEngineSqlServer(),
-          RdbEngine.SQLITE,
-          new RdbEngineSqlite(),
-          RdbEngine.YUGABYTE,
-          new RdbEngineYugabyte(),
-          RdbEngine.MARIADB,
-          new RdbEngineMariaDB(),
-          RdbEngine.DB2,
-          new RdbEngineDb2());
+      ImmutableMap.<RdbEngine, RdbEngineStrategy>builder()
+          .put(RdbEngine.MYSQL, new RdbEngineMysql())
+          .put(RdbEngine.ORACLE, new RdbEngineOracle())
+          .put(RdbEngine.POSTGRESQL, new RdbEnginePostgresql())
+          .put(RdbEngine.SQL_SERVER, new RdbEngineSqlServer())
+          .put(RdbEngine.SQLITE, new RdbEngineSqlite())
+          .put(RdbEngine.YUGABYTE, new RdbEngineYugabyte())
+          .put(RdbEngine.MARIADB, new RdbEngineMariaDB())
+          .put(RdbEngine.DB2, new RdbEngineDb2())
+          .put(RdbEngine.SPANNER, new RdbEngineSpanner())
+          .build();
 
   @Mock private HikariDataSource dataSource;
   @Mock private Connection connection;
@@ -159,6 +154,9 @@ public class JdbcAdminTest {
       case POSTGRESQL:
       case YUGABYTE:
         when(sqlException.getSQLState()).thenReturn("42P01");
+        break;
+      case SPANNER:
+        when(sqlException.getErrorCode()).thenReturn(Code.INVALID_ARGUMENT_VALUE);
         break;
       case ORACLE:
         when(sqlException.getErrorCode()).thenReturn(942);
@@ -266,6 +264,16 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     getTableMetadata_forX_ShouldReturnTableMetadata(
         RdbEngine.DB2,
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forSpanner_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.SPANNER,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + METADATA_SCHEMA
             + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
@@ -556,6 +564,20 @@ public class JdbcAdminTest {
         "CREATE TABLE IF NOT EXISTS \""
             + METADATA_SCHEMA
             + "\".\"namespaces\"(\"namespace_name\" VARCHAR(128) NOT NULL, PRIMARY KEY (\"namespace_name\"))",
+        "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
+  }
+
+  @Test
+  public void createNamespace_forSpanner_shouldExecuteCreateNamespaceStatement()
+      throws ExecutionException, SQLException {
+    createNamespace_forX_shouldExecuteCreateNamespaceStatement(
+        RdbEngine.SPANNER,
+        Collections.singletonList("CREATE SCHEMA \"my_ns\""),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS \"" + METADATA_SCHEMA + "\""),
+        "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" LIMIT 1",
+        "CREATE TABLE IF NOT EXISTS \""
+            + METADATA_SCHEMA
+            + "\".\"namespaces\"(\"namespace_name\" VARCHAR(128), PRIMARY KEY (\"namespace_name\"))",
         "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
   }
 
@@ -1720,6 +1742,13 @@ public class JdbcAdminTest {
         RdbEngine.DB2, "TRUNCATE TABLE \"my_ns\".\"foo_table\" IMMEDIATE");
   }
 
+  @Test
+  public void truncateTable_forSpanner_shouldExecuteTruncateTableStatement()
+      throws SQLException, ExecutionException {
+    truncateTable_forX_shouldExecuteTruncateTableStatement(
+        RdbEngine.SPANNER, "DELETE FROM \"my_ns\".\"foo_table\" WHERE TRUE");
+  }
+
   private void truncateTable_forX_shouldExecuteTruncateTableStatement(
       RdbEngine rdbEngine, String expectedTruncateTableStatement)
       throws SQLException, ExecutionException {
@@ -1893,6 +1922,19 @@ public class JdbcAdminTest {
         "DROP TABLE \"" + METADATA_SCHEMA + "\".\"metadata\"");
   }
 
+  @Test
+  public void dropTable_forSpannerWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata()
+      throws Exception {
+    dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
+        RdbEngine.SPANNER,
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"" + METADATA_SCHEMA + "\".\"metadata\"",
+        "DROP TABLE \"" + METADATA_SCHEMA + "\".\"metadata\"");
+  }
+
   private void dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
       RdbEngine rdbEngine, String... expectedSqlStatements) throws Exception {
     // Arrange
@@ -1916,6 +1958,15 @@ public class JdbcAdminTest {
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
+
+    // Mock the table metadata fetch issued by JdbcAdmin.dropTableInternal before the DROP.
+    PreparedStatement metadataSelectStatement = mock(PreparedStatement.class);
+    ResultSet metadataResultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                "c1", DataType.TEXT.toString(), "PARTITION", null, false));
+    when(metadataSelectStatement.executeQuery()).thenReturn(metadataResultSet);
+    when(connection.prepareStatement(any())).thenReturn(metadataSelectStatement);
 
     ResultSet resultSetForSelectAllNamespacesTable =
         mockResultSet(
@@ -2017,6 +2068,19 @@ public class JdbcAdminTest {
         "SELECT DISTINCT \"full_table_name\" FROM \"" + METADATA_SCHEMA + "\".\"metadata\"");
   }
 
+  @Test
+  public void
+      dropTable_forSpannerWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable()
+          throws Exception {
+    dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
+        RdbEngine.SPANNER,
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"" + METADATA_SCHEMA + "\".\"metadata\"");
+  }
+
   private void
       dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
           RdbEngine rdbEngine, String... expectedSqlStatements) throws Exception {
@@ -2041,6 +2105,15 @@ public class JdbcAdminTest {
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
+
+    // Mock the table metadata fetch issued by JdbcAdmin.dropTableInternal before the DROP.
+    PreparedStatement metadataSelectStatement = mock(PreparedStatement.class);
+    ResultSet metadataResultSet =
+        mockResultSet(
+            new SelectAllFromMetadataTableResultSetMocker.Row(
+                "c1", DataType.TEXT.toString(), "PARTITION", null, false));
+    when(metadataSelectStatement.executeQuery()).thenReturn(metadataResultSet);
+    when(connection.prepareStatement(any())).thenReturn(metadataSelectStatement);
 
     ResultSet resultSetForSelectAllNamespacesTable =
         mockResultSet(
@@ -2570,6 +2643,15 @@ public class JdbcAdminTest {
             + "\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
   }
 
+  @Test
+  public void getNamespaceTableNames_forSpanner_ShouldReturnTableNames() throws Exception {
+    getNamespaceTableNames_forX_ShouldReturnTableNames(
+        RdbEngine.SPANNER,
+        "SELECT DISTINCT \"full_table_name\" FROM \""
+            + METADATA_SCHEMA
+            + "\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
+  }
+
   private void getNamespaceTableNames_forX_ShouldReturnTableNames(
       RdbEngine rdbEngine, String expectedSelectStatement) throws Exception {
     // Arrange
@@ -2778,6 +2860,13 @@ public class JdbcAdminTest {
   public void namespaceExists_forDb2WithExistingNamespace_shouldReturnTrue() throws Exception {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
         RdbEngine.DB2,
+        "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" WHERE \"namespace_name\" = ?");
+  }
+
+  @Test
+  public void namespaceExists_forSpannerWithExistingNamespace_shouldReturnTrue() throws Exception {
+    namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
+        RdbEngine.SPANNER,
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" WHERE \"namespace_name\" = ?");
   }
 
@@ -4753,6 +4842,12 @@ public class JdbcAdminTest {
         RdbEngine.DB2, "SELECT * FROM \"" + METADATA_SCHEMA + "\".\"namespaces\"");
   }
 
+  @Test
+  public void getNamespaceNames_forSpanner_ShouldReturnNamespaceNames() throws Exception {
+    getNamespaceNames_forX_ShouldReturnNamespaceNames(
+        RdbEngine.SPANNER, "SELECT * FROM \"" + METADATA_SCHEMA + "\".\"namespaces\"");
+  }
+
   private void getNamespaceNames_forX_ShouldReturnNamespaceNames(
       RdbEngine rdbEngine, String expectedSelectStatement) throws Exception {
     // Arrange
@@ -4818,10 +4913,17 @@ public class JdbcAdminTest {
         .thenReturn("pk1")
         .thenReturn("pk2")
         .thenReturn("col");
-    when(columnResults.getInt(JDBC_COL_DATA_TYPE))
-        .thenReturn(Types.VARCHAR)
-        .thenReturn(Types.VARCHAR)
-        .thenReturn(Types.REAL);
+    if (rdbEngine == RdbEngine.SPANNER) {
+      when(columnResults.getInt(JDBC_COL_DATA_TYPE))
+          .thenReturn(Types.NVARCHAR)
+          .thenReturn(Types.NVARCHAR)
+          .thenReturn(Types.REAL);
+    } else {
+      when(columnResults.getInt(JDBC_COL_DATA_TYPE))
+          .thenReturn(Types.VARCHAR)
+          .thenReturn(Types.VARCHAR)
+          .thenReturn(Types.REAL);
+    }
     when(columnResults.getString(JDBC_COL_TYPE_NAME))
         .thenReturn("VARCHAR")
         .thenReturn("VARCHAR")
@@ -5156,6 +5258,20 @@ public class JdbcAdminTest {
         "CREATE TABLE IF NOT EXISTS \""
             + METADATA_SCHEMA
             + "\".\"namespaces\"(\"namespace_name\" VARCHAR(128) NOT NULL, PRIMARY KEY (\"namespace_name\"))",
+        "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
+  }
+
+  @Test
+  public void repairNamespace_forSpanner_shouldCreateNamespaceIfNotExistsAndUpsertMetadata()
+      throws ExecutionException, SQLException {
+    repairNamespace_forX_shouldWorkProperly(
+        RdbEngine.SPANNER,
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS \"my_ns\""),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS \"" + METADATA_SCHEMA + "\""),
+        "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" LIMIT 1",
+        "CREATE TABLE IF NOT EXISTS \""
+            + METADATA_SCHEMA
+            + "\".\"namespaces\"(\"namespace_name\" VARCHAR(128), PRIMARY KEY (\"namespace_name\"))",
         "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
   }
 
@@ -5670,6 +5786,19 @@ public class JdbcAdminTest {
         "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
   }
 
+  @Test
+  public void
+      createNamespaceTableIfNotExists_forSpanner_shouldCreateMetadataSchemaAndNamespacesTableIfNotExists()
+          throws ExecutionException, SQLException {
+    createNamespaceTableIfNotExists_forX_shouldCreateMetadataSchemaAndNamespacesTableIfNotExists(
+        RdbEngine.SPANNER,
+        "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" LIMIT 1",
+        "CREATE TABLE IF NOT EXISTS \""
+            + METADATA_SCHEMA
+            + "\".\"namespaces\"(\"namespace_name\" VARCHAR(128), PRIMARY KEY (\"namespace_name\"))",
+        "INSERT INTO \"" + METADATA_SCHEMA + "\".\"namespaces\" VALUES (?)");
+  }
+
   public void
       createNamespaceTableIfNotExists_forX_shouldCreateMetadataSchemaAndNamespacesTableIfNotExists(
           RdbEngine rdbEngine,
@@ -5719,6 +5848,10 @@ public class JdbcAdminTest {
       case YUGABYTE:
         duplicateKeyException = mock(SQLException.class);
         when(duplicateKeyException.getSQLState()).thenReturn("23505");
+        break;
+      case SPANNER:
+        duplicateKeyException = mock(SQLException.class);
+        when(duplicateKeyException.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
         break;
       case SQLITE:
         SQLiteException sqLiteException = mock(SQLiteException.class);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -50,6 +50,7 @@ public class JdbcConfigTest {
     props.setProperty(JdbcConfig.DB2_VARIABLE_KEY_COLUMN_SIZE, "64");
     props.setProperty(JdbcConfig.ORACLE_TIME_COLUMN_DEFAULT_DATE_COMPONENT, "2020-01-01");
     props.setProperty(JdbcConfig.DB2_TIME_COLUMN_DEFAULT_DATE_COMPONENT, "2022-01-01");
+    props.setProperty(JdbcConfig.SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT, "2024-01-01");
 
     // Act
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(props));
@@ -88,6 +89,8 @@ public class JdbcConfigTest {
         .isEqualTo(LocalDate.parse("2020-01-01", DateTimeFormatter.ISO_LOCAL_DATE));
     assertThat(config.getDb2TimeColumnDefaultDateComponent())
         .isEqualTo(LocalDate.parse("2022-01-01", DateTimeFormatter.ISO_LOCAL_DATE));
+    assertThat(config.getSpannerTimeColumnDefaultDateComponent())
+        .isEqualTo(LocalDate.parse("2024-01-01", DateTimeFormatter.ISO_LOCAL_DATE));
   }
 
   @Test
@@ -145,6 +148,8 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_ORACLE_TIME_COLUMN_DEFAULT_DATE_COMPONENT);
     assertThat(config.getDb2TimeColumnDefaultDateComponent())
         .isEqualTo(JdbcConfig.DEFAULT_DB2_TIME_COLUMN_DEFAULT_DATE_COMPONENT);
+    assertThat(config.getSpannerTimeColumnDefaultDateComponent())
+        .isEqualTo(JdbcConfig.DEFAULT_SPANNER_TIME_COLUMN_DEFAULT_DATE_COMPONENT);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -1,6 +1,8 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -26,6 +28,9 @@ public class JdbcUtilsTest {
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+    // setConnectionCredentials is a default interface method that copies username/password from
+    // JdbcConfig to HikariConfig. Mocks no-op default methods, so call the real implementation.
+    doCallRealMethod().when(rdbEngine).setConnectionCredentials(any(), any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
@@ -13,7 +13,8 @@ public enum RdbEngine {
   SQLITE,
   YUGABYTE,
   MARIADB,
-  DB2;
+  DB2,
+  SPANNER;
 
   public static RdbEngineStrategy createRdbEngineStrategy(RdbEngine rdbEngine) {
     switch (rdbEngine) {
@@ -33,6 +34,8 @@ public enum RdbEngine {
         return new RdbEngineMariaDB();
       case DB2:
         return new RdbEngineDb2();
+      case SPANNER:
+        return new RdbEngineSpanner();
       default:
         throw new AssertionError("Unsupported rdbEngine " + rdbEngine);
     }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
@@ -1,0 +1,439 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.rpc.Code;
+import com.scalar.db.api.LikeExpression;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.DateColumn;
+import com.scalar.db.io.TimeColumn;
+import com.scalar.db.io.TimestampColumn;
+import com.zaxxer.hikari.HikariConfig;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RdbEngineSpannerTest {
+
+  private RdbEngineSpanner rdbEngine;
+
+  @BeforeEach
+  void setUp() {
+    rdbEngine = new RdbEngineSpanner();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SpannerCredentialsProvider.clear();
+  }
+
+  @Test
+  void getDriverClassName_ShouldReturnSpannerDriver() {
+    assertThat(rdbEngine.getDriverClassName())
+        .isEqualTo("com.google.cloud.spanner.jdbc.JdbcDriver");
+  }
+
+  @Test
+  void getDataTypeForEngine_ShouldMapEachScalarDbDataTypeCorrectly() {
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.INT)).isEqualTo("bigint");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.BIGINT)).isEqualTo("bigint");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.BLOB)).isEqualTo("bytea");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.BOOLEAN)).isEqualTo("boolean");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.FLOAT)).isEqualTo("real");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.DOUBLE)).isEqualTo("double precision");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.TEXT)).isEqualTo("text");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.DATE)).isEqualTo("date");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.TIME)).isEqualTo("timestamp with time zone");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.TIMESTAMP))
+        .isEqualTo("timestamp with time zone");
+    assertThat(rdbEngine.getDataTypeForEngine(DataType.TIMESTAMPTZ))
+        .isEqualTo("timestamp with time zone");
+  }
+
+  @Test
+  void getDataTypeForKey_ShouldReturnNullForAllTypes() {
+    for (DataType dataType : DataType.values()) {
+      assertThat(rdbEngine.getDataTypeForKey(dataType)).isNull();
+    }
+  }
+
+  @Test
+  void getSqlTypes_IntShouldMapToBigint() {
+    assertThat(rdbEngine.getSqlTypes(DataType.INT)).isEqualTo(Types.BIGINT);
+  }
+
+  @Test
+  void getSqlTypes_TimeAndTimestampShouldMapToTimestampWithTimezone() {
+    assertThat(rdbEngine.getSqlTypes(DataType.TIME)).isEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
+    assertThat(rdbEngine.getSqlTypes(DataType.TIMESTAMP)).isEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
+  }
+
+  @Test
+  void getSqlTypes_OtherTypesShouldFallThroughToPostgresqlMapping() {
+    // Sanity: non-overridden type should not return BIGINT or TIMESTAMP_WITH_TIMEZONE.
+    assertThat(rdbEngine.getSqlTypes(DataType.TEXT)).isNotEqualTo(Types.BIGINT);
+    assertThat(rdbEngine.getSqlTypes(DataType.BOOLEAN)).isNotEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
+  }
+
+  @Test
+  void truncateTableSql_ShouldReturnDeleteWhereTrue() {
+    assertThat(rdbEngine.truncateTableSql("ns", "tbl"))
+        .isEqualTo("DELETE FROM \"ns\".\"tbl\" WHERE TRUE");
+  }
+
+  @Test
+  void renameTableSql_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> rdbEngine.renameTableSql("ns", "old", "new"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void dropTableSql_WithoutIndexesOrMixedOrders_ShouldReturnDropTableOnly() {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.getSecondaryIndexNames()).thenReturn(Collections.emptySet());
+    when(metadata.getClusteringOrders()).thenReturn(Collections.emptyMap());
+
+    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+
+    assertThat(sqls).hasSize(1);
+    assertThat(sqls[0]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
+  }
+
+  @Test
+  void dropTableSql_WithSecondaryIndexes_ShouldDropIndexesBeforeTable() {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.getSecondaryIndexNames()).thenReturn(ImmutableSet.of("c1"));
+    when(metadata.getClusteringOrders()).thenReturn(Collections.emptyMap());
+
+    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+
+    assertThat(sqls).hasSize(2);
+    assertThat(sqls[0]).startsWith("DROP INDEX");
+    assertThat(sqls[1]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
+  }
+
+  @Test
+  void dropTableSql_WithMixedClusteringOrders_ShouldDropClusteringOrderIndex() {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.getSecondaryIndexNames()).thenReturn(Collections.emptySet());
+    when(metadata.getClusteringOrders())
+        .thenReturn(ImmutableMap.of("ck1", Order.ASC, "ck2", Order.DESC));
+
+    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+
+    assertThat(sqls).hasSize(2);
+    assertThat(sqls[0]).startsWith("DROP INDEX");
+    assertThat(sqls[1]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
+  }
+
+  @Test
+  void getEscape_BackslashEscape_ShouldReturnNull() {
+    LikeExpression like = mock(LikeExpression.class);
+    when(like.getEscape()).thenReturn("\\");
+
+    assertThat(rdbEngine.getEscape(like)).isNull();
+  }
+
+  @Test
+  void getEscape_NonBackslashEscape_ShouldThrowUnsupportedOperationException() {
+    LikeExpression like = mock(LikeExpression.class);
+    when(like.getEscape()).thenReturn("+");
+
+    assertThatThrownBy(() -> rdbEngine.getEscape(like))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void getEscape_EmptyEscape_ShouldThrowUnsupportedOperationException() {
+    LikeExpression like = mock(LikeExpression.class);
+    when(like.getEscape()).thenReturn("");
+
+    assertThatThrownBy(() -> rdbEngine.getEscape(like))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void isDuplicateTableError_ShouldAlwaysReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
+
+    assertThat(rdbEngine.isDuplicateTableError(e)).isFalse();
+  }
+
+  @Test
+  void isCreateMetadataSchemaDuplicateSchemaError_ShouldAlwaysReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
+
+    assertThat(rdbEngine.isCreateMetadataSchemaDuplicateSchemaError(e)).isFalse();
+  }
+
+  @Test
+  void isDuplicateKeyError_AlreadyExistsCode_ShouldReturnTrue() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
+
+    assertThat(rdbEngine.isDuplicateKeyError(e)).isTrue();
+  }
+
+  @Test
+  void isDuplicateKeyError_OtherCode_ShouldReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.NOT_FOUND_VALUE);
+
+    assertThat(rdbEngine.isDuplicateKeyError(e)).isFalse();
+  }
+
+  @Test
+  void isUndefinedTableError_InvalidArgumentCode_ShouldReturnTrue() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.INVALID_ARGUMENT_VALUE);
+
+    assertThat(rdbEngine.isUndefinedTableError(e)).isTrue();
+  }
+
+  @Test
+  void isUndefinedTableError_OtherCode_ShouldReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.NOT_FOUND_VALUE);
+
+    assertThat(rdbEngine.isUndefinedTableError(e)).isFalse();
+  }
+
+  @Test
+  void isUndefinedIndexError_NotFoundCode_ShouldReturnTrue() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.NOT_FOUND_VALUE);
+
+    assertThat(rdbEngine.isUndefinedIndexError(e)).isTrue();
+  }
+
+  @Test
+  void isUndefinedIndexError_OtherCode_ShouldReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.INVALID_ARGUMENT_VALUE);
+
+    assertThat(rdbEngine.isUndefinedIndexError(e)).isFalse();
+  }
+
+  @Test
+  void isConflict_AbortedCode_ShouldReturnTrue() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.ABORTED_VALUE);
+
+    assertThat(rdbEngine.isConflict(e)).isTrue();
+  }
+
+  @Test
+  void isConflict_OtherCode_ShouldReturnFalse() {
+    SQLException e = mock(SQLException.class);
+    when(e.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
+
+    assertThat(rdbEngine.isConflict(e)).isFalse();
+  }
+
+  @Test
+  void throwIfRenameColumnNotSupported_ShouldAlwaysThrow() {
+    TableMetadata metadata = mock(TableMetadata.class);
+    assertThatThrownBy(() -> rdbEngine.throwIfRenameColumnNotSupported("col", metadata))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void throwIfAlterColumnTypeNotSupported_BlobToText_ShouldNotThrow() {
+    assertThatCode(() -> rdbEngine.throwIfAlterColumnTypeNotSupported(DataType.BLOB, DataType.TEXT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void throwIfAlterColumnTypeNotSupported_TextToBlob_ShouldThrow() {
+    // Reverse direction is not supported.
+    assertThatThrownBy(
+            () -> rdbEngine.throwIfAlterColumnTypeNotSupported(DataType.TEXT, DataType.BLOB))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void throwIfAlterColumnTypeNotSupported_IntToBigint_ShouldThrow() {
+    assertThatThrownBy(
+            () -> rdbEngine.throwIfAlterColumnTypeNotSupported(DataType.INT, DataType.BIGINT))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void requiresExplicitDropIndexBeforeDropColumn_ShouldReturnTrue() {
+    assertThat(rdbEngine.requiresExplicitDropIndexBeforeDropColumn()).isTrue();
+  }
+
+  @Test
+  void parseTimeColumn_NullValue_ShouldReturnNullColumn() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getObject("t", OffsetDateTime.class)).thenReturn(null);
+
+    TimeColumn column = rdbEngine.parseTimeColumn(rs, "t");
+
+    assertThat(column.hasNullValue()).isTrue();
+    assertThat(column.getName()).isEqualTo("t");
+  }
+
+  @Test
+  void parseTimeColumn_NonUtcOffset_ShouldNormalizeToUtc() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    // 14:30 at +09:00 == 05:30 UTC
+    OffsetDateTime stored = OffsetDateTime.of(2024, 1, 1, 14, 30, 0, 0, ZoneOffset.ofHours(9));
+    when(rs.getObject("t", OffsetDateTime.class)).thenReturn(stored);
+
+    TimeColumn column = rdbEngine.parseTimeColumn(rs, "t");
+
+    assertThat(column.hasNullValue()).isFalse();
+    assertThat(column.getTimeValue()).isEqualTo(LocalTime.of(5, 30));
+  }
+
+  @Test
+  void parseTimestampColumn_NullValue_ShouldReturnNullColumn() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getObject("ts", OffsetDateTime.class)).thenReturn(null);
+
+    TimestampColumn column = rdbEngine.parseTimestampColumn(rs, "ts");
+
+    assertThat(column.hasNullValue()).isTrue();
+    assertThat(column.getName()).isEqualTo("ts");
+  }
+
+  @Test
+  void parseTimestampColumn_NonUtcOffset_ShouldNormalizeToUtc() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    // 2024-06-15 14:30:45 at +09:00 == 2024-06-15 05:30:45 UTC
+    OffsetDateTime stored = OffsetDateTime.of(2024, 6, 15, 14, 30, 45, 0, ZoneOffset.ofHours(9));
+    when(rs.getObject("ts", OffsetDateTime.class)).thenReturn(stored);
+
+    TimestampColumn column = rdbEngine.parseTimestampColumn(rs, "ts");
+
+    assertThat(column.hasNullValue()).isFalse();
+    assertThat(column.getTimestampValue()).isEqualTo(LocalDateTime.of(2024, 6, 15, 5, 30, 45));
+  }
+
+  @Test
+  void parseDateColumn_NullValue_ShouldReturnNullColumn() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("d")).thenReturn(null);
+
+    DateColumn column = rdbEngine.parseDateColumn(rs, "d");
+
+    assertThat(column.hasNullValue()).isTrue();
+    assertThat(column.getName()).isEqualTo("d");
+  }
+
+  @Test
+  void parseDateColumn_ValidDateString_ShouldParseToLocalDate() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("d")).thenReturn("2024-06-15");
+
+    DateColumn column = rdbEngine.parseDateColumn(rs, "d");
+
+    assertThat(column.hasNullValue()).isFalse();
+    assertThat(column.getDateValue()).isEqualTo(LocalDate.of(2024, 6, 15));
+  }
+
+  @Test
+  void setConnectionCredentials_NoPassword_ShouldNotConfigureProvider() {
+    JdbcConfig config = mock(JdbcConfig.class);
+    when(config.getPassword()).thenReturn(Optional.empty());
+    HikariConfig hikariConfig = mock(HikariConfig.class);
+
+    rdbEngine.setConnectionCredentials(config, hikariConfig);
+
+    verify(hikariConfig, never()).addDataSourceProperty(eq("credentialsProvider"), any());
+  }
+
+  @Test
+  void setConnectionCredentials_ValidServiceAccountKey_ShouldRegisterAndSetProperty() {
+    JdbcConfig config = mock(JdbcConfig.class);
+    when(config.getPassword()).thenReturn(Optional.of(SAMPLE_SERVICE_ACCOUNT_KEY));
+    HikariConfig hikariConfig = mock(HikariConfig.class);
+
+    rdbEngine.setConnectionCredentials(config, hikariConfig);
+
+    verify(hikariConfig, times(1))
+        .addDataSourceProperty("credentialsProvider", SpannerCredentialsProvider.class.getName());
+    assertThat(new SpannerCredentialsProvider().getCredentials()).isNotNull();
+  }
+
+  @Test
+  void setConnectionCredentials_InvalidKey_ShouldThrowIllegalArgumentException() {
+    JdbcConfig config = mock(JdbcConfig.class);
+    when(config.getPassword()).thenReturn(Optional.of("not-a-service-account-json"));
+    HikariConfig hikariConfig = mock(HikariConfig.class);
+
+    assertThatThrownBy(() -> rdbEngine.setConnectionCredentials(config, hikariConfig))
+        .isInstanceOf(IllegalArgumentException.class);
+    verify(hikariConfig, never()).addDataSourceProperty(eq("credentialsProvider"), any());
+  }
+
+  /**
+   * A syntactically valid (but non-functional) service-account key — enough for {@code
+   * GoogleCredentials.fromStream} to parse without making a network call. The private key is a
+   * freshly-generated RSA key not associated with any real Google Cloud account.
+   */
+  private static final String SAMPLE_SERVICE_ACCOUNT_KEY =
+      "{\n"
+          + "  \"type\": \"service_account\",\n"
+          + "  \"project_id\": \"test-project\",\n"
+          + "  \"private_key_id\": \"00000000000000000000000000000000\",\n"
+          + "  \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n"
+          + "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDJ5uvFzWuQJG+e\\n"
+          + "pgWcRk/1nKQqQQTQFA8D1lxFB2QM7NlV4bAnHU7u4q5sGmu/Wkp8VeQmPCb1Cqtm\\n"
+          + "9PpKcQlmgY0HYqWvk+TgnBp6qYoLWXjrUiwT8FhMQeqGn1x0mflp1tHo/p/bYYpJ\\n"
+          + "lDc3VXkD0Rx6Z2QdOG5y+kMU4Df1BX2xvGmx2OBP3K9hREsUlHWN8TUMBl3uAvjB\\n"
+          + "qflbS6FA2kmJrK6pIY7w08DTkvmf4nW4xMtWMS/X5y+fQeYg0yc7Bd5b4LPlfWJ7\\n"
+          + "+H/qZWkfEoq3pCVpHocoVSahNGowS4JfIv5PT9TXk8m4Yg4xpgFNIz5uUgsVDohh\\n"
+          + "UyR9OaRnAgMBAAECggEAOoaPjdU6/hpPx9MX0KVxUUH7VVHYkmf7AnphLWjfAMBT\\n"
+          + "8rLAZSZ3gXBgaQ6f4f8gsEAfYn0wZc+I2spJL0V3X0xfEGwzkQUAPkpcaPuJAJIm\\n"
+          + "ouEKfkPCYsDJhBu6nqJ0Q1G8mztMAdvdwQHjRy03PQ5Z+rK2qEOTKOqXqGTLrIhu\\n"
+          + "Z9j5TBN0F+QMpfM6EAMCihMpAA3dVoH+6MvK0c2tLwqOQ6eWylPbVyzCVgNcJC8I\\n"
+          + "gE0RxIb+u4KYdt1ECqhrHckRjV7xUIqjKqMqYY/rrAIDC0OzPe2C/HEN6Y+mqg5Z\\n"
+          + "PQYW5L6dQwUmBn0cJ30/w7Sf/8Rk+yEQU6f5vGEpgQKBgQD+NS3dFpDjeySt9HhT\\n"
+          + "EzFnzJ/RYMQiPofPgpwGWE/QYPaKdQtaFu2pHjAzZ8HDvMGpDHYK4Bz1q6VKNYQ7\\n"
+          + "yFY4bJv7uG6ZkGLbtcfSxSpqWYzz4cpSBjzpb7K6S2QaHxHxFaCbgGxC2hcJNTMG\\n"
+          + "8MmS8VgvgDxuJ9R4Bpp6yvHv+wKBgQDLZfOJZ8UzS9gmkF9k1zN+w9Z8jp5l5Bne\\n"
+          + "Y3WP5Ctwf5HzZk2FbTDP9j2LGhSlGOj8dfbOl4Gh9w6JzLgYvDKIrV5G7DWkoNZ7\\n"
+          + "HxRjrAgxoYhOoofmBpe0IxYyZMe+i1B0c8M+EfQF13X1uwLqWaT4Tcw6QIxuNi8E\\n"
+          + "QmKuLY01BQKBgFWqB2gDYKD1iNJp+qEK35JHYTxc6Zwgl3a4ZyyOY6ePzFdQ3K6v\\n"
+          + "fU2rH+CkQGJeXqe3QwDIBafMmRu9N7sC9o7NDCeyahVLAE6NxYpnOhz3Y9Lu0AVe\\n"
+          + "oyV2ESgKR+TrJM3uLbTApMrZgUPYPoynRjJZhZ8XU+Y5bSMqrUOPmO99AoGBAJtA\\n"
+          + "TEZD9WuQOzbAKxXxmm+e2YT8JgC+XpBjZEgPL5T+ZrV2bk8Y2hpeP2ydeBz6Hh4k\\n"
+          + "FjC5bjMuLArD5y1eCrqjdNXLdIFNMLlhZCwgI31g9BYZxuDdiTkMOZkEEv5SBGYQ\\n"
+          + "5WDKnAxsLpdcLsDdMhgexsQk59m/Jz6oKnCAbHJ9AoGAOxDbV/Z31D4mOjkTW2HG\\n"
+          + "0OVkxgcjFmRf06AbTVO0pCZ6fH3vjJj1hytiAswABQ41DkhBKyaKv8OzvAbACEPs\\n"
+          + "lWY/LqJ5vG2x3/jvJSc6YL8FUBmcBzaLNfDoXM4gOxQzRzxEm4XKdL+wxx6/RFhE\\n"
+          + "0Ns6YZmhjXzqnzVOUBNG7vU=\\n"
+          + "-----END PRIVATE KEY-----\\n\",\n"
+          + "  \"client_email\": \"test@test-project.iam.gserviceaccount.com\",\n"
+          + "  \"client_id\": \"000000000000000000000\",\n"
+          + "  \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\n"
+          + "  \"token_uri\": \"https://oauth2.googleapis.com/token\"\n"
+          + "}";
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
@@ -395,15 +395,6 @@ public class RdbEngineSpannerTest {
     verify(hikariConfig, never()).addDataSourceProperty(eq("credentialsProvider"), any());
   }
 
-  @Test
-  void getConnectionProperties_ShouldReturnPostgresqlDialect() {
-    JdbcConfig config = mock(JdbcConfig.class);
-
-    assertThat(rdbEngine.getConnectionProperties(config))
-        .hasSize(1)
-        .containsEntry("dialect", "POSTGRESQL");
-  }
-
   /**
    * A syntactically valid (but non-functional) service-account key — enough for {@code
    * GoogleCredentials.fromStream} to parse without making a network call. The private key is a

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
@@ -377,9 +377,11 @@ public class RdbEngineSpannerTest {
 
     rdbEngine.setConnectionCredentials(config, hikariConfig);
 
+    // The first registration in a clean JVM goes into Slot0.
     verify(hikariConfig, times(1))
-        .addDataSourceProperty("credentialsProvider", SpannerCredentialsProvider.class.getName());
-    assertThat(new SpannerCredentialsProvider().getCredentials()).isNotNull();
+        .addDataSourceProperty(
+            "credentialsProvider", SpannerCredentialsProvider.Slot0.class.getName());
+    assertThat(new SpannerCredentialsProvider.Slot0().getCredentials()).isNotNull();
   }
 
   @Test
@@ -391,6 +393,15 @@ public class RdbEngineSpannerTest {
     assertThatThrownBy(() -> rdbEngine.setConnectionCredentials(config, hikariConfig))
         .isInstanceOf(IllegalArgumentException.class);
     verify(hikariConfig, never()).addDataSourceProperty(eq("credentialsProvider"), any());
+  }
+
+  @Test
+  void getConnectionProperties_ShouldReturnPostgresqlDialect() {
+    JdbcConfig config = mock(JdbcConfig.class);
+
+    assertThat(rdbEngine.getConnectionProperties(config))
+        .hasSize(1)
+        .containsEntry("dialect", "POSTGRESQL");
   }
 
   /**

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
@@ -111,42 +111,39 @@ public class RdbEngineSpannerTest {
   }
 
   @Test
-  void dropTableSql_WithoutIndexesOrMixedOrders_ShouldReturnDropTableOnly() {
+  void dropTableInternalSqlsBeforeDropTable_WithoutIndexesOrMixedOrders_ShouldReturnEmpty() {
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.getSecondaryIndexNames()).thenReturn(Collections.emptySet());
     when(metadata.getClusteringOrders()).thenReturn(Collections.emptyMap());
 
-    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+    String[] sqls = rdbEngine.dropTableInternalSqlsBeforeDropTable("ns", "tbl", metadata);
 
-    assertThat(sqls).hasSize(1);
-    assertThat(sqls[0]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
+    assertThat(sqls).isEmpty();
   }
 
   @Test
-  void dropTableSql_WithSecondaryIndexes_ShouldDropIndexesBeforeTable() {
+  void dropTableInternalSqlsBeforeDropTable_WithSecondaryIndexes_ShouldReturnIndexDrop() {
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.getSecondaryIndexNames()).thenReturn(ImmutableSet.of("c1"));
     when(metadata.getClusteringOrders()).thenReturn(Collections.emptyMap());
 
-    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+    String[] sqls = rdbEngine.dropTableInternalSqlsBeforeDropTable("ns", "tbl", metadata);
 
-    assertThat(sqls).hasSize(2);
+    assertThat(sqls).hasSize(1);
     assertThat(sqls[0]).startsWith("DROP INDEX");
-    assertThat(sqls[1]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
   }
 
   @Test
-  void dropTableSql_WithMixedClusteringOrders_ShouldDropClusteringOrderIndex() {
+  void dropTableInternalSqlsBeforeDropTable_WithMixedClusteringOrders_ShouldReturnIndexDrop() {
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.getSecondaryIndexNames()).thenReturn(Collections.emptySet());
     when(metadata.getClusteringOrders())
         .thenReturn(ImmutableMap.of("ck1", Order.ASC, "ck2", Order.DESC));
 
-    String[] sqls = rdbEngine.dropTableSql(metadata, "ns", "tbl");
+    String[] sqls = rdbEngine.dropTableInternalSqlsBeforeDropTable("ns", "tbl", metadata);
 
-    assertThat(sqls).hasSize(2);
+    assertThat(sqls).hasSize(1);
     assertThat(sqls[0]).startsWith("DROP INDEX");
-    assertThat(sqls[1]).isEqualTo("DROP TABLE \"ns\".\"tbl\"");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTest.java
@@ -4,6 +4,7 @@ import static com.scalar.db.storage.jdbc.RdbEngine.DB2;
 import static com.scalar.db.storage.jdbc.RdbEngine.MYSQL;
 import static com.scalar.db.storage.jdbc.RdbEngine.ORACLE;
 import static com.scalar.db.storage.jdbc.RdbEngine.POSTGRESQL;
+import static com.scalar.db.storage.jdbc.RdbEngine.SPANNER;
 import static com.scalar.db.storage.jdbc.RdbEngine.SQL_SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -102,6 +103,7 @@ public class RdbEngineTest {
     DATA_TYPE_MAP
         .get(ORACLE)
         .put(new Column(JDBCType.NUMERIC, "NUMBER", 1, 0, DataType.BOOLEAN), DataType.BOOLEAN);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.BOOLEAN, "boolean"), DataType.BOOLEAN);
 
     // INT
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.TINYINT, "TINYINT"), DataType.INT);
@@ -118,6 +120,9 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.SMALLINT, "SMALLINT"), DataType.INT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.INTEGER, "INT"), DataType.INT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.BIGINT, "BIGINT"), DataType.BIGINT);
+    // Spanner has no native INT — INT is an alias for BIGINT, so JDBCType.INTEGER falls through.
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.INTEGER, "int4"), null);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.SMALLINT, "smallint"), null);
 
     // BIGINT
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIGINT, "BIGINT"), DataType.BIGINT);
@@ -126,6 +131,7 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BIGINT, "bigserial"), null);
     DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.BIGINT, "BIGINT"), null);
     DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BIGINT, "bigint"), DataType.BIGINT);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.BIGINT, "bigint"), DataType.BIGINT);
 
     // FLOAT
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.REAL, "FLOAT"), DataType.FLOAT);
@@ -134,6 +140,7 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.REAL, "real"), DataType.FLOAT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.REAL, "REAL", 24, 0), DataType.FLOAT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.REAL, "REAL", 10, 0), DataType.FLOAT);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.REAL, "real"), DataType.FLOAT);
 
     // DOUBLE
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.DOUBLE, "DOUBLE"), DataType.DOUBLE);
@@ -144,6 +151,9 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.FLOAT, "FLOAT", 54, 0), null);
     DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.DOUBLE, "real"), DataType.DOUBLE);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.DOUBLE, "DOUBLE", 53, 0), DataType.DOUBLE);
+    DATA_TYPE_MAP
+        .get(SPANNER)
+        .put(new Column(JDBCType.DOUBLE, "double precision"), DataType.DOUBLE);
 
     // TEXT
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.CHAR, "CHAR"), DataType.TEXT);
@@ -176,6 +186,8 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.CHAR, "GRAPHIC", 3, 0), DataType.TEXT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.VARCHAR, "VARGRAPHIC", 512, 0), DataType.TEXT);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.CLOB, "DCLOB", 512, 10), DataType.TEXT);
+    // Spanner JDBC reports text columns as NVARCHAR; jsonb is rejected.
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.NVARCHAR, "text"), DataType.TEXT);
 
     // BLOB
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BINARY, "BINARY"), DataType.BLOB);
@@ -197,6 +209,7 @@ public class RdbEngineTest {
     DATA_TYPE_MAP
         .get(DB2)
         .put(new Column(JDBCType.BINARY, "VARCHAR () FOR BIT DATA", 512, 0), DataType.BLOB);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.BINARY, "bytea"), DataType.BLOB);
 
     // NUMERIC/DECIMAL
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.NUMERIC, "NUMERIC"), null);
@@ -281,6 +294,22 @@ public class RdbEngineTest {
         .put(
             new Column(JDBCType.TIMESTAMP, "TIMESTAMP", DataType.TIMESTAMPTZ),
             DataType.TIMESTAMPTZ);
+    // Spanner: DATE → DATE; TIMESTAMP defaults to TIMESTAMPTZ but honors TIME / TIMESTAMP
+    // overrides.
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.DATE, "date"), DataType.DATE);
+    DATA_TYPE_MAP
+        .get(SPANNER)
+        .put(new Column(JDBCType.TIMESTAMP, "timestamp with time zone"), DataType.TIMESTAMPTZ);
+    DATA_TYPE_MAP
+        .get(SPANNER)
+        .put(
+            new Column(JDBCType.TIMESTAMP, "timestamp with time zone", DataType.TIME),
+            DataType.TIME);
+    DATA_TYPE_MAP
+        .get(SPANNER)
+        .put(
+            new Column(JDBCType.TIMESTAMP, "timestamp with time zone", DataType.TIMESTAMP),
+            DataType.TIMESTAMP);
 
     // Other unsupported data types
     DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIT, "BIT", 8, 0), null);
@@ -294,6 +323,9 @@ public class RdbEngineTest {
     DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.OTHER, ""), null);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.OTHER, "DECFLOAT"), null);
     DATA_TYPE_MAP.get(DB2).put(new Column(JDBCType.OTHER, "XML"), null);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.OTHER, ""), null);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.NUMERIC, "numeric"), null);
+    DATA_TYPE_MAP.get(SPANNER).put(new Column(JDBCType.NVARCHAR, "jsonb"), null);
   }
 
   @Immutable

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpannerTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,5 +77,54 @@ public class RdbEngineTimeTypeSpannerTest {
   void convert_OffsetDateTime_ShouldReturnSameTimestampTz() {
     OffsetDateTime timestampTz = OffsetDateTime.of(2024, 6, 15, 14, 30, 45, 0, ZoneOffset.UTC);
     assertThat(strategy.convert(timestampTz)).isEqualTo(timestampTz);
+  }
+
+  @Test
+  void convert_OffsetDateTimeWithNonUtcOffset_ShouldPreserveOffset() {
+    OffsetDateTime timestampTz =
+        OffsetDateTime.of(2024, 6, 15, 14, 30, 45, 0, ZoneOffset.ofHours(9));
+    OffsetDateTime result = strategy.convert(timestampTz);
+    assertThat(result).isEqualTo(timestampTz);
+    assertThat(result.getOffset()).isEqualTo(ZoneOffset.ofHours(9));
+  }
+
+  @Test
+  void convert_LocalDateTimeWithNanos_ShouldPreserveNanos() {
+    LocalDateTime timestamp = LocalDateTime.of(2024, 6, 15, 14, 30, 45, 123_456_789);
+    OffsetDateTime result = strategy.convert(timestamp);
+    assertThat(result).isEqualTo(OffsetDateTime.of(timestamp, ZoneOffset.UTC));
+    assertThat(result.getNano()).isEqualTo(123_456_789);
+  }
+
+  @Test
+  void convert_LocalDateOnLeapDay_ShouldReturnSameDate() {
+    LocalDate leapDay = LocalDate.of(2020, 2, 29);
+    assertThat(strategy.convert(leapDay)).isEqualTo(leapDay);
+  }
+
+  @Test
+  void dateFormatter_ParsesValidDate() {
+    LocalDate parsed = RdbEngineTimeTypeSpanner.DATE_FORMATTER.parse("2020-03-04", LocalDate::from);
+    assertThat(parsed).isEqualTo(LocalDate.of(2020, 3, 4));
+  }
+
+  @Test
+  void dateFormatter_RejectsInvalidDate() {
+    // Strict resolver style must reject impossible dates such as Feb 30.
+    assertThatThrownBy(
+            () -> RdbEngineTimeTypeSpanner.DATE_FORMATTER.parse("2020-02-30", LocalDate::from))
+        .isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  void dateFormatter_ParsesLeapDay() {
+    LocalDate parsed = RdbEngineTimeTypeSpanner.DATE_FORMATTER.parse("2020-02-29", LocalDate::from);
+    assertThat(parsed).isEqualTo(LocalDate.of(2020, 2, 29));
+  }
+
+  @Test
+  void dateFormatter_FormatsWithZeroPadding() {
+    String formatted = RdbEngineTimeTypeSpanner.DATE_FORMATTER.format(LocalDate.of(2024, 3, 4));
+    assertThat(formatted).isEqualTo("2024-03-04");
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSpannerTest.java
@@ -1,0 +1,79 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RdbEngineTimeTypeSpannerTest {
+
+  private RdbEngineTimeTypeSpanner strategy;
+  private JdbcConfig config;
+
+  @BeforeEach
+  void setUp() {
+    config = mock(JdbcConfig.class);
+    when(config.getSpannerTimeColumnDefaultDateComponent()).thenReturn(LocalDate.of(1970, 1, 1));
+    strategy = new RdbEngineTimeTypeSpanner(config);
+  }
+
+  @Test
+  void convert_LocalDate_ShouldReturnSameDate() {
+    LocalDate date = LocalDate.of(2024, 6, 15);
+    assertThat(strategy.convert(date)).isEqualTo(date);
+  }
+
+  @Test
+  void convert_LocalTime_ShouldReturnOffsetDateTimeAtEpochDateUtc() {
+    LocalTime time = LocalTime.of(14, 30, 45, 123456789);
+    OffsetDateTime result = strategy.convert(time);
+    assertThat(result.toLocalDate()).isEqualTo(LocalDate.of(1970, 1, 1));
+    assertThat(result.toLocalTime()).isEqualTo(time);
+    assertThat(result.getOffset()).isEqualTo(ZoneOffset.UTC);
+  }
+
+  @Test
+  void convert_LocalTime_Midnight_ShouldReturnEpochMidnightUtc() {
+    LocalTime midnight = LocalTime.MIDNIGHT;
+    OffsetDateTime result = strategy.convert(midnight);
+    assertThat(result).isEqualTo(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+  }
+
+  @Test
+  void convert_LocalTime_MaxTime_ShouldReturnEpochMaxTimeUtc() {
+    LocalTime maxTime = LocalTime.of(23, 59, 59, 999999999);
+    OffsetDateTime result = strategy.convert(maxTime);
+    assertThat(result.toLocalTime()).isEqualTo(maxTime);
+    assertThat(result.toLocalDate()).isEqualTo(LocalDate.of(1970, 1, 1));
+  }
+
+  @Test
+  void convert_LocalTime_ShouldUseConfiguredDateComponent() {
+    LocalDate customDate = LocalDate.of(2024, 1, 1);
+    when(config.getSpannerTimeColumnDefaultDateComponent()).thenReturn(customDate);
+    LocalTime time = LocalTime.of(12, 34, 56);
+    OffsetDateTime result = strategy.convert(time);
+    assertThat(result.toLocalDate()).isEqualTo(customDate);
+    assertThat(result.toLocalTime()).isEqualTo(time);
+    assertThat(result.getOffset()).isEqualTo(ZoneOffset.UTC);
+  }
+
+  @Test
+  void convert_LocalDateTime_ShouldReturnSameTimestamp() {
+    LocalDateTime timestamp = LocalDateTime.of(2024, 6, 15, 14, 30, 45);
+    assertThat(strategy.convert(timestamp)).isEqualTo(OffsetDateTime.of(timestamp, ZoneOffset.UTC));
+  }
+
+  @Test
+  void convert_OffsetDateTime_ShouldReturnSameTimestampTz() {
+    OffsetDateTime timestampTz = OffsetDateTime.of(2024, 6, 15, 14, 30, 45, 0, ZoneOffset.UTC);
+    assertThat(strategy.convert(timestampTz)).isEqualTo(timestampTz);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
@@ -345,6 +345,10 @@ public class ResultInterpreterTest {
     Timestamp timestamp =
         Timestamp.valueOf(LocalDateTime.of(LocalDate.of(2024, 1, 1), subMicrosecondTime));
     when(resultSet.getTimestamp(ANY_COLUMN_NAME_1)).thenReturn(timestamp);
+    // SPANNER uses getObject(col, OffsetDateTime.class) since TIME is stored as TIMESTAMPTZ
+    when(resultSet.getObject(ANY_COLUMN_NAME_1, OffsetDateTime.class))
+        .thenReturn(
+            OffsetDateTime.of(LocalDate.of(1970, 1, 1), subMicrosecondTime, ZoneOffset.UTC));
 
     ResultInterpreter interpreter =
         new ResultInterpreter(Collections.emptyList(), tableMetadata, rdbEngineStrategy);
@@ -380,8 +384,12 @@ public class ResultInterpreterTest {
     when(resultSet.wasNull()).thenReturn(false);
 
     LocalDateTime subMillisecondTimestamp = LocalDateTime.of(2024, 1, 15, 12, 30, 45, 123_456_789);
+    // Default engines use getObject(col, LocalDateTime.class)
     when(resultSet.getObject(ANY_COLUMN_NAME_1, LocalDateTime.class))
         .thenReturn(subMillisecondTimestamp);
+    // SPANNER uses getObject(col, OffsetDateTime.class) since TIMESTAMP is stored as TIMESTAMPTZ
+    when(resultSet.getObject(ANY_COLUMN_NAME_1, OffsetDateTime.class))
+        .thenReturn(OffsetDateTime.of(subMillisecondTimestamp, ZoneOffset.UTC));
 
     ResultInterpreter interpreter =
         new ResultInterpreter(Collections.emptyList(), tableMetadata, rdbEngineStrategy);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/SpannerCredentialsProviderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/SpannerCredentialsProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.google.auth.Credentials;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,46 +17,161 @@ public class SpannerCredentialsProviderTest {
   }
 
   @Test
-  void getCredentials_AfterRegister_ReturnsRegistered() {
+  void getCredentials_AfterRegister_ReturnsRegistered() throws Exception {
     Credentials credentials = mock(Credentials.class);
-    SpannerCredentialsProvider.register(credentials);
+    String className = SpannerCredentialsProvider.register(credentials, key("a"));
 
-    SpannerCredentialsProvider provider = new SpannerCredentialsProvider();
+    SpannerCredentialsProvider provider = instantiate(className);
 
     assertThat(provider.getCredentials()).isSameAs(credentials);
   }
 
   @Test
-  void register_SameCredentialsTwice_IsIdempotent() {
-    Credentials credentials = mock(Credentials.class);
-    SpannerCredentialsProvider.register(credentials);
-    SpannerCredentialsProvider.register(credentials);
+  void register_FirstCredentials_AssignsSlot0() {
+    String className = SpannerCredentialsProvider.register(mock(Credentials.class), key("a"));
 
-    assertThat(new SpannerCredentialsProvider().getCredentials()).isSameAs(credentials);
+    assertThat(className).isEqualTo(SpannerCredentialsProvider.Slot0.class.getName());
   }
 
   @Test
-  void register_DifferentCredentials_ThrowsIllegalStateException() {
+  void register_SameIdentityKeyTwice_ReturnsSameSlot() throws Exception {
     Credentials first = mock(Credentials.class);
-    Credentials second = mock(Credentials.class);
-    SpannerCredentialsProvider.register(first);
+    Credentials second = mock(Credentials.class); // Different instance, same identity bytes.
+    byte[] identity = key("a");
 
-    assertThatThrownBy(() -> SpannerCredentialsProvider.register(second))
+    String firstSlot = SpannerCredentialsProvider.register(first, identity);
+    String secondSlot = SpannerCredentialsProvider.register(second, identity);
+
+    assertThat(secondSlot).isEqualTo(firstSlot);
+    // The slot keeps the first registered credentials — re-registering doesn't overwrite.
+    assertThat(instantiate(firstSlot).getCredentials()).isSameAs(first);
+  }
+
+  @Test
+  void register_DifferentIdentityKeys_AssignsDifferentSlots() throws Exception {
+    Credentials a = mock(Credentials.class);
+    Credentials b = mock(Credentials.class);
+
+    String classA = SpannerCredentialsProvider.register(a, key("a"));
+    String classB = SpannerCredentialsProvider.register(b, key("b"));
+
+    assertThat(classA).isEqualTo(SpannerCredentialsProvider.Slot0.class.getName());
+    assertThat(classB).isEqualTo(SpannerCredentialsProvider.Slot1.class.getName());
+    assertThat(instantiate(classA).getCredentials()).isSameAs(a);
+    assertThat(instantiate(classB).getCredentials()).isSameAs(b);
+  }
+
+  @Test
+  void register_FillsAllFiveSlots_ReturnsDistinctSlotClasses() throws Exception {
+    Credentials c0 = mock(Credentials.class);
+    Credentials c1 = mock(Credentials.class);
+    Credentials c2 = mock(Credentials.class);
+    Credentials c3 = mock(Credentials.class);
+    Credentials c4 = mock(Credentials.class);
+
+    String n0 = SpannerCredentialsProvider.register(c0, key("0"));
+    String n1 = SpannerCredentialsProvider.register(c1, key("1"));
+    String n2 = SpannerCredentialsProvider.register(c2, key("2"));
+    String n3 = SpannerCredentialsProvider.register(c3, key("3"));
+    String n4 = SpannerCredentialsProvider.register(c4, key("4"));
+
+    assertThat(n0).isEqualTo(SpannerCredentialsProvider.Slot0.class.getName());
+    assertThat(n1).isEqualTo(SpannerCredentialsProvider.Slot1.class.getName());
+    assertThat(n2).isEqualTo(SpannerCredentialsProvider.Slot2.class.getName());
+    assertThat(n3).isEqualTo(SpannerCredentialsProvider.Slot3.class.getName());
+    assertThat(n4).isEqualTo(SpannerCredentialsProvider.Slot4.class.getName());
+    assertThat(instantiate(n0).getCredentials()).isSameAs(c0);
+    assertThat(instantiate(n1).getCredentials()).isSameAs(c1);
+    assertThat(instantiate(n2).getCredentials()).isSameAs(c2);
+    assertThat(instantiate(n3).getCredentials()).isSameAs(c3);
+    assertThat(instantiate(n4).getCredentials()).isSameAs(c4);
+  }
+
+  @Test
+  void register_SixthDistinctIdentityKey_ThrowsIllegalStateException() {
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("0"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("1"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("2"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("3"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("4"));
+
+    assertThatThrownBy(() -> SpannerCredentialsProvider.register(mock(Credentials.class), key("5")))
         .isInstanceOf(IllegalStateException.class);
-    assertThat(new SpannerCredentialsProvider().getCredentials()).isSameAs(first);
+  }
+
+  @Test
+  void register_AlreadyRegisteredIdentityAfterSlotsFull_ReturnsExistingSlot() {
+    String firstSlot = SpannerCredentialsProvider.register(mock(Credentials.class), key("0"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("1"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("2"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("3"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("4"));
+
+    String again = SpannerCredentialsProvider.register(mock(Credentials.class), key("0"));
+
+    assertThat(again).isEqualTo(firstSlot);
+  }
+
+  @Test
+  void register_IdentityKeyIsDefensivelyCopied() throws Exception {
+    byte[] identity = key("a");
+    Credentials credentials = mock(Credentials.class);
+
+    String className = SpannerCredentialsProvider.register(credentials, identity);
+
+    // Mutating the caller's array after registration must not affect lookup.
+    identity[0] = (byte) (identity[0] ^ 0x01);
+    String lookupWithMutated = SpannerCredentialsProvider.register(credentials, identity);
+    assertThat(lookupWithMutated).isNotEqualTo(className);
+    // And the original identity bytes should still find the original slot.
+    String lookupWithOriginal = SpannerCredentialsProvider.register(credentials, key("a"));
+    assertThat(lookupWithOriginal).isEqualTo(className);
   }
 
   @Test
   void getCredentials_WithoutRegister_ThrowsIllegalStateException() {
     SpannerCredentialsProvider.clear();
 
-    assertThatThrownBy(() -> new SpannerCredentialsProvider().getCredentials())
+    assertThatThrownBy(() -> new SpannerCredentialsProvider.Slot0().getCredentials())
         .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
   void register_NullCredentials_ThrowsNullPointerException() {
-    assertThatThrownBy(() -> SpannerCredentialsProvider.register(null))
+    assertThatThrownBy(() -> SpannerCredentialsProvider.register(null, key("a")))
         .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void register_NullIdentityKey_ThrowsNullPointerException() {
+    assertThatThrownBy(() -> SpannerCredentialsProvider.register(mock(Credentials.class), null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void clear_AfterRegister_ResetsAllSlots() {
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("0"));
+    SpannerCredentialsProvider.register(mock(Credentials.class), key("1"));
+
+    SpannerCredentialsProvider.clear();
+
+    // After clear, the next registration should land in Slot0 again.
+    String className = SpannerCredentialsProvider.register(mock(Credentials.class), key("0"));
+    assertThat(className).isEqualTo(SpannerCredentialsProvider.Slot0.class.getName());
+  }
+
+  private static byte[] key(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Mirrors how the Spanner JDBC driver instantiates the credentials provider — by FQCN with a
+   * no-arg constructor. Verifies that the slot subclasses are reachable that way.
+   */
+  private static SpannerCredentialsProvider instantiate(String className) throws Exception {
+    return Class.forName(className)
+        .asSubclass(SpannerCredentialsProvider.class)
+        .getDeclaredConstructor()
+        .newInstance();
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/SpannerCredentialsProviderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/SpannerCredentialsProviderTest.java
@@ -1,0 +1,61 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.google.auth.Credentials;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class SpannerCredentialsProviderTest {
+
+  @AfterEach
+  void tearDown() {
+    SpannerCredentialsProvider.clear();
+  }
+
+  @Test
+  void getCredentials_AfterRegister_ReturnsRegistered() {
+    Credentials credentials = mock(Credentials.class);
+    SpannerCredentialsProvider.register(credentials);
+
+    SpannerCredentialsProvider provider = new SpannerCredentialsProvider();
+
+    assertThat(provider.getCredentials()).isSameAs(credentials);
+  }
+
+  @Test
+  void register_SameCredentialsTwice_IsIdempotent() {
+    Credentials credentials = mock(Credentials.class);
+    SpannerCredentialsProvider.register(credentials);
+    SpannerCredentialsProvider.register(credentials);
+
+    assertThat(new SpannerCredentialsProvider().getCredentials()).isSameAs(credentials);
+  }
+
+  @Test
+  void register_DifferentCredentials_ThrowsIllegalStateException() {
+    Credentials first = mock(Credentials.class);
+    Credentials second = mock(Credentials.class);
+    SpannerCredentialsProvider.register(first);
+
+    assertThatThrownBy(() -> SpannerCredentialsProvider.register(second))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(new SpannerCredentialsProvider().getCredentials()).isSameAs(first);
+  }
+
+  @Test
+  void getCredentials_WithoutRegister_ThrowsIllegalStateException() {
+    SpannerCredentialsProvider.clear();
+
+    assertThatThrownBy(() -> new SpannerCredentialsProvider().getCredentials())
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void register_NullCredentials_ThrowsNullPointerException() {
+    assertThatThrownBy(() -> SpannerCredentialsProvider.register(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -325,6 +325,7 @@ public class QueryBuilderTest {
       case MYSQL:
       case POSTGRESQL:
       case YUGABYTE:
+      case SPANNER:
       case MARIADB:
       case DB2:
         expectedQuery =
@@ -1298,6 +1299,11 @@ public class QueryBuilderTest {
             "INSERT INTO n1.t1 (p1,v1,v2,v3) VALUES (?,?,?,?) "
                 + "ON CONFLICT (p1) DO UPDATE SET v1=?,v2=?,v3=?";
         break;
+      case SPANNER:
+        expectedQuery =
+            "INSERT INTO n1.t1 (p1,v1,v2,v3) VALUES (?,?,?,?) "
+                + "ON CONFLICT (p1) DO UPDATE SET v1=excluded.v1,v2=excluded.v2,v3=excluded.v3";
+        break;
       case ORACLE:
         expectedQuery =
             "MERGE INTO n1.t1 t1 USING (SELECT ? p1 FROM DUAL) t2 ON (t1.p1=t2.p1) "
@@ -1345,6 +1351,12 @@ public class QueryBuilderTest {
         verify(preparedStatement).setString(6, "v2Value");
         verify(preparedStatement).setString(7, "v3Value");
         break;
+      case SPANNER:
+        verify(preparedStatement).setString(1, "p1Value");
+        verify(preparedStatement).setString(2, "v1Value");
+        verify(preparedStatement).setString(3, "v2Value");
+        verify(preparedStatement).setString(4, "v3Value");
+        break;
       case ORACLE:
       case SQL_SERVER:
       case DB2:
@@ -1374,6 +1386,11 @@ public class QueryBuilderTest {
         expectedQuery =
             "INSERT INTO n1.t1 (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?) "
                 + "ON CONFLICT (p1,c1) DO UPDATE SET v1=?,v2=?,v3=?";
+        break;
+      case SPANNER:
+        expectedQuery =
+            "INSERT INTO n1.t1 (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?) "
+                + "ON CONFLICT (p1,c1) DO UPDATE SET v1=excluded.v1,v2=excluded.v2,v3=excluded.v3";
         break;
       case ORACLE:
         expectedQuery =
@@ -1426,6 +1443,13 @@ public class QueryBuilderTest {
         verify(preparedStatement).setString(7, "v2Value");
         verify(preparedStatement).setString(8, "v3Value");
         break;
+      case SPANNER:
+        verify(preparedStatement).setString(1, "p1Value");
+        verify(preparedStatement).setString(2, "c1Value");
+        verify(preparedStatement).setString(3, "v1Value");
+        verify(preparedStatement).setString(4, "v2Value");
+        verify(preparedStatement).setString(5, "v3Value");
+        break;
       case ORACLE:
       case SQL_SERVER:
       case DB2:
@@ -1458,6 +1482,11 @@ public class QueryBuilderTest {
         expectedQuery =
             "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?";
+        break;
+      case SPANNER:
+        expectedQuery =
+            "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?) "
+                + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=excluded.v1,v2=excluded.v2,v3=excluded.v3,v4=excluded.v4";
         break;
       case ORACLE:
         expectedQuery =
@@ -1519,6 +1548,16 @@ public class QueryBuilderTest {
         verify(preparedStatement).setString(11, "v3Value");
         verify(preparedStatement).setString(12, "v4Value");
         break;
+      case SPANNER:
+        verify(preparedStatement).setString(1, "p1Value");
+        verify(preparedStatement).setString(2, "p2Value");
+        verify(preparedStatement).setString(3, "c1Value");
+        verify(preparedStatement).setString(4, "c2Value");
+        verify(preparedStatement).setString(5, "v1Value");
+        verify(preparedStatement).setString(6, "v2Value");
+        verify(preparedStatement).setString(7, "v3Value");
+        verify(preparedStatement).setString(8, "v4Value");
+        break;
       case ORACLE:
       case SQL_SERVER:
       case DB2:
@@ -1557,6 +1596,11 @@ public class QueryBuilderTest {
         expectedQuery =
             "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?,v5=?";
+        break;
+      case SPANNER:
+        expectedQuery =
+            "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?) "
+                + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=excluded.v1,v2=excluded.v2,v3=excluded.v3,v4=excluded.v4,v5=excluded.v5";
         break;
       case ORACLE:
         expectedQuery =
@@ -1621,6 +1665,17 @@ public class QueryBuilderTest {
         verify(preparedStatement).setString(13, "v4Value");
         verify(preparedStatement).setNull(14, Types.VARCHAR);
         break;
+      case SPANNER:
+        verify(preparedStatement).setString(1, "p1Value");
+        verify(preparedStatement).setString(2, "p2Value");
+        verify(preparedStatement).setString(3, "c1Value");
+        verify(preparedStatement).setString(4, "c2Value");
+        verify(preparedStatement).setString(5, "v1Value");
+        verify(preparedStatement).setString(6, "v2Value");
+        verify(preparedStatement).setString(7, "v3Value");
+        verify(preparedStatement).setString(8, "v4Value");
+        verify(preparedStatement).setNull(9, Types.VARCHAR);
+        break;
       case ORACLE:
       case SQL_SERVER:
       case DB2:
@@ -1666,6 +1721,7 @@ public class QueryBuilderTest {
         break;
       case POSTGRESQL:
       case YUGABYTE:
+      case SPANNER:
         expectedQuery = "INSERT INTO n1.t1 (p1) VALUES (?) ON CONFLICT (p1) DO NOTHING";
         break;
       case ORACLE:
@@ -1701,6 +1757,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case SPANNER:
       case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         break;
@@ -1722,6 +1779,7 @@ public class QueryBuilderTest {
         break;
       case POSTGRESQL:
       case YUGABYTE:
+      case SPANNER:
         expectedQuery = "INSERT INTO n1.t1 (p1,c1) VALUES (?,?) ON CONFLICT (p1,c1) DO NOTHING";
         break;
       case ORACLE:
@@ -1763,6 +1821,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case SPANNER:
       case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "c1Value");
@@ -1787,6 +1846,7 @@ public class QueryBuilderTest {
         break;
       case POSTGRESQL:
       case YUGABYTE:
+      case SPANNER:
         expectedQuery =
             "INSERT INTO n1.t1 (p1,p2,c1,c2) VALUES (?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO NOTHING";
@@ -1832,6 +1892,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case SPANNER:
       case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -687,7 +688,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
         admin.createIndex(namespace1, getTable4(), getColumnName3(), options);
       }
       admin.createIndex(namespace1, getTable4(), getColumnName4(), options);
-      admin.createIndex(namespace1, getTable4(), getColumnName5(), options);
+      if (isIndexOnFloatColumnSupported()) {
+        admin.createIndex(namespace1, getTable4(), getColumnName5(), options);
+      }
       admin.createIndex(namespace1, getTable4(), getColumnName6(), options);
       if (isIndexOnBooleanColumnSupported()) {
         admin.createIndex(namespace1, getTable4(), getColumnName7(), options);
@@ -708,7 +711,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
         assertThat(admin.indexExists(namespace1, getTable4(), getColumnName3())).isTrue();
       }
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName4())).isTrue();
-      assertThat(admin.indexExists(namespace1, getTable4(), getColumnName5())).isTrue();
+      if (isIndexOnFloatColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, getTable4(), getColumnName5())).isTrue();
+      }
       assertThat(admin.indexExists(namespace1, getTable4(), getColumnName6())).isTrue();
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(admin.indexExists(namespace1, getTable4(), getColumnName7())).isTrue();
@@ -730,12 +735,11 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
           .contains(
               getColumnName2(),
               getColumnName4(),
-              getColumnName5(),
               getColumnName9(),
               getColumnName10(),
               getColumnName11(),
               getColumnName12());
-      int indexCount = 8;
+      int indexCount = 7;
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(actualSecondaryIndexNames).contains(getColumnName7());
         indexCount++;
@@ -750,6 +754,10 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       }
       if (isIndexOnBlobColumnSupported()) {
         assertThat(actualSecondaryIndexNames).contains(getColumnName8());
+        indexCount++;
+      }
+      if (isIndexOnFloatColumnSupported()) {
+        assertThat(actualSecondaryIndexNames).contains(getColumnName5());
         indexCount++;
       }
       assertThat(actualSecondaryIndexNames).hasSize(indexCount);
@@ -863,7 +871,6 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
               .addSecondaryIndex(getColumnName2())
               .addSecondaryIndex(getColumnName3())
               .addSecondaryIndex(getColumnName4())
-              .addSecondaryIndex(getColumnName5())
               .addSecondaryIndex(getColumnName6())
               .addSecondaryIndex(getColumnName9())
               .addSecondaryIndex(getColumnName10())
@@ -878,6 +885,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       }
       if (isIndexOnBlobColumnSupported()) {
         metadataBuilder.addSecondaryIndex(getColumnName8());
+      }
+      if (isIndexOnFloatColumnSupported()) {
+        metadataBuilder.addSecondaryIndex(getColumnName5());
       }
       admin.createTable(namespace1, getTable4(), metadataBuilder.build(), options);
       storage = storageFactory.getStorage();
@@ -911,7 +921,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       admin.dropIndex(namespace1, getTable4(), getColumnName2());
       admin.dropIndex(namespace1, getTable4(), getColumnName3());
       admin.dropIndex(namespace1, getTable4(), getColumnName4());
-      admin.dropIndex(namespace1, getTable4(), getColumnName5());
+      if (isIndexOnFloatColumnSupported()) {
+        admin.dropIndex(namespace1, getTable4(), getColumnName5());
+      }
       admin.dropIndex(namespace1, getTable4(), getColumnName6());
       if (isIndexOnBooleanColumnSupported()) {
         admin.dropIndex(namespace1, getTable4(), getColumnName7());
@@ -1109,6 +1121,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForExistingTable_ShouldRenameTableCorrectly() throws ExecutionException {
     String newTableName = "new" + getTable4();
@@ -1519,6 +1532,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
     // Arrange
@@ -1528,6 +1542,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_IfNewTableNameAlreadyExists_ShouldThrowIllegalArgumentException()
       throws ExecutionException {
@@ -1553,6 +1568,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForExistingTableWithIndexes_ShouldRenameTableAndIndexesCorrectly()
       throws ExecutionException {
@@ -1592,6 +1608,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_IfOnlyOneTableExists_ShouldRenameTableCorrectly()
       throws ExecutionException {
@@ -1710,6 +1727,14 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   }
 
   protected boolean isCreateIndexOnTextColumnEnabled() {
+    return true;
+  }
+
+  protected boolean isIndexOnFloatColumnSupported() {
+    return true;
+  }
+
+  protected boolean isRenameTableSupported() {
     return true;
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,8 +74,8 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   private static final int ATTEMPT_COUNT = 5;
   private static final int THREAD_NUM = 10;
 
-  private DistributedStorageAdmin admin;
-  private DistributedStorage storage;
+  protected DistributedStorageAdmin admin;
+  protected DistributedStorage storage;
   private String namespace;
 
   private long seed;
@@ -88,15 +89,23 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getStorageAdmin();
+    admin = createStorageAdmin(factory);
     namespace = getNamespace();
     createTable();
-    storage = factory.getStorage();
+    storage = createStorage(factory);
     seed = System.currentTimeMillis();
     System.out.println("The seed used in the conditional mutation integration test is " + seed);
     random = ThreadLocal.withInitial(Random::new);
     operatorAndDataTypeList = getOperatorAndDataTypeListForTest();
     executorService = Executors.newFixedThreadPool(getThreadNum());
+  }
+
+  protected DistributedStorageAdmin createStorageAdmin(StorageFactory factory) {
+    return factory.getStorageAdmin();
+  }
+
+  protected DistributedStorage createStorage(StorageFactory factory) {
+    return factory.getStorage();
   }
 
   protected void initialize(String testName) throws Exception {}
@@ -112,6 +121,12 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   }
 
   private void createTable() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(namespace, true, options);
+    admin.createTable(namespace, TABLE, getTableMetadata(), true, options);
+  }
+
+  protected TableMetadata getTableMetadata() {
     TableMetadata.Builder tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(PARTITION_KEY, DataType.TEXT)
@@ -131,10 +146,7 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
     if (isConditionOnBlobColumnSupported()) {
       tableMetadata.addColumn(COL_NAME11, DataType.BLOB);
     }
-
-    Map<String, String> options = getCreationOptions();
-    admin.createNamespace(namespace, true, options);
-    admin.createTable(namespace, TABLE, tableMetadata.build(), true, options);
+    return tableMetadata.build();
   }
 
   protected Map<String, String> getCreationOptions() {
@@ -1716,9 +1728,35 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
   private void executeInParallel(List<Callable<Void>> testCallables)
       throws InterruptedException, java.util.concurrent.ExecutionException {
-    List<Future<Void>> futures = executorService.invokeAll(testCallables);
+    int total = testCallables.size();
+    AtomicInteger completed = new AtomicInteger(0);
+    AtomicInteger lastLoggedPercent = new AtomicInteger(-1);
+
+    List<Callable<Void>> tracked = new ArrayList<>(total);
+    for (Callable<Void> callable : testCallables) {
+      tracked.add(
+          () -> {
+            Void result = callable.call();
+            logProgress(completed, total, lastLoggedPercent);
+            return result;
+          });
+    }
+
+    List<Future<Void>> futures = executorService.invokeAll(tracked);
     for (Future<Void> future : futures) {
       future.get();
+    }
+  }
+
+  private static void logProgress(
+      AtomicInteger completed, int total, AtomicInteger lastLoggedPercent) {
+    // Log for every 10% completed
+    int done = completed.incrementAndGet();
+    int percent = done * 100 / total;
+    int lastLogged = lastLoggedPercent.get();
+    if (percent / 10 > lastLogged / 10) {
+      lastLoggedPercent.set(percent);
+      logger.info("Progress: {}% ({}/{})", percent, done, total);
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
@@ -1035,38 +1035,6 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
     testCallables.add(
         () -> {
           scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(true, "+%scalar[$]", "+"),
-              ImmutableList.of(3),
-              "escape % with specified escape");
-          return null;
-        });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(true, "+_scalar[$]", "+"),
-              ImmutableList.of(4),
-              "escape _ with specified escape");
-          return null;
-        });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(true, "\\%scalar[$]", ""),
-              ImmutableList.of(5, 6),
-              "no escape character");
-          return null;
-        });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(true, "\\_scalar[$]", ""),
-              ImmutableList.of(6),
-              "no escape character");
-          return null;
-        });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
               prepareScanWithLike(false, "\\%scalar[$]"),
               ImmutableList.of(1, 2, 4, 5, 6, 7),
               "not like and escape % with default escape");
@@ -1080,22 +1048,57 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
               "not like and escape _ with default escape");
           return null;
         });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(false, "+%scalar[$]", "+"),
-              ImmutableList.of(1, 2, 4, 5, 6, 7),
-              "not like and escape % with specified escape");
-          return null;
-        });
-    testCallables.add(
-        () -> {
-          scan_WithLikeCondition_ShouldReturnProperResult(
-              prepareScanWithLike(false, "\\_scalar[$]", ""),
-              ImmutableList.of(1, 2, 3, 4, 5, 7),
-              "not like with no escape character");
-          return null;
-        });
+    if (isLikeExpressionWithCustomEscapeCharSupported()) {
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(true, "+%scalar[$]", "+"),
+                ImmutableList.of(3),
+                "escape % with specified escape");
+            return null;
+          });
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(true, "+_scalar[$]", "+"),
+                ImmutableList.of(4),
+                "escape _ with specified escape");
+            return null;
+          });
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(true, "\\%scalar[$]", ""),
+                ImmutableList.of(5, 6),
+                "no escape character");
+            return null;
+          });
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(true, "\\_scalar[$]", ""),
+                ImmutableList.of(6),
+                "no escape character");
+            return null;
+          });
+
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(false, "+%scalar[$]", "+"),
+                ImmutableList.of(1, 2, 4, 5, 6, 7),
+                "not like and escape % with specified escape");
+            return null;
+          });
+      testCallables.add(
+          () -> {
+            scan_WithLikeCondition_ShouldReturnProperResult(
+                prepareScanWithLike(false, "\\_scalar[$]", ""),
+                ImmutableList.of(1, 2, 3, 4, 5, 7),
+                "not like with no escape character");
+            return null;
+          });
+    }
 
     executeInParallel(testCallables);
   }
@@ -1268,6 +1271,10 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
   }
 
   protected boolean isConditionOnBlobColumnSupported() {
+    return true;
+  }
+
+  protected boolean isLikeExpressionWithCustomEscapeCharSupported() {
     return true;
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterAll;
@@ -80,16 +81,24 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
-    admin = factory.getStorageAdmin();
+    admin = createStorageAdmin(factory);
     namespaceBaseName = getNamespaceBaseName();
     clusteringKeyTypes = getClusteringKeyTypes();
     executorService = Executors.newFixedThreadPool(getThreadNum());
     createTables();
-    storage = factory.getStorage();
+    storage = createStorage(factory);
     seed = System.currentTimeMillis();
     System.out.println(
         "The seed used in the multiple clustering key scan integration test is " + seed);
     random = ThreadLocal.withInitial(Random::new);
+  }
+
+  protected DistributedStorageAdmin createStorageAdmin(StorageFactory factory) {
+    return factory.getStorageAdmin();
+  }
+
+  protected DistributedStorage createStorage(StorageFactory factory) {
+    return factory.getStorage();
   }
 
   protected void initialize(String testName) throws Exception {}
@@ -2093,9 +2102,35 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
 
   private void executeInParallel(List<Callable<Void>> testCallables)
       throws InterruptedException, java.util.concurrent.ExecutionException {
-    List<Future<Void>> futures = executorService.invokeAll(testCallables);
+    int total = testCallables.size();
+    AtomicInteger completed = new AtomicInteger(0);
+    AtomicInteger lastLoggedPercent = new AtomicInteger(-1);
+
+    List<Callable<Void>> tracked = new ArrayList<>(total);
+    for (Callable<Void> callable : testCallables) {
+      tracked.add(
+          () -> {
+            Void result = callable.call();
+            logProgress(completed, total, lastLoggedPercent);
+            return result;
+          });
+    }
+
+    List<Future<Void>> futures = executorService.invokeAll(tracked);
     for (Future<Void> future : futures) {
       future.get();
+    }
+  }
+
+  private static void logProgress(
+      AtomicInteger completed, int total, AtomicInteger lastLoggedPercent) {
+    // Log for every 10% completed
+    int done = completed.incrementAndGet();
+    int percent = done * 100 / total;
+    int lastLogged = lastLoggedPercent.get();
+    if (percent / 10 > lastLogged / 10) {
+      lastLoggedPercent.set(percent);
+      logger.info("Progress: {}% ({}/{})", percent, done, total);
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -244,16 +244,18 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
     // Act
     List<Result> results = scanAll(scan);
 
-    // Assert
+    // Assert order-independent since no ordering is specified in the scan and the Spanner emulator
+    // voluntarily randomizes query results without ORDER BY.
     assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).contains(PARTITION_KEY)).isTrue();
-    assertThat(results.get(0).getInt(PARTITION_KEY)).isEqualTo(1);
-    assertThat(results.get(0).contains(INDEX_COL_NAME)).isTrue();
-    assertThat(results.get(0).getInt(INDEX_COL_NAME)).isEqualTo(secondaryIndexValue.getIntValue());
-    assertThat(results.get(1).contains(PARTITION_KEY)).isTrue();
-    assertThat(results.get(1).getInt(PARTITION_KEY)).isEqualTo(2);
-    assertThat(results.get(1).contains(INDEX_COL_NAME)).isTrue();
-    assertThat(results.get(1).getInt(INDEX_COL_NAME)).isEqualTo(secondaryIndexValue.getIntValue());
+    Set<Integer> expectedPartitionKeys = Sets.newHashSet(1, 2);
+    Set<Integer> actualPartitionKeys = new HashSet<>();
+    for (Result result : results) {
+      assertThat(result.contains(PARTITION_KEY)).isTrue();
+      actualPartitionKeys.add(result.getInt(PARTITION_KEY));
+      assertThat(result.contains(INDEX_COL_NAME)).isTrue();
+      assertThat(result.getInt(INDEX_COL_NAME)).isEqualTo(secondaryIndexValue.getIntValue());
+    }
+    assertThat(actualPartitionKeys).isEqualTo(expectedPartitionKeys);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -575,7 +576,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
         admin.createIndex(namespace1, table, COL_NAME3, options);
       }
       admin.createIndex(namespace1, table, COL_NAME4, options);
-      admin.createIndex(namespace1, table, COL_NAME5, options);
+      if (isIndexOnFloatColumnSupported()) {
+        admin.createIndex(namespace1, table, COL_NAME5, options);
+      }
       admin.createIndex(namespace1, table, COL_NAME6, options);
       if (isIndexOnBooleanColumnSupported()) {
         admin.createIndex(namespace1, table, COL_NAME7, options);
@@ -596,7 +599,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
         assertThat(admin.indexExists(namespace1, table, COL_NAME3)).isTrue();
       }
       assertThat(admin.indexExists(namespace1, table, COL_NAME4)).isTrue();
-      assertThat(admin.indexExists(namespace1, table, COL_NAME5)).isTrue();
+      if (isIndexOnFloatColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, table, COL_NAME5)).isTrue();
+      }
       assertThat(admin.indexExists(namespace1, table, COL_NAME6)).isTrue();
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(admin.indexExists(namespace1, table, COL_NAME7)).isTrue();
@@ -615,8 +620,8 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       Set<String> actualSecondaryIndexNames =
           admin.getTableMetadata(namespace1, table).getSecondaryIndexNames();
       assertThat(actualSecondaryIndexNames)
-          .contains(COL_NAME2, COL_NAME4, COL_NAME5, COL_NAME9, COL_NAME10, COL_NAME11, COL_NAME12);
-      int indexCount = 8;
+          .contains(COL_NAME2, COL_NAME4, COL_NAME9, COL_NAME10, COL_NAME11, COL_NAME12);
+      int indexCount = 7;
       if (isIndexOnBooleanColumnSupported()) {
         assertThat(actualSecondaryIndexNames).contains(COL_NAME7);
         indexCount++;
@@ -632,6 +637,10 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       if (isIndexOnBlobColumnSupported()) {
         assertThat(actualSecondaryIndexNames).contains(COL_NAME8);
         indexCount += 1;
+      }
+      if (isIndexOnFloatColumnSupported()) {
+        assertThat(actualSecondaryIndexNames).contains(COL_NAME5);
+        indexCount++;
       }
       assertThat(actualSecondaryIndexNames).hasSize(indexCount);
     } finally {
@@ -733,7 +742,6 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
               .addSecondaryIndex(COL_NAME2)
               .addSecondaryIndex(COL_NAME3)
               .addSecondaryIndex(COL_NAME4)
-              .addSecondaryIndex(COL_NAME5)
               .addSecondaryIndex(COL_NAME6)
               .addSecondaryIndex(COL_NAME9)
               .addSecondaryIndex(COL_NAME9)
@@ -745,6 +753,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       }
       if (isIndexOnBlobColumnSupported()) {
         metadataBuilder = metadataBuilder.addSecondaryIndex(COL_NAME8);
+      }
+      if (isIndexOnFloatColumnSupported()) {
+        metadataBuilder = metadataBuilder.addSecondaryIndex(COL_NAME5);
       }
       if (isTimestampTypeSupported()) {
         metadataBuilder.addColumn(COL_NAME13, DataType.TIMESTAMP);
@@ -781,7 +792,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       admin.dropIndex(namespace1, table, COL_NAME2);
       admin.dropIndex(namespace1, table, COL_NAME3);
       admin.dropIndex(namespace1, table, COL_NAME4);
-      admin.dropIndex(namespace1, table, COL_NAME5);
+      if (isIndexOnFloatColumnSupported()) {
+        admin.dropIndex(namespace1, table, COL_NAME5);
+      }
       admin.dropIndex(namespace1, table, COL_NAME6);
       if (isIndexOnBooleanColumnSupported()) {
         admin.dropIndex(namespace1, table, COL_NAME7);
@@ -1369,6 +1382,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForExistingTable_ShouldRenameTableCorrectly() throws ExecutionException {
     String newTableName = "new" + TABLE4;
@@ -1396,6 +1410,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
     // Arrange
@@ -1405,6 +1420,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_IfNewTableNameAlreadyExists_ShouldThrowIllegalArgumentException()
       throws ExecutionException {
@@ -1430,6 +1446,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_ForExistingTableWithIndexes_ShouldRenameTableAndIndexesCorrectly()
       throws ExecutionException {
@@ -1467,6 +1484,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     }
   }
 
+  @EnabledIf("isRenameTableSupported")
   @Test
   public void renameTable_IfOnlyOneTableExists_ShouldRenameTableCorrectly()
       throws ExecutionException {
@@ -1620,6 +1638,14 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   protected boolean isCreateIndexOnTextColumnEnabled() {
+    return true;
+  }
+
+  protected boolean isIndexOnFloatColumnSupported() {
+    return true;
+  }
+
+  protected boolean isRenameTableSupported() {
     return true;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
@@ -284,19 +284,33 @@ public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBas
     populateRecordsForLike();
     DistributedTransaction transaction = manager.start();
     Scan scan1 = prepareCrossPartitionScanWithLike(true, "%scalar[$]");
-    Scan scan2 = prepareCrossPartitionScanWithLike(true, "+_scalar[$]", "+");
-    Scan scan3 = prepareCrossPartitionScanWithLike(false, "\\_scalar[$]");
+    Scan scan2 = prepareCrossPartitionScanWithLike(false, "\\_scalar[$]");
 
     // Act
     List<Result> actual1 = transaction.scan(scan1);
     List<Result> actual2 = transaction.scan(scan2);
-    List<Result> actual3 = transaction.scan(scan3);
     transaction.commit();
 
     // Assert
     assertScanResult(actual1, ImmutableList.of(1, 2, 3));
-    assertScanResult(actual2, ImmutableList.of(3));
-    assertScanResult(actual3, ImmutableList.of(1, 2));
+    assertScanResult(actual2, ImmutableList.of(1, 2));
+  }
+
+  @Test
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord()
+          throws TransactionException {
+    // Arrange
+    populateRecordsForLike();
+    DistributedTransaction transaction = manager.start();
+    Scan scan = prepareCrossPartitionScanWithLike(true, "+_scalar[$]", "+");
+
+    // Act
+    List<Result> actual = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertScanResult(actual, ImmutableList.of(3));
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
@@ -269,21 +269,37 @@ public abstract class TwoPhaseCommitTransactionCrossPartitionScanIntegrationTest
     populateRecordsForLike(manager2, namespace2, TABLE_2);
     TwoPhaseCommitTransaction transaction = manager2.start();
     Scan scan1 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "%scalar[$]");
-    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "+_scalar[$]", "+");
-    Scan scan3 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, false, "\\_scalar[$]");
+    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, false, "\\_scalar[$]");
 
     // Act
     List<Result> actual1 = transaction.scan(scan1);
     List<Result> actual2 = transaction.scan(scan2);
-    List<Result> actual3 = transaction.scan(scan3);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
 
     // Assert
     assertScanResult(actual1, ImmutableList.of(1, 2, 3));
-    assertScanResult(actual2, ImmutableList.of(3));
-    assertScanResult(actual3, ImmutableList.of(1, 2));
+    assertScanResult(actual2, ImmutableList.of(1, 2));
+  }
+
+  @Test
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecords()
+          throws TransactionException {
+    // Arrange
+    populateRecordsForLike(manager2, namespace2, TABLE_2);
+    TwoPhaseCommitTransaction transaction = manager2.start();
+    Scan scan = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "+_scalar[$]", "+");
+
+    // Act
+    List<Result> actual = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    assertScanResult(actual, ImmutableList.of(3));
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -220,7 +220,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
                     .put("col12", "INT")
                     .put("col13", "BLOB")
                     .build())
-            .put("secondary-index", Arrays.asList("col7", "col12"))
+            .put("secondary-index", Arrays.asList("col8", "col12"))
             .put("compaction-strategy", "LCS")
             .put("network-strategy", "SimpleStrategy")
             .put("replication-factor", "1")
@@ -478,7 +478,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
             .addColumn("col13", DataType.BLOB)
             .removeSecondaryIndex("col1")
             .removeSecondaryIndex("col5")
-            .addSecondaryIndex("col7")
+            .addSecondaryIndex("col8")
             .addSecondaryIndex("col12")
             .build();
     TableMetadata expectedTable2Metadata =

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -220,7 +220,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
                     .put("col12", "INT")
                     .put("col13", "BLOB")
                     .build())
-            .put("secondary-index", Arrays.asList("col3", "col12"))
+            .put("secondary-index", Arrays.asList("col7", "col12"))
             .put("compaction-strategy", "LCS")
             .put("network-strategy", "SimpleStrategy")
             .put("replication-factor", "1")
@@ -478,7 +478,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
             .addColumn("col13", DataType.BLOB)
             .removeSecondaryIndex("col1")
             .removeSecondaryIndex("col5")
-            .addSecondaryIndex("col3")
+            .addSecondaryIndex("col7")
             .addSecondaryIndex("col12")
             .build();
     TableMetadata expectedTable2Metadata =

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -114,8 +114,8 @@ public abstract class ConsensusCommitCrossPartitionScanIntegrationTestBase
     // Arrange
     populateRecordsForLike();
     DistributedTransaction transaction = manager.start();
-    Put put = preparePut(999, "\\scalar[$]");
-    Scan scan = prepareCrossPartitionScanWithLike(true, "\\_scalar[$]", "");
+    Put put = preparePut(999, "&scalar[$]");
+    Scan scan = prepareCrossPartitionScanWithLike(true, "&_scalar[$]");
 
     // Act Assert
     assertDoesNotThrow(
@@ -132,8 +132,8 @@ public abstract class ConsensusCommitCrossPartitionScanIntegrationTestBase
     // Arrange
     populateRecordsForLike();
     DistributedTransaction transaction = manager.start();
-    Put put = preparePut(999, "\\scalar[$]");
-    Scan scan = prepareCrossPartitionScanWithLike(true, "\\%scalar[$]", "");
+    Put put = preparePut(999, "&scalar[$]");
+    Scan scan = prepareCrossPartitionScanWithLike(true, "&%scalar[$]");
 
     // Act
     Throwable thrown =

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -130,8 +130,8 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
     populateRecords(manager1, namespace1, TABLE_1);
     populateRecordsForLike(manager2, namespace2, TABLE_2);
     Scan scan1 = Scan.newBuilder(prepareCrossPartitionScan(namespace1, TABLE_1, 1, 0, 2)).build();
-    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "\\_scalar[$]", "");
-    Put put = preparePut(namespace2, TABLE_2, 999, "\\scalar[$]");
+    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "&_scalar[$]");
+    Put put = preparePut(namespace2, TABLE_2, 999, "&scalar[$]");
 
     TwoPhaseCommitTransaction transaction1 = manager1.start();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());
@@ -165,8 +165,8 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
     populateRecords(manager1, namespace1, TABLE_1);
     populateRecordsForLike(manager2, namespace2, TABLE_2);
     Scan scan1 = Scan.newBuilder(prepareCrossPartitionScan(namespace1, TABLE_1, 1, 0, 2)).build();
-    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "\\scalar[$]", "");
-    Put put = preparePut(namespace2, TABLE_2, 999, "\\scalar[$]");
+    Scan scan2 = prepareCrossPartitionScanWithLike(namespace2, TABLE_2, true, "&%scalar[$]");
+    Put put = preparePut(namespace2, TABLE_2, 999, "&scalar[$]");
 
     TwoPhaseCommitTransaction transaction1 = manager1.start();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());


### PR DESCRIPTION
## Description

Adds support for **Google Cloud Spanner** as a JDBC storage in ScalarDB. The adapter targets Spanner's PostgreSQL-compatible dialect via the official `com.google.cloud.spanner:google-cloud-spanner-jdbc` driver.

A new configuration is introduced: 
- `scalar.db.jdbc.spanner.time_column.default_date_component`: Since TIME data is encoded into a Spanner `TIMESTAMP WITH TIME ZONE` data type. Time value is appended to a static date value. This config is only relevant for the import table use case. A similar config can be found with Oracle and Db2.

The adapter has the following limitations:
- FLOAT column cannot be used as partition key, clustering key or secondary index
- Renaming a table or a column is not supported
- Only altering the column type from BLOB to TEXT is supported
- `\` (backslash) is used as the default escape character for LIKE expression and cannot be configured or disabled

Regarding authentication, Spanner credentials (Google Cloud service account key in JSON format) are passed via the `scalardb.jdbc.password` ScalarDB property. The `scalardb.jdbc.username` property is never used. Authentication through the JDBC driver is done via the `credentialsProvider` JDBC property with requires setting a JVM wide system property `ENABLE_CREDENTIALS_PROVIDER`. 

## Related issues and/or PRs

N/A

## Changes made
- Add `RdbEngineSpanner` extending `RdbEnginePostgreSQL`
- Spanner is not added to the current CI because some tests take more than 2 hours to complete. For now, a workflow dispatch action for Spanner has only been created. This is only temporary.
- Update the integration test to handle the limitations explained above.


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The Spanner adapter has been validated against both the Spanner emulator (via the new GitHub Actions workflow) and a real Cloud Spanner instance

cf. the [Spanner CI run](https://github.com/scalar-labs/scalardb/actions/runs/25051357006) 

## Release notes

Added support for Google Cloud Spanner as a JDBC storage, via its PostgreSQL-compatible dialect.