### PR TITLE
Rename AuthenticationMethod.PASSWORD to USERPASS

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -560,8 +560,8 @@ public interface AuthAdmin {
 
   /** The authentication methods. */
   enum AuthenticationMethod {
-    /** Password-based authentication. */
-    PASSWORD,
+    /** Username and password-based authentication. */
+    USERPASS,
 
     /** OpenID Connect (OIDC) authentication. */
     OIDC,


### PR DESCRIPTION
## Description

Rename the `AuthenticationMethod.PASSWORD` enum constant to `USERPASS` to better reflect that this authentication method uses both a username and password, not just a password.

## Related issues and/or PRs

- Related to #3433 (Add AuthenticationMethod support to AuthAdmin for OIDC integration)

## Changes made

- Renamed `AuthenticationMethod.PASSWORD` to `AuthenticationMethod.USERPASS` in `AuthAdmin.java`.
- Updated the Javadoc from "Password-based authentication" to "Username and password-based authentication".

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Release notes

N/A