### PR TITLE
Backport to branch(3.18) : Apply test-name suffix to coordinator namespace exactly once in Consensus Commit integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
@@ -15,7 +15,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCassandra
 
   @Override
   protected Properties getProps(String testName) {
-    return CassandraEnv.getProperties(testName);
+    return ConsensusCommitCassandraEnv.getProperties(testName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
@@ -8,6 +8,10 @@ public final class ConsensusCommitCassandraEnv {
 
   public static Properties getProperties(String testName) {
     Properties properties = CassandraEnv.getProperties(testName);
+
+    // Add testName as a coordinator schema suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
+
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(properties);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
@@ -14,7 +14,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCosmos
 
   @Override
   protected Properties getProps(String testName) {
-    return CosmosEnv.getProperties(testName);
+    return ConsensusCommitCosmosEnv.getProperties(testName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
@@ -9,6 +9,10 @@ public final class ConsensusCommitCosmosEnv {
 
   public static Properties getProperties(String testName) {
     Properties properties = CosmosEnv.getProperties(testName);
+
+    // Add testName as a coordinator schema suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
+
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(properties);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminRepairTableIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminRepairTableIntegrationTestWithDynamo.java
@@ -10,7 +10,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithDynamo
 
   @Override
   protected Properties getProps(String testName) {
-    return DynamoEnv.getProperties(testName);
+    return ConsensusCommitDynamoEnv.getProperties(testName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
@@ -9,6 +9,10 @@ public final class ConsensusCommitDynamoEnv {
 
   public static Properties getProperties(String testName) {
     Properties properties = DynamoEnv.getProperties(testName);
+
+    // Add testName as a coordinator schema suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
+
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(properties);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
@@ -21,9 +21,9 @@ public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
 
   @Override
   protected Properties getProps(String testName) {
-    Properties properties = JdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
     testUtils = new JdbcAdminImportTestUtils(properties);
-    return JdbcEnv.getProperties(testName);
+    return properties;
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
@@ -24,7 +24,7 @@ public class ConsensusCommitAdminImportTableWithMetadataDecouplingIntegrationTes
 
   @Override
   protected Properties getProps(String testName) {
-    Properties properties = JdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
 
     // Set the isolation level for consistency reads for virtual tables
     RdbEngineStrategy rdbEngine =

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -41,7 +41,7 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
 
   @Override
   protected Properties getProps(String testName) {
-    Properties properties = JdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
     rdbEngine = RdbEngineFactory.create(new JdbcConfig(new DatabaseConfig(properties)));
     return properties;
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminRepairTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminRepairTableIntegrationTestWithJdbcDatabase.java
@@ -14,7 +14,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithJdbcDatabase
 
   @Override
   protected Properties getProps(String testName) {
-    return JdbcEnv.getProperties(testName);
+    return ConsensusCommitJdbcEnv.getProperties(testName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
@@ -8,6 +8,10 @@ public final class ConsensusCommitJdbcEnv {
 
   public static Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
+
+    // Add testName as a coordinator schema suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
+
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(properties);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
@@ -36,16 +36,20 @@ public class ConsensusCommitNullMetadataIntegrationTestWithMultiStorage
     }
 
     // Define namespace mapping from namespace1 to cassandra, from namespace2 to jdbc, and from
-    // the coordinator namespace to cassandra
+    // the coordinator namespace (with the test-name suffix) to cassandra
+    String coordinatorNamespace = Coordinator.NAMESPACE + "_" + testName;
     props.setProperty(
         MultiStorageConfig.NAMESPACE_MAPPING,
-        namespace1 + ":cassandra," + namespace2 + ":jdbc," + Coordinator.NAMESPACE + ":cassandra");
+        namespace1 + ":cassandra," + namespace2 + ":jdbc," + coordinatorNamespace + ":cassandra");
 
     // The default storage is cassandra
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
     // Metadata cache expiration time
     props.setProperty(DatabaseConfig.METADATA_CACHE_EXPIRATION_TIME_SECS, "1");
+
+    // Add testName as a coordinator namespace suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(props, testName);
 
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(props);
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
@@ -36,16 +36,20 @@ public class ConsensusCommitSpecificIntegrationTestWithMultiStorage
     }
 
     // Define namespace mapping from namespace1 to cassandra, from namespace2 to jdbc, and from
-    // the coordinator namespace to cassandra
+    // the coordinator namespace (with the test-name suffix) to cassandra
+    String coordinatorNamespace = Coordinator.NAMESPACE + "_" + testName;
     props.setProperty(
         MultiStorageConfig.NAMESPACE_MAPPING,
-        namespace1 + ":cassandra," + namespace2 + ":jdbc," + Coordinator.NAMESPACE + ":cassandra");
+        namespace1 + ":cassandra," + namespace2 + ":jdbc," + coordinatorNamespace + ":cassandra");
 
     // The default storage is cassandra
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
     // Metadata cache expiration time
     props.setProperty(DatabaseConfig.METADATA_CACHE_EXPIRATION_TIME_SECS, "1");
+
+    // Add testName as a coordinator namespace suffix
+    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(props, testName);
 
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(props);
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
@@ -13,7 +13,7 @@ public class ConsensusCommitAdminIntegrationTestWithObjectStorage
 
   @Override
   protected Properties getProps(String testName) {
-    return ObjectStorageEnv.getProperties(testName);
+    return ConsensusCommitObjectStorageEnv.getProperties(testName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairTableIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminRepairTableIntegrationTestWithObjectStorage.java
@@ -10,7 +10,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithObjectStorage
 
   @Override
   protected Properties getProps(String testName) {
-    return ObjectStorageEnv.getProperties(testName);
+    return ConsensusCommitObjectStorageEnv.getProperties(testName);
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableIntegrationTestBase.java
@@ -15,10 +15,6 @@ public abstract class ConsensusCommitAdminImportTableIntegrationTestBase
   protected final Properties getProperties(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
@@ -24,10 +24,6 @@ public abstract class ConsensusCommitAdminIntegrationTestBase
   protected final Properties getProperties(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
@@ -10,10 +10,6 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
   protected final Properties getProperties(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -26,10 +26,6 @@ public abstract class ConsensusCommitCrossPartitionScanIntegrationTestBase
   protected final Properties getProperties(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -90,9 +90,6 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
 
     Properties properties = getProperties(testName);
 
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     StorageFactory factory = StorageFactory.create(properties);
     admin = factory.getStorageAdmin();
     databaseConfig = new DatabaseConfig(properties);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -29,10 +29,6 @@ public abstract class ConsensusCommitIntegrationTestBase
   protected final Properties getProperties(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -88,9 +88,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
 
     Properties properties = getProperties(testName);
 
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     StorageFactory factory = StorageFactory.create(properties);
     admin = factory.getStorageAdmin();
     databaseConfig = new DatabaseConfig(properties);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -127,9 +127,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     Properties properties = getProperties(testName);
 
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     StorageFactory factory = StorageFactory.create(properties);
     admin = factory.getStorageAdmin();
     databaseConfig = new DatabaseConfig(properties);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -59,9 +59,6 @@ public abstract class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBa
     initialize(TEST_NAME);
     Properties properties = getProperties(TEST_NAME);
 
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, TEST_NAME);
-
     // Enable to include metadata
     properties.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -26,10 +26,6 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
   protected final Properties getProperties1(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps1(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 
@@ -37,10 +33,6 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
   protected final Properties getProperties2(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps2(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
@@ -15,10 +15,6 @@ public abstract class TwoPhaseConsensusCommitIntegrationTestBase
   protected final Properties getProperties1(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps1(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 
@@ -26,10 +22,6 @@ public abstract class TwoPhaseConsensusCommitIntegrationTestBase
   protected final Properties getProperties2(String testName) {
     Properties properties = new Properties();
     properties.putAll(getProps2(testName));
-
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, testName);
-
     return properties;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -69,12 +69,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void beforeAll() throws Exception {
     initialize();
     Properties properties1 = getProperties1(TEST_NAME);
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties1, TEST_NAME);
-
     Properties properties2 = getProperties2(TEST_NAME);
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties2, TEST_NAME);
 
     namespace1 = getNamespace1();
     namespace2 = getNamespace2();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -59,9 +59,6 @@ public abstract class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrati
     initialize(TEST_NAME);
     Properties properties = getProperties(TEST_NAME);
 
-    // Add testName as a coordinator namespace suffix
-    ConsensusCommitTestUtils.addSuffixToCoordinatorNamespace(properties, TEST_NAME);
-
     // Enable to include metadata
     properties.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
 


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3571
- **Commit to backport:** ffad08a789e82e2fa04df92b1a32b0cab9d8f076

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.18-pull-3571 &&
git cherry-pick --no-rerere-autoupdate -m1 ffad08a789e82e2fa04df92b1a32b0cab9d8f076
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!