### PR TITLE
Refactor S3 and Cloud Storage integration test

### DIFF
--- a/.github/workflows/object-storage-adapter-check.yaml
+++ b/.github/workflows/object-storage-adapter-check.yaml
@@ -49,70 +49,27 @@ env:
   CLOUD_STORAGE_BUCKET_BASE_NAME: scalardb-test-bucket
 
 jobs:
+  plan-test-groups:
+    name: Plan test groups
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          MATRIX=$(jq -c '{include: .}' ci/object-storage-test-groups.json)
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+
   integration-test-s3:
-    name: S3 integration test (${{ matrix.test_group.label }})
+    name: S3 integration test (${{ matrix.label }})
+    needs: plan-test-groups
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        test_group:
-          - label: consensus_commit_default
-            tests_filter: '--tests "**.ConsensusCommitIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit
-            group_commit_enabled: false
-          - label: consensus_commit_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-gc
-            group_commit_enabled: true
-          - label: consensus_commit_admin
-            tests_filter: '--tests "**.ConsensusCommitAdminIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-admin
-            group_commit_enabled: false
-          - label: consensus_commit_admin_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitAdminIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-admin-gc
-            group_commit_enabled: true
-          - label: consensus_commit_specific
-            tests_filter: '--tests "**.ConsensusCommitSpecificIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-specific
-            group_commit_enabled: false
-          - label: consensus_commit_specific_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitSpecificIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-specific-gc
-            group_commit_enabled: true
-          - label: storage_scan_single
-            tests_filter: '--tests "**.ObjectStorageSingle**"'
-            bucket_suffix: storage-scan-single
-            group_commit_enabled: false
-          - label: storage_scan_multiple
-            tests_filter: '--tests "**.ObjectStorageMultiple**"'
-            bucket_suffix: storage-scan-multiple
-            group_commit_enabled: false
-          - label: storage_wrapper
-            tests_filter: '--tests "**.ObjectStorageWrapper**"'
-            bucket_suffix: storage-wrapper
-            group_commit_enabled: false
-          - label: storage_admin
-            tests_filter: '--tests "**.ObjectStorageAdmin**"'
-            bucket_suffix: storage-admin
-            group_commit_enabled: false
-          - label: storage_cm
-            tests_filter: '--tests "**.ObjectStorageConditionalMutation**"'
-            bucket_suffix: storage-cm
-            group_commit_enabled: false
-          - label: storage_others
-            tests_filter: '--tests "**.ObjectStorageCaseSensitivity**" --tests "**.ObjectStorageColumnValue**" --tests "**.ObjectStorageCrossPartition**" --tests "**.ObjectStorageIntegrationTest" --tests "**.ObjectStorageJapanese**" --tests "**.ObjectStorageMutationAtomicity**" --tests "**.ObjectStorageWithReservedKeyword**"'
-            bucket_suffix: storage
-            group_commit_enabled: false
-          - label: two_phase_consensus_commit
-            tests_filter: '--tests "**.TwoPhaseConsensusCommit**"'
-            bucket_suffix: 2pcc
-            group_commit_enabled: false
-          - label: single_crud_operation_transaction
-            tests_filter: '--tests "**.SingleCrudOperationTransaction**"'
-            bucket_suffix: single-crud
-            group_commit_enabled: false
+      matrix: ${{ fromJSON(needs.plan-test-groups.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -147,79 +104,31 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Execute Gradle 'integrationTestObjectStorage' task
-        run: ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.storage=s3 -Dscalardb.object_storage.endpoint=${{ env.S3_REGION }}/${{ env.S3_BUCKET_BASE_NAME }}-${{ matrix.test_group.bucket_suffix }} -Dscalardb.object_storage.username='${{ env.AWS_ACCESS_KEY_ID }}' -Dscalardb.object_storage.password='${{ env.AWS_SECRET_ACCESS_KEY }}' ${{ matrix.test_group.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }} ${{ matrix.test_group.tests_filter }}
+        run: >-
+          ./gradlew integrationTestObjectStorage
+          -Dscalardb.object_storage.storage=s3
+          -Dscalardb.object_storage.endpoint=${{ env.S3_REGION }}/${{ env.S3_BUCKET_BASE_NAME }}-${{ matrix.bucket_suffix }}
+          -Dscalardb.object_storage.username='${{ env.AWS_ACCESS_KEY_ID }}'
+          -Dscalardb.object_storage.password='${{ env.AWS_SECRET_ACCESS_KEY }}'
+          ${{ matrix.test_group != '' && format('-Dscalardb.object_storage.test_group={0}', matrix.test_group) || '' }}
+          ${{ matrix.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+          ${{ matrix.tests_filter }}
 
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: s3_integration_test_reports_${{ matrix.test_group.label }}
+          name: s3_integration_test_reports_${{ matrix.label }}
           path: core/build/reports/tests/integrationTestObjectStorage
 
   integration-test-cloud-storage:
-    name: Cloud Storage integration test (${{ matrix.test_group.label }})
+    name: Cloud Storage integration test (${{ matrix.label }})
+    needs: plan-test-groups
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        test_group:
-          - label: consensus_commit_default
-            tests_filter: '--tests "**.ConsensusCommitIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit
-            group_commit_enabled: false
-          - label: consensus_commit_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-gc
-            group_commit_enabled: true
-          - label: consensus_commit_admin
-            tests_filter: '--tests "**.ConsensusCommitAdminIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-admin
-            group_commit_enabled: false
-          - label: consensus_commit_admin_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitAdminIntegrationTestWithObjectStorage" --tests "**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-admin-gc
-            group_commit_enabled: true
-          - label: consensus_commit_specific
-            tests_filter: '--tests "**.ConsensusCommitSpecificIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-specific
-            group_commit_enabled: false
-          - label: consensus_commit_specific_with_group_commit
-            tests_filter: '--tests "**.ConsensusCommitSpecificIntegrationTestWithObjectStorage"'
-            bucket_suffix: consensus-commit-specific-gc
-            group_commit_enabled: true
-          - label: storage_scan_single
-            tests_filter: '--tests "**.ObjectStorageSingle**"'
-            bucket_suffix: storage-scan-single
-            group_commit_enabled: false
-          - label: storage_scan_multiple
-            tests_filter: '--tests "**.ObjectStorageMultiple**"'
-            bucket_suffix: storage-scan-multiple
-            group_commit_enabled: false
-          - label: storage_wrapper
-            tests_filter: '--tests "**.ObjectStorageWrapper**"'
-            bucket_suffix: storage-wrapper
-            group_commit_enabled: false
-          - label: storage_admin
-            tests_filter: '--tests "**.ObjectStorageAdmin**"'
-            bucket_suffix: storage-admin
-            group_commit_enabled: false
-          - label: storage_cm
-            tests_filter: '--tests "**.ObjectStorageConditionalMutation**"'
-            bucket_suffix: storage-cm
-            group_commit_enabled: false
-          - label: storage_others
-            tests_filter: '--tests "**.ObjectStorageCaseSensitivity**" --tests "**.ObjectStorageColumnValue**" --tests "**.ObjectStorageCrossPartition**" --tests "**.ObjectStorageIntegrationTest" --tests "**.ObjectStorageJapanese**" --tests "**.ObjectStorageMutationAtomicity**" --tests "**.ObjectStorageWithReservedKeyword**"'
-            bucket_suffix: storage
-            group_commit_enabled: false
-          - label: two_phase_consensus_commit
-            tests_filter: '--tests "**.TwoPhaseConsensusCommit**"'
-            bucket_suffix: 2pcc
-            group_commit_enabled: false
-          - label: single_crud_operation_transaction
-            tests_filter: '--tests "**.SingleCrudOperationTransaction**"'
-            bucket_suffix: single-crud
-            group_commit_enabled: false
+      matrix: ${{ fromJSON(needs.plan-test-groups.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -254,11 +163,19 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Execute Gradle 'integrationTestObjectStorage' task
-        run: ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.storage=cloud-storage -Dscalardb.object_storage.endpoint=${{ env.CLOUD_STORAGE_BUCKET_BASE_NAME }}-${{ matrix.test_group.bucket_suffix }} -Dscalardb.object_storage.username='${{ env.CLOUD_STORAGE_PROJECT_ID }}' -Dscalardb.object_storage.password='${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}' ${{ matrix.test_group.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }} ${{ matrix.test_group.tests_filter }}
+        run: >-
+          ./gradlew integrationTestObjectStorage
+          -Dscalardb.object_storage.storage=cloud-storage
+          -Dscalardb.object_storage.endpoint=${{ env.CLOUD_STORAGE_BUCKET_BASE_NAME }}-${{ matrix.bucket_suffix }}
+          -Dscalardb.object_storage.username='${{ env.CLOUD_STORAGE_PROJECT_ID }}'
+          -Dscalardb.object_storage.password='${{ env.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}'
+          ${{ matrix.test_group != '' && format('-Dscalardb.object_storage.test_group={0}', matrix.test_group) || '' }}
+          ${{ matrix.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+          ${{ matrix.tests_filter }}
 
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: cloud_storage_integration_test_reports_${{ matrix.test_group.label }}
+          name: cloud_storage_integration_test_reports_${{ matrix.label }}
           path: core/build/reports/tests/integrationTestObjectStorage

--- a/.github/workflows/object-storage-adapter-check.yaml
+++ b/.github/workflows/object-storage-adapter-check.yaml
@@ -40,13 +40,6 @@ env:
   # Oracle JDK that are linux compatible and publicly available through direct download exist for all LTS versions
   SET_UP_INT_TEST_RUNTIME_NON_ORACLE_JDK: "${{ (github.event_name == 'workflow_dispatch' && !(inputs.INT_TEST_JAVA_RUNTIME_VERSION == '8' && inputs.INT_TEST_JAVA_RUNTIME_VENDOR == 'temurin') && !(inputs.INT_TEST_JAVA_RUNTIME_VENDOR == 'oracle')) && 'true' || 'false' }}"
   INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT: '"-Dscalardb.consensus_commit.coordinator.group_commit.enabled=true" "-Dscalardb.consensus_commit.coordinator.group_commit.old_group_abort_timeout_millis=15000" --tests "**.ConsensusCommit**"'
-  AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-  S3_REGION: us-east-1
-  S3_BUCKET_BASE_NAME: s3-scalardb-test-bucket
-  CLOUD_STORAGE_PROJECT_ID: ${{ secrets.CLOUD_STORAGE_PROJECT_ID }}
-  CLOUD_STORAGE_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}
-  CLOUD_STORAGE_BUCKET_BASE_NAME: scalardb-test-bucket
 
 jobs:
   plan-test-groups:
@@ -66,6 +59,12 @@ jobs:
     name: S3 integration test (${{ matrix.label }})
     needs: plan-test-groups
     runs-on: ubuntu-latest
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+      S3_REGION: us-east-1
+      S3_BUCKET_BASE_NAME: s3-scalardb-test-bucket
 
     strategy:
       fail-fast: false
@@ -125,6 +124,11 @@ jobs:
     name: Cloud Storage integration test (${{ matrix.label }})
     needs: plan-test-groups
     runs-on: ubuntu-latest
+
+    env:
+      CLOUD_STORAGE_PROJECT_ID: ${{ secrets.CLOUD_STORAGE_PROJECT_ID }}
+      CLOUD_STORAGE_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_STORAGE_SERVICE_ACCOUNT_KEY }}
+      CLOUD_STORAGE_BUCKET_BASE_NAME: scalardb-test-bucket
 
     strategy:
       fail-fast: false

--- a/ci/object-storage-test-groups.json
+++ b/ci/object-storage-test-groups.json
@@ -1,0 +1,100 @@
+[
+  {
+    "label": "consensus_commit_default",
+    "test_group": "consensus_commit",
+    "tests_filter": "--tests \"**.ConsensusCommitIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "consensus_commit_with_group_commit",
+    "test_group": "consensus_commit",
+    "tests_filter": "--tests \"**.ConsensusCommitIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit-gc",
+    "group_commit_enabled": true
+  },
+  {
+    "label": "consensus_commit_admin",
+    "test_group": "consensus_commit_admin",
+    "tests_filter": "--tests \"**.ConsensusCommitAdminIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit-admin",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "consensus_commit_admin_with_group_commit",
+    "test_group": "consensus_commit_admin",
+    "tests_filter": "--tests \"**.ConsensusCommitAdminIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit-admin-gc",
+    "group_commit_enabled": true
+  },
+  {
+    "label": "consensus_commit_specific",
+    "test_group": "consensus_commit_specific",
+    "tests_filter": "--tests \"**.ConsensusCommitSpecificIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit-specific",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "consensus_commit_specific_with_group_commit",
+    "test_group": "consensus_commit_specific",
+    "tests_filter": "--tests \"**.ConsensusCommitSpecificIntegrationTestWithObjectStorage\"",
+    "bucket_suffix": "consensus-commit-specific-gc",
+    "group_commit_enabled": true
+  },
+  {
+    "label": "storage_scan_single",
+    "test_group": "storage_scan_single",
+    "tests_filter": "--tests \"**.ObjectStorageSingle**\"",
+    "bucket_suffix": "storage-scan-single",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "storage_scan_multiple",
+    "test_group": "storage_scan_multiple",
+    "tests_filter": "--tests \"**.ObjectStorageMultiple**\"",
+    "bucket_suffix": "storage-scan-multiple",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "storage_wrapper",
+    "test_group": "storage_wrapper",
+    "tests_filter": "--tests \"**.ObjectStorageWrapper**\"",
+    "bucket_suffix": "storage-wrapper",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "storage_admin",
+    "test_group": "storage_admin",
+    "tests_filter": "--tests \"**.ObjectStorageAdmin**\"",
+    "bucket_suffix": "storage-admin",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "storage_cm",
+    "test_group": "storage_cm",
+    "tests_filter": "--tests \"**.ObjectStorageConditionalMutation**\"",
+    "bucket_suffix": "storage-cm",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "storage_others",
+    "test_group": "",
+    "tests_filter": "",
+    "bucket_suffix": "storage",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "two_phase_consensus_commit",
+    "test_group": "two_phase_consensus_commit",
+    "tests_filter": "--tests \"**.TwoPhaseConsensusCommit**\"",
+    "bucket_suffix": "2pcc",
+    "group_commit_enabled": false
+  },
+  {
+    "label": "single_crud_operation_transaction",
+    "test_group": "single_crud_operation_transaction",
+    "tests_filter": "--tests \"**.SingleCrudOperationTransaction**\"",
+    "bucket_suffix": "single-crud",
+    "group_commit_enabled": false
+  }
+]

--- a/ci/object-storage-test-groups.json
+++ b/ci/object-storage-test-groups.json
@@ -2,42 +2,42 @@
   {
     "label": "consensus_commit_default",
     "test_group": "consensus_commit",
-    "tests_filter": "--tests \"**.ConsensusCommitIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommit*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit",
     "group_commit_enabled": false
   },
   {
     "label": "consensus_commit_with_group_commit",
     "test_group": "consensus_commit",
-    "tests_filter": "--tests \"**.ConsensusCommitIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitNullMetadataIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommit*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit-gc",
     "group_commit_enabled": true
   },
   {
     "label": "consensus_commit_admin",
     "test_group": "consensus_commit_admin",
-    "tests_filter": "--tests \"**.ConsensusCommitAdminIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommitAdmin*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit-admin",
     "group_commit_enabled": false
   },
   {
     "label": "consensus_commit_admin_with_group_commit",
     "test_group": "consensus_commit_admin",
-    "tests_filter": "--tests \"**.ConsensusCommitAdminIntegrationTestWithObjectStorage\" --tests \"**.ConsensusCommitAdminRepairIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommitAdmin*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit-admin-gc",
     "group_commit_enabled": true
   },
   {
     "label": "consensus_commit_specific",
     "test_group": "consensus_commit_specific",
-    "tests_filter": "--tests \"**.ConsensusCommitSpecificIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommitSpecific*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit-specific",
     "group_commit_enabled": false
   },
   {
     "label": "consensus_commit_specific_with_group_commit",
     "test_group": "consensus_commit_specific",
-    "tests_filter": "--tests \"**.ConsensusCommitSpecificIntegrationTestWithObjectStorage\"",
+    "tests_filter": "--tests \"**.ConsensusCommitSpecific*WithObjectStorage\"",
     "bucket_suffix": "consensus-commit-specific-gc",
     "group_commit_enabled": true
   },

--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -28,7 +28,11 @@ blob-storage:
       az storage container create \
             --name test-container \
             --connection-string "DefaultEndpointsProtocol=http;AccountName=test;AccountKey=test;BlobEndpoint=http://localhost:10000/test;"
-      ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.test_group=all -Dscalardb.object_storage.endpoint=http://localhost:10000/test/test-container -Dscalardb.object_storage.username=test -Dscalardb.object_storage.password=test
+      ./gradlew integrationTestObjectStorage \
+        -Dscalardb.object_storage.test_group=all \
+        -Dscalardb.object_storage.endpoint=http://localhost:10000/test/test-container \
+        -Dscalardb.object_storage.username=test \
+        -Dscalardb.object_storage.password=test
 
 cassandra:
   - label: cassandra_%VERSION%

--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -28,7 +28,7 @@ blob-storage:
       az storage container create \
             --name test-container \
             --connection-string "DefaultEndpointsProtocol=http;AccountName=test;AccountKey=test;BlobEndpoint=http://localhost:10000/test;"
-      ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.endpoint=http://localhost:10000/test/test-container -Dscalardb.object_storage.username=test -Dscalardb.object_storage.password=test
+      ./gradlew integrationTestObjectStorage -Dscalardb.object_storage.test_group=all -Dscalardb.object_storage.endpoint=http://localhost:10000/test/test-container -Dscalardb.object_storage.username=test -Dscalardb.object_storage.password=test
 
 cassandra:
   - label: cassandra_%VERSION%

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
@@ -5,7 +5,11 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegration
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit_admin")
 public class ConsensusCommitAdminIntegrationTestWithObjectStorage
     extends ConsensusCommitAdminIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "consensus_commit_admin")
+    matches = "consensus_commit_admin|all")
 public class ConsensusCommitAdminIntegrationTestWithObjectStorage
     extends ConsensusCommitAdminIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairIntegrationTestWithObjectStorage.java
@@ -5,7 +5,11 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminRepairIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit_admin")
 public class ConsensusCommitAdminRepairIntegrationTestWithObjectStorage
     extends ConsensusCommitAdminRepairIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairIntegrationTestWithObjectStorage.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "consensus_commit_admin")
+    matches = "consensus_commit_admin|all")
 public class ConsensusCommitAdminRepairIntegrationTestWithObjectStorage
     extends ConsensusCommitAdminRepairIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
@@ -5,7 +5,9 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitCrossPartitionSc
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
 public class ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage
     extends ConsensusCommitCrossPartitionScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit|all")
 public class ConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage
     extends ConsensusCommitCrossPartitionScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitIntegrationTestWithObjectStorage.java
@@ -9,7 +9,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
 public class ConsensusCommitIntegrationTestWithObjectStorage
     extends ConsensusCommitIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitIntegrationTestWithObjectStorage.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit|all")
 public class ConsensusCommitIntegrationTestWithObjectStorage
     extends ConsensusCommitIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitNullMetadataIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitNullMetadataIntegrationTestWithObjectStorage.java
@@ -2,7 +2,9 @@ package com.scalar.db.storage.objectstorage;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
 public class ConsensusCommitNullMetadataIntegrationTestWithObjectStorage
     extends ConsensusCommitNullMetadataIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitNullMetadataIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitNullMetadataIntegrationTestWithObjectStorage.java
@@ -4,7 +4,9 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataInte
 import java.util.Properties;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit|all")
 public class ConsensusCommitNullMetadataIntegrationTestWithObjectStorage
     extends ConsensusCommitNullMetadataIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -10,7 +10,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit_specific")
 public class ConsensusCommitSpecificIntegrationTestWithObjectStorage
     extends ConsensusCommitSpecificIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "consensus_commit_specific")
+    matches = "consensus_commit_specific|all")
 public class ConsensusCommitSpecificIntegrationTestWithObjectStorage
     extends ConsensusCommitSpecificIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
@@ -2,7 +2,9 @@ package com.scalar.db.storage.objectstorage;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
 public class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage
     extends ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
@@ -4,7 +4,9 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitWithIncludeMetad
 import java.util.Properties;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "consensus_commit")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "consensus_commit|all")
 public class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage
     extends ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminCaseSensitivityIntegrationTest.java
@@ -8,7 +8,9 @@ import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
 public class ObjectStorageAdminCaseSensitivityIntegrationTest
     extends DistributedStorageAdminCaseSensitivityIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminCaseSensitivityIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminCaseSensitivityIntegrationTest.java
@@ -10,7 +10,9 @@ import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_admin|all")
 public class ObjectStorageAdminCaseSensitivityIntegrationTest
     extends DistributedStorageAdminCaseSensitivityIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminIntegrationTest.java
@@ -7,7 +7,9 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
 public class ObjectStorageAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminIntegrationTest.java
@@ -9,7 +9,9 @@ import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_admin|all")
 public class ObjectStorageAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminRepairIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminRepairIntegrationTest.java
@@ -6,7 +6,9 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
 public class ObjectStorageAdminRepairIntegrationTest
     extends DistributedStorageAdminRepairIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminRepairIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageAdminRepairIntegrationTest.java
@@ -8,7 +8,9 @@ import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_admin")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_admin|all")
 public class ObjectStorageAdminRepairIntegrationTest
     extends DistributedStorageAdminRepairIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageConditionalMutationIntegrationTest.java
@@ -6,7 +6,9 @@ import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_cm")
 public class ObjectStorageConditionalMutationIntegrationTest
     extends DistributedStorageConditionalMutationIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageConditionalMutationIntegrationTest.java
@@ -8,7 +8,7 @@ import java.util.Properties;
 import java.util.Random;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_cm")
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_cm|all")
 public class ObjectStorageConditionalMutationIntegrationTest
     extends DistributedStorageConditionalMutationIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultipleClusteringKeyScanIntegrationTest.java
@@ -9,7 +9,11 @@ import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_scan_multiple")
 public class ObjectStorageMultipleClusteringKeyScanIntegrationTest
     extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultipleClusteringKeyScanIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "storage_scan_multiple")
+    matches = "storage_scan_multiple|all")
 public class ObjectStorageMultipleClusteringKeyScanIntegrationTest
     extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultiplePartitionKeyIntegrationTest.java
@@ -9,7 +9,11 @@ import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_scan_multiple")
 public class ObjectStorageMultiplePartitionKeyIntegrationTest
     extends DistributedStorageMultiplePartitionKeyIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageMultiplePartitionKeyIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "storage_scan_multiple")
+    matches = "storage_scan_multiple|all")
 public class ObjectStorageMultiplePartitionKeyIntegrationTest
     extends DistributedStorageMultiplePartitionKeyIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSingleClusteringKeyScanIntegrationTest.java
@@ -9,7 +9,11 @@ import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_scan_single")
 public class ObjectStorageSingleClusteringKeyScanIntegrationTest
     extends DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSingleClusteringKeyScanIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "storage_scan_single")
+    matches = "storage_scan_single|all")
 public class ObjectStorageSingleClusteringKeyScanIntegrationTest
     extends DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSinglePartitionKeyIntegrationTest.java
@@ -9,7 +9,11 @@ import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_scan_single")
 public class ObjectStorageSinglePartitionKeyIntegrationTest
     extends DistributedStorageSinglePartitionKeyIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageSinglePartitionKeyIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "storage_scan_single")
+    matches = "storage_scan_single|all")
 public class ObjectStorageSinglePartitionKeyIntegrationTest
     extends DistributedStorageSinglePartitionKeyIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperIntegrationTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_wrapper")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ObjectStorageWrapperIntegrationTest {
   private static final Logger logger =

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperIntegrationTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_wrapper")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_wrapper|all")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ObjectStorageWrapperIntegrationTest {
   private static final Logger logger =

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperLargeObjectWriteIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperLargeObjectWriteIntegrationTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_wrapper")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ObjectStorageWrapperLargeObjectWriteIntegrationTest {
   private static final Logger logger =

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperLargeObjectWriteIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ObjectStorageWrapperLargeObjectWriteIntegrationTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@EnabledIfSystemProperty(named = "scalardb.object_storage.test_group", matches = "storage_wrapper")
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "storage_wrapper|all")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ObjectStorageWrapperLargeObjectWriteIntegrationTest {
   private static final Logger logger =

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage.java
@@ -4,7 +4,11 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "single_crud_operation_transaction")
 public class SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage
     extends SingleCrudOperationTransactionAdminIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "single_crud_operation_transaction")
+    matches = "single_crud_operation_transaction|all")
 public class SingleCrudOperationTransactionAdminIntegrationTestWithObjectStorage
     extends SingleCrudOperationTransactionAdminIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionIntegrationTestWithObjectStorage.java
@@ -10,7 +10,11 @@ import com.scalar.db.io.Key;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionIntegrationTestBase;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "single_crud_operation_transaction")
 public class SingleCrudOperationTransactionIntegrationTestWithObjectStorage
     extends SingleCrudOperationTransactionIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/SingleCrudOperationTransactionIntegrationTestWithObjectStorage.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "single_crud_operation_transaction")
+    matches = "single_crud_operation_transaction|all")
 public class SingleCrudOperationTransactionIntegrationTestWithObjectStorage
     extends SingleCrudOperationTransactionIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
@@ -5,7 +5,11 @@ import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitCrossPar
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "two_phase_consensus_commit")
 public class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "two_phase_consensus_commit")
+    matches = "two_phase_consensus_commit|all")
 public class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitIntegrationTestWithObjectStorage.java
@@ -5,7 +5,11 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitIntegrationTestBase;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "two_phase_consensus_commit")
 public class TwoPhaseConsensusCommitIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitIntegrationTestWithObjectStorage.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "two_phase_consensus_commit")
+    matches = "two_phase_consensus_commit|all")
 public class TwoPhaseConsensusCommitIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -2,7 +2,11 @@ package com.scalar.db.storage.objectstorage;
 
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitSpecificIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "two_phase_consensus_commit")
 public class TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "two_phase_consensus_commit")
+    matches = "two_phase_consensus_commit|all")
 public class TwoPhaseConsensusCommitSpecificIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
@@ -2,7 +2,11 @@ package com.scalar.db.storage.objectstorage;
 
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@EnabledIfSystemProperty(
+    named = "scalardb.object_storage.test_group",
+    matches = "two_phase_consensus_commit")
 public class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @EnabledIfSystemProperty(
     named = "scalardb.object_storage.test_group",
-    matches = "two_phase_consensus_commit")
+    matches = "two_phase_consensus_commit|all")
 public class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithObjectStorage
     extends TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 


### PR DESCRIPTION
## Description

The object storage integration test workflow requires manually listing every test class in `--tests` filters. When a new test class is added without updating these filters, it silently goes unexecuted in CI. Additionally, the S3 and Cloud Storage jobs duplicate the same ~60-line matrix definition, risking definition drift between them.

This PR introduces a catch-all mechanism using `@EnabledIfSystemProperty` so that any new test class is automatically picked up by the "others" group, and consolidates the duplicated matrix into a single shared JSON file.

## Related issues and/or PRs

- #3232 

## Changes made

  - Add `@EnabledIfSystemProperty` to `test classes, leaving 7 unannotated classes as the catch-all "others" group
  - Create `ci/object-storage-test-groups.json` to define the test matrix in a single place
  - Add a plan-test-groups job to the workflow that reads the JSON file and outputs the matrix
  - Replace inline matrix definitions with the shared matrix from plan-test-groups
  - Conditionally pass `-Dscalardb.object_storage.test_group` to Gradle only when `matrix.test_group` is non-empty, so the "others" group runs all unannotated tests by default
  - Reformat the Gradle command from a single long line to multi-line using >- for readability

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A