### PR TITLE
Disable index-related tests for Object Storage that were missed in the backport of #3503

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -266,6 +266,24 @@ public class ConsensusCommitSpecificIntegrationTestWithObjectStorage
   @Override
   @Disabled("Object Storage does not support index-related operations")
   public void
+      get_GetWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
       scan_ScanAllWithIndexConditionForDeletedWhenCoordinatorStateAborted_ShouldRollBackAndReturnAllRecords(
           Isolation isolation) {}
 


### PR DESCRIPTION
## Description

The backport [#3503](https://github.com/scalar-labs/scalardb/pull/3503) (which backported [#3488](https://github.com/scalar-labs/scalardb/pull/3488) to the 3.17 branch) added three new index-based tests to `ConsensusCommitSpecificIntegrationTestBase`. Object Storage does not support secondary indexes, so all index-based tests in `ConsensusCommitSpecificIntegrationTestWithObjectStorage` are overridden with `@Disabled("Object Storage does not support index-related operations")`. However, the 3.17 backport missed adding the corresponding `@Disabled` overrides for the three new tests, which caused the Object Storage integration test job to fail with `IllegalArgumentException` from `OperationChecker` (`OPERATION_CHECK_ERROR_INDEX_NON_INDEXED_COLUMN_SPECIFIED`) on 3 isolation levels each (9 failures total) across all Java versions in the 3.17 CI run.

The override block already exists on `master`; this PR brings it over to 3.17.

Reference failed run: https://github.com/scalar-labs/scalardb/actions/runs/24931966290

## Related issues and/or PRs

- Related to #3503
- Related to #3488

## Changes made

- Added three `@Disabled` overrides in `ConsensusCommitSpecificIntegrationTestWithObjectStorage` for the following tests, matching the contents already present on `master`:
  - `get_GetWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult`
  - `scan_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult`
  - `getScanner_ScanWithIndexForPreparedWhenCoordinatorStateAbortedAndIndexKeyMatchesAfterImage_ShouldRollBackAndFilterOutResult`

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation to reflect the changes.
- [X] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [X] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [X] Tests (unit, integration, etc.) have been added for the changes.
- [X] My changes generate no new warnings.
- [X] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This is a 3.17-only fix; `master` already contains the equivalent overrides, so no forward-port is needed. The 3.16 branch does not have Object Storage support and is unaffected.

## Release notes

N/A