### PR TITLE
Backport to branch(3) : Add ScalarDbUtils.getStorageAdmins() utility to retrieve underlying storage admins

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.multistorage;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -18,8 +19,7 @@ import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.service.StorageFactory;
-import java.util.ArrayList;
-import java.util.HashMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,54 +39,55 @@ public class MultiStorage extends AbstractDistributedStorage {
   /** @deprecated Will be removed in 5.0.0. */
   @Deprecated private final Map<String, DistributedStorage> tableStorageMap;
 
-  private final Map<String, DistributedStorage> namespaceStorageMap;
-  private final DistributedStorage defaultStorage;
-  private final List<DistributedStorage> storages;
+  private final Map<String, String> namespaceStorageNameMap;
+  private final String defaultStorageName;
+  private final Map<String, DistributedStorage> nameStorageMap;
 
   @Inject
   public MultiStorage(DatabaseConfig databaseConfig) {
     super(databaseConfig);
     MultiStorageConfig config = new MultiStorageConfig(databaseConfig);
 
-    storages = new ArrayList<>();
-    Map<String, DistributedStorage> nameStorageMap = new HashMap<>();
-    config
-        .getDatabasePropertiesMap()
-        .forEach(
-            (storageName, properties) -> {
-              StorageFactory factory = StorageFactory.create(properties);
-              DistributedStorage storage = factory.getStorage();
-              nameStorageMap.put(storageName, storage);
-              storages.add(storage);
-            });
+    nameStorageMap =
+        config.getDatabasePropertiesMap().entrySet().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Map.Entry::getKey, e -> StorageFactory.create(e.getValue()).getStorage()));
 
-    tableStorageMap = new HashMap<>();
-    config
-        .getTableStorageMap()
-        .forEach(
-            (table, storageName) -> tableStorageMap.put(table, nameStorageMap.get(storageName)));
+    tableStorageMap =
+        config.getTableStorageMap().entrySet().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Map.Entry::getKey, e -> nameStorageMap.get(e.getValue())));
 
-    namespaceStorageMap = new HashMap<>();
-    config
-        .getNamespaceStorageMap()
-        .forEach(
-            (table, storageName) ->
-                namespaceStorageMap.put(table, nameStorageMap.get(storageName)));
+    namespaceStorageNameMap = ImmutableMap.copyOf(config.getNamespaceStorageMap());
 
-    defaultStorage = nameStorageMap.get(config.getDefaultStorage());
+    defaultStorageName = config.getDefaultStorage();
   }
 
   @VisibleForTesting
   MultiStorage(
       DatabaseConfig databaseConfig,
+      Map<String, DistributedStorage> nameStorageMap,
       Map<String, DistributedStorage> tableStorageMap,
-      Map<String, DistributedStorage> namespaceStorageMap,
-      DistributedStorage defaultStorage) {
+      Map<String, String> namespaceStorageNameMap,
+      String defaultStorageName) {
     super(databaseConfig);
-    this.tableStorageMap = tableStorageMap;
-    this.namespaceStorageMap = namespaceStorageMap;
-    this.defaultStorage = defaultStorage;
-    storages = null;
+    this.nameStorageMap = ImmutableMap.copyOf(nameStorageMap);
+    this.tableStorageMap = ImmutableMap.copyOf(tableStorageMap);
+    this.namespaceStorageNameMap = ImmutableMap.copyOf(namespaceStorageNameMap);
+    this.defaultStorageName = defaultStorageName;
+  }
+
+  /**
+   * Returns a map of underlying storages keyed by the user-defined storage name (configured via
+   * {@code scalar.db.multi_storage.storages}).
+   *
+   * @return an unmodifiable map of underlying storages keyed by storage name
+   */
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public Map<String, DistributedStorage> getNameStorageMap() {
+    return nameStorageMap;
   }
 
   @Override
@@ -150,13 +151,13 @@ public class MultiStorage extends AbstractDistributedStorage {
       return storage;
     }
     String namespace = operation.forNamespace().get();
-    storage = namespaceStorageMap.get(namespace);
-    return storage != null ? storage : defaultStorage;
+    String storageName = namespaceStorageNameMap.getOrDefault(namespace, defaultStorageName);
+    return nameStorageMap.get(storageName);
   }
 
   @Override
   public void close() {
-    for (DistributedStorage storage : storages) {
+    for (DistributedStorage storage : nameStorageMap.values()) {
       storage.close();
     }
   }

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.multistorage;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.StorageInfo;
@@ -14,10 +15,8 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.ScalarDbUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,52 +37,41 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   /** @deprecated Will be removed in 5.0.0. */
   @Deprecated private final Map<String, DistributedStorageAdmin> tableAdminMap;
 
-  private final Map<String, AdminHolder> namespaceAdminMap;
-  private final AdminHolder defaultAdmin;
-  private final List<DistributedStorageAdmin> admins;
+  private final Map<String, String> namespaceStorageNameMap;
+  private final String defaultStorageName;
+  private final Map<String, DistributedStorageAdmin> nameAdminMap;
 
   @Inject
   public MultiStorageAdmin(DatabaseConfig databaseConfig) {
     MultiStorageConfig config = new MultiStorageConfig(databaseConfig);
 
-    admins = new ArrayList<>();
-    Map<String, DistributedStorageAdmin> nameAdminMap = new HashMap<>();
-    config
-        .getDatabasePropertiesMap()
-        .forEach(
-            (storageName, properties) -> {
-              StorageFactory factory = StorageFactory.create(properties);
-              DistributedStorageAdmin admin = factory.getStorageAdmin();
-              nameAdminMap.put(storageName, admin);
-              admins.add(admin);
-            });
+    nameAdminMap =
+        config.getDatabasePropertiesMap().entrySet().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Map.Entry::getKey, e -> StorageFactory.create(e.getValue()).getStorageAdmin()));
 
-    tableAdminMap = new HashMap<>();
-    config
-        .getTableStorageMap()
-        .forEach((table, storageName) -> tableAdminMap.put(table, nameAdminMap.get(storageName)));
+    tableAdminMap =
+        config.getTableStorageMap().entrySet().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Map.Entry::getKey, e -> nameAdminMap.get(e.getValue())));
 
-    namespaceAdminMap = new HashMap<>();
-    config
-        .getNamespaceStorageMap()
-        .forEach(
-            (namespace, storageName) ->
-                namespaceAdminMap.put(
-                    namespace, new AdminHolder(storageName, nameAdminMap.get(storageName))));
+    namespaceStorageNameMap = ImmutableMap.copyOf(config.getNamespaceStorageMap());
 
-    defaultAdmin =
-        new AdminHolder(config.getDefaultStorage(), nameAdminMap.get(config.getDefaultStorage()));
+    defaultStorageName = config.getDefaultStorage();
   }
 
   @VisibleForTesting
   MultiStorageAdmin(
+      Map<String, DistributedStorageAdmin> nameAdminMap,
       Map<String, DistributedStorageAdmin> tableAdminMap,
-      Map<String, AdminHolder> namespaceAdminMap,
-      AdminHolder defaultAdmin) {
-    this.tableAdminMap = tableAdminMap;
-    this.namespaceAdminMap = namespaceAdminMap;
-    this.defaultAdmin = defaultAdmin;
-    admins = null;
+      Map<String, String> namespaceStorageNameMap,
+      String defaultStorageName) {
+    this.nameAdminMap = ImmutableMap.copyOf(nameAdminMap);
+    this.tableAdminMap = ImmutableMap.copyOf(tableAdminMap);
+    this.namespaceStorageNameMap = ImmutableMap.copyOf(namespaceStorageNameMap);
+    this.defaultStorageName = defaultStorageName;
   }
 
   @Override
@@ -256,18 +244,21 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     //     => returned
     // - ns4 and ns5 are in the default storage (cosmos)
     //     => returned
-    Set<String> namespaceNames = new HashSet<>(defaultAdmin.admin.getNamespaceNames());
+    DistributedStorageAdmin defaultAdmin = nameAdminMap.get(defaultStorageName);
+    Set<String> namespaceNames = new HashSet<>(defaultAdmin.getNamespaceNames());
 
     Set<DistributedStorageAdmin> adminsWithoutDefaultAdmin =
-        namespaceAdminMap.values().stream().map(holder -> holder.admin).collect(Collectors.toSet());
-    adminsWithoutDefaultAdmin.remove(defaultAdmin.admin);
+        namespaceStorageNameMap.values().stream()
+            .map(nameAdminMap::get)
+            .collect(Collectors.toSet());
+    adminsWithoutDefaultAdmin.remove(defaultAdmin);
 
     for (DistributedStorageAdmin admin : adminsWithoutDefaultAdmin) {
       Set<String> existingNamespaces = admin.getNamespaceNames();
       // Filter out namespace not in the mapping
       for (String existingNamespace : existingNamespaces) {
-        AdminHolder holder = namespaceAdminMap.get(existingNamespace);
-        if (holder != null && admin.equals(holder.admin)) {
+        String storageName = namespaceStorageNameMap.get(existingNamespace);
+        if (storageName != null && admin.equals(nameAdminMap.get(storageName))) {
           namespaceNames.add(existingNamespace);
         }
       }
@@ -279,10 +270,10 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   @Override
   public StorageInfo getStorageInfo(String namespace) throws ExecutionException {
     try {
-      AdminHolder holder = getAdminHolder(namespace);
-      StorageInfo storageInfo = holder.admin.getStorageInfo(namespace);
+      String storageName = getStorageName(namespace);
+      StorageInfo storageInfo = nameAdminMap.get(storageName).getStorageInfo(namespace);
       return new StorageInfoImpl(
-          holder.storageName,
+          storageName,
           storageInfo.getMutationAtomicityUnit(),
           storageInfo.getMaxAtomicMutationsCount(),
           storageInfo.isConsistentVirtualTableReadGuaranteed());
@@ -342,16 +333,12 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     return getAdmin(namespace, table).getVirtualTableInfo(namespace, table);
   }
 
-  private AdminHolder getAdminHolder(String namespace) {
-    AdminHolder adminHolder = namespaceAdminMap.get(namespace);
-    if (adminHolder != null) {
-      return adminHolder;
-    }
-    return defaultAdmin;
+  private String getStorageName(String namespace) {
+    return namespaceStorageNameMap.getOrDefault(namespace, defaultStorageName);
   }
 
   private DistributedStorageAdmin getAdmin(String namespace) {
-    return getAdminHolder(namespace).admin;
+    return nameAdminMap.get(getStorageName(namespace));
   }
 
   private DistributedStorageAdmin getAdmin(String namespace, String table) {
@@ -363,21 +350,21 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     return getAdmin(namespace);
   }
 
-  @Override
-  public void close() {
-    for (DistributedStorageAdmin admin : admins) {
-      admin.close();
-    }
+  /**
+   * Returns a map of underlying storage admins keyed by the user-defined storage name (configured
+   * via {@code scalar.db.multi_storage.storages}).
+   *
+   * @return an unmodifiable map of underlying storage admins keyed by storage name
+   */
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public Map<String, DistributedStorageAdmin> getNameAdminMap() {
+    return nameAdminMap;
   }
 
-  @VisibleForTesting
-  static class AdminHolder {
-    private final String storageName;
-    private final DistributedStorageAdmin admin;
-
-    AdminHolder(String storageName, DistributedStorageAdmin admin) {
-      this.storageName = storageName;
-      this.admin = admin;
+  @Override
+  public void close() {
+    for (DistributedStorageAdmin admin : nameAdminMap.values()) {
+      admin.close();
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.GetBuilder;
 import com.scalar.db.api.GetWithIndex;
@@ -28,6 +29,7 @@ import com.scalar.db.api.UpdateIfExists;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.api.UpsertBuilder;
 import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.BlobColumn;
@@ -50,6 +52,8 @@ import com.scalar.db.io.TimeColumn;
 import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.io.Value;
+import com.scalar.db.storage.multistorage.MultiStorageAdmin;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -512,5 +516,32 @@ public final class ScalarDbUtils {
       default:
         throw new AssertionError("Unsupported data type: " + dataType);
     }
+  }
+
+  /**
+   * Returns a map of underlying storage admins keyed by the storage name.
+   *
+   * <p>For {@link MultiStorageAdmin}, this returns the map of user-defined storage names (from the
+   * {@code scalar.db.multi_storage.storages} configuration) to their corresponding admins. For any
+   * other single-storage admin, this returns a single-entry map whose key is the storage name
+   * returned by {@link DistributedStorageAdmin#getStorageInfo(String)}.
+   *
+   * <p>This utility is useful when a caller needs to interact with each underlying storage
+   * individually (e.g., performing per-storage health checks) without having to know whether the
+   * given admin is a multi-storage admin or a single-storage one.
+   *
+   * @param admin a distributed storage admin
+   * @return a map of underlying storage admins keyed by storage name
+   * @throws ExecutionException if retrieving the storage information fails
+   */
+  public static Map<String, DistributedStorageAdmin> getStorageAdmins(DistributedStorageAdmin admin)
+      throws ExecutionException {
+    if (admin instanceof MultiStorageAdmin) {
+      return ((MultiStorageAdmin) admin).getNameAdminMap();
+    }
+    // For a single-storage admin, `getStorageInfo` ignores the namespace argument and returns a
+    // constant storage name, so passing an empty string is safe here.
+    String storageName = admin.getStorageInfo("").getStorageName();
+    return Collections.singletonMap(storageName, admin);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -48,14 +48,17 @@ public class MultiStorageAdminTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
+    Map<String, DistributedStorageAdmin> nameAdminMap = new HashMap<>();
+    nameAdminMap.put("s1", admin1);
+    nameAdminMap.put("s2", admin2);
+    nameAdminMap.put("s3", admin3);
     Map<String, DistributedStorageAdmin> tableAdminMap = new HashMap<>();
     tableAdminMap.put(NAMESPACE1 + "." + TABLE1, admin1);
     tableAdminMap.put(NAMESPACE1 + "." + TABLE2, admin2);
-    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
-    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
-    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put(NAMESPACE2, s2);
-    multiStorageAdmin = new MultiStorageAdmin(tableAdminMap, namespaceAdminMap, s3);
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put(NAMESPACE2, "s2");
+    multiStorageAdmin =
+        new MultiStorageAdmin(nameAdminMap, tableAdminMap, namespaceStorageNameMap, "s3");
   }
 
   @Test
@@ -758,15 +761,14 @@ public class MultiStorageAdminTest {
       getNamespaceNames_WithExistingNamespacesNotInMapping_ShouldReturnExistingNamespacesInMappingAndFromDefaultAdmin()
           throws ExecutionException {
     // Arrange
-    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
-    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
-    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
-
-    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", s1);
-    namespaceAdminMap.put("ns2", s2);
-    namespaceAdminMap.put("ns3", s2);
-    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
+    Map<String, DistributedStorageAdmin> nameAdminMap =
+        ImmutableMap.of("s1", admin1, "s2", admin2, "s3", admin3);
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put("ns1", "s1");
+    namespaceStorageNameMap.put("ns2", "s2");
+    namespaceStorageNameMap.put("ns3", "s2");
+    multiStorageAdmin =
+        new MultiStorageAdmin(nameAdminMap, Collections.emptyMap(), namespaceStorageNameMap, "s3");
 
     when(admin1.getNamespaceNames()).thenReturn(ImmutableSet.of("ns1", "ns2"));
     when(admin2.getNamespaceNames()).thenReturn(ImmutableSet.of("ns3"));
@@ -786,14 +788,13 @@ public class MultiStorageAdminTest {
   public void getNamespaceNames_WithNamespaceInMappingButNotExisting_ShouldReturnEmptySet()
       throws ExecutionException {
     // Arrange
-    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
-    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
-    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
-
-    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", s1);
-    namespaceAdminMap.put("ns2", s2);
-    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
+    Map<String, DistributedStorageAdmin> nameAdminMap =
+        ImmutableMap.of("s1", admin1, "s2", admin2, "s3", admin3);
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put("ns1", "s1");
+    namespaceStorageNameMap.put("ns2", "s2");
+    multiStorageAdmin =
+        new MultiStorageAdmin(nameAdminMap, Collections.emptyMap(), namespaceStorageNameMap, "s3");
 
     when(admin1.getNamespaceNames()).thenReturn(Collections.emptySet());
     when(admin2.getNamespaceNames()).thenReturn(Collections.emptySet());
@@ -813,14 +814,13 @@ public class MultiStorageAdminTest {
   public void getNamespaceNames_WithExistingNamespaceButNotInMapping_ShouldReturnEmptySet()
       throws ExecutionException {
     // Arrange
-    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
-    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
-    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
-
-    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", s1);
-    namespaceAdminMap.put("ns2", s2);
-    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
+    Map<String, DistributedStorageAdmin> nameAdminMap =
+        ImmutableMap.of("s1", admin1, "s2", admin2, "s3", admin3);
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put("ns1", "s1");
+    namespaceStorageNameMap.put("ns2", "s2");
+    multiStorageAdmin =
+        new MultiStorageAdmin(nameAdminMap, Collections.emptyMap(), namespaceStorageNameMap, "s3");
 
     when(admin1.getNamespaceNames()).thenReturn(ImmutableSet.of("ns2"));
     when(admin2.getNamespaceNames()).thenReturn(Collections.emptySet());
@@ -854,14 +854,13 @@ public class MultiStorageAdminTest {
   @Test
   public void getStorageInfo_ShouldReturnProperStorageInfo() throws ExecutionException {
     // Arrange
-    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
-    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
-    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
-
-    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", s1);
-    namespaceAdminMap.put("ns2", s2);
-    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
+    Map<String, DistributedStorageAdmin> nameAdminMap =
+        ImmutableMap.of("s1", admin1, "s2", admin2, "s3", admin3);
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put("ns1", "s1");
+    namespaceStorageNameMap.put("ns2", "s2");
+    multiStorageAdmin =
+        new MultiStorageAdmin(nameAdminMap, Collections.emptyMap(), namespaceStorageNameMap, "s3");
 
     when(admin1.getStorageInfo(anyString()))
         .thenReturn(

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -44,14 +44,18 @@ public class MultiStorageTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
+    Map<String, DistributedStorage> nameStorageMap = new HashMap<>();
+    nameStorageMap.put("s1", storage1);
+    nameStorageMap.put("s2", storage2);
+    nameStorageMap.put("s3", storage3);
     Map<String, DistributedStorage> tableStorageMap = new HashMap<>();
     tableStorageMap.put(NAMESPACE1 + "." + TABLE1, storage1);
     tableStorageMap.put(NAMESPACE1 + "." + TABLE2, storage2);
-    Map<String, DistributedStorage> namespaceStorageMap = new HashMap<>();
-    namespaceStorageMap.put(NAMESPACE2, storage2);
-    DistributedStorage defaultStorage = storage3;
+    Map<String, String> namespaceStorageNameMap = new HashMap<>();
+    namespaceStorageNameMap.put(NAMESPACE2, "s2");
     multiStorage =
-        new MultiStorage(databaseConfig, tableStorageMap, namespaceStorageMap, defaultStorage);
+        new MultiStorage(
+            databaseConfig, nameStorageMap, tableStorageMap, namespaceStorageNameMap, "s3");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
@@ -3,11 +3,15 @@ package com.scalar.db.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.GetWithIndex;
 import com.scalar.db.api.Insert;
@@ -18,18 +22,23 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.ScanWithIndex;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.ResultImpl;
+import com.scalar.db.common.StorageInfoImpl;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DoubleColumn;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
+import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -632,5 +641,39 @@ public class ScalarDbUtilsTest {
 
     // Assert
     assertThat(actual).isNotPresent();
+  }
+
+  @Test
+  public void getStorageAdmins_MultiStorageAdminGiven_ShouldReturnUnderlyingNameAdminMap()
+      throws ExecutionException {
+    // Arrange
+    DistributedStorageAdmin admin1 = mock(DistributedStorageAdmin.class);
+    DistributedStorageAdmin admin2 = mock(DistributedStorageAdmin.class);
+    MultiStorageAdmin multiStorageAdmin = mock(MultiStorageAdmin.class);
+    when(multiStorageAdmin.getNameAdminMap())
+        .thenReturn(ImmutableMap.of("s1", admin1, "s2", admin2));
+
+    // Act
+    Map<String, DistributedStorageAdmin> actual = ScalarDbUtils.getStorageAdmins(multiStorageAdmin);
+
+    // Assert
+    assertThat(actual).containsOnly(entry("s1", admin1), entry("s2", admin2));
+  }
+
+  @Test
+  public void getStorageAdmins_SingleAdminGiven_ShouldReturnSingleEntryMap()
+      throws ExecutionException {
+    // Arrange
+    DistributedStorageAdmin admin = mock(DistributedStorageAdmin.class);
+    when(admin.getStorageInfo(""))
+        .thenReturn(
+            new StorageInfoImpl(
+                "jdbc", StorageInfo.MutationAtomicityUnit.STORAGE, Integer.MAX_VALUE, true));
+
+    // Act
+    Map<String, DistributedStorageAdmin> actual = ScalarDbUtils.getStorageAdmins(admin);
+
+    // Assert
+    assertThat(actual).containsOnly(entry("jdbc", admin));
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3512
- **Commit to backport:** 62266079310f193f4b1a1ba6cf5d3fe20c687ae7

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3512 &&
git cherry-pick --no-rerere-autoupdate -m1 62266079310f193f4b1a1ba6cf5d3fe20c687ae7
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!