### PR TITLE
Backport to branch(3.15) : [addendum] Upgrade YugabyteDB to 2025.2 with table lock and remove schema version workarounds

### DIFF
--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -217,8 +217,12 @@ jdbc:
     run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
 
   - label: yugabytedb
-    display_name: YugabyteDB 2
-    setup: "docker run --name yugabyte -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.20.4.0-b50 bin/yugabyted start --background=false --master_flag=\"ysql_enable_db_catalog_version_mode=false\" --tserver_flags=\"ysql_enable_db_catalog_version_mode=false\""
+    display_name: YugabyteDB 2025.2
+    # enable_object_locking_for_table_locks: Uses table-level locks for DDL to avoid "Restart read
+    # required" errors when concurrent DDL operations conflict with catalog version checks.
+    # ysql_yb_ddl_transaction_block_enabled: Required companion flag — without it,
+    # enable_object_locking_for_table_locks causes YugabyteDB to crash (OOM/exit 137) on startup.
+    setup: "docker run --name yugabyte -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2025.2.2.2-b11 bash -c \"bin/yugabyted start --master_flags=\\\"allowed_preview_flags_csv={enable_object_locking_for_table_locks,ysql_yb_ddl_transaction_block_enabled},enable_object_locking_for_table_locks=true,ysql_yb_ddl_transaction_block_enabled=true\\\" --tserver_flags=\\\"allowed_preview_flags_csv={enable_object_locking_for_table_locks,ysql_yb_ddl_transaction_block_enabled},enable_object_locking_for_table_locks=true,ysql_yb_ddl_transaction_block_enabled=true\\\" && tail -f /dev/null\""
     db_healthcheck: docker exec yugabyte bash -c "PGPASSWORD=yugabyte ysqlsh -h \$(hostname -i) -U yugabyte -c 'SELECT 1;'" > /dev/null 2>&1
     create_test_user: |
       docker exec yugabyte bash -c "PGPASSWORD=yugabyte ysqlsh -h \$(hostname -i) -U yugabyte -c \"

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
@@ -6,6 +6,7 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminImportTable
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -22,10 +23,13 @@ public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProps(String testName) {
     Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
-    testUtils = new JdbcAdminImportTestUtils(properties);
+    if (testUtils == null) {
+      testUtils = new JdbcAdminImportTestUtils(properties);
+    }
     return properties;
   }
 
+  @AfterAll
   @Override
   public void afterAll() {
     try {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class ConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
     extends ConsensusCommitCrossPartitionScanIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProps(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class ConsensusCommitIntegrationTestWithJdbcDatabase
     extends ConsensusCommitIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProps(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitNullMetadataIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitNullMetadataIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class ConsensusCommitNullMetadataIntegrationTestWithJdbcDatabase
     extends ConsensusCommitNullMetadataIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabase
     extends ConsensusCommitSpecificIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase
     extends ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
@@ -5,6 +5,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -21,10 +22,13 @@ public class JdbcAdminImportTableIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
-    testUtils = new JdbcAdminImportTestUtils(properties);
-    return JdbcEnv.getProperties(testName);
+    if (testUtils == null) {
+      testUtils = new JdbcAdminImportTestUtils(properties);
+    }
+    return properties;
   }
 
+  @AfterAll
   @Override
   public void afterAll() {
     try {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminRepairTableIntegrationTest.java
@@ -1,16 +1,11 @@
 package com.scalar.db.storage.jdbc;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.scalar.db.api.DistributedStorageAdminRepairTableIntegrationTestBase;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 public class JdbcAdminRepairTableIntegrationTest
     extends DistributedStorageAdminRepairTableIntegrationTestBase {
-  @LazyInit private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
@@ -18,25 +13,7 @@ public class JdbcAdminRepairTableIntegrationTest
   }
 
   @Override
-  protected void initialize(String testName) throws Exception {
-    super.initialize(testName);
-    Properties properties = getProperties(testName);
-    adminTestUtils = new JdbcAdminTestUtils(properties);
-    rdbEngine = RdbEngineFactory.create(new JdbcConfig(new DatabaseConfig(properties)));
-  }
-
-  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(getProperties(testName));
-  }
-
-  @Override
-  protected void waitForDifferentSessionDdl() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
-      // This is needed to avoid schema or catalog version mismatch database errors.
-      Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
-      return;
-    }
-    super.waitForDifferentSessionDdl();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -3,6 +3,9 @@ package com.scalar.db.storage.jdbc;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.util.AdminTestUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
@@ -11,6 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public class JdbcAdminTestUtils extends AdminTestUtils {
@@ -18,14 +22,30 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   private final String metadataSchema;
   private final RdbEngineStrategy rdbEngine;
   private final BasicDataSource dataSource;
+  @Nullable private final String coordinatorNamespace;
 
   public JdbcAdminTestUtils(Properties properties) {
     super(properties);
-    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    DatabaseConfig databaseConfig = new DatabaseConfig(properties);
+    JdbcConfig config = new JdbcConfig(databaseConfig);
     metadataSchema =
         config.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     rdbEngine = RdbEngineFactory.create(config);
     dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
+
+    // ConsensusCommitConfig requires scalar.db.transaction_manager to be 'consensus-commit', so
+    // only resolve the coordinator namespace when applicable. For other transaction managers
+    // (e.g., 'jdbc'), leave it null since they have no coordinator table.
+    if (databaseConfig
+        .getTransactionManager()
+        .equals(ConsensusCommitConfig.TRANSACTION_MANAGER_NAME)) {
+      coordinatorNamespace =
+          new ConsensusCommitConfig(databaseConfig)
+              .getCoordinatorNamespace()
+              .orElse(Coordinator.NAMESPACE);
+    } else {
+      coordinatorNamespace = null;
+    }
   }
 
   @Override
@@ -98,6 +118,19 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   public void dropIndex(String namespace, String table, String indexName) throws SQLException {
     String sql = rdbEngine.dropIndexSql(namespace, table, indexName);
     execute(sql);
+  }
+
+  public void deleteAllRowsWithSql(String namespace, String table) throws ExecutionException {
+    String sql = "DELETE FROM " + rdbEngine.encloseFullTableName(namespace, table);
+    try {
+      execute(sql);
+    } catch (SQLException e) {
+      throw new ExecutionException("Failed to delete all rows from " + namespace + "." + table, e);
+    }
+  }
+
+  public void deleteAllRowsFromCoordinatorTableWithSql() throws ExecutionException {
+    deleteAllRowsWithSql(coordinatorNamespace, Coordinator.TABLE);
   }
 
   private void execute(String sql) throws SQLException {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
@@ -2,23 +2,47 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageColumnValueIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseColumnValueIntegrationTest
     extends DistributedStorageColumnValueIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable() throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), TABLE);
+      return;
+    }
+    super.truncateTable();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
@@ -2,23 +2,47 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageConditionalMutationIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseConditionalMutationIntegrationTest
     extends DistributedStorageConditionalMutationIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable() throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), TABLE);
+      return;
+    }
+    super.truncateTable();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageCrossPartitionScanIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.Collections;
@@ -10,19 +11,31 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class JdbcDatabaseCrossPartitionScanIntegrationTest
     extends DistributedStorageCrossPartitionScanIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
-    return JdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 
   @Override
@@ -44,8 +57,30 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
   }
 
   @Override
+  protected void truncateTable() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespaceBaseName(), CONDITION_TEST_TABLE);
+      return;
+    }
+    super.truncateTable();
+  }
+
+  @Override
+  protected void truncateTable(DataType firstColumnType, DataType secondColumnType)
+      throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(
+          getNamespaceBaseName() + firstColumnType, firstColumnType + "_" + secondColumnType);
+      return;
+    }
+    super.truncateTable(firstColumnType, secondColumnType);
+  }
+
+  @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcEnv.isYugabyte()) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -56,12 +91,13 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
     List<String> allColumnNames =
         prepareNonKeyColumns(0).stream().map(Column::getName).collect(Collectors.toList());
 
-    if ((JdbcTestUtils.isOracle(rdbEngine)
+    if (JdbcTestUtils.isOracle(rdbEngine)
         || JdbcTestUtils.isSqlServer(rdbEngine)
-        || JdbcTestUtils.isSqlite(rdbEngine))) {
-      // Oracle, SQLServer and SQLite do not support having too many conditions as CNF because it
-      // is converted internally to a query with conditions in DNF which can be too large for the
-      // storage to process.
+        || JdbcTestUtils.isSqlite(rdbEngine)
+        || JdbcEnv.isYugabyte()) {
+      // Oracle, SQLServer, SQLite and YugabyteDB do not support having too many conditions as CNF
+      // because it is converted internally to a query with conditions in DNF which can be too large
+      // for the storage to process.
       // So we split the columns into two parts randomly to split the test into two executions
       Collections.shuffle(allColumnNames, random.get());
       return Stream.of(

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
@@ -2,18 +2,42 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
-    return JdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable() throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), getTableName());
+      return;
+    }
+    super.truncateTable();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseJapaneseIntegrationTest.java
@@ -1,13 +1,39 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
+import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseJapaneseIntegrationTest
     extends DistributedStorageJapaneseIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties(String testName) {
-    return JdbcEnv.getProperties(testName);
+    Properties properties = JdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable() throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), TABLE);
+      return;
+    }
+    super.truncateTable();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
@@ -4,24 +4,38 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.scalar.db.api.DistributedStorageMultipleClusteringKeyScanIntegrationTestBase;
+import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
     extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
 
   @LazyInit private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 
   @Override
@@ -33,8 +47,36 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected void truncateTable(
+      DataType firstClusteringKeyType,
+      Order firstClusteringOrder,
+      DataType secondClusteringKeyType,
+      Order secondClusteringOrder)
+      throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(
+          getNamespaceBaseName() + firstClusteringKeyType + "_" + firstClusteringOrder,
+          firstClusteringKeyType
+              + "_"
+              + firstClusteringOrder
+              + "_"
+              + secondClusteringKeyType
+              + "_"
+              + secondClusteringOrder);
+      return;
+    }
+    super.truncateTable(
+        firstClusteringKeyType,
+        firstClusteringOrder,
+        secondClusteringKeyType,
+        secondClusteringOrder);
+  }
+
+  @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcEnv.isYugabyte()) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -44,7 +86,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
   //       fix is released.
   @SuppressWarnings("unused")
   private boolean isYugabyteDb() {
-    return JdbcTestUtils.isYugabyte(rdbEngine);
+    return JdbcEnv.isYugabyte();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
@@ -5,23 +5,36 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.scalar.db.api.DistributedStorageMultiplePartitionKeyIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
     extends DistributedStorageMultiplePartitionKeyIntegrationTestBase {
 
   @LazyInit private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 
   @Override
@@ -33,8 +46,22 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected void truncateTable(DataType firstPartitionKeyType, DataType secondPartitionKeyType)
+      throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(
+          getNamespaceBaseName() + firstPartitionKeyType,
+          firstPartitionKeyType + "_" + secondPartitionKeyType);
+      return;
+    }
+    super.truncateTable(firstPartitionKeyType, secondPartitionKeyType);
+  }
+
+  @Override
   protected boolean isParallelDdlSupported() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
+    if (JdbcEnv.isYugabyte()) {
       return false;
     }
     return super.isParallelDdlSupported();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
@@ -2,23 +2,47 @@ package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.TestUtils;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseSecondaryIndexIntegrationTest
     extends DistributedStorageSecondaryIndexIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(DataType secondaryIndexType) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), secondaryIndexType.toString());
+      return;
+    }
+    super.truncateTable(secondaryIndexType);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
@@ -3,24 +3,51 @@ package com.scalar.db.storage.jdbc;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.DistributedStorageSingleClusteringKeyScanIntegrationTestBase;
+import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
     extends DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(DataType clusteringKeyType, Order clusteringOrder)
+      throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(
+          getNamespace(), clusteringKeyType + "_" + clusteringOrder);
+      return;
+    }
+    super.truncateTable(clusteringKeyType, clusteringOrder);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
@@ -4,23 +4,47 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.DistributedStorageSinglePartitionKeyIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcDatabaseSinglePartitionKeyIntegrationTest
     extends DistributedStorageSinglePartitionKeyIntegrationTestBase {
 
   private RdbEngineStrategy rdbEngine;
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = JdbcEnv.getProperties(testName);
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(DataType partitionKeyType) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(getNamespace(), partitionKeyType.toString());
+      return;
+    }
+    super.truncateTable(partitionKeyType);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -61,4 +61,12 @@ public final class JdbcEnv {
     props.setProperty(DatabaseConfig.STORAGE, "jdbc");
     return JdbcUtils.isSqlite(new JdbcConfig(new DatabaseConfig(props)));
   }
+
+  public static boolean isDb2() {
+    return System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL).startsWith("jdbc:db2:");
+  }
+
+  public static boolean isYugabyte() {
+    return System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL).startsWith("jdbc:yugabytedb:");
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.DataType;
@@ -11,7 +10,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.slf4j.Logger;
@@ -31,7 +29,9 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     properties.putAll(JdbcEnv.getProperties(testName));
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     rdbEngine = RdbEngineFactory.create(config);
-    testUtils = new JdbcAdminImportTestUtils(properties);
+    if (testUtils == null) {
+      testUtils = new JdbcAdminImportTestUtils(properties);
+    }
     return properties;
   }
 
@@ -199,15 +199,5 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   @SuppressWarnings("unused")
   private boolean isSqlite() {
     return JdbcEnv.isSqlite();
-  }
-
-  @Override
-  protected void waitForDifferentSessionDdl() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
-      // This is needed to avoid schema or catalog version mismatch database errors.
-      Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
-      return;
-    }
-    super.waitForDifferentSessionDdl();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderIntegrationTest.java
@@ -1,15 +1,10 @@
 package com.scalar.db.storage.jdbc;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.google.errorprone.annotations.concurrent.LazyInit;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 public class JdbcSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTestBase {
-  @LazyInit private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
@@ -17,34 +12,7 @@ public class JdbcSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTest
   }
 
   @Override
-  protected void initialize(String testName) throws Exception {
-    super.initialize(testName);
-    Properties properties = getProperties(testName);
-    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    rdbEngine = RdbEngineFactory.create(config);
-  }
-
-  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(getProperties(testName));
-  }
-
-  @Override
-  protected void waitForCreationIfNecessary() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
-      Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
-      return;
-    }
-    super.waitForCreationIfNecessary();
-  }
-
-  // Reading namespace information right after table deletion could fail with YugabyteDB.
-  // It should be retried.
-  @Override
-  protected boolean couldFailToReadNamespaceAfterDeletingTable() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
-      return true;
-    }
-    return super.couldFailToReadNamespaceAfterDeletingTable();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,39 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class SingleCrudOperationTransactionIntegrationTestWithJdbcDatabase
     extends SingleCrudOperationTransactionIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProps(String testName) {
-    return JdbcEnv.getProperties(testName);
+    Properties properties = JdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,57 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
     extends TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProps1(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @Override
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable1(namespace, table);
+  }
+
+  @Override
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable2(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,57 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class TwoPhaseConsensusCommitIntegrationTestWithJdbcDatabase
     extends TwoPhaseConsensusCommitIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProps1(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @Override
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable1(namespace, table);
+  }
+
+  @Override
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable2(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,57 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitSpecificIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class TwoPhaseConsensusCommitSpecificIntegrationTestWithJdbcDatabase
     extends TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties1(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @Override
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable1(namespace, table);
+  }
+
+  @Override
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable2(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,48 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithJdbcDatabase
     extends TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase {
 
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
   @Override
   protected Properties getProperties(String testName) {
-    return ConsensusCommitJdbcEnv.getProperties(testName);
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminRepairTableIntegrationTest.java
@@ -1,22 +1,14 @@
 package com.scalar.db.transaction.jdbc;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.scalar.db.api.DistributedTransactionAdminRepairTableIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcAdminTestUtils;
-import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
-import com.scalar.db.storage.jdbc.JdbcTestUtils;
-import com.scalar.db.storage.jdbc.RdbEngineFactory;
-import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 public class JdbcTransactionAdminRepairTableIntegrationTest
     extends DistributedTransactionAdminRepairTableIntegrationTestBase {
-  @LazyInit private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
@@ -27,14 +19,6 @@ public class JdbcTransactionAdminRepairTableIntegrationTest
   }
 
   @Override
-  protected void initialize(String testName) throws Exception {
-    super.initialize(testName);
-    Properties properties = getProperties(testName);
-    adminTestUtils = new JdbcAdminTestUtils(properties);
-    rdbEngine = RdbEngineFactory.create(new JdbcConfig(new DatabaseConfig(properties)));
-  }
-
-  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(JdbcEnv.getProperties(testName));
   }
@@ -42,15 +26,5 @@ public class JdbcTransactionAdminRepairTableIntegrationTest
   @Override
   protected boolean hasCoordinatorTables() {
     return false;
-  }
-
-  @Override
-  protected void waitForDifferentSessionDdl() {
-    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
-      // This is needed to avoid schema or catalog version mismatch database errors.
-      Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
-      return;
-    }
-    super.waitForDifferentSessionDdl();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionCrossPartitionScanIntegrationTest.java
@@ -2,12 +2,17 @@ package com.scalar.db.transaction.jdbc;
 
 import com.scalar.db.api.DistributedTransactionCrossPartitionScanIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.jdbc.JdbcAdminTestUtils;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 
 public class JdbcTransactionCrossPartitionScanIntegrationTest
     extends DistributedTransactionCrossPartitionScanIntegrationTestBase {
+
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected String getTestName() {
@@ -19,6 +24,27 @@ public class JdbcTransactionCrossPartitionScanIntegrationTest
     Properties properties = new Properties();
     properties.putAll(JdbcEnv.getProperties(testName));
     properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, JdbcConfig.TRANSACTION_MANAGER_NAME);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -2,12 +2,17 @@ package com.scalar.db.transaction.jdbc;
 
 import com.scalar.db.api.DistributedTransactionIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.jdbc.JdbcAdminTestUtils;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
+
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
 
   @Override
   protected String getTestName() {
@@ -19,7 +24,28 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
     Properties properties = new Properties();
     properties.putAll(JdbcEnv.getProperties(testName));
     properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, JdbcConfig.TRANSACTION_MANAGER_NAME);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
     return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
   }
 
   @Disabled("JDBC transactions don't support getState()")

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -87,6 +87,16 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
     } catch (Exception e) {
       logger.warn("Failed to close admin", e);
     }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
+
+    testDataList.clear();
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -49,7 +49,7 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_col_val";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  protected static final String TABLE = "test_table";
   private static final String PARTITION_KEY = "pkey";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
@@ -121,6 +121,10 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
 
   @BeforeEach
   public void setUp() throws Exception {
+    truncateTable();
+  }
+
+  protected void truncateTable() throws ExecutionException {
     admin.truncateTable(namespace, TABLE);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -56,7 +56,7 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_cond_mutation";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  protected static final String TABLE = "test_table";
   private static final String PARTITION_KEY = "pkey";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
@@ -141,6 +141,10 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
   @BeforeEach
   public void setUp() throws Exception {
+    truncateTable();
+  }
+
+  protected void truncateTable() throws ExecutionException {
     admin.truncateTable(namespace, TABLE);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
@@ -69,7 +69,7 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_cross_part_scan";
   private static final String NAMESPACE_BASE_NAME = "int_test_" + TEST_NAME + "_";
-  private static final String CONDITION_TEST_TABLE = "condition_test_table";
+  protected static final String CONDITION_TEST_TABLE = "condition_test_table";
   private static final String PARTITION_KEY_NAME = "pk";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
@@ -692,11 +692,11 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
     truncateTable();
   }
 
-  private void truncateTable() throws ExecutionException {
+  protected void truncateTable() throws ExecutionException {
     admin.truncateTable(getNamespaceName(), CONDITION_TEST_TABLE);
   }
 
-  private void truncateTable(DataType firstColumnType, DataType secondColumnType)
+  protected void truncateTable(DataType firstColumnType, DataType secondColumnType)
       throws ExecutionException {
     admin.truncateTable(
         getNamespaceName(firstColumnType), getTableName(firstColumnType, secondColumnType));

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -153,7 +153,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     truncateTable();
   }
 
-  private void truncateTable() throws ExecutionException {
+  protected void truncateTable() throws ExecutionException {
     admin.truncateTable(namespace, getTableName());
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
@@ -27,7 +27,7 @@ public abstract class DistributedStorageJapaneseIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_jp";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private static final String TABLE = "test_table";
+  protected static final String TABLE = "test_table";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";
@@ -77,7 +77,7 @@ public abstract class DistributedStorageJapaneseIntegrationTestBase {
     truncateTable();
   }
 
-  private void truncateTable() throws ExecutionException {
+  protected void truncateTable() throws ExecutionException {
     admin.truncateTable(namespace, TABLE);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -248,7 +248,7 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
     executeDdls(testCallables.subList(testCallables.size() - 1, testCallables.size()));
   }
 
-  private void truncateTable(
+  protected void truncateTable(
       DataType firstClusteringKeyType,
       Order firstClusteringOrder,
       DataType secondClusteringKeyType,

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
@@ -192,7 +192,7 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
     executeDdls(testCallables.subList(testCallables.size() - 1, testCallables.size()));
   }
 
-  private void truncateTable(DataType firstPartitionKeyType, DataType secondPartitionKeyType)
+  protected void truncateTable(DataType firstPartitionKeyType, DataType secondPartitionKeyType)
       throws ExecutionException {
     admin.truncateTable(
         getNamespaceName(firstPartitionKeyType),

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -132,7 +132,7 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
     admin.dropNamespace(namespace);
   }
 
-  private void truncateTable(DataType secondaryIndexType) throws ExecutionException {
+  protected void truncateTable(DataType secondaryIndexType) throws ExecutionException {
     admin.truncateTable(namespace, getTableName(secondaryIndexType));
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -148,7 +148,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
     admin.dropNamespace(namespace);
   }
 
-  private void truncateTable(DataType clusteringKeyType, Order clusteringOrder)
+  protected void truncateTable(DataType clusteringKeyType, Order clusteringOrder)
       throws ExecutionException {
     admin.truncateTable(namespace, getTableName(clusteringKeyType, clusteringOrder));
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -132,7 +132,7 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
     admin.dropNamespace(namespace);
   }
 
-  private void truncateTable(DataType partitionKeyType) throws ExecutionException {
+  protected void truncateTable(DataType partitionKeyType) throws ExecutionException {
     admin.truncateTable(namespace, getTableName(partitionKeyType));
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
@@ -104,8 +104,16 @@ public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBas
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin.truncateTable(namespace, TABLE);
-    admin.truncateTable(namespace, TABLE_WITH_TEXT);
+    truncateTable(namespace, TABLE);
+    truncateTable(namespace, TABLE_WITH_TEXT);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    admin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin.truncateCoordinatorTables();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -145,7 +145,15 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin.truncateTable(namespace, TABLE);
+    truncateTable(namespace, TABLE);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    admin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin.truncateCoordinatorTables();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
@@ -114,9 +114,21 @@ public abstract class TwoPhaseCommitTransactionCrossPartitionScanIntegrationTest
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin1.truncateTable(namespace1, TABLE_1);
+    truncateTable1(namespace1, TABLE_1);
+    truncateCoordinatorTables();
+    truncateTable2(namespace2, TABLE_2);
+  }
+
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    admin1.truncateTable(namespace, table);
+  }
+
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    admin2.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin1.truncateCoordinatorTables();
-    admin2.truncateTable(namespace2, TABLE_2);
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -159,9 +159,21 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin1.truncateTable(namespace1, TABLE_1);
+    truncateTable1(namespace1, TABLE_1);
+    truncateCoordinatorTables();
+    truncateTable2(namespace2, TABLE_2);
+  }
+
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    admin1.truncateTable(namespace, table);
+  }
+
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    admin2.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin1.truncateCoordinatorTables();
-    admin2.truncateTable(namespace2, TABLE_2);
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -170,8 +170,16 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   }
 
   private void truncateTables() throws ExecutionException {
-    consensusCommitAdmin.truncateTable(namespace1, TABLE_1);
-    consensusCommitAdmin.truncateTable(namespace2, TABLE_2);
+    truncateTable(namespace1, TABLE_1);
+    truncateTable(namespace2, TABLE_2);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    consensusCommitAdmin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     consensusCommitAdmin.truncateCoordinatorTables();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -196,8 +196,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void truncateTables() throws ExecutionException {
-    consensusCommitAdmin.truncateTable(namespace1, TABLE_1);
-    consensusCommitAdmin.truncateTable(namespace2, TABLE_2);
+    truncateTable(namespace1, TABLE_1);
+    truncateTable(namespace2, TABLE_2);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    consensusCommitAdmin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     consensusCommitAdmin.truncateCoordinatorTables();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -90,7 +90,15 @@ public abstract class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBa
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin.truncateTable(namespace, TABLE);
+    truncateTable(namespace, TABLE);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    admin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin.truncateCoordinatorTables();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -139,9 +139,21 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void truncateTables() throws ExecutionException {
-    consensusCommitAdmin1.truncateTable(namespace1, TABLE_1);
+    truncateTable1(namespace1, TABLE_1);
+    truncateCoordinatorTables();
+    truncateTable2(namespace2, TABLE_2);
+  }
+
+  protected void truncateTable1(String namespace, String table) throws ExecutionException {
+    consensusCommitAdmin1.truncateTable(namespace, table);
+  }
+
+  protected void truncateTable2(String namespace, String table) throws ExecutionException {
+    consensusCommitAdmin2.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     consensusCommitAdmin1.truncateCoordinatorTables();
-    consensusCommitAdmin2.truncateTable(namespace2, TABLE_2);
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase.java
@@ -90,7 +90,15 @@ public abstract class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrati
 
   @BeforeEach
   public void setUp() throws Exception {
-    admin.truncateTable(namespace, TABLE);
+    truncateTable(namespace, TABLE);
+    truncateCoordinatorTables();
+  }
+
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    admin.truncateTable(namespace, table);
+  }
+
+  protected void truncateCoordinatorTables() throws ExecutionException {
     admin.truncateCoordinatorTables();
   }
 


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3585
- **Commit to backport:** 6181e4ecc6b825717bbe2483d3fd6c1c0a385d27

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.15-pull-3585 &&
git cherry-pick --no-rerere-autoupdate -m1 6181e4ecc6b825717bbe2483d3fd6c1c0a385d27
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!