### PR TITLE
Rename isolation operation attribute to transaction-isolation in ConsensusCommitOperationAttributes

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -209,7 +209,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   public DistributedTransaction begin(String txId, Map<String, String> attributes) {
     return begin(
         txId,
-        ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
+        ConsensusCommitOperationAttributes.getTransactionIsolation(attributes).orElse(isolation),
         false,
         false);
   }
@@ -218,7 +218,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   public DistributedTransaction beginReadOnly(String txId, Map<String, String> attributes) {
     return begin(
         txId,
-        ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
+        ConsensusCommitOperationAttributes.getTransactionIsolation(attributes).orElse(isolation),
         true,
         false);
   }
@@ -300,7 +300,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     String txId = UUID.randomUUID().toString();
     return begin(
         txId,
-        ConsensusCommitOperationAttributes.getIsolation(attributes).orElse(isolation),
+        ConsensusCommitOperationAttributes.getTransactionIsolation(attributes).orElse(isolation),
         readOnly,
         true);
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributes.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributes.java
@@ -18,8 +18,9 @@ public final class ConsensusCommitOperationAttributes {
   public static final String INSERT_MODE_ENABLED =
       OPERATION_ATTRIBUTE_PREFIX + "insert-mode-enabled";
 
-  /** The operation attribute key for the isolation level. */
-  public static final String ISOLATION = OPERATION_ATTRIBUTE_PREFIX + "isolation";
+  /** The operation attribute key for the transaction isolation level. */
+  public static final String TRANSACTION_ISOLATION =
+      OPERATION_ATTRIBUTE_PREFIX + "transaction-isolation";
 
   private ConsensusCommitOperationAttributes() {}
 
@@ -122,35 +123,35 @@ public final class ConsensusCommitOperationAttributes {
   }
 
   /**
-   * Sets the specified isolation level in the operation attributes.
+   * Sets the specified transaction isolation level in the operation attributes.
    *
    * @param attributes the operation attributes
-   * @param isolation the isolation level
+   * @param isolation the transaction isolation level
    */
-  public static void setIsolation(Map<String, String> attributes, Isolation isolation) {
-    attributes.put(ISOLATION, isolation.name());
+  public static void setTransactionIsolation(Map<String, String> attributes, Isolation isolation) {
+    attributes.put(TRANSACTION_ISOLATION, isolation.name());
   }
 
   /**
-   * Clears the isolation level from the operation attributes.
+   * Clears the transaction isolation level from the operation attributes.
    *
    * @param attributes the operation attributes
    */
-  public static void clearIsolation(Map<String, String> attributes) {
-    attributes.remove(ISOLATION);
+  public static void clearTransactionIsolation(Map<String, String> attributes) {
+    attributes.remove(TRANSACTION_ISOLATION);
   }
 
   /**
-   * Returns the isolation level from the operation attributes.
+   * Returns the transaction isolation level from the operation attributes.
    *
    * @param attributes the operation attributes
-   * @return an {@code Optional} containing the isolation level, or an empty {@code Optional} if not
-   *     set
-   * @throws IllegalArgumentException if the isolation level value in the attributes is not a valid
-   *     {@link Isolation}
+   * @return an {@code Optional} containing the transaction isolation level, or an empty {@code
+   *     Optional} if not set
+   * @throws IllegalArgumentException if the transaction isolation level value in the attributes is
+   *     not a valid {@link Isolation}
    */
-  public static Optional<Isolation> getIsolation(Map<String, String> attributes) {
-    String value = attributes.get(ISOLATION);
+  public static Optional<Isolation> getTransactionIsolation(Map<String, String> attributes) {
+    String value = attributes.get(TRANSACTION_ISOLATION);
     if (value == null) {
       return Optional.empty();
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -264,7 +264,7 @@ public class ConsensusCommitManagerTest {
       begin_TxIdAndAttributesWithIsolationGiven_ReturnWithSpecifiedTxIdAndSpecifiedIsolation() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    ConsensusCommitOperationAttributes.setIsolation(attributes, Isolation.SERIALIZABLE);
+    ConsensusCommitOperationAttributes.setTransactionIsolation(attributes, Isolation.SERIALIZABLE);
 
     // Act
     ConsensusCommit transaction = (ConsensusCommit) manager.begin(ANY_TX_ID, attributes);
@@ -295,7 +295,7 @@ public class ConsensusCommitManagerTest {
       beginReadOnly_TxIdAndAttributesWithIsolationGiven_ReturnWithSpecifiedTxIdAndSpecifiedIsolationInReadOnlyMode() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    ConsensusCommitOperationAttributes.setIsolation(attributes, Isolation.SERIALIZABLE);
+    ConsensusCommitOperationAttributes.setTransactionIsolation(attributes, Isolation.SERIALIZABLE);
 
     // Act
     DistributedTransaction transaction = manager.beginReadOnly(ANY_TX_ID, attributes);
@@ -857,7 +857,7 @@ public class ConsensusCommitManagerTest {
             .namespace("ns")
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     Result result = mock(Result.class);
@@ -916,7 +916,7 @@ public class ConsensusCommitManagerTest {
             .namespace("ns")
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     List<Result> results =
@@ -1329,7 +1329,7 @@ public class ConsensusCommitManagerTest {
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
             .intValue("col", 0)
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     // Act
@@ -1425,7 +1425,7 @@ public class ConsensusCommitManagerTest {
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
             .intValue("col", 0)
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     // Act
@@ -1481,7 +1481,7 @@ public class ConsensusCommitManagerTest {
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
             .intValue("col", 0)
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     // Act
@@ -1537,7 +1537,7 @@ public class ConsensusCommitManagerTest {
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
             .intValue("col", 0)
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     // Act
@@ -1587,7 +1587,7 @@ public class ConsensusCommitManagerTest {
             .namespace("ns")
             .table("tbl")
             .partitionKey(Key.ofInt("pk", 0))
-            .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+            .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
             .build();
 
     // Act
@@ -1705,7 +1705,7 @@ public class ConsensusCommitManagerTest {
                 .table("tbl")
                 .partitionKey(Key.ofInt("pk", 0))
                 .intValue("col", 0)
-                .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+                .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
                 .build(),
             Delete.newBuilder()
                 .namespace("ns")
@@ -1768,7 +1768,7 @@ public class ConsensusCommitManagerTest {
                 .namespace("ns")
                 .table("tbl")
                 .partitionKey(Key.ofInt("pk", 0))
-                .attribute(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE")
+                .attribute(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE")
                 .build());
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributesTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributesTest.java
@@ -194,70 +194,71 @@ public class ConsensusCommitOperationAttributesTest {
   }
 
   @Test
-  public void setIsolation_MapGiven_ShouldAddIsolationToAttributes() {
+  public void setTransactionIsolation_MapGiven_ShouldAddIsolationToAttributes() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
 
     // Act
-    ConsensusCommitOperationAttributes.setIsolation(attributes, Isolation.SERIALIZABLE);
+    ConsensusCommitOperationAttributes.setTransactionIsolation(attributes, Isolation.SERIALIZABLE);
 
     // Assert
     assertThat(attributes)
-        .containsEntry(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE");
+        .containsEntry(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE");
   }
 
   @Test
-  public void clearIsolation_MapGiven_ShouldRemoveIsolationFromAttributes() {
+  public void clearTransactionIsolation_MapGiven_ShouldRemoveIsolationFromAttributes() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    attributes.put(ConsensusCommitOperationAttributes.ISOLATION, "SNAPSHOT");
+    attributes.put(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SNAPSHOT");
 
     // Act
-    ConsensusCommitOperationAttributes.clearIsolation(attributes);
+    ConsensusCommitOperationAttributes.clearTransactionIsolation(attributes);
 
     // Assert
-    assertThat(attributes).doesNotContainKey(ConsensusCommitOperationAttributes.ISOLATION);
+    assertThat(attributes)
+        .doesNotContainKey(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION);
   }
 
   @Test
-  public void getIsolation_IsolationSetInAttributes_ShouldReturnIsolation() {
+  public void getTransactionIsolation_IsolationSetInAttributes_ShouldReturnIsolation() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    attributes.put(ConsensusCommitOperationAttributes.ISOLATION, "SERIALIZABLE");
+    attributes.put(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "SERIALIZABLE");
 
     // Act Assert
-    assertThat(ConsensusCommitOperationAttributes.getIsolation(attributes))
+    assertThat(ConsensusCommitOperationAttributes.getTransactionIsolation(attributes))
         .hasValue(Isolation.SERIALIZABLE);
   }
 
   @Test
-  public void getIsolation_IsolationSetInLowerCaseInAttributes_ShouldReturnIsolation() {
+  public void getTransactionIsolation_IsolationSetInLowerCaseInAttributes_ShouldReturnIsolation() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    attributes.put(ConsensusCommitOperationAttributes.ISOLATION, "snapshot");
+    attributes.put(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "snapshot");
 
     // Act Assert
-    assertThat(ConsensusCommitOperationAttributes.getIsolation(attributes))
+    assertThat(ConsensusCommitOperationAttributes.getTransactionIsolation(attributes))
         .hasValue(Isolation.SNAPSHOT);
   }
 
   @Test
-  public void getIsolation_IsolationNotSetInAttributes_ShouldReturnEmpty() {
+  public void getTransactionIsolation_IsolationNotSetInAttributes_ShouldReturnEmpty() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
 
     // Act Assert
-    assertThat(ConsensusCommitOperationAttributes.getIsolation(attributes)).isEmpty();
+    assertThat(ConsensusCommitOperationAttributes.getTransactionIsolation(attributes)).isEmpty();
   }
 
   @Test
-  public void getIsolation_InvalidIsolationSetInAttributes_ShouldThrowException() {
+  public void getTransactionIsolation_InvalidIsolationSetInAttributes_ShouldThrowException() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
-    attributes.put(ConsensusCommitOperationAttributes.ISOLATION, "invalid");
+    attributes.put(ConsensusCommitOperationAttributes.TRANSACTION_ISOLATION, "invalid");
 
     // Act Assert
-    assertThatThrownBy(() -> ConsensusCommitOperationAttributes.getIsolation(attributes))
+    assertThatThrownBy(() -> ConsensusCommitOperationAttributes.getTransactionIsolation(attributes))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
## Description

The operation attribute key for the isolation level in `ConsensusCommitOperationAttributes` was named simply `ISOLATION` (with the underlying attribute key `cc-isolation`). Since this attribute applies to a transaction, the name is ambiguous and inconsistent with how it is described elsewhere. This PR renames the constant, the underlying attribute key, and the related accessor methods to use `TRANSACTION_ISOLATION` / `transaction-isolation` for clarity and consistency. This is a pre-release breaking change of an unreleased API; backward compatibility is not preserved.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3466

## Changes made

- Rename the public constant `ConsensusCommitOperationAttributes.ISOLATION` to `TRANSACTION_ISOLATION`.
- Change the underlying attribute key value from `cc-isolation` to `cc-transaction-isolation`.
- Rename the accessor methods on `ConsensusCommitOperationAttributes`:
  - `setIsolation` → `setTransactionIsolation`
  - `clearIsolation` → `clearTransactionIsolation`
  - `getIsolation` → `getTransactionIsolation`
- Update Javadoc to consistently use the term "transaction isolation level".
- Update the call sites in `ConsensusCommitManager` and the relevant unit tests in `ConsensusCommitManagerTest` and `ConsensusCommitOperationAttributesTest`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This renames an unreleased API introduced earlier on `master` (see #3517). Because the API has not yet been released, the rename is applied in place without a deprecation alias.

## Release notes

Same as https://github.com/scalar-labs/scalardb/pull/3466
