### PR TITLE
Backport to branch(3.17) : Change scheduled removal version of deprecated APIs from 5.0.0 to 4.0.0

### DIFF
--- a/core/src/main/java/com/scalar/db/api/ConditionalExpression.java
+++ b/core/src/main/java/com/scalar/db/api/ConditionalExpression.java
@@ -39,7 +39,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param value a value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public ConditionalExpression(String columnName, Value<?> value, Operator operator) {
@@ -63,7 +63,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param booleanValue a BOOLEAN value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -77,7 +77,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param intValue an INT value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -91,7 +91,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param bigIntValue a BIGINT value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -105,7 +105,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param floatValue a FLOAT value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -119,7 +119,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param doubleValue a DOUBLE value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -133,7 +133,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param textValue a TEXT value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -147,7 +147,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param blobValue a BLOB value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -161,7 +161,7 @@ public class ConditionalExpression {
    * @param columnName a name of target column
    * @param blobValue a BLOB value used to compare with the target column
    * @param operator an operator used to compare the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -173,7 +173,7 @@ public class ConditionalExpression {
    * Returns the column name of target column.
    *
    * @return the column name of target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public String getName() {
@@ -184,7 +184,7 @@ public class ConditionalExpression {
    * Returns the value used to compare with the target column.
    *
    * @return the value used to compare with the target column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Value<?> getValue() {

--- a/core/src/main/java/com/scalar/db/api/CrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/CrudOperable.java
@@ -68,7 +68,7 @@ public interface CrudOperable<E extends TransactionException> {
    *
    * @param put a {@code Put} command
    * @throws E if the transaction CRUD operation fails
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   void put(Put put) throws E;
@@ -81,7 +81,7 @@ public interface CrudOperable<E extends TransactionException> {
    *
    * @param puts a list of {@code Put} commands
    * @throws E if the transaction CRUD operation fails
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated
@@ -141,7 +141,7 @@ public interface CrudOperable<E extends TransactionException> {
    *
    * @param deletes a list of {@code Delete} commands
    * @throws E if the transaction CRUD operation fails
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/Delete.java
+++ b/core/src/main/java/com/scalar/db/api/Delete.java
@@ -35,7 +35,7 @@ public class Delete extends Mutation {
    * Constructs a {@code Delete} with the specified partition {@code Key}.
    *
    * @param partitionKey a partition key (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Delete#newBuilder()} instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -50,7 +50,7 @@ public class Delete extends Mutation {
    *
    * @param partitionKey a partition {@code Key} (it might be composed of multiple values)
    * @param clusteringKey a clustering {@code Key} (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Delete#newBuilder()} instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -63,7 +63,7 @@ public class Delete extends Mutation {
    * Copy a Delete.
    *
    * @param delete a Delete
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Delete#newBuilder(Delete)} instead.
    */
   @Deprecated
@@ -93,7 +93,7 @@ public class Delete extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Delete builder instead; to create a Delete builder, use {@link Delete#newBuilder()}
    */
   @Override
@@ -103,7 +103,7 @@ public class Delete extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Delete builder instead; to create a Delete builder, use {@link Delete#newBuilder()}
    */
   @Override
@@ -113,7 +113,7 @@ public class Delete extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Delete builder instead; to create a Delete builder, use {@link Delete#newBuilder()}
    */
   @Override
@@ -128,7 +128,7 @@ public class Delete extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Delete builder instead; to create a Delete builder, use {@link Delete#newBuilder()}
    */
   @Override

--- a/core/src/main/java/com/scalar/db/api/DeleteIf.java
+++ b/core/src/main/java/com/scalar/db/api/DeleteIf.java
@@ -25,7 +25,7 @@ public class DeleteIf implements MutationCondition {
    * Constructs a {@code DeleteIf} with the specified conditional expressions.
    *
    * @param expressions a variable length expressions specified with {@code ConditionalExpression}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -39,7 +39,7 @@ public class DeleteIf implements MutationCondition {
    * Constructs a {@code DeleteIf} with the specified list of conditional expressions.
    *
    * @param expressions a list of expressions specified with {@code ConditionalExpression}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/DeleteIfExists.java
+++ b/core/src/main/java/com/scalar/db/api/DeleteIfExists.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
 public class DeleteIfExists implements MutationCondition {
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -73,7 +73,7 @@ public interface DistributedStorage extends AutoCloseable {
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void with(String namespace, String tableName);
@@ -82,7 +82,7 @@ public interface DistributedStorage extends AutoCloseable {
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withNamespace(String namespace);
@@ -91,7 +91,7 @@ public interface DistributedStorage extends AutoCloseable {
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getNamespace();
@@ -100,7 +100,7 @@ public interface DistributedStorage extends AutoCloseable {
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withTable(String tableName);
@@ -109,7 +109,7 @@ public interface DistributedStorage extends AutoCloseable {
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getTable();

--- a/core/src/main/java/com/scalar/db/api/DistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransaction.java
@@ -25,7 +25,7 @@ public interface DistributedTransaction extends TransactionCrudOperable {
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void with(String namespace, String tableName);
@@ -34,7 +34,7 @@ public interface DistributedTransaction extends TransactionCrudOperable {
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withNamespace(String namespace);
@@ -43,7 +43,7 @@ public interface DistributedTransaction extends TransactionCrudOperable {
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getNamespace();
@@ -52,7 +52,7 @@ public interface DistributedTransaction extends TransactionCrudOperable {
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withTable(String tableName);
@@ -61,7 +61,7 @@ public interface DistributedTransaction extends TransactionCrudOperable {
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getTable();

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -12,7 +12,7 @@ public interface DistributedTransactionManager
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void with(String namespace, String tableName);
@@ -21,7 +21,7 @@ public interface DistributedTransactionManager
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withNamespace(String namespace);
@@ -30,7 +30,7 @@ public interface DistributedTransactionManager
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getNamespace();
@@ -39,7 +39,7 @@ public interface DistributedTransactionManager
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withTable(String tableName);
@@ -48,7 +48,7 @@ public interface DistributedTransactionManager
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getTable();

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -45,7 +45,7 @@ public class Get extends Selection {
    * Constructs a {@code Get} with the specified partition {@code Key}.
    *
    * @param partitionKey a partition key (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Get#newBuilder()}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link Get#newBuilder()}
    *     instead
    */
   @Deprecated
@@ -60,7 +60,7 @@ public class Get extends Selection {
    *
    * @param partitionKey a partition {@code Key} (it might be composed of multiple values)
    * @param clusteringKey a clustering {@code Key} (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Get#newBuilder()}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link Get#newBuilder()}
    *     instead
    */
   @Deprecated
@@ -103,7 +103,7 @@ public class Get extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -113,7 +113,7 @@ public class Get extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -123,7 +123,7 @@ public class Get extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -138,7 +138,7 @@ public class Get extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -148,7 +148,7 @@ public class Get extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/GetWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/GetWithIndex.java
@@ -29,7 +29,7 @@ public class GetWithIndex extends Get {
    * Constructs an {@code GetWithIndex} with the specified index {@code Key}.
    *
    * @param indexKey an index key
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Get#newBuilder()}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link Get#newBuilder()}
    *     instead
    */
   @Deprecated
@@ -51,7 +51,7 @@ public class GetWithIndex extends Get {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -61,7 +61,7 @@ public class GetWithIndex extends Get {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -71,7 +71,7 @@ public class GetWithIndex extends Get {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -81,7 +81,7 @@ public class GetWithIndex extends Get {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated
@@ -91,7 +91,7 @@ public class GetWithIndex extends Get {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/Insert.java
+++ b/core/src/main/java/com/scalar/db/api/Insert.java
@@ -34,7 +34,7 @@ public class Insert extends Mutation {
     return columns;
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Nonnull
   @Override
@@ -42,7 +42,7 @@ public class Insert extends Mutation {
     throw new UnsupportedOperationException();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public Mutation withCondition(MutationCondition condition) {
@@ -54,7 +54,7 @@ public class Insert extends Mutation {
     throw new UnsupportedOperationException();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Operation withConsistency(Consistency consistency) {

--- a/core/src/main/java/com/scalar/db/api/Isolation.java
+++ b/core/src/main/java/com/scalar/db/api/Isolation.java
@@ -1,6 +1,6 @@
 package com.scalar.db.api;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
 @Deprecated
 public enum Isolation {
   SNAPSHOT,

--- a/core/src/main/java/com/scalar/db/api/Mutation.java
+++ b/core/src/main/java/com/scalar/db/api/Mutation.java
@@ -18,7 +18,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public abstract class Mutation extends Operation {
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated @Nullable private MutationCondition condition;
 
   Mutation(
@@ -36,7 +36,7 @@ public abstract class Mutation extends Operation {
   /**
    * @param partitionKey a partition key
    * @param clusteringKey a clustering key
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Mutation(Key partitionKey, Key clusteringKey) {
@@ -46,7 +46,7 @@ public abstract class Mutation extends Operation {
 
   /**
    * @param mutation a mutation
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Mutation(Mutation mutation) {
@@ -58,7 +58,7 @@ public abstract class Mutation extends Operation {
    * Returns the {@link MutationCondition}
    *
    * @return {@code MutationCondition}
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   @Nonnull
@@ -71,7 +71,7 @@ public abstract class Mutation extends Operation {
    *
    * @param condition a {@code MutationCondition}
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Mutation withCondition(MutationCondition condition) {

--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -47,7 +47,7 @@ public abstract class Operation {
    *
    * @param partitionKey the partition key
    * @param clusteringKey the clustering key
-   * @deprecated As of release 3.15.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation(Key partitionKey, @Nullable Key clusteringKey) {
@@ -66,7 +66,7 @@ public abstract class Operation {
    * @param tableName the table name
    * @param partitionKey the partition key
    * @param clusteringKey the clustering key
-   * @deprecated As of release 3.15.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation(
@@ -83,7 +83,7 @@ public abstract class Operation {
    * Constructs an {@code Operation}.
    *
    * @param operation the operation
-   * @deprecated As of release 3.15.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation(Operation operation) {
@@ -134,7 +134,7 @@ public abstract class Operation {
    *
    * @param namespace target namespace for this operation
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation forNamespace(String namespace) {
@@ -147,7 +147,7 @@ public abstract class Operation {
    *
    * @param tableName target table name for this operation
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation forTable(String tableName) {
@@ -189,7 +189,7 @@ public abstract class Operation {
    *
    * @param consistency consistency level to set
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Operation withConsistency(Consistency consistency) {

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -64,7 +64,7 @@ public class Put extends Mutation {
    * Constructs a {@code Put} with the specified partition {@link Key}.
    *
    * @param partitionKey a partition {@code Key} (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Put#newBuilder()}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link Put#newBuilder()}
    *     instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -79,7 +79,7 @@ public class Put extends Mutation {
    *
    * @param partitionKey a partition {@code Key} (it might be composed of multiple values)
    * @param clusteringKey a clustering {@code Key} (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Put#newBuilder()}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link Put#newBuilder()}
    *     instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -93,7 +93,7 @@ public class Put extends Mutation {
    * Copy a Put.
    *
    * @param put a Put
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Put#newBuilder(Put)} instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -129,7 +129,7 @@ public class Put extends Mutation {
    *
    * @param value a {@code Value} to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -144,7 +144,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param booleanValue a BOOLEAN value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -159,7 +159,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BOOLEAN value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -175,7 +175,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BOOLEAN value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -194,7 +194,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param intValue a INT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -209,7 +209,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a INT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -225,7 +225,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a INT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -244,7 +244,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param bigIntValue a BIGINT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -259,7 +259,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BIGINT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -275,7 +275,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BIGINT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -294,7 +294,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param floatValue a value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -309,7 +309,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a FLOAT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -325,7 +325,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a FLOAT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -344,7 +344,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param doubleValue a DOUBLE value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -359,7 +359,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a DOUBLE value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -375,7 +375,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a DOUBLE value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -394,7 +394,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param textValue a TEXT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -409,7 +409,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a TEXT value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -425,7 +425,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param blobValue a BLOB value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -440,7 +440,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BLOB value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -456,7 +456,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param blobValue a BLOB value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -471,7 +471,7 @@ public class Put extends Mutation {
    * @param columnName a column name of the value
    * @param value a BLOB value to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -486,7 +486,7 @@ public class Put extends Mutation {
    *
    * @param values a collection of {@code Value}s to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Put withValues(Collection<Value<?>> values) {
@@ -502,7 +502,7 @@ public class Put extends Mutation {
    *
    * @param column a column to put
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @Deprecated
@@ -515,7 +515,7 @@ public class Put extends Mutation {
    * Returns a map of {@link Value}s.
    *
    * @return a map of {@code Value}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Map<String, Value<?>> getValues() {
@@ -780,7 +780,7 @@ public class Put extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @Deprecated
@@ -790,7 +790,7 @@ public class Put extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @Deprecated
@@ -800,7 +800,7 @@ public class Put extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @Deprecated
@@ -810,7 +810,7 @@ public class Put extends Mutation {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Put builder instead; to create a Put builder, use {@link Put#newBuilder()}
    */
   @Override
@@ -830,7 +830,7 @@ public class Put extends Mutation {
    * Consensus Commit.
    *
    * @return whether implicit pre-read is enabled for this Put
-   * @deprecated As of release 3.15.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Use {@link
    *     ConsensusCommitOperationAttributes#isImplicitPreReadEnabled(Put)} instead
    */
   @SuppressWarnings("InlineMeSuggester")
@@ -844,7 +844,7 @@ public class Put extends Mutation {
    * Commit.
    *
    * @return whether the insert mode is enabled for this Put
-   * @deprecated As of release 3.15.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Use {@link
    *     ConsensusCommitOperationAttributes#isInsertModeEnabled(Put)} instead
    */
   @SuppressWarnings("InlineMeSuggester")

--- a/core/src/main/java/com/scalar/db/api/PutIf.java
+++ b/core/src/main/java/com/scalar/db/api/PutIf.java
@@ -23,7 +23,7 @@ public class PutIf implements MutationCondition {
    * Constructs a {@code PutIf} with the specified conditional expressions.
    *
    * @param expressions a variable length expressions specified with {@code ConditionalExpression}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated
@@ -37,7 +37,7 @@ public class PutIf implements MutationCondition {
    * Constructs a {@code PutIf} with the specified list of conditional expressions.
    *
    * @param expressions a list of expressions specified with {@code ConditionalExpression}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/PutIfExists.java
+++ b/core/src/main/java/com/scalar/db/api/PutIfExists.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
 public class PutIfExists implements MutationCondition {
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/PutIfNotExists.java
+++ b/core/src/main/java/com/scalar/db/api/PutIfNotExists.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
 public class PutIfNotExists implements MutationCondition {
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link ConditionBuilder}
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link ConditionBuilder}
    *     to build a condition instead
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/Result.java
+++ b/core/src/main/java/com/scalar/db/api/Result.java
@@ -24,7 +24,7 @@ public interface Result {
    * Returns the partition {@link Key}
    *
    * @return an {@code Optional} with the partition {@code Key}
-   * @deprecated As of release 3.8.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.8.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<Key> getPartitionKey();
@@ -33,7 +33,7 @@ public interface Result {
    * Returns the clustering {@link Key}
    *
    * @return an {@code Optional} with the clustering {@code Key}
-   * @deprecated As of release 3.8.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.8.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<Key> getClusteringKey();
@@ -45,7 +45,7 @@ public interface Result {
    *
    * @param columnName a column name of the {@code Value}
    * @return an {@code Optional} with the {@code Value}
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<Value<?>> getValue(String columnName);
@@ -57,7 +57,7 @@ public interface Result {
    * default value.
    *
    * @return a map of {@code Value}s
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Map<String, Value<?>> getValues();

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -73,7 +73,7 @@ public class Scan extends Selection {
    * Constructs a {@code Scan} with the specified partition {@link Key}.
    *
    * @param partitionKey a partition key (it might be composed of multiple values)
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder()} instead
    */
   @Deprecated
@@ -90,7 +90,7 @@ public class Scan extends Selection {
    * Copy a Scan.
    *
    * @param scan a Scan
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder(Scan)} instead
    */
   @Deprecated
@@ -131,7 +131,7 @@ public class Scan extends Selection {
    *
    * @param clusteringKey a starting clustering key
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -145,7 +145,7 @@ public class Scan extends Selection {
    * @param clusteringKey a starting clustering key
    * @param inclusive indicates whether the boundary is inclusive or not
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -179,7 +179,7 @@ public class Scan extends Selection {
    *
    * @param clusteringKey an ending clustering key
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -193,7 +193,7 @@ public class Scan extends Selection {
    * @param clusteringKey an ending clustering key
    * @param inclusive indicates whether the boundary is inclusive or not
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -238,7 +238,7 @@ public class Scan extends Selection {
    *
    * @param ordering a scan ordering
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -261,7 +261,7 @@ public class Scan extends Selection {
    *
    * @param limit the number of results to be returned
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -271,7 +271,7 @@ public class Scan extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -281,7 +281,7 @@ public class Scan extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -291,7 +291,7 @@ public class Scan extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -306,7 +306,7 @@ public class Scan extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -316,7 +316,7 @@ public class Scan extends Selection {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -401,7 +401,7 @@ public class Scan extends Selection {
      *
      * @param columnName the column name of a clustering key in an entry to order
      * @param order the {@code Order} of results
-     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #asc(String)}
+     * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #asc(String)}
      *     or {@link #desc(String)} to create an Ordering object
      */
     @Deprecated
@@ -434,7 +434,7 @@ public class Scan extends Selection {
      * Returns the column name of the ordering clustering key
      *
      * @return the column name of the ordering clustering key
-     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+     * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
      */
     @Deprecated
     public String getName() {

--- a/core/src/main/java/com/scalar/db/api/ScanAll.java
+++ b/core/src/main/java/com/scalar/db/api/ScanAll.java
@@ -46,7 +46,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder()} instead
    */
   @Deprecated
@@ -59,7 +59,7 @@ public class ScanAll extends Scan {
    * Copy a ScanAll.
    *
    * @param scanAll a ScanAll
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder(Scan)} instead
    */
   @Deprecated
@@ -122,7 +122,7 @@ public class ScanAll extends Scan {
    *
    * @param ordering a scan ordering
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Deprecated
@@ -132,7 +132,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -142,7 +142,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -152,7 +152,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -162,7 +162,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -172,7 +172,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -182,7 +182,7 @@ public class ScanAll extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override

--- a/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
@@ -45,7 +45,7 @@ public class ScanWithIndex extends Scan {
 
   /**
    * @param indexKey an index key
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder()} instead
    */
   @Deprecated
@@ -58,7 +58,7 @@ public class ScanWithIndex extends Scan {
    * Copy a ScanWithIndex.
    *
    * @param scanWithIndex a ScanWithIndex
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     Scan#newBuilder(Scan)} instead
    */
   @Deprecated
@@ -128,7 +128,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -138,7 +138,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -148,7 +148,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -158,7 +158,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -168,7 +168,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override
@@ -178,7 +178,7 @@ public class ScanWithIndex extends Scan {
   }
 
   /**
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use the setter method of the
    *     Scan builder instead; to create a Scan builder, use {@link Scan#newBuilder()}
    */
   @Override

--- a/core/src/main/java/com/scalar/db/api/Selection.java
+++ b/core/src/main/java/com/scalar/db/api/Selection.java
@@ -41,7 +41,7 @@ public abstract class Selection extends Operation {
   /**
    * @param partitionKey a partition key
    * @param clusteringKey a clustering key
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Selection(Key partitionKey, Key clusteringKey) {
@@ -52,7 +52,7 @@ public abstract class Selection extends Operation {
 
   /**
    * @param selection a selection
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Selection(Selection selection) {
@@ -66,7 +66,7 @@ public abstract class Selection extends Operation {
    *
    * @param projection a column name to project
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Selection withProjection(String projection) {
@@ -79,7 +79,7 @@ public abstract class Selection extends Operation {
    *
    * @param projections a collection of the column names to project
    * @return this object
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   public Selection withProjections(Collection<String> projections) {
@@ -87,7 +87,7 @@ public abstract class Selection extends Operation {
     return this;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0. */
   @Deprecated
   public void clearProjections() {
     projections.clear();

--- a/core/src/main/java/com/scalar/db/api/SerializableStrategy.java
+++ b/core/src/main/java/com/scalar/db/api/SerializableStrategy.java
@@ -1,5 +1,5 @@
 package com.scalar.db.api;
 
-/** @deprecated As of release 3.2.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.2.0. Will be removed in release 4.0.0 */
 @Deprecated
 public interface SerializableStrategy {}

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -55,7 +55,7 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    *     still fail if the cause is nontransient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   @Override
@@ -71,7 +71,7 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    *     still fail if the cause is nontransient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated
@@ -143,7 +143,7 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    *     still fail if the cause is nontransient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
@@ -62,7 +62,7 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
    */
   @Deprecated
   @Override
@@ -81,7 +81,7 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated
@@ -163,7 +163,7 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
-   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0. Use {@link #mutate(List)}
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
    *     instead.
    */
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
@@ -29,7 +29,7 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void with(String namespace, String tableName);
@@ -38,7 +38,7 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withNamespace(String namespace);
@@ -47,7 +47,7 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getNamespace();
@@ -56,7 +56,7 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withTable(String tableName);
@@ -65,7 +65,7 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getTable();

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -21,7 +21,7 @@ public interface TwoPhaseCommitTransactionManager
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void with(String namespace, String tableName);
@@ -30,7 +30,7 @@ public interface TwoPhaseCommitTransactionManager
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withNamespace(String namespace);
@@ -39,7 +39,7 @@ public interface TwoPhaseCommitTransactionManager
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getNamespace();
@@ -48,7 +48,7 @@ public interface TwoPhaseCommitTransactionManager
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   void withTable(String tableName);
@@ -57,7 +57,7 @@ public interface TwoPhaseCommitTransactionManager
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   Optional<String> getTable();

--- a/core/src/main/java/com/scalar/db/api/Update.java
+++ b/core/src/main/java/com/scalar/db/api/Update.java
@@ -46,7 +46,7 @@ public class Update extends Mutation {
     throw new UnsupportedOperationException();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Operation withConsistency(Consistency consistency) {

--- a/core/src/main/java/com/scalar/db/api/Upsert.java
+++ b/core/src/main/java/com/scalar/db/api/Upsert.java
@@ -34,7 +34,7 @@ public class Upsert extends Mutation {
     return columns;
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Nonnull
   @Override
@@ -42,7 +42,7 @@ public class Upsert extends Mutation {
     throw new UnsupportedOperationException();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public Mutation withCondition(MutationCondition condition) {
@@ -54,7 +54,7 @@ public class Upsert extends Mutation {
     throw new UnsupportedOperationException();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Operation withConsistency(Consistency consistency) {

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedStorage.java
@@ -21,7 +21,7 @@ public abstract class AbstractDistributedStorage implements DistributedStorage {
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
@@ -29,28 +29,28 @@ public abstract class AbstractDistributedStorage implements DistributedStorage {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransaction.java
@@ -29,7 +29,7 @@ public abstract class AbstractDistributedTransaction implements DistributedTrans
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
@@ -37,28 +37,28 @@ public abstract class AbstractDistributedTransaction implements DistributedTrans
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -27,7 +27,7 @@ public abstract class AbstractDistributedTransactionManager
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
@@ -35,28 +35,28 @@ public abstract class AbstractDistributedTransactionManager
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/common/AbstractResult.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractResult.java
@@ -41,7 +41,7 @@ public abstract class AbstractResult implements Result {
     }
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Value<?>> getValue(String columnName) {
@@ -53,7 +53,7 @@ public abstract class AbstractResult implements Result {
     }
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Map<String, Value<?>> getValues() {

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
@@ -29,7 +29,7 @@ public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommi
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
@@ -37,28 +37,28 @@ public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommi
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -27,7 +27,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
@@ -35,28 +35,28 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -112,14 +112,14 @@ public class ActiveTransactionManagedDistributedTransactionManager
       return new SynchronizedScanner(this, super.getScanner(scan));
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
@@ -131,7 +131,7 @@ public class ActiveTransactionManagedDistributedTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -118,14 +118,14 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       return new SynchronizedScanner(this, super.getScanner(scan));
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
@@ -137,7 +137,7 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -29,35 +29,35 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     this.transaction = transaction;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transaction.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transaction.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transaction.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     transaction.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -84,14 +84,14 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     return transaction.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     transaction.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
@@ -103,7 +103,7 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     transaction.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -31,35 +31,35 @@ public abstract class DecoratedDistributedTransactionManager
     this.transactionManager = transactionManager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transactionManager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transactionManager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transactionManager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     transactionManager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -182,14 +182,14 @@ public abstract class DecoratedDistributedTransactionManager
     return transactionManager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     transactionManager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -216,7 +216,7 @@ public abstract class DecoratedDistributedTransactionManager
     transactionManager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -31,35 +31,35 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     this.transaction = transaction;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transaction.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transaction.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transaction.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     transaction.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -86,14 +86,14 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     return transaction.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     transaction.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
@@ -105,7 +105,7 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     transaction.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -30,35 +30,35 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     this.transactionManager = transactionManager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transactionManager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transactionManager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transactionManager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     transactionManager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -115,14 +115,14 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     return transactionManager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     transactionManager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -149,7 +149,7 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     transactionManager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/common/ProjectedResult.java
+++ b/core/src/main/java/com/scalar/db/common/ProjectedResult.java
@@ -36,7 +36,7 @@ public class ProjectedResult extends AbstractResult {
     containedColumnNames = builder.build();
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
@@ -45,7 +45,7 @@ public class ProjectedResult extends AbstractResult {
     return partitionKey;
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {

--- a/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
@@ -19,7 +19,7 @@ public class ReadOnlyDistributedTransaction extends DecoratedDistributedTransact
     super(transaction);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
@@ -27,7 +27,7 @@ public class ReadOnlyDistributedTransaction extends DecoratedDistributedTransact
         CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
@@ -70,7 +70,7 @@ public class ReadOnlyDistributedTransaction extends DecoratedDistributedTransact
     return super.batch(operations);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/common/ResultImpl.java
@@ -28,14 +28,14 @@ public class ResultImpl extends AbstractResult {
     this.metadata = Objects.requireNonNull(metadata);
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
     return Optional.of(ScalarDbUtils.getPartitionKey(this, metadata));
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -78,7 +78,7 @@ public class StateManagedDistributedTransactionManager
       return super.getScanner(scan);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void put(Put put) throws CrudException {
@@ -86,7 +86,7 @@ public class StateManagedDistributedTransactionManager
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void put(List<Put> puts) throws CrudException {
@@ -100,7 +100,7 @@ public class StateManagedDistributedTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -84,7 +84,7 @@ public class StateManagedTwoPhaseCommitTransactionManager
       return super.getScanner(scan);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void put(Put put) throws CrudException {
@@ -92,7 +92,7 @@ public class StateManagedTwoPhaseCommitTransactionManager
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void put(List<Put> puts) throws CrudException {
@@ -106,7 +106,7 @@ public class StateManagedTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
@@ -72,7 +72,7 @@ public class OperationChecker {
       }
 
       // The following check is not needed when we use GetWithIndex. But we need to keep it for
-      // backward compatibility. We will remove it in release 5.0.0.
+      // backward compatibility. We will remove it in release 4.0.0.
       if (get.getClusteringKey().isPresent()) {
         throw new IllegalArgumentException(
             CoreError.OPERATION_CHECK_ERROR_INDEX_CLUSTERING_KEY_SPECIFIED.buildMessage(get));
@@ -116,7 +116,7 @@ public class OperationChecker {
       }
 
       // The following checks are not needed when we use ScanWithIndex. But we need to keep them for
-      // backward compatibility. We will remove them in release 5.0.0.
+      // backward compatibility. We will remove them in release 4.0.0.
       if (scan.getStartClusteringKey().isPresent() || scan.getEndClusteringKey().isPresent()) {
         throw new IllegalArgumentException(
             CoreError.OPERATION_CHECK_ERROR_INDEX_CLUSTERING_KEY_SPECIFIED.buildMessage(scan));

--- a/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
@@ -15,7 +15,7 @@ public class UnknownTransactionStatusException extends TransactionException {
 
   /**
    * @return the transaction ID associated with the transaction whose status is unknown
-   * @deprecated As of release 3.9.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.9.0. Will be removed in release 4.0.0
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")

--- a/core/src/main/java/com/scalar/db/io/BigIntValue.java
+++ b/core/src/main/java/com/scalar/db/io/BigIntValue.java
@@ -14,7 +14,7 @@ import javax.annotation.concurrent.Immutable;
  * numbers Double-precision floating-point format can exactly represent.
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/BlobValue.java
+++ b/core/src/main/java/com/scalar/db/io/BlobValue.java
@@ -17,7 +17,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a binary data
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/BooleanValue.java
+++ b/core/src/main/java/com/scalar/db/io/BooleanValue.java
@@ -12,7 +12,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a boolean data
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/DoubleValue.java
+++ b/core/src/main/java/com/scalar/db/io/DoubleValue.java
@@ -12,7 +12,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a double precision floating point number
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/FloatValue.java
+++ b/core/src/main/java/com/scalar/db/io/FloatValue.java
@@ -12,7 +12,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a single precision floating point number
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/IntValue.java
+++ b/core/src/main/java/com/scalar/db/io/IntValue.java
@@ -12,7 +12,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a 32-bit signed integer
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable

--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -36,7 +36,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * Constructs a {@code Key} with the specified {@link Value}s
    *
    * @param values one or more {@link Value}s which this key is composed of
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Key(Value<?>... values) {
@@ -49,7 +49,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * Constructs a {@code Key} with the specified list of {@link Value}s
    *
    * @param values a list of {@link Value}s which this key is composed of
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Key(List<Value<?>> values) {
@@ -73,7 +73,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param booleanValue a BOOLEAN value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     #ofBoolean(String, boolean)} instead
    */
   @Deprecated
@@ -86,7 +86,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param intValue an INT value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofInt(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofInt(String,
    *     int)} instead
    */
   @Deprecated
@@ -99,7 +99,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param bigIntValue a BIGINT value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBigInt(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofBigInt(String,
    *     long)} instead
    */
   @Deprecated
@@ -112,7 +112,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param floatValue a FLOAT value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofFloat(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofFloat(String,
    *     float)} instead
    */
   @Deprecated
@@ -125,7 +125,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param doubleValue a DOUBLE value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofDouble(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofDouble(String,
    *     double)} instead
    */
   @Deprecated
@@ -138,7 +138,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param textValue a TEXT value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofText(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofText(String,
    *     String)} instead
    */
   @Deprecated
@@ -151,7 +151,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param blobValue a BLOB value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBlob(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofBlob(String,
    *     byte[])} instead
    */
   @Deprecated
@@ -164,7 +164,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param blobValue a BLOB value of the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBlob(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #ofBlob(String,
    *     ByteBuffer)} instead
    */
   @Deprecated
@@ -179,7 +179,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v1 a value of the 1st column
    * @param n2 a column name of the 2nd column
    * @param v2 a value of the 2nd column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #of(String,
    *     Object, String, Object)} instead
    */
   @Deprecated
@@ -196,7 +196,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v2 a value of the 2nd column
    * @param n3 a column name of the 3rd column
    * @param v3 a value of the 3rd column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #of(String,
    *     Object, String, Object, String, Object)} instead
    */
   @Deprecated
@@ -215,7 +215,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v3 a value of the 3rd column
    * @param n4 a column of the 4th column
    * @param v4 a value of the 4th column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #of(String,
    *     Object, String, Object, String, Object, String, Object)} instead
    */
   @Deprecated
@@ -237,7 +237,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v4 a value of the 4th column
    * @param n5 a column of the 5th column
    * @param v5 a value of the 5th column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link #of(String,
    *     Object, String, Object, String, Object, String, Object, String, Object)} instead
    */
   @Deprecated
@@ -300,7 +300,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * this method. Users should not depend on it.
    *
    * @return list of {@code Value} which this key is composed of
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   @Nonnull
@@ -526,7 +526,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
 
   /**
    * @return an iterator of the values which this key is composed of
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   @Nonnull
@@ -936,7 +936,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
     /**
      * @param value a value to add
      * @return a builder object
-     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+     * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
      */
     @Deprecated
     public Builder add(Value<?> value) {
@@ -947,7 +947,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
     /**
      * @param values a list of values to add
      * @return a builder object
-     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+     * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
      */
     @Deprecated
     public Builder addAll(Collection<? extends Value<?>> values) {

--- a/core/src/main/java/com/scalar/db/io/TextValue.java
+++ b/core/src/main/java/com/scalar/db/io/TextValue.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
  * A {@code Value} (column) for a string
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 @Immutable
@@ -30,7 +30,7 @@ public final class TextValue implements Value<Optional<String>> {
    *
    * @param name name of the {@code Value} (column)
    * @param value value of the {@code Value} (column) in byte array
-   * @deprecated As of release 3.5.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.5.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public TextValue(String name, @Nullable byte[] value) {
@@ -47,7 +47,7 @@ public final class TextValue implements Value<Optional<String>> {
    * anonymous.
    *
    * @param value value of the {@code Value} (column)
-   * @deprecated As of release 3.5.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.5.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public TextValue(@Nullable byte[] value) {
@@ -96,7 +96,7 @@ public final class TextValue implements Value<Optional<String>> {
    *
    * @return an {@code Optional} of the content of this {@code Value} in byte array
    * @deprecated As of release 3.2.0, replaced by {@link #getAsBytes()}. Will be removed in release
-   *     5.0.0
+   *     4.0.0
    */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
@@ -110,7 +110,7 @@ public final class TextValue implements Value<Optional<String>> {
    *
    * @return an {@code Optional} of the content of this {@code Value} in {@code String}
    * @deprecated As of release 3.2.0, replaced by {@link #getAsString()}. Will be removed in release
-   *     5.0.0
+   *     4.0.0
    */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated

--- a/core/src/main/java/com/scalar/db/io/Value.java
+++ b/core/src/main/java/com/scalar/db/io/Value.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
  * An abstraction for storage entry's value (column).
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 public interface Value<T> extends Comparable<Value<T>> {

--- a/core/src/main/java/com/scalar/db/io/ValueVisitor.java
+++ b/core/src/main/java/com/scalar/db/io/ValueVisitor.java
@@ -4,7 +4,7 @@ package com.scalar.db.io;
  * A visitor interface to traverse multiple {@code Value}s
  *
  * @author Hiroyuki Yamada
- * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
  */
 @Deprecated
 public interface ValueVisitor {

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
 @Deprecated
 @ThreadSafe
 public class AdminService implements DistributedStorageAdmin {

--- a/core/src/main/java/com/scalar/db/service/StorageFactory.java
+++ b/core/src/main/java/com/scalar/db/service/StorageFactory.java
@@ -16,7 +16,7 @@ public class StorageFactory {
 
   /**
    * @param config a database config
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     #create(Properties)}, {@link #create(Path)}, {@link #create(File)}, or {@link
    *     #create(String)} instead
    */
@@ -38,7 +38,7 @@ public class StorageFactory {
    * Returns a {@link DistributedStorageAdmin} instance
    *
    * @return a {@link DistributedStorageAdmin} instance
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     #getStorageAdmin()} instead
    */
   @SuppressWarnings("InlineMeSuggester")

--- a/core/src/main/java/com/scalar/db/service/StorageModule.java
+++ b/core/src/main/java/com/scalar/db/service/StorageModule.java
@@ -17,7 +17,7 @@ import com.scalar.db.storage.jdbc.JdbcDatabase;
 import com.scalar.db.storage.multistorage.MultiStorage;
 import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 
-/** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
 @Deprecated
 public class StorageModule extends AbstractModule {
 

--- a/core/src/main/java/com/scalar/db/service/StorageService.java
+++ b/core/src/main/java/com/scalar/db/service/StorageService.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
 @Deprecated
 @ThreadSafe
 public class StorageService implements DistributedStorage {
@@ -27,35 +27,35 @@ public class StorageService implements DistributedStorage {
     this.storage = storage;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     storage.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     storage.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return storage.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     storage.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -21,7 +21,7 @@ public class TransactionFactory {
 
   /**
    * @param config a database config
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0. Use {@link
    *     #create(Properties)}, {@link #create(Path)}, {@link #create(File)}, or {@link
    *     #create(String)} instead
    */

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -25,7 +25,7 @@ import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitManager;
 import com.scalar.db.transaction.jdbc.JdbcTransactionAdmin;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 
-/** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
 @Deprecated
 public class TransactionModule extends AbstractModule {
 

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
 @Deprecated
 @ThreadSafe
 public class TransactionService implements DistributedTransactionManager {
@@ -37,35 +37,35 @@ public class TransactionService implements DistributedTransactionManager {
     this.manager = manager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     manager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     manager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return manager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     manager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -193,14 +193,14 @@ public class TransactionService implements DistributedTransactionManager {
     return manager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -227,7 +227,7 @@ public class TransactionService implements DistributedTransactionManager {
     manager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 5.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
 @Deprecated
 @Immutable
 public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransactionManager {
@@ -35,35 +35,35 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     this.manager = manager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     manager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withNamespace(String namespace) {
     manager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return manager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public void withTable(String tableName) {
     manager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<String> getTable() {
@@ -130,14 +130,14 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     return manager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -164,7 +164,7 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     manager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -42,7 +42,7 @@ public class DynamoConfig {
     secretAccessKey = databaseConfig.getPassword().orElse(null);
     if (databaseConfig.getProperties().containsKey("scalar.db.dynamo.endpoint-override")) {
       logger.warn(
-          "The property \"scalar.db.dynamo.endpoint-override\" is deprecated and will be removed in 5.0.0. "
+          "The property \"scalar.db.dynamo.endpoint-override\" is deprecated and will be removed in 4.0.0. "
               + "Please use \""
               + ENDPOINT_OVERRIDE
               + "\" instead");

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class MultiStorage extends AbstractDistributedStorage {
 
-  /** @deprecated Will be removed in 5.0.0. */
+  /** @deprecated Will be removed in 4.0.0. */
   @Deprecated private final Map<String, DistributedStorage> tableStorageMap;
 
   private final Map<String, DistributedStorage> namespaceStorageMap;

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class MultiStorageAdmin implements DistributedStorageAdmin {
 
-  /** @deprecated Will be removed in 5.0.0. */
+  /** @deprecated Will be removed in 4.0.0. */
   @Deprecated private final Map<String, DistributedStorageAdmin> tableAdminMap;
 
   private final Map<String, AdminHolder> namespaceAdminMap;

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -96,7 +96,7 @@ public class MultiStorageConfig {
     logger.warn(
         "The table mapping property \""
             + TABLE_MAPPING
-            + "\" is deprecated and will be removed in 5.0.0. "
+            + "\" is deprecated and will be removed in 4.0.0. "
             + "Please use the namespace mapping property \""
             + NAMESPACE_MAPPING
             + "\" instead");
@@ -142,7 +142,7 @@ public class MultiStorageConfig {
 
   /**
    * @return a table storage mapping
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public Map<String, String> getTableStorageMap() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -111,7 +111,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     return crud.getScanner(scan, context);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
@@ -120,7 +120,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     crud.put(put, context);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
@@ -137,7 +137,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     crud.delete(delete, context);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -102,7 +102,7 @@ public class ConsensusCommitConfig {
 
     if (properties.containsKey("scalar.db.isolation_level")) {
       logger.warn(
-          "The property \"scalar.db.isolation_level\" is deprecated and will be removed in 5.0.0. "
+          "The property \"scalar.db.isolation_level\" is deprecated and will be removed in 4.0.0. "
               + "Please use \""
               + ISOLATION_LEVEL
               + "\" instead");
@@ -123,7 +123,7 @@ public class ConsensusCommitConfig {
       if (properties.containsKey("scalar.db.consensus_commit.serializable_strategy")) {
         logger.warn(
             "The property \"scalar.db.consensus_commit.serializable_strategy\" is deprecated and will "
-                + "be removed in 5.0.0. The EXTRA_READ strategy is always used for the SERIALIZABLE "
+                + "be removed in 4.0.0. The EXTRA_READ strategy is always used for the SERIALIZABLE "
                 + "isolation level.");
       }
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -398,7 +398,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -410,7 +410,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -462,7 +462,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -61,7 +61,7 @@ public class Coordinator {
 
   /**
    * @param storage a storage
-   * @deprecated As of release 3.3.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.3.0. Will be removed in release 4.0.0
    */
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Deprecated

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -50,7 +50,7 @@ public class FilteredResult extends AbstractResult {
     containedColumnNames = builder.build();
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
@@ -59,7 +59,7 @@ public class FilteredResult extends AbstractResult {
     return partitionKey;
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
@@ -39,14 +39,14 @@ public class MergedResult extends AbstractResult {
     this.metadata = metadata;
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<com.scalar.db.io.Key> getPartitionKey() {
     return Optional.of(put.getPartitionKey());
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<com.scalar.db.io.Key> getClusteringKey() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
@@ -7,7 +7,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * transactions avoid an anti-dependency that is the root cause of the anomalies in Snapshot
  * Isolation.
  *
- * @deprecated As of release 3.16.0. Will be removed in release 5.0.0
+ * @deprecated As of release 3.16.0. Will be removed in release 4.0.0
  */
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_INTERFACE")
 @Deprecated

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -29,14 +29,14 @@ public class TransactionResult extends AbstractResult {
     this.result = checkNotNull(result);
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
     return result.getPartitionKey();
   }
 
-  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  /** @deprecated As of release 3.8.0. Will be removed in release 4.0.0 */
   @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -99,14 +99,14 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     return crud.getScanner(scan, context);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     putInternal(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
@@ -127,7 +127,7 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     deleteInternal(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -343,7 +343,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -355,7 +355,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -407,7 +407,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -138,7 +138,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
@@ -156,7 +156,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     }
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
@@ -180,7 +180,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     }
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -292,7 +292,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -304,7 +304,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -356,7 +356,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -223,7 +223,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException {
@@ -238,7 +238,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     }
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
@@ -343,7 +343,7 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     }
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -205,7 +205,7 @@ public final class ScalarDbUtils {
       return true;
     }
 
-    // We need to keep this for backward compatibility. We will remove it in release 5.0.0.
+    // We need to keep this for backward compatibility. We will remove it in release 4.0.0.
     List<Column<?>> columns = selection.getPartitionKey().getColumns();
     if (columns.size() == 1) {
       String name = columns.get(0).getName();
@@ -248,7 +248,7 @@ public final class ScalarDbUtils {
    *
    * @param column a column to convert
    * @return a value converted from the column
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public static Value<?> toValue(Column<?> column) {
@@ -283,7 +283,7 @@ public final class ScalarDbUtils {
    *
    * @param value a value to convert
    * @return a column converted from the value
-   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
   @Deprecated
   public static Column<?> toColumn(Value<?> value) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -48,7 +48,7 @@ public class SchemaLoader {
         if (STORAGE_SPECIFIC_OPTION_LIST.contains(arg)) {
           logger.warn(
               "Storage-specific options (--cassandra, --cosmos, --dynamo, --jdbc) "
-                  + "are deprecated and will be removed in 5.0.0. Please use "
+                  + "are deprecated and will be removed in 4.0.0. Please use "
                   + "the --config option along with your config file instead");
           // Remove the storage specific option from args
           commandArgs = Arrays.stream(args).filter(a -> !a.equals(arg)).toArray(String[]::new);


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3520
- **Commit to backport:** a76cd8849288fed37e7de48ca878007580eeb10b

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.17-pull-3520 &&
git cherry-pick --no-rerere-autoupdate -m1 a76cd8849288fed37e7de48ca878007580eeb10b
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!