### PR TITLE
Update ScalarDB dependency version to 3.18.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.17.3'
+    implementation 'com.scalar-labs:scalardb:3.18.0'
 }
 ```
 
@@ -46,7 +46,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.17.3</version>
+  <version>3.18.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description

This PR updates the ScalarDB dependency version to 3.18.0 in README, as ScalarDB 3.18.0 has been released.

## Related issues and/or PRs

N/A

## Changes made

- Updated ScalarDB dependency version to 3.18.0.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
