### PR TITLE
Add tx_write_set column to the Coordinator table

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 public final class Attribute {
   public static final String ID = "tx_id";
   public static final String CHILD_IDS = "tx_child_ids";
+  public static final String WRITE_SET = "tx_write_set";
   public static final String STATE = "tx_state";
   public static final String VERSION = "tx_version";
   public static final String PREPARED_AT = "tx_prepared_at";

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -525,7 +525,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     }
     // These columns were recently added. Therefore, it's possible Coordinator tables created
     // earlier don't have these columns.
-    List<String> potentialMissingColumnNames = ImmutableList.of(Attribute.CHILD_IDS);
+    List<String> potentialMissingColumnNames =
+        ImmutableList.of(Attribute.CHILD_IDS, Attribute.WRITE_SET);
 
     // Verify the potentially missing columns.
     for (String columnName : potentialMissingColumnNames) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -40,6 +40,7 @@ public class Coordinator {
       TableMetadata.newBuilder()
           .addColumn(Attribute.ID, DataType.TEXT)
           .addColumn(Attribute.CHILD_IDS, DataType.TEXT)
+          .addColumn(Attribute.WRITE_SET, DataType.BLOB)
           .addColumn(Attribute.STATE, DataType.INT)
           .addColumn(Attribute.CREATED_AT, DataType.BIGINT)
           .addPartitionKey(Attribute.ID)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -998,8 +998,9 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void upgrade_CoordinatorTableExistsButMissingChildIdsColumn_ShouldAddChildIdsColumn()
-      throws ExecutionException {
+  public void
+      upgrade_CoordinatorTableExistsButMissingChildIdsAndWriteSetColumns_ShouldAddMissingColumns()
+          throws ExecutionException {
     // Arrange
     Map<String, String> options = Collections.emptyMap();
     TableMetadata oldCoordinatorMetadata =
@@ -1020,6 +1021,9 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .addNewColumnToTable(
             coordinatorNamespaceName, Coordinator.TABLE, Attribute.CHILD_IDS, DataType.TEXT);
+    verify(distributedStorageAdmin)
+        .addNewColumnToTable(
+            coordinatorNamespaceName, Coordinator.TABLE, Attribute.WRITE_SET, DataType.BLOB);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -536,7 +536,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
     TableMetadata oldCoordinatorTableMetadata =
         TableMetadata.newBuilder()
             .addColumn(Attribute.ID, DataType.TEXT)
-            // `tx_child_ids` is missing.
+            // `tx_child_ids` and `tx_write_set` are missing.
             .addColumn(Attribute.STATE, DataType.INT)
             .addColumn(Attribute.CREATED_AT, DataType.BIGINT)
             .addPartitionKey(Attribute.ID)


### PR DESCRIPTION
## Description

This PR adds a new `tx_write_set` (BLOB) column to the Coordinator table schema. The column is the first piece of an upcoming feature that records the write set of each transaction in the Coordinator table, which will enable proactive recovery of orphan PREPARED records (rather than relying solely on per-record lazy recovery) and lay the groundwork for future backup-based recovery.

The column is added unconditionally on the master branch. Existing Coordinator tables created with earlier versions are migrated automatically by `Admin.upgrade()`, which detects the missing column and adds it via `ALTER TABLE`. The runtime logic that populates the column will be added in a follow-up PR.

## Related issues and/or PRs

- branch 3 version (opt-in via configuration): #3570

## Changes made

- Added `Attribute.WRITE_SET = "tx_write_set"` constant.
- Added the `tx_write_set` (BLOB) column to `Coordinator.TABLE_METADATA`.
- Included `Attribute.WRITE_SET` in `ConsensusCommitAdmin.upgradeCoordinatorTable()`'s `potentialMissingColumnNames` so existing tables receive the column during `Admin.upgrade()`.
- Updated the unit test in `ConsensusCommitAdminTestBase` to verify that both `tx_child_ids` and `tx_write_set` are added when missing (test method renamed to `upgrade_CoordinatorTableExistsButMissingChildIdsAndWriteSetColumns_ShouldAddMissingColumns`).
- Updated the comment in `SchemaLoaderIntegrationTestBase.upgrade_WithOldCoordinatorTableSchema_ShouldProperlyUpdateTheSchema` to reflect that both columns are part of the upgrade migration.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The follow-up PR will add the proto definitions and the runtime logic that populates the new column on commit/abort.

## Release notes

Added a `tx_write_set` column to the Coordinator table and runtime population of it on commit/abort, laying the groundwork for proactive transaction recovery. The column is added automatically to existing Coordinator tables when `Admin.upgrade()` is run.