### PR TITLE
Backport to branch(3) : Propagate transaction attributes to in-transaction operations

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/api/AbstractDistributedTransactionProvider.java
@@ -2,6 +2,7 @@ package com.scalar.db.api;
 
 import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
 import com.scalar.db.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
+import com.scalar.db.common.AttributePropagatingDistributedTransactionManager;
 import com.scalar.db.common.StateManagedDistributedTransactionManager;
 import com.scalar.db.common.StateManagedTwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -18,8 +19,16 @@ public abstract class AbstractDistributedTransactionProvider
     // Wrap the transaction manager for state management
     transactionManager = new StateManagedDistributedTransactionManager(transactionManager);
 
+    if (config.isAttributePropagationEnabled()) {
+      // Wrap the transaction manager for transaction-scoped attribute propagation
+      transactionManager =
+          new AttributePropagatingDistributedTransactionManager(transactionManager);
+    }
+
     if (config.isActiveTransactionManagementEnabled()) {
-      // Wrap the transaction manager for active transaction management
+      // Wrap the transaction manager for active transaction management. This must be the
+      // outermost wrapping so that transactions returned by resume / join (which come from the
+      // active transaction registry) carry the behavior of every inner decorator.
       transactionManager =
           new ActiveTransactionManagedDistributedTransactionManager(
               transactionManager, config.getActiveTransactionManagementExpirationTimeMillis());

--- a/core/src/main/java/com/scalar/db/api/DatabaseOperationAttributes.java
+++ b/core/src/main/java/com/scalar/db/api/DatabaseOperationAttributes.java
@@ -16,22 +16,42 @@ public final class DatabaseOperationAttributes {
 
   private DatabaseOperationAttributes() {}
 
-  public static boolean isCrossPartitionScanEnabled(ScanAll scanAll) {
+  /**
+   * Returns whether cross-partition scan is enabled for the given {@link ScanAll} according to the
+   * operation attribute, falling back to the given default value when the attribute is absent.
+   *
+   * @param scanAll the scan
+   * @param defaultValue the value to return when the attribute is not set on the operation
+   * @return {@code true} if cross-partition scan is enabled by the operation attribute (or by
+   *     {@code defaultValue} when the attribute is absent)
+   */
+  public static boolean isCrossPartitionScanEnabled(ScanAll scanAll, boolean defaultValue) {
     return scanAll
         .getAttribute(CROSS_PARTITION_SCAN_ENABLED)
         .map(Boolean::parseBoolean)
-        .orElse(false);
+        .orElse(defaultValue);
   }
 
   public static void setCrossPartitionScanEnabled(Map<String, String> attributes, boolean enabled) {
     attributes.put(CROSS_PARTITION_SCAN_ENABLED, Boolean.toString(enabled));
   }
 
-  public static boolean isCrossPartitionScanFilteringEnabled(ScanAll scanAll) {
+  /**
+   * Returns whether cross-partition scan filtering is enabled for the given {@link ScanAll}
+   * according to the operation attribute, falling back to the given default value when the
+   * attribute is absent.
+   *
+   * @param scanAll the scan
+   * @param defaultValue the value to return when the attribute is not set on the operation
+   * @return {@code true} if cross-partition scan filtering is enabled by the operation attribute
+   *     (or by {@code defaultValue} when the attribute is absent)
+   */
+  public static boolean isCrossPartitionScanFilteringEnabled(
+      ScanAll scanAll, boolean defaultValue) {
     return scanAll
         .getAttribute(CROSS_PARTITION_SCAN_FILTERING_ENABLED)
         .map(Boolean::parseBoolean)
-        .orElse(false);
+        .orElse(defaultValue);
   }
 
   public static void setCrossPartitionScanFilteringEnabled(
@@ -39,11 +59,21 @@ public final class DatabaseOperationAttributes {
     attributes.put(CROSS_PARTITION_SCAN_FILTERING_ENABLED, Boolean.toString(enabled));
   }
 
-  public static boolean isCrossPartitionScanOrderingEnabled(ScanAll scanAll) {
+  /**
+   * Returns whether cross-partition scan ordering is enabled for the given {@link ScanAll}
+   * according to the operation attribute, falling back to the given default value when the
+   * attribute is absent.
+   *
+   * @param scanAll the scan
+   * @param defaultValue the value to return when the attribute is not set on the operation
+   * @return {@code true} if cross-partition scan ordering is enabled by the operation attribute (or
+   *     by {@code defaultValue} when the attribute is absent)
+   */
+  public static boolean isCrossPartitionScanOrderingEnabled(ScanAll scanAll, boolean defaultValue) {
     return scanAll
         .getAttribute(CROSS_PARTITION_SCAN_ORDERING_ENABLED)
         .map(Boolean::parseBoolean)
-        .orElse(false);
+        .orElse(defaultValue);
   }
 
   public static void setCrossPartitionScanOrderingEnabled(

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
@@ -1,0 +1,332 @@
+package com.scalar.db.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.TransactionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link DistributedTransactionManager} decorator that wraps the transactions it returns with
+ * {@link AttributePropagatingDistributedTransaction} so that attributes given to any
+ * attribute-taking {@code begin*} / {@code start*} variant (including read-only variants) are
+ * propagated to every operation issued on the transaction.
+ *
+ * <p>This decorator wraps the transaction only when the attributes map is non-empty, so
+ * attribute-free begin/start variants continue to return the same concrete transaction type as the
+ * underlying manager.
+ */
+@ThreadSafe
+public class AttributePropagatingDistributedTransactionManager
+    extends DecoratedDistributedTransactionManager {
+
+  public AttributePropagatingDistributedTransactionManager(
+      DistributedTransactionManager transactionManager) {
+    super(transactionManager);
+  }
+
+  @Override
+  public DistributedTransaction begin(Map<String, String> attributes) throws TransactionException {
+    return wrapIfNeeded(super.begin(attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction begin(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.begin(txId, attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.beginReadOnly(attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.beginReadOnly(txId, attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction start(Map<String, String> attributes) throws TransactionException {
+    return wrapIfNeeded(super.start(attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction start(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.start(txId, attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.startReadOnly(attributes), attributes);
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return wrapIfNeeded(super.startReadOnly(txId, attributes), attributes);
+  }
+
+  private DistributedTransaction wrapIfNeeded(
+      DistributedTransaction transaction, Map<String, String> attributes) {
+    if (attributes.isEmpty()) {
+      return transaction;
+    }
+    return new AttributePropagatingDistributedTransaction(transaction, attributes);
+  }
+
+  /**
+   * A {@link DistributedTransaction} decorator that propagates the transaction-scoped attributes
+   * given to any attribute-taking {@code begin*} / {@code start*} variant (including read-only
+   * variants) into every operation issued on the transaction. If an operation already carries an
+   * attribute with the same name, the operation's value wins.
+   */
+  @NotThreadSafe
+  @VisibleForTesting
+  static class AttributePropagatingDistributedTransaction extends DecoratedDistributedTransaction {
+
+    private final ImmutableMap<String, String> transactionAttributes;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    AttributePropagatingDistributedTransaction(
+        DistributedTransaction transaction, Map<String, String> transactionAttributes) {
+      super(transaction);
+      this.transactionAttributes = ImmutableMap.copyOf(transactionAttributes);
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      return super.get(mergeAttributes(get));
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      return super.scan(mergeAttributes(scan));
+    }
+
+    @Override
+    public Scanner getScanner(Scan scan) throws CrudException {
+      return super.getScanner(mergeAttributes(scan));
+    }
+
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
+    @Override
+    public void put(Put put) throws CrudException {
+      super.put(mergeAttributes(put));
+    }
+
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      super.put(mergeAttributesForEach(puts));
+    }
+
+    @Override
+    public void insert(Insert insert) throws CrudException {
+      super.insert(mergeAttributes(insert));
+    }
+
+    @Override
+    public void upsert(Upsert upsert) throws CrudException {
+      super.upsert(mergeAttributes(upsert));
+    }
+
+    @Override
+    public void update(Update update) throws CrudException {
+      super.update(mergeAttributes(update));
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      super.delete(mergeAttributes(delete));
+    }
+
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      super.delete(mergeAttributesForEach(deletes));
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      super.mutate(this.<Mutation>mergeAttributesForEach(mutations));
+    }
+
+    @Override
+    public List<BatchResult> batch(List<? extends Operation> operations) throws CrudException {
+      return super.batch(this.<Operation>mergeAttributesForEach(operations));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Operation> List<T> mergeAttributesForEach(List<? extends T> operations) {
+      // Allocates a new list only when some element actually needs merging. Returns the original
+      // list (same reference) when every element is forwarded unchanged so a common case of "no tx
+      // attribute needs to be added on any operation" avoids allocating a list copy.
+      for (int i = 0; i < operations.size(); i++) {
+        T operation = operations.get(i);
+        T mergedOperation = mergeAttributes(operation);
+        if (mergedOperation == operation) {
+          continue;
+        }
+        // Found an operation that needed merging: allocate the new list, backfill the prior
+        // unchanged elements, and merge the remaining elements.
+        List<T> merged = new ArrayList<>(operations.size());
+        merged.addAll(operations.subList(0, i));
+        merged.add(mergedOperation);
+        for (int j = i + 1; j < operations.size(); j++) {
+          merged.add(mergeAttributes(operations.get(j)));
+        }
+        return merged;
+      }
+      return (List<T>) operations;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Operation> T mergeAttributes(T operation) {
+      if (containsAllTransactionAttributeKeys(operation)) {
+        return operation;
+      }
+      if (operation instanceof Put) {
+        return (T) mergeAttributesIntoPut((Put) operation);
+      }
+      if (operation instanceof Insert) {
+        return (T) mergeAttributesIntoInsert((Insert) operation);
+      }
+      if (operation instanceof Upsert) {
+        return (T) mergeAttributesIntoUpsert((Upsert) operation);
+      }
+      if (operation instanceof Update) {
+        return (T) mergeAttributesIntoUpdate((Update) operation);
+      }
+      if (operation instanceof Delete) {
+        return (T) mergeAttributesIntoDelete((Delete) operation);
+      }
+      if (operation instanceof Get) {
+        return (T) mergeAttributesIntoGet((Get) operation);
+      }
+      if (operation instanceof Scan) {
+        return (T) mergeAttributesIntoScan((Scan) operation);
+      }
+      return operation;
+    }
+
+    private boolean containsAllTransactionAttributeKeys(Operation operation) {
+      Map<String, String> operationAttributes = operation.getAttributes();
+      for (String key : transactionAttributes.keySet()) {
+        if (!operationAttributes.containsKey(key)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private Put mergeAttributesIntoPut(Put put) {
+      Map<String, String> existing = put.getAttributes();
+      PutBuilder.BuildableFromExisting builder = Put.newBuilder(put);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Insert mergeAttributesIntoInsert(Insert insert) {
+      Map<String, String> existing = insert.getAttributes();
+      InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Upsert mergeAttributesIntoUpsert(Upsert upsert) {
+      Map<String, String> existing = upsert.getAttributes();
+      UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Update mergeAttributesIntoUpdate(Update update) {
+      Map<String, String> existing = update.getAttributes();
+      UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Delete mergeAttributesIntoDelete(Delete delete) {
+      Map<String, String> existing = delete.getAttributes();
+      DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Get mergeAttributesIntoGet(Get get) {
+      Map<String, String> existing = get.getAttributes();
+      GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+
+    private Scan mergeAttributesIntoScan(Scan scan) {
+      Map<String, String> existing = scan.getAttributes();
+      ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan);
+      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+        if (!existing.containsKey(entry.getKey())) {
+          builder.attribute(entry.getKey(), entry.getValue());
+        }
+      }
+      return builder.build();
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
@@ -144,8 +144,8 @@ public class OperationChecker {
   }
 
   private void check(ScanAll scanAll) throws ExecutionException {
-    if (!config.isCrossPartitionScanEnabled()
-        && !DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll)) {
+    if (!DatabaseOperationAttributes.isCrossPartitionScanEnabled(
+        scanAll, config.isCrossPartitionScanEnabled())) {
       throw new IllegalArgumentException(
           CoreError.OPERATION_CHECK_ERROR_CROSS_PARTITION_SCAN.buildMessage(scanAll));
     }
@@ -159,16 +159,16 @@ public class OperationChecker {
           CoreError.OPERATION_CHECK_ERROR_LIMIT.buildMessage(scanAll));
     }
 
-    if (!config.isCrossPartitionScanOrderingEnabled()
-        && !DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll)
+    if (!DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(
+            scanAll, config.isCrossPartitionScanOrderingEnabled())
         && !scanAll.getOrderings().isEmpty()) {
       throw new IllegalArgumentException(
           CoreError.OPERATION_CHECK_ERROR_CROSS_PARTITION_SCAN_ORDERING.buildMessage(scanAll));
     }
     checkOrderingsForScanAll(scanAll, metadata);
 
-    if (!config.isCrossPartitionScanFilteringEnabled()
-        && !DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll)
+    if (!DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(
+            scanAll, config.isCrossPartitionScanFilteringEnabled())
         && !scanAll.getConjunctions().isEmpty()) {
       throw new IllegalArgumentException(
           CoreError.OPERATION_CHECK_ERROR_CROSS_PARTITION_SCAN_FILTERING.buildMessage(scanAll));

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -34,6 +34,7 @@ public class DatabaseConfig {
   private long metadataCacheExpirationTimeSecs;
   private boolean activeTransactionManagementEnabled;
   private long activeTransactionManagementExpirationTimeMillis;
+  private boolean attributePropagationEnabled;
   @Nullable private String defaultNamespaceName;
   private boolean crossPartitionScanEnabled;
   private boolean crossPartitionScanFilteringEnabled;
@@ -53,6 +54,8 @@ public class DatabaseConfig {
       PREFIX + "active_transaction_management.enabled";
   public static final String ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS =
       PREFIX + "active_transaction_management.expiration_time_millis";
+  public static final String ATTRIBUTE_PROPAGATION_ENABLED =
+      PREFIX + "attribute_propagation.enabled";
   public static final String DEFAULT_NAMESPACE_NAME = PREFIX + "default_namespace_name";
   public static final String SCAN_PREFIX = PREFIX + "cross_partition_scan.";
   public static final String CROSS_PARTITION_SCAN = SCAN_PREFIX + "enabled";
@@ -108,6 +111,7 @@ public class DatabaseConfig {
         getBoolean(getProperties(), ACTIVE_TRANSACTION_MANAGEMENT_ENABLED, true);
     activeTransactionManagementExpirationTimeMillis =
         getActiveTransactionManagementExpirationTimeMillis(getProperties());
+    attributePropagationEnabled = getBoolean(getProperties(), ATTRIBUTE_PROPAGATION_ENABLED, true);
     defaultNamespaceName = getString(getProperties(), DEFAULT_NAMESPACE_NAME, null);
     crossPartitionScanEnabled = getBoolean(getProperties(), CROSS_PARTITION_SCAN, true);
     crossPartitionScanFilteringEnabled =
@@ -160,6 +164,10 @@ public class DatabaseConfig {
 
   public long getActiveTransactionManagementExpirationTimeMillis() {
     return activeTransactionManagementExpirationTimeMillis;
+  }
+
+  public boolean isAttributePropagationEnabled() {
+    return attributePropagationEnabled;
   }
 
   public Optional<String> getDefaultNamespaceName() {

--- a/core/src/test/java/com/scalar/db/api/DatabaseOperationAttributesTest.java
+++ b/core/src/test/java/com/scalar/db/api/DatabaseOperationAttributesTest.java
@@ -8,6 +8,17 @@ import org.junit.jupiter.api.Test;
 
 public class DatabaseOperationAttributesTest {
 
+  private static ScanAll scanAllWithAttribute(String key, String value) {
+    return (ScanAll)
+        Scan.newBuilder().namespace("ns").table("tbl").all().attribute(key, value).build();
+  }
+
+  private static ScanAll scanAllWithoutAttributes() {
+    return (ScanAll) Scan.newBuilder().namespace("ns").table("tbl").all().build();
+  }
+
+  // -------------------- cross_partition_scan --------------------
+
   @Test
   public void setCrossPartitionScanEnabled_ShouldSetAttribute() {
     // Arrange
@@ -25,32 +36,35 @@ public class DatabaseOperationAttributesTest {
   public void isCrossPartitionScanEnabled_WithAttributeSetToTrue_ShouldReturnTrue() {
     // Arrange
     ScanAll scanAll =
-        (ScanAll)
-            Scan.newBuilder()
-                .namespace("ns")
-                .table("tbl")
-                .all()
-                .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "true")
-                .build();
+        scanAllWithAttribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "true");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll);
-
-    // Assert
-    assertThat(actual).isTrue();
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, false)).isTrue();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, true)).isTrue();
   }
 
   @Test
-  public void isCrossPartitionScanEnabled_WithAttributeNotSet_ShouldReturnFalse() {
+  public void isCrossPartitionScanEnabled_WithAttributeSetToFalse_ShouldReturnFalse() {
     // Arrange
-    ScanAll scanAll = (ScanAll) Scan.newBuilder().namespace("ns").table("tbl").all().build();
+    ScanAll scanAll =
+        scanAllWithAttribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "false");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll);
-
-    // Assert
-    assertThat(actual).isFalse();
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, false)).isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, true)).isFalse();
   }
+
+  @Test
+  public void isCrossPartitionScanEnabled_WithAttributeNotSet_ShouldReturnDefaultValue() {
+    // Arrange
+    ScanAll scanAll = scanAllWithoutAttributes();
+
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, false)).isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanEnabled(scanAll, true)).isTrue();
+  }
+
+  // -------------------- cross_partition_scan_filtering --------------------
 
   @Test
   public void setCrossPartitionScanFilteringEnabled_ShouldSetAttribute() {
@@ -69,33 +83,43 @@ public class DatabaseOperationAttributesTest {
   public void isCrossPartitionScanFilteringEnabled_WithAttributeSetToTrue_ShouldReturnTrue() {
     // Arrange
     ScanAll scanAll =
-        (ScanAll)
-            Scan.newBuilder()
-                .namespace("ns")
-                .table("tbl")
-                .all()
-                .attribute(
-                    DatabaseOperationAttributes.CROSS_PARTITION_SCAN_FILTERING_ENABLED, "true")
-                .build();
+        scanAllWithAttribute(
+            DatabaseOperationAttributes.CROSS_PARTITION_SCAN_FILTERING_ENABLED, "true");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll);
-
-    // Assert
-    assertThat(actual).isTrue();
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, false))
+        .isTrue();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, true))
+        .isTrue();
   }
 
   @Test
-  public void isCrossPartitionScanFilteringEnabled_WithAttributeNotSet_ShouldReturnFalse() {
+  public void isCrossPartitionScanFilteringEnabled_WithAttributeSetToFalse_ShouldReturnFalse() {
     // Arrange
-    ScanAll scanAll = (ScanAll) Scan.newBuilder().namespace("ns").table("tbl").all().build();
+    ScanAll scanAll =
+        scanAllWithAttribute(
+            DatabaseOperationAttributes.CROSS_PARTITION_SCAN_FILTERING_ENABLED, "false");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll);
-
-    // Assert
-    assertThat(actual).isFalse();
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, false))
+        .isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, true))
+        .isFalse();
   }
+
+  @Test
+  public void isCrossPartitionScanFilteringEnabled_WithAttributeNotSet_ShouldReturnDefaultValue() {
+    // Arrange
+    ScanAll scanAll = scanAllWithoutAttributes();
+
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, false))
+        .isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanFilteringEnabled(scanAll, true))
+        .isTrue();
+  }
+
+  // -------------------- cross_partition_scan_ordering --------------------
 
   @Test
   public void setCrossPartitionScanOrderingEnabled_ShouldSetAttribute() {
@@ -114,31 +138,39 @@ public class DatabaseOperationAttributesTest {
   public void isCrossPartitionScanOrderingEnabled_WithAttributeSetToTrue_ShouldReturnTrue() {
     // Arrange
     ScanAll scanAll =
-        (ScanAll)
-            Scan.newBuilder()
-                .namespace("ns")
-                .table("tbl")
-                .all()
-                .attribute(
-                    DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ORDERING_ENABLED, "true")
-                .build();
+        scanAllWithAttribute(
+            DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ORDERING_ENABLED, "true");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll);
-
-    // Assert
-    assertThat(actual).isTrue();
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, false))
+        .isTrue();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, true))
+        .isTrue();
   }
 
   @Test
-  public void isCrossPartitionScanOrderingEnabled_WithAttributeNotSet_ShouldReturnFalse() {
+  public void isCrossPartitionScanOrderingEnabled_WithAttributeSetToFalse_ShouldReturnFalse() {
     // Arrange
-    ScanAll scanAll = (ScanAll) Scan.newBuilder().namespace("ns").table("tbl").all().build();
+    ScanAll scanAll =
+        scanAllWithAttribute(
+            DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ORDERING_ENABLED, "false");
 
-    // Act
-    boolean actual = DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll);
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, false))
+        .isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, true))
+        .isFalse();
+  }
 
-    // Assert
-    assertThat(actual).isFalse();
+  @Test
+  public void isCrossPartitionScanOrderingEnabled_WithAttributeNotSet_ShouldReturnDefaultValue() {
+    // Arrange
+    ScanAll scanAll = scanAllWithoutAttributes();
+
+    // Act Assert
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, false))
+        .isFalse();
+    assertThat(DatabaseOperationAttributes.isCrossPartitionScanOrderingEnabled(scanAll, true))
+        .isTrue();
   }
 }

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManagerTest.java
@@ -1,0 +1,907 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
+import com.scalar.db.common.AttributePropagatingDistributedTransactionManager.AttributePropagatingDistributedTransaction;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Key;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AttributePropagatingDistributedTransactionManagerTest {
+
+  private static final String TX_ID = "test-tx-id";
+  private static final String NAMESPACE = "ns";
+  private static final String TABLE = "tbl";
+
+  @Mock private DistributedTransactionManager wrappedTransactionManager;
+  @Mock private DistributedTransaction innerTransaction;
+
+  private AttributePropagatingDistributedTransactionManager transactionManager;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    // Arrange
+    transactionManager =
+        new AttributePropagatingDistributedTransactionManager(wrappedTransactionManager);
+  }
+
+  private Map<String, String> singleAttribute() {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("k", "v");
+    return attributes;
+  }
+
+  // -------------------- wraps when attributes non-empty --------------------
+
+  @Test
+  public void begin_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.begin(attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin(attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+    assertThat(((DecoratedDistributedTransaction) actual).getOriginalTransaction())
+        .isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void beginWithTxId_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.begin(TX_ID, attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin(TX_ID, attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+    assertThat(((DecoratedDistributedTransaction) actual).getOriginalTransaction())
+        .isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void beginReadOnly_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.beginReadOnly(attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.beginReadOnly(attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+    assertThat(((DecoratedDistributedTransaction) actual).getOriginalTransaction())
+        .isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void
+      beginReadOnlyWithTxId_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+          throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.beginReadOnly(TX_ID, attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.beginReadOnly(TX_ID, attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+    assertThat(((DecoratedDistributedTransaction) actual).getOriginalTransaction())
+        .isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void start_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.start(attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.start(attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void startWithTxId_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.start(TX_ID, attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.start(TX_ID, attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void startReadOnly_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+      throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.startReadOnly(attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.startReadOnly(attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  @Test
+  public void
+      startReadOnlyWithTxId_WithNonEmptyAttributes_ShouldWrapWithAttributePropagatingDecorator()
+          throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = singleAttribute();
+    when(wrappedTransactionManager.startReadOnly(TX_ID, attributes)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.startReadOnly(TX_ID, attributes);
+
+    // Assert
+    assertThat(actual).isInstanceOf(AttributePropagatingDistributedTransaction.class);
+  }
+
+  // -------------------- does not wrap when attributes empty --------------------
+
+  @Test
+  public void begin_WithEmptyAttributes_ShouldForwardDelegateTransaction()
+      throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.begin(Collections.emptyMap())).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin(Collections.emptyMap());
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void beginWithTxId_WithEmptyAttributes_ShouldForwardDelegateTransaction()
+      throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.begin(TX_ID, Collections.emptyMap()))
+        .thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin(TX_ID, Collections.emptyMap());
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void beginReadOnly_WithEmptyAttributes_ShouldForwardDelegateTransaction()
+      throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.beginReadOnly(Collections.emptyMap()))
+        .thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.beginReadOnly(Collections.emptyMap());
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+  }
+
+  @Test
+  public void beginReadOnlyWithTxId_WithEmptyAttributes_ShouldForwardDelegateTransaction()
+      throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.beginReadOnly(TX_ID, Collections.emptyMap()))
+        .thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.beginReadOnly(TX_ID, Collections.emptyMap());
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+  }
+
+  // -------------------- overloads without attributes do not wrap --------------------
+
+  @Test
+  public void begin_WithoutArguments_ShouldForwardDelegateTransaction()
+      throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.begin()).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin();
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+    verify(wrappedTransactionManager).begin();
+  }
+
+  @Test
+  public void begin_WithOnlyTxId_ShouldForwardDelegateTransaction() throws TransactionException {
+    // Arrange
+    when(wrappedTransactionManager.begin(TX_ID)).thenReturn(innerTransaction);
+
+    // Act
+    DistributedTransaction actual = transactionManager.begin(TX_ID);
+
+    // Assert
+    assertThat(actual).isSameAs(innerTransaction);
+    verify(wrappedTransactionManager).begin(TX_ID);
+  }
+
+  // -------------------- non-begin methods pass through --------------------
+
+  @Test
+  public void close_ShouldDelegate() {
+    // Act
+    transactionManager.close();
+
+    // Assert
+    verify(wrappedTransactionManager).close();
+  }
+
+  @Test
+  public void constructor_ShouldNotTouchDelegate() {
+    // Arrange
+    DistributedTransactionManager newDelegate = mock(DistributedTransactionManager.class);
+
+    // Act
+    new AttributePropagatingDistributedTransactionManager(newDelegate);
+
+    // Assert
+    verifyNoInteractions(newDelegate);
+  }
+
+  @SuppressFBWarnings({"SIC_INNER_SHOULD_BE_STATIC", "EI_EXPOSE_REP2"})
+  @SuppressWarnings("ClassCanBeStatic")
+  @Nested
+  public class AttributePropagatingDistributedTransactionTest {
+
+    private static final String TRANSACTION_ID = "test-tx-id";
+    private static final String TX_ATTR_KEY_1 = "cc-implicit-pre-read-enabled";
+    private static final String TX_ATTR_VALUE_1 = "true";
+    private static final String TX_ATTR_KEY_2 = "tenant-id";
+    private static final String TX_ATTR_VALUE_2 = "tenant-1";
+
+    @Mock private DistributedTransaction wrappedTransaction;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
+      when(wrappedTransaction.getId()).thenReturn(TRANSACTION_ID);
+    }
+
+    private AttributePropagatingDistributedTransaction newDecorator(
+        Map<String, String> transactionAttributes) {
+      return new AttributePropagatingDistributedTransaction(
+          wrappedTransaction, transactionAttributes);
+    }
+
+    private Map<String, String> twoTransactionAttributes() {
+      Map<String, String> attributes = new HashMap<>();
+      attributes.put(TX_ATTR_KEY_1, TX_ATTR_VALUE_1);
+      attributes.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+      return attributes;
+    }
+
+    private Put buildPut(Map<String, String> attributes) {
+      PutBuilder.BuildableFromExisting builder =
+          Put.newBuilder(
+              Put.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Get buildGet(Map<String, String> attributes) {
+      GetBuilder.BuildableGetOrGetWithIndexFromExisting builder =
+          Get.newBuilder(
+              Get.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Scan buildScan(Map<String, String> attributes) {
+      ScanBuilder.BuildableScanOrScanAllFromExisting builder =
+          Scan.newBuilder(
+              Scan.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Insert buildInsert(Map<String, String> attributes) {
+      InsertBuilder.BuildableFromExisting builder =
+          Insert.newBuilder(
+              Insert.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Upsert buildUpsert(Map<String, String> attributes) {
+      UpsertBuilder.BuildableFromExisting builder =
+          Upsert.newBuilder(
+              Upsert.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Update buildUpdate(Map<String, String> attributes) {
+      UpdateBuilder.BuildableFromExisting builder =
+          Update.newBuilder(
+              Update.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    private Delete buildDelete(Map<String, String> attributes) {
+      DeleteBuilder.BuildableFromExisting builder =
+          Delete.newBuilder(
+              Delete.newBuilder()
+                  .namespace(NAMESPACE)
+                  .table(TABLE)
+                  .partitionKey(Key.ofText("pk", "v"))
+                  .build());
+      attributes.forEach(builder::attribute);
+      return builder.build();
+    }
+
+    // -------------------- happy path: each operation type --------------------
+
+    @Test
+    public void get_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Get get = buildGet(Collections.emptyMap());
+      Get expected = buildGet(twoTransactionAttributes());
+      when(wrappedTransaction.get(any(Get.class))).thenReturn(Optional.empty());
+
+      // Act
+      decorator.get(get);
+
+      // Assert
+      verify(wrappedTransaction).get(eq(expected));
+    }
+
+    @Test
+    public void scan_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Scan scan = buildScan(Collections.emptyMap());
+      Scan expected = buildScan(twoTransactionAttributes());
+      when(wrappedTransaction.scan(any(Scan.class))).thenReturn(Collections.emptyList());
+
+      // Act
+      decorator.scan(scan);
+
+      // Assert
+      verify(wrappedTransaction).scan(eq(expected));
+    }
+
+    @Test
+    public void getScanner_WithTransactionAttributes_ShouldMergeIntoOperation()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Scan scan = buildScan(Collections.emptyMap());
+      Scan expected = buildScan(twoTransactionAttributes());
+      Scanner expectedScanner = mock(Scanner.class);
+      when(wrappedTransaction.getScanner(any(Scan.class))).thenReturn(expectedScanner);
+
+      // Act
+      Scanner actual = decorator.getScanner(scan);
+
+      // Assert
+      assertThat(actual).isSameAs(expectedScanner);
+      verify(wrappedTransaction).getScanner(eq(expected));
+    }
+
+    @Test
+    public void put_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put = buildPut(Collections.emptyMap());
+      Put expected = buildPut(twoTransactionAttributes());
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(eq(expected));
+    }
+
+    @Test
+    public void insert_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Insert insert = buildInsert(Collections.emptyMap());
+      Insert expected = buildInsert(twoTransactionAttributes());
+
+      // Act
+      decorator.insert(insert);
+
+      // Assert
+      verify(wrappedTransaction).insert(eq(expected));
+    }
+
+    @Test
+    public void upsert_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Upsert upsert = buildUpsert(Collections.emptyMap());
+      Upsert expected = buildUpsert(twoTransactionAttributes());
+
+      // Act
+      decorator.upsert(upsert);
+
+      // Assert
+      verify(wrappedTransaction).upsert(eq(expected));
+    }
+
+    @Test
+    public void update_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Update update = buildUpdate(Collections.emptyMap());
+      Update expected = buildUpdate(twoTransactionAttributes());
+
+      // Act
+      decorator.update(update);
+
+      // Assert
+      verify(wrappedTransaction).update(eq(expected));
+    }
+
+    @Test
+    public void delete_WithTransactionAttributes_ShouldMergeIntoOperation() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Delete delete = buildDelete(Collections.emptyMap());
+      Delete expected = buildDelete(twoTransactionAttributes());
+
+      // Act
+      decorator.delete(delete);
+
+      // Assert
+      verify(wrappedTransaction).delete(eq(expected));
+    }
+
+    // -------------------- precedence: operation-side wins --------------------
+
+    @Test
+    public void put_WhenOperationHasSameKey_ShouldKeepOperationValue() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(Collections.singletonMap(TX_ATTR_KEY_1, "true"));
+      Put put = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "false"));
+      Put expected = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "false"));
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(eq(expected));
+    }
+
+    @Test
+    public void put_WhenOperationHasPartialOverlap_ShouldFillOnlyMissingKeys()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+      Map<String, String> expectedAttributes = new HashMap<>();
+      expectedAttributes.put(TX_ATTR_KEY_1, "operation-wins");
+      expectedAttributes.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+      Put expected = buildPut(expectedAttributes);
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(eq(expected));
+    }
+
+    // -------------------- fast path: full overlap returns same instance --------------------
+
+    @Test
+    public void put_WhenOperationAlreadyHasAllKeys_ShouldForwardSameInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put = buildPut(twoTransactionAttributes());
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(same(put));
+    }
+
+    // -------------------- empty transaction attributes --------------------
+
+    @Test
+    public void put_WhenTransactionAttributesEmpty_ShouldForwardSameInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator = newDecorator(Collections.emptyMap());
+      Put put = buildPut(Collections.emptyMap());
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(same(put));
+    }
+
+    // -------------------- defensive snapshot --------------------
+
+    @Test
+    public void put_WhenTransactionAttributesMutatedAfterConstruction_ShouldUseSnapshot()
+        throws CrudException {
+      // Arrange
+      Map<String, String> transactionAttributes = new HashMap<>();
+      transactionAttributes.put(TX_ATTR_KEY_1, TX_ATTR_VALUE_1);
+      AttributePropagatingDistributedTransaction decorator = newDecorator(transactionAttributes);
+      transactionAttributes.put(TX_ATTR_KEY_2, "added-after");
+      transactionAttributes.remove(TX_ATTR_KEY_1);
+
+      Put put = buildPut(Collections.emptyMap());
+      Put expected = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, TX_ATTR_VALUE_1));
+
+      // Act
+      decorator.put(put);
+
+      // Assert
+      verify(wrappedTransaction).put(eq(expected));
+    }
+
+    // -------------------- mutate / batch --------------------
+
+    @Test
+    public void mutate_WithTransactionAttributes_ShouldMergeIntoEachMutation()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put = buildPut(Collections.emptyMap());
+      Delete delete = buildDelete(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+      List<Mutation> mutations = Arrays.asList(put, delete);
+
+      Put expectedPut = buildPut(twoTransactionAttributes());
+      Map<String, String> expectedDeleteAttrs = new HashMap<>();
+      expectedDeleteAttrs.put(TX_ATTR_KEY_1, "operation-wins");
+      expectedDeleteAttrs.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+      Delete expectedDelete = buildDelete(expectedDeleteAttrs);
+      List<Mutation> expected = Arrays.asList(expectedPut, expectedDelete);
+
+      // Act
+      decorator.mutate(mutations);
+
+      // Assert
+      verify(wrappedTransaction).mutate(eq(expected));
+    }
+
+    @Test
+    public void batch_WithTransactionAttributes_ShouldMergeIntoEachOperation()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Get get = buildGet(Collections.emptyMap());
+      Put put = buildPut(Collections.emptyMap());
+      List<Operation> operations = Arrays.asList(get, put);
+
+      Get expectedGet = buildGet(twoTransactionAttributes());
+      Put expectedPut = buildPut(twoTransactionAttributes());
+      List<Operation> expected = Arrays.asList(expectedGet, expectedPut);
+
+      when(wrappedTransaction.batch(any())).thenReturn(Collections.emptyList());
+
+      // Act
+      decorator.batch(operations);
+
+      // Assert
+      verify(wrappedTransaction).batch(eq(expected));
+    }
+
+    @Test
+    public void mutate_WhenEveryMutationAlreadyHasAllKeys_ShouldForwardSameListInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put = buildPut(twoTransactionAttributes());
+      Delete delete = buildDelete(twoTransactionAttributes());
+      List<Mutation> mutations = Arrays.asList(put, delete);
+
+      // Act
+      decorator.mutate(mutations);
+
+      // Assert: no element needed merging, so no new list is allocated.
+      verify(wrappedTransaction).mutate(same(mutations));
+    }
+
+    @Test
+    public void batch_WhenEveryOperationAlreadyHasAllKeys_ShouldForwardSameListInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Get get = buildGet(twoTransactionAttributes());
+      Put put = buildPut(twoTransactionAttributes());
+      List<Operation> operations = Arrays.asList(get, put);
+      when(wrappedTransaction.batch(any())).thenReturn(Collections.emptyList());
+
+      // Act
+      decorator.batch(operations);
+
+      // Assert: no element needed merging, so no new list is allocated.
+      verify(wrappedTransaction).batch(same(operations));
+    }
+
+    // -------------------- deprecated put(List) / delete(List) --------------------
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void putList_WithTransactionAttributes_ShouldMergeIntoEachPut() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put1 = buildPut(Collections.emptyMap());
+      Put put2 = buildPut(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+      List<Put> puts = Arrays.asList(put1, put2);
+
+      Put expectedPut1 = buildPut(twoTransactionAttributes());
+      Map<String, String> expectedPut2Attrs = new HashMap<>();
+      expectedPut2Attrs.put(TX_ATTR_KEY_1, "operation-wins");
+      expectedPut2Attrs.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+      Put expectedPut2 = buildPut(expectedPut2Attrs);
+      List<Put> expected = Arrays.asList(expectedPut1, expectedPut2);
+
+      // Act
+      decorator.put(puts);
+
+      // Assert
+      verify(wrappedTransaction).put(eq(expected));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void putList_WhenEveryPutAlreadyHasAllKeys_ShouldForwardSameListInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put1 = buildPut(twoTransactionAttributes());
+      Put put2 = buildPut(twoTransactionAttributes());
+      List<Put> puts = Arrays.asList(put1, put2);
+
+      // Act
+      decorator.put(puts);
+
+      // Assert: no element needed merging, so no new list is allocated.
+      verify(wrappedTransaction).put(same(puts));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void deleteList_WithTransactionAttributes_ShouldMergeIntoEachDelete()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Delete delete1 = buildDelete(Collections.emptyMap());
+      Delete delete2 = buildDelete(Collections.singletonMap(TX_ATTR_KEY_1, "operation-wins"));
+      List<Delete> deletes = Arrays.asList(delete1, delete2);
+
+      Delete expectedDelete1 = buildDelete(twoTransactionAttributes());
+      Map<String, String> expectedDelete2Attrs = new HashMap<>();
+      expectedDelete2Attrs.put(TX_ATTR_KEY_1, "operation-wins");
+      expectedDelete2Attrs.put(TX_ATTR_KEY_2, TX_ATTR_VALUE_2);
+      Delete expectedDelete2 = buildDelete(expectedDelete2Attrs);
+      List<Delete> expected = Arrays.asList(expectedDelete1, expectedDelete2);
+
+      // Act
+      decorator.delete(deletes);
+
+      // Assert
+      verify(wrappedTransaction).delete(eq(expected));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void deleteList_WhenEveryDeleteAlreadyHasAllKeys_ShouldForwardSameListInstance()
+        throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Delete delete1 = buildDelete(twoTransactionAttributes());
+      Delete delete2 = buildDelete(twoTransactionAttributes());
+      List<Delete> deletes = Arrays.asList(delete1, delete2);
+
+      // Act
+      decorator.delete(deletes);
+
+      // Assert: no element needed merging, so no new list is allocated.
+      verify(wrappedTransaction).delete(same(deletes));
+    }
+
+    // -------------------- pass-through --------------------
+
+    @Test
+    public void commit_ShouldDelegate() throws Exception {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+
+      // Act
+      decorator.commit();
+
+      // Assert
+      verify(wrappedTransaction).commit();
+    }
+
+    @Test
+    public void rollback_ShouldDelegate() throws Exception {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+
+      // Act
+      decorator.rollback();
+
+      // Assert
+      verify(wrappedTransaction).rollback();
+    }
+
+    @Test
+    public void abort_ShouldDelegate() throws Exception {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+
+      // Act
+      decorator.abort();
+
+      // Assert
+      verify(wrappedTransaction).abort();
+    }
+
+    @Test
+    public void getId_ShouldDelegate() {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+
+      // Act
+      String actual = decorator.getId();
+
+      // Assert
+      assertThat(actual).isEqualTo(TRANSACTION_ID);
+    }
+
+    @Test
+    public void get_ShouldReturnDelegateResult() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Get get = buildGet(Collections.emptyMap());
+      Optional<Result> expected = Optional.of(mock(Result.class));
+      when(wrappedTransaction.get(any(Get.class))).thenReturn(expected);
+
+      // Act
+      Optional<Result> actual = decorator.get(get);
+
+      // Assert
+      assertThat(actual).isSameAs(expected);
+    }
+
+    // -------------------- snapshot stability across multiple calls --------------------
+
+    @Test
+    public void multipleCalls_ShouldUseSameSnapshot() throws CrudException {
+      // Arrange
+      AttributePropagatingDistributedTransaction decorator =
+          newDecorator(twoTransactionAttributes());
+      Put put1 = buildPut(Collections.emptyMap());
+      Put put2 = buildPut(Collections.emptyMap());
+      Put expected = buildPut(twoTransactionAttributes());
+
+      // Act
+      decorator.put(put1);
+      decorator.put(put2);
+
+      // Assert
+      ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+      verify(wrappedTransaction, times(2)).put(captor.capture());
+      assertThat(captor.getAllValues()).containsExactly(expected, expected);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -2111,6 +2111,73 @@ public class OperationCheckerTest {
     assertThatCode(() -> operationChecker.check(scanAll)).doesNotThrowAnyException();
   }
 
+  @Test
+  public void
+      whenCheckingScanAllOperationWithCrossPartitionScanEnabledButAttributeDisabled_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .projections(Arrays.asList(COL1, COL2, COL3))
+            .limit(10)
+            .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "false")
+            .build();
+    when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
+    operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scanAll))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingScanAllOperationWithOrderingsAndCrossPartitionScanOrderingEnabledButAttributeDisabled_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .projections(Arrays.asList(COL1, COL2, COL3))
+            .ordering(Ordering.desc(COL1))
+            .limit(10)
+            .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ORDERING_ENABLED, "false")
+            .build();
+    when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
+    when(databaseConfig.isCrossPartitionScanOrderingEnabled()).thenReturn(true);
+    operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scanAll))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingScanAllOperationWithConjunctionsAndCrossPartitionScanFilteringEnabledButAttributeDisabled_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .all()
+            .where(ConditionBuilder.column(COL1).isEqualToInt(10))
+            .projections(Arrays.asList(COL1, COL2, COL3))
+            .limit(10)
+            .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_FILTERING_ENABLED, "false")
+            .build();
+    when(databaseConfig.isCrossPartitionScanEnabled()).thenReturn(true);
+    when(databaseConfig.isCrossPartitionScanFilteringEnabled()).thenReturn(true);
+    operationChecker = new OperationChecker(databaseConfig, metadataManager, storageInfoProvider);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scanAll))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   @ParameterizedTest
   @EnumSource(StorageInfo.MutationAtomicityUnit.class)
   public void check_MutationsGiven_ForAtomicityUnit_ShouldBehaveCorrectly(

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -39,6 +39,7 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
@@ -68,6 +69,7 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -98,6 +100,7 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -130,6 +133,7 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -424,5 +428,21 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getScanFetchSize()).isEqualTo(1000);
+  }
+
+  @Test
+  public void constructor_PropertiesWithAttributePropagationEnabledGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props.setProperty(DatabaseConfig.ATTRIBUTE_PROPAGATION_ENABLED, "false");
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.isAttributePropagationEnabled()).isFalse();
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -43,6 +43,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3148,6 +3149,54 @@ public abstract class DistributedTransactionIntegrationTestBase {
       Optional<Result> deleteResult = get(prepareGet(0, 1));
       assertThat(deleteResult).isEmpty();
     }
+  }
+
+  @Test
+  public void
+      scan_CrossPartitionScanDisabledByTransactionAttribute_ShouldThrowIllegalArgumentException()
+          throws TransactionException {
+    // Arrange
+    Map<String, String> attributes = new HashMap<>();
+    DatabaseOperationAttributes.setCrossPartitionScanEnabled(attributes, false);
+    Scan scanAll = Scan.newBuilder().namespace(namespace).table(TABLE).all().build();
+
+    // Act Assert: the transaction-scoped attribute is propagated to the scan and overrides the
+    // config default, so cross-partition scan must be rejected.
+    DistributedTransaction transaction = manager.begin(attributes);
+    try {
+      assertThatThrownBy(() -> transaction.scan(scanAll))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cross-partition scan is not enabled");
+    } finally {
+      transaction.rollback();
+    }
+  }
+
+  @Test
+  public void
+      scan_CrossPartitionScanDisabledByTransactionAttributeButEnabledByScanAttribute_ShouldScanProperly()
+          throws TransactionException {
+    // Arrange
+    populateRecords();
+    Map<String, String> attributes = new HashMap<>();
+    DatabaseOperationAttributes.setCrossPartitionScanEnabled(attributes, false);
+    // The scan-level attribute is authoritative over the transaction-scoped attribute: fast-path
+    // in the propagating decorator keeps the scan's value of "true".
+    Scan scanAll =
+        Scan.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .all()
+            .attribute(DatabaseOperationAttributes.CROSS_PARTITION_SCAN_ENABLED, "true")
+            .build();
+
+    // Act
+    DistributedTransaction transaction = manager.begin(attributes);
+    List<Result> results = transaction.scan(scanAll);
+    transaction.commit();
+
+    // Assert
+    assertThat(results).hasSize(NUM_ACCOUNTS * NUM_TYPES);
   }
 
   protected Optional<Result> get(Get get) throws TransactionException {

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -501,4 +501,16 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @EnumSource(ScanType.class)
   public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
       ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void
+      scan_CrossPartitionScanDisabledByTransactionAttribute_ShouldThrowIllegalArgumentException() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void
+      scan_CrossPartitionScanDisabledByTransactionAttributeButEnabledByScanAttribute_ShouldScanProperly() {}
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3517
- **Commit to backport:** 56af957a2e1d60b98f99f495fabf1cbc9ac9be86

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3517 &&
git cherry-pick --no-rerere-autoupdate -m1 56af957a2e1d60b98f99f495fabf1cbc9ac9be86
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!