### PR TITLE
Propagate transaction attributes to in-transaction operations

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransaction.java
@@ -1,0 +1,244 @@
+package com.scalar.db.common;
+
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
+import com.scalar.db.exception.transaction.CrudException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A {@link DistributedTransaction} decorator that propagates the transaction-scoped attributes
+ * given to {@code begin(..., Map<String, String>)} into every operation issued on the transaction.
+ * If an operation already carries an attribute with the same name, the operation's value wins.
+ */
+@NotThreadSafe
+public class AttributePropagatingDistributedTransaction extends DecoratedDistributedTransaction {
+
+  private final ImmutableMap<String, String> transactionAttributes;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public AttributePropagatingDistributedTransaction(
+      DistributedTransaction transaction, Map<String, String> transactionAttributes) {
+    super(transaction);
+    this.transactionAttributes = ImmutableMap.copyOf(transactionAttributes);
+  }
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException {
+    return super.get(mergeAttributes(get));
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException {
+    return super.scan(mergeAttributes(scan));
+  }
+
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return super.getScanner(mergeAttributes(scan));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(Put put) throws CrudException {
+    super.put(mergeAttributes(put));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    super.put(mergeAttributesForList(puts));
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    super.insert(mergeAttributes(insert));
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    super.upsert(mergeAttributes(upsert));
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    super.update(mergeAttributes(update));
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    super.delete(mergeAttributes(delete));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    super.delete(mergeAttributesForList(deletes));
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    List<Mutation> merged = new ArrayList<>(mutations.size());
+    for (Mutation mutation : mutations) {
+      merged.add(mergeAttributes(mutation));
+    }
+    super.mutate(merged);
+  }
+
+  @Override
+  public List<BatchResult> batch(List<? extends Operation> operations) throws CrudException {
+    List<Operation> merged = new ArrayList<>(operations.size());
+    for (Operation operation : operations) {
+      merged.add(mergeAttributes(operation));
+    }
+    return super.batch(merged);
+  }
+
+  private <T extends Operation> List<T> mergeAttributesForList(List<T> operations) {
+    List<T> merged = new ArrayList<>(operations.size());
+    for (T operation : operations) {
+      merged.add(mergeAttributes(operation));
+    }
+    return merged;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Operation> T mergeAttributes(T operation) {
+    if (containsAllTransactionAttributeKeys(operation)) {
+      return operation;
+    }
+    if (operation instanceof Put) {
+      return (T) mergeAttributesIntoPut((Put) operation);
+    }
+    if (operation instanceof Insert) {
+      return (T) mergeAttributesIntoInsert((Insert) operation);
+    }
+    if (operation instanceof Upsert) {
+      return (T) mergeAttributesIntoUpsert((Upsert) operation);
+    }
+    if (operation instanceof Update) {
+      return (T) mergeAttributesIntoUpdate((Update) operation);
+    }
+    if (operation instanceof Delete) {
+      return (T) mergeAttributesIntoDelete((Delete) operation);
+    }
+    if (operation instanceof Get) {
+      return (T) mergeAttributesIntoGet((Get) operation);
+    }
+    if (operation instanceof Scan) {
+      return (T) mergeAttributesIntoScan((Scan) operation);
+    }
+    return operation;
+  }
+
+  private boolean containsAllTransactionAttributeKeys(Operation operation) {
+    Map<String, String> operationAttributes = operation.getAttributes();
+    for (String key : transactionAttributes.keySet()) {
+      if (!operationAttributes.containsKey(key)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private Put mergeAttributesIntoPut(Put put) {
+    Map<String, String> existing = put.getAttributes();
+    PutBuilder.BuildableFromExisting builder = Put.newBuilder(put);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Insert mergeAttributesIntoInsert(Insert insert) {
+    Map<String, String> existing = insert.getAttributes();
+    InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Upsert mergeAttributesIntoUpsert(Upsert upsert) {
+    Map<String, String> existing = upsert.getAttributes();
+    UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Update mergeAttributesIntoUpdate(Update update) {
+    Map<String, String> existing = update.getAttributes();
+    UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Delete mergeAttributesIntoDelete(Delete delete) {
+    Map<String, String> existing = delete.getAttributes();
+    DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Get mergeAttributesIntoGet(Get get) {
+    Map<String, String> existing = get.getAttributes();
+    GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private Scan mergeAttributesIntoScan(Scan scan) {
+    Map<String, String> existing = scan.getAttributes();
+    ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -24,6 +24,7 @@ import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransactionManager;
 import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
+import com.scalar.db.common.AttributePropagatingDistributedTransaction;
 import com.scalar.db.common.ReadOnlyDistributedTransaction;
 import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.VirtualTableInfoManager;
@@ -207,20 +208,30 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
 
   @Override
   public DistributedTransaction begin(String txId, Map<String, String> attributes) {
-    return begin(
-        txId,
-        ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
-        false,
-        false);
+    DistributedTransaction transaction =
+        begin(
+            txId,
+            ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
+            false,
+            false);
+    if (!attributes.isEmpty()) {
+      transaction = new AttributePropagatingDistributedTransaction(transaction, attributes);
+    }
+    return transaction;
   }
 
   @Override
   public DistributedTransaction beginReadOnly(String txId, Map<String, String> attributes) {
-    return begin(
-        txId,
-        ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
-        true,
-        false);
+    DistributedTransaction transaction =
+        begin(
+            txId,
+            ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
+            true,
+            false);
+    if (!attributes.isEmpty()) {
+      transaction = new AttributePropagatingDistributedTransaction(transaction, attributes);
+    }
+    return transaction;
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingDistributedTransactionTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingDistributedTransactionTest.java
@@ -1,0 +1,426 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AttributePropagatingDistributedTransactionTest {
+
+  private static final String TRANSACTION_ID = "test-tx-id";
+  private static final String NAMESPACE = "ns";
+  private static final String TABLE = "tbl";
+  private static final String TX_ATTR_KEY_1 = "cc-implicit-pre-read-enabled";
+  private static final String TX_ATTR_VALUE_1 = "true";
+  private static final String TX_ATTR_KEY_2 = "tenant-id";
+  private static final String TX_ATTR_VALUE_2 = "tenant-1";
+
+  @Mock private DistributedTransaction delegate;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(delegate.getId()).thenReturn(TRANSACTION_ID);
+  }
+
+  private AttributePropagatingDistributedTransaction newDecorator(
+      Map<String, String> transactionAttributes) {
+    return new AttributePropagatingDistributedTransaction(delegate, transactionAttributes);
+  }
+
+  private Map<String, String> twoTransactionAttributes() {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(TX_ATTR_KEY_1, TX_ATTR_VALUE_1);
+    attributes.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+    return attributes;
+  }
+
+  private Put buildPut(Map<String, String> attributes) {
+    PutBuilder.BuildableFromExisting builder =
+        Put.newBuilder(
+            Put.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Get buildGet(Map<String, String> attributes) {
+    GetBuilder.BuildableGetOrGetWithIndexFromExisting builder =
+        Get.newBuilder(
+            Get.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Scan buildScan(Map<String, String> attributes) {
+    ScanBuilder.BuildableScanOrScanAllFromExisting builder =
+        Scan.newBuilder(
+            Scan.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Insert buildInsert(Map<String, String> attributes) {
+    InsertBuilder.BuildableFromExisting builder =
+        Insert.newBuilder(
+            Insert.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Upsert buildUpsert(Map<String, String> attributes) {
+    UpsertBuilder.BuildableFromExisting builder =
+        Upsert.newBuilder(
+            Upsert.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Update buildUpdate(Map<String, String> attributes) {
+    UpdateBuilder.BuildableFromExisting builder =
+        Update.newBuilder(
+            Update.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  private Delete buildDelete(Map<String, String> attributes) {
+    DeleteBuilder.BuildableFromExisting builder =
+        Delete.newBuilder(
+            Delete.newBuilder()
+                .namespace(NAMESPACE)
+                .table(TABLE)
+                .partitionKey(Key.ofText("pk", "v"))
+                .build());
+    attributes.forEach(builder::attribute);
+    return builder.build();
+  }
+
+  // -------------------- happy path: each operation type --------------------
+
+  @Test
+  public void get_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Get get = buildGet(Collections.emptyMap());
+    Get expected = buildGet(twoTransactionAttributes());
+    when(delegate.get(any(Get.class))).thenReturn(Optional.empty());
+
+    decorator.get(get);
+
+    verify(delegate).get(eq(expected));
+  }
+
+  @Test
+  public void scan_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Scan scan = buildScan(Collections.emptyMap());
+    Scan expected = buildScan(twoTransactionAttributes());
+    when(delegate.scan(any(Scan.class))).thenReturn(Collections.emptyList());
+
+    decorator.scan(scan);
+
+    verify(delegate).scan(eq(expected));
+  }
+
+  @Test
+  public void getScanner_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Scan scan = buildScan(Collections.emptyMap());
+    Scan expected = buildScan(twoTransactionAttributes());
+    Scanner expectedScanner = mock(Scanner.class);
+    when(delegate.getScanner(any(Scan.class))).thenReturn(expectedScanner);
+
+    Scanner actual = decorator.getScanner(scan);
+
+    assertThat(actual).isSameAs(expectedScanner);
+    verify(delegate).getScanner(eq(expected));
+  }
+
+  @Test
+  public void put_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Put put = buildPut(Collections.emptyMap());
+    Put expected = buildPut(twoTransactionAttributes());
+
+    decorator.put(put);
+
+    verify(delegate).put(eq(expected));
+  }
+
+  @Test
+  public void insert_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Insert insert = buildInsert(Collections.emptyMap());
+    Insert expected = buildInsert(twoTransactionAttributes());
+
+    decorator.insert(insert);
+
+    verify(delegate).insert(eq(expected));
+  }
+
+  @Test
+  public void upsert_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Upsert upsert = buildUpsert(Collections.emptyMap());
+    Upsert expected = buildUpsert(twoTransactionAttributes());
+
+    decorator.upsert(upsert);
+
+    verify(delegate).upsert(eq(expected));
+  }
+
+  @Test
+  public void update_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Update update = buildUpdate(Collections.emptyMap());
+    Update expected = buildUpdate(twoTransactionAttributes());
+
+    decorator.update(update);
+
+    verify(delegate).update(eq(expected));
+  }
+
+  @Test
+  public void delete_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Delete delete = buildDelete(Collections.emptyMap());
+    Delete expected = buildDelete(twoTransactionAttributes());
+
+    decorator.delete(delete);
+
+    verify(delegate).delete(eq(expected));
+  }
+
+  // -------------------- precedence: operation-side wins --------------------
+
+  @Test
+  public void put_WhenOperationHasSameKey_ShouldKeepOperationValue() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator =
+        newDecorator(Collections.singletonMap(TX_ATTR_KEY_1, "true"));
+
+    Put put = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "false"));
+    Put expected = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "false"));
+
+    decorator.put(put);
+
+    verify(delegate).put(eq(expected));
+  }
+
+  @Test
+  public void put_WhenOperationHasPartialOverlap_ShouldFillOnlyMissingKeys() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+
+    Put put = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+    Map<String, String> expectedAttributes = new HashMap<>();
+    expectedAttributes.put(TX_ATTR_KEY_1, "operation-wins");
+    expectedAttributes.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+    Put expected = buildPut(expectedAttributes);
+
+    decorator.put(put);
+
+    verify(delegate).put(eq(expected));
+  }
+
+  // -------------------- fast path: full overlap returns same instance --------------------
+
+  @Test
+  public void put_WhenOperationAlreadyHasAllKeys_ShouldForwardSameInstance() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Put put = buildPut(twoTransactionAttributes());
+
+    decorator.put(put);
+
+    verify(delegate).put(same(put));
+  }
+
+  // -------------------- empty transaction attributes --------------------
+
+  @Test
+  public void put_WhenTransactionAttributesEmpty_ShouldForwardSameInstance() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(Collections.emptyMap());
+    Put put = buildPut(Collections.emptyMap());
+
+    decorator.put(put);
+
+    verify(delegate).put(same(put));
+  }
+
+  // -------------------- defensive snapshot --------------------
+
+  @Test
+  public void put_WhenTransactionAttributesMutatedAfterConstruction_ShouldUseSnapshot()
+      throws CrudException {
+    Map<String, String> transactionAttributes = new HashMap<>();
+    transactionAttributes.put(TX_ATTR_KEY_1, TX_ATTR_VALUE_1);
+    AttributePropagatingDistributedTransaction decorator = newDecorator(transactionAttributes);
+
+    transactionAttributes.put(TX_ATTR_KEY_2, "added-after");
+    transactionAttributes.remove(TX_ATTR_KEY_1);
+
+    Put put = buildPut(Collections.emptyMap());
+    Put expected = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, TX_ATTR_VALUE_1));
+
+    decorator.put(put);
+
+    verify(delegate).put(eq(expected));
+  }
+
+  // -------------------- mutate / batch --------------------
+
+  @Test
+  public void mutate_WithTransactionAttributes_ShouldMergeIntoEachMutation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+
+    Put put = buildPut(Collections.emptyMap());
+    Delete delete = buildDelete(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+    List<Mutation> mutations = Arrays.asList(put, delete);
+
+    Put expectedPut = buildPut(twoTransactionAttributes());
+    Map<String, String> expectedDeleteAttrs = new HashMap<>();
+    expectedDeleteAttrs.put(TX_ATTR_KEY_1, "operation-wins");
+    expectedDeleteAttrs.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+    Delete expectedDelete = buildDelete(expectedDeleteAttrs);
+    List<Mutation> expected = Arrays.asList(expectedPut, expectedDelete);
+
+    decorator.mutate(mutations);
+
+    verify(delegate).mutate(eq(expected));
+  }
+
+  @Test
+  public void batch_WithTransactionAttributes_ShouldMergeIntoEachOperation() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+
+    Get get = buildGet(Collections.emptyMap());
+    Put put = buildPut(Collections.emptyMap());
+    List<Operation> operations = Arrays.asList(get, put);
+
+    Get expectedGet = buildGet(twoTransactionAttributes());
+    Put expectedPut = buildPut(twoTransactionAttributes());
+    List<Operation> expected = Arrays.asList(expectedGet, expectedPut);
+
+    when(delegate.batch(any())).thenReturn(Collections.emptyList());
+
+    decorator.batch(operations);
+
+    verify(delegate).batch(eq(expected));
+  }
+
+  // -------------------- pass-through --------------------
+
+  @Test
+  public void commit_ShouldDelegate() throws Exception {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    decorator.commit();
+    verify(delegate).commit();
+  }
+
+  @Test
+  public void rollback_ShouldDelegate() throws Exception {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    decorator.rollback();
+    verify(delegate).rollback();
+  }
+
+  @Test
+  public void abort_ShouldDelegate() throws Exception {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    decorator.abort();
+    verify(delegate).abort();
+  }
+
+  @Test
+  public void getId_ShouldDelegate() {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    assertThat(decorator.getId()).isEqualTo(TRANSACTION_ID);
+  }
+
+  @Test
+  public void get_ShouldReturnDelegateResult() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Get get = buildGet(Collections.emptyMap());
+    Optional<Result> expected = Optional.of(mock(Result.class));
+    when(delegate.get(any(Get.class))).thenReturn(expected);
+
+    Optional<Result> actual = decorator.get(get);
+
+    assertThat(actual).isSameAs(expected);
+  }
+
+  // -------------------- snapshot stability across multiple calls --------------------
+
+  @Test
+  public void multipleCalls_ShouldUseSameSnapshot() throws CrudException {
+    AttributePropagatingDistributedTransaction decorator = newDecorator(twoTransactionAttributes());
+    Put put1 = buildPut(Collections.emptyMap());
+    Put put2 = buildPut(Collections.emptyMap());
+    Put expected = buildPut(twoTransactionAttributes());
+
+    decorator.put(put1);
+    decorator.put(put2);
+
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(delegate, times(2)).put(captor.capture());
+    assertThat(captor.getAllValues()).containsExactly(expected, expected);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -32,6 +32,7 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
+import com.scalar.db.common.AttributePropagatingDistributedTransaction;
 import com.scalar.db.common.DecoratedDistributedTransaction;
 import com.scalar.db.common.ReadOnlyDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
@@ -267,12 +268,14 @@ public class ConsensusCommitManagerTest {
     ConsensusCommitOperationAttributes.setIsolation(attributes, Isolation.SERIALIZABLE);
 
     // Act
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin(ANY_TX_ID, attributes);
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID, attributes);
 
     // Assert
-    assertThat(transaction.getTransactionContext().transactionId).isEqualTo(ANY_TX_ID);
-    assertThat(transaction.getTransactionContext().isolation).isEqualTo(Isolation.SERIALIZABLE);
-    assertThat(transaction.getTransactionContext().readOnly).isFalse();
+    ConsensusCommit inner =
+        (ConsensusCommit) ((DecoratedDistributedTransaction) transaction).getOriginalTransaction();
+    assertThat(inner.getTransactionContext().transactionId).isEqualTo(ANY_TX_ID);
+    assertThat(inner.getTransactionContext().isolation).isEqualTo(Isolation.SERIALIZABLE);
+    assertThat(inner.getTransactionContext().readOnly).isFalse();
   }
 
   @Test
@@ -301,7 +304,6 @@ public class ConsensusCommitManagerTest {
     DistributedTransaction transaction = manager.beginReadOnly(ANY_TX_ID, attributes);
 
     // Assert
-    assertThat(transaction).isInstanceOf(ReadOnlyDistributedTransaction.class);
     ConsensusCommit inner =
         (ConsensusCommit) ((DecoratedDistributedTransaction) transaction).getOriginalTransaction();
     assertThat(inner.getTransactionContext().transactionId).isEqualTo(ANY_TX_ID);
@@ -325,6 +327,58 @@ public class ConsensusCommitManagerTest {
     assertThat(inner.getTransactionContext().transactionId).isEqualTo(ANY_TX_ID);
     assertThat(inner.getTransactionContext().isolation).isEqualTo(Isolation.SNAPSHOT);
     assertThat(inner.getTransactionContext().readOnly).isTrue();
+  }
+
+  @Test
+  public void begin_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator() {
+    // Arrange
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("custom-key", "custom-value");
+
+    // Act
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID, attributes);
+
+    // Assert
+    assertThat(transaction).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void begin_WithEmptyAttributes_ShouldNotWrapWithAttributePropagatingDecorator() {
+    // Arrange
+    Map<String, String> attributes = new HashMap<>();
+
+    // Act
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID, attributes);
+
+    // Assert
+    assertThat(transaction).isInstanceOf(ConsensusCommit.class);
+    assertThat(transaction).isNotInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void beginReadOnly_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator() {
+    // Arrange
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("custom-key", "custom-value");
+
+    // Act
+    DistributedTransaction transaction = manager.beginReadOnly(ANY_TX_ID, attributes);
+
+    // Assert
+    assertThat(transaction).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void beginReadOnly_WithEmptyAttributes_ShouldNotWrapWithAttributePropagatingDecorator() {
+    // Arrange
+    Map<String, String> attributes = new HashMap<>();
+
+    // Act
+    DistributedTransaction transaction = manager.beginReadOnly(ANY_TX_ID, attributes);
+
+    // Assert
+    assertThat(transaction).isInstanceOf(ReadOnlyDistributedTransaction.class);
+    assertThat(transaction).isNotInstanceOf(AttributePropagatingDistributedTransaction.class);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -3,18 +3,29 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.db.api.DatabaseOperationAttributes;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionIntegrationTestBase;
+import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Insert;
 import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
+import com.scalar.db.service.TransactionFactory;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public abstract class ConsensusCommitIntegrationTestBase
@@ -930,5 +941,82 @@ public abstract class ConsensusCommitIntegrationTestBase
     // Assert
     Optional<Result> optResult = get(prepareGet(0, 0));
     assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void scan_CrossPartitionScanWithTransactionAttribute_ShouldPropagateAndSucceed()
+      throws Exception {
+    // Arrange: build a manager with cross-partition-scan disabled at the config level so that
+    // the propagation of the transaction-scoped attribute is what gates the operation.
+    try (DistributedTransactionManager localManager = createManagerWithoutCrossPartitionScan()) {
+      populateRecords();
+
+      Map<String, String> attributes = new HashMap<>();
+      DatabaseOperationAttributes.setCrossPartitionScanEnabled(attributes, true);
+
+      Scan scanAll = Scan.newBuilder().namespace(namespace).table(TABLE).all().build();
+
+      // Act
+      DistributedTransaction transaction = localManager.begin(attributes);
+      List<Result> results = transaction.scan(scanAll);
+      transaction.commit();
+
+      // Assert: every (accountId, accountType) pair populated by populateRecords() must be
+      // present with the expected balance.
+      assertThat(results).hasSize(NUM_ACCOUNTS * NUM_TYPES);
+      Set<List<Integer>> observedKeys = new HashSet<>();
+      for (Result result : results) {
+        int accountId = result.getInt(ACCOUNT_ID);
+        int accountType = result.getInt(ACCOUNT_TYPE);
+        observedKeys.add(Arrays.asList(accountId, accountType));
+        assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      }
+      Set<List<Integer>> expectedKeys = new HashSet<>();
+      for (int i = 0; i < NUM_ACCOUNTS; i++) {
+        for (int j = 0; j < NUM_TYPES; j++) {
+          expectedKeys.add(Arrays.asList(i, j));
+        }
+      }
+      assertThat(observedKeys).isEqualTo(expectedKeys);
+    }
+  }
+
+  @Test
+  public void
+      scan_CrossPartitionScanWithTransactionAttributeButOperationOverridesItToFalse_ShouldThrowIllegalArgumentException()
+          throws Exception {
+    // Arrange
+    try (DistributedTransactionManager localManager = createManagerWithoutCrossPartitionScan()) {
+      Map<String, String> attributes = new HashMap<>();
+      DatabaseOperationAttributes.setCrossPartitionScanEnabled(attributes, true);
+
+      // Operation explicitly sets cross-partition-scan-enabled to "false" -- operation-side
+      // value must win over the transaction-scoped "true" -- so the scan must be rejected.
+      Scan scanAll =
+          Scan.newBuilder()
+              .namespace(namespace)
+              .table(TABLE)
+              .all()
+              .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "false")
+              .build();
+
+      // Act Assert
+      DistributedTransaction transaction = localManager.begin(attributes);
+      try {
+        assertThatThrownBy(() -> transaction.scan(scanAll))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cross-partition scan is not enabled");
+      } finally {
+        transaction.rollback();
+      }
+    }
+  }
+
+  private DistributedTransactionManager createManagerWithoutCrossPartitionScan() {
+    Properties properties = getProperties(getTestName());
+    properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN, "false");
+    properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_FILTERING, "false");
+    properties.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_ORDERING, "false");
+    return TransactionFactory.create(properties).getTransactionManager();
   }
 }


### PR DESCRIPTION
## Description

`DistributedTransactionManager#begin(..., Map<String, String>)` accepts transaction-scoped attributes, but those attributes are not visible from the operations issued inside the transaction. Users have to attach the same attribute (for example `db-cross-partition-scan-enabled `) to every `Scan` explicitly when they want it applied to the whole transaction, which is redundant and easy to get wrong.

This PR makes the transaction-scoped attributes flow into every operation (`get` / `scan` / `getScanner` / `put` / `insert` / `upsert` / `update` / `delete` / `mutate` / `batch`) so the same setting can be expressed once at `begin` time.

## Related issues and/or PRs

N/A

## Changes made

- Added `AttributePropagatingDistributedTransaction` (internal decorator) that merges the transaction-scoped attributes into every operation issued on the transaction. Operation-side attributes take precedence; an operation that already carries every key is forwarded unchanged.
- Wired the decorator from `ConsensusCommitManager#begin`/`#beginReadOnly`. The wrap is skipped when the attributes map is empty, so `begin()` / `begin(txId)` keep returning the same concrete type as before and existing callers that cast to the underlying transaction continue to work.
- Other transaction managers opt out by simply not wrapping — forwarding managers (for example the cluster client) leave propagation to the side that owns the transaction.
- Added unit tests for the decorator and manager wiring, and integration tests that exercise propagation and operation-side precedence end-to-end through ConsensusCommit using the `db-cross-partition-scan-enabled` attribute.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `DistributedTransaction` public surface is unchanged — no `getAttributes()` accessor is exposed on the transaction. Propagation is entirely an internal concern of the transaction managers that own the local transaction.

## Release notes

Added propagation of transaction-scoped attributes given to `DistributedTransactionManager#begin(..., Map<String, String>)` to every operation issued on the transaction in Consensus Commit.