### PR TITLE
Suppress ReferenceEquality error-prone warning in AttributePropagatingDistributedTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
@@ -189,7 +189,7 @@ public class AttributePropagatingDistributedTransactionManager
       return super.batch(this.<Operation>mergeAttributesForEach(operations));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "ReferenceEquality"})
     private <T extends Operation> List<T> mergeAttributesForEach(List<? extends T> operations) {
       // Allocates a new list only when some element actually needs merging. Returns the original
       // list (same reference) when every element is forwarded unchanged so a common case of "no tx


### PR DESCRIPTION
## Description

`AttributePropagatingDistributedTransactionManager`, which was added in #3517, emits an error-prone `ReferenceEquality` warning at the `==` comparison in `mergeAttributesForEach`. The reference-equality check is intentional — it is used to detect when `mergeAttributes` returned the exact same instance (i.e., no merge was needed) so we can skip allocating a new list — but error-prone cannot infer that intent and emits a warning.

## Related issues and/or PRs

Follow-up to #3517.

## Changes made

- Add `"ReferenceEquality"` to the existing `@SuppressWarnings` on `mergeAttributesForEach` in `AttributePropagatingDistributedTransactionManager`. Switching to `Objects.equals` / `equals()` would defeat the optimization that this method is built around, so suppression is the appropriate fix.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Verified locally with \`./gradlew :core:compileJava --rerun-tasks\` — the \`ReferenceEquality\` warning is no longer emitted.

## Release notes

N/A