### PR TITLE
Backport to branch(3.18) : Refactor JdbcAdmin#internalTableExists to use system catalog

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -189,17 +189,15 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
 
   @Override
   public boolean tableExists(String namespace, String table) throws Exception {
-    String fullTableName = rdbEngine.encloseFullTableName(namespace, table);
-    String sql = rdbEngine.internalTableExistsCheckSql(fullTableName);
     try {
-      execute(sql);
-      return true;
+      return withConnection(
+          dataSource,
+          requiresExplicitCommit,
+          (ThrowableFunction<Connection, Boolean, SQLException>)
+              connection ->
+                  JdbcAdmin.internalTableExists(
+                      connection, rdbEngine, namespace, table, requiresExplicitCommit));
     } catch (SQLException e) {
-      // An exception will be thrown if the table does not exist when executing the select
-      // query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return false;
-      }
       throw new Exception(
           String.format(
               "Checking if the %s table exists failed", getFullTableName(namespace, table)),

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
@@ -6,6 +6,7 @@ import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cassandra.ClusterManager;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcTestUtils;
 import com.scalar.db.storage.jdbc.JdbcUtils;
@@ -163,18 +164,9 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   }
 
   private boolean tableExistsOnJdbc(String namespace, String table) throws Exception {
-    String fullTableName = rdbEngine.encloseFullTableName(namespace, table);
-    String sql = rdbEngine.internalTableExistsCheckSql(fullTableName);
-    try (Connection connection = dataSource.getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute(sql);
-      return true;
+    try (Connection connection = dataSource.getConnection()) {
+      return JdbcAdmin.internalTableExists(connection, rdbEngine, namespace, table, false);
     } catch (SQLException e) {
-      // An exception will be thrown if the table does not exist when executing the select
-      // query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return false;
-      }
       throw new Exception(
           String.format(
               "Checking if the %s table exists failed", getFullTableName(namespace, table)),

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -333,7 +333,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             execute(connection, rdbEngine.dropNamespaceSql(namespace), requiresExplicitCommit);
           });
     } catch (SQLException e) {
-      rdbEngine.dropNamespaceTranslateSQLException(e, namespace);
+      throw new ExecutionException("Dropping the " + namespace + " schema failed", e);
     }
   }
 
@@ -1444,18 +1444,22 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   private boolean internalTableExists(Connection connection, String namespace, String table)
       throws SQLException {
-    String fullTableName = encloseFullTableName(namespace, table);
-    String sql = rdbEngine.internalTableExistsCheckSql(fullTableName);
-    try {
-      execute(connection, sql, requiresExplicitCommit);
-      return true;
-    } catch (SQLException e) {
-      // An exception will be thrown if the table does not exist when executing the select query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return false;
-      }
-      throw e;
-    }
+    return internalTableExists(connection, rdbEngine, namespace, table, requiresExplicitCommit);
+  }
+
+  public static boolean internalTableExists(
+      Connection connection,
+      RdbEngineStrategy rdbEngine,
+      String schema,
+      String table,
+      boolean requiresExplicitCommit)
+      throws SQLException {
+    return executeQuery(
+        connection,
+        rdbEngine.internalTableExistsCheckSql(),
+        requiresExplicitCommit,
+        ps -> rdbEngine.bindInternalTableExistsCheckParams(ps, schema, table),
+        ResultSet::next);
   }
 
   private void createSchemaIfNotExists(Connection connection, String schema) throws SQLException {
@@ -1464,7 +1468,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       execute(connection, sqls, requiresExplicitCommit);
     } catch (SQLException e) {
       // Suppress exceptions indicating the duplicate metadata schema
-      if (!rdbEngine.isCreateMetadataSchemaDuplicateSchemaError(e)) {
+      if (!rdbEngine.isDuplicateSchemaError(e)) {
         throw e;
       }
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -10,7 +10,6 @@ import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DateColumn;
 import com.scalar.db.io.TimeColumn;
@@ -232,7 +231,7 @@ class RdbEngineDb2 extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     // SQL error code -601: Name already used
     return e.getErrorCode() == -601;
   }
@@ -240,12 +239,6 @@ class RdbEngineDb2 extends AbstractRdbEngine {
   @Override
   public String dropNamespaceSql(String namespace) {
     return "DROP SCHEMA " + enclose(namespace) + " RESTRICT";
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException {
-    throw new ExecutionException("Dropping the schema failed: " + namespace, e);
   }
 
   @Override
@@ -287,8 +280,8 @@ class RdbEngineDb2 extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT 1 FROM " + fullTableName + " LIMIT 1";
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM SYSCAT.TABLES" + " WHERE TABSCHEMA = ? AND TABNAME = ? AND TYPE = 'T'";
   }
 
   @Override
@@ -380,12 +373,6 @@ class RdbEngineDb2 extends AbstractRdbEngine {
     // SPACE indexspace-name CONSTRAINS COLUMNS OF THE TABLE SO NO TWO ROWS CAN CONTAIN DUPLICATE
     // VALUES IN THOSE COLUMNS. RID OF EXISTING ROW IS X record-id
     return e.getErrorCode() == -803;
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    // SQL error code -204: name IS AN UNDEFINED NAME
-    return e.getErrorCode() == -204;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.storage.jdbc.query.InsertOnDuplicateKeyUpdateQuery;
@@ -91,19 +90,13 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     return false;
   }
 
   @Override
   public String dropNamespaceSql(String namespace) {
     return "DROP SCHEMA " + enclose(namespace);
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException {
-    throw new ExecutionException("Dropping the schema failed: " + namespace, e);
   }
 
   @Override
@@ -154,8 +147,8 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT 1 FROM " + fullTableName + " LIMIT 1";
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM INFORMATION_SCHEMA.TABLES" + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
   }
 
   @Override
@@ -209,18 +202,6 @@ class RdbEngineMysql extends AbstractRdbEngine {
     // Error number: 1022; Symbol: ER_DUP_KEY; SQLSTATE: 23000
     // Message: Can't write; duplicate key in table '%s'
     return e.getSQLState().equals("23000");
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-    // Error number: 1049; Symbol: ER_BAD_DB_ERROR; SQLSTATE: 42000
-    // Message: Unknown database '%s'
-
-    // Error number: 1146; Symbol: ER_NO_SUCH_TABLE; SQLSTATE: 42S02
-    // Message: Table '%s.%s' doesn't exist
-
-    return e.getErrorCode() == 1049 || e.getErrorCode() == 1146;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -10,7 +10,6 @@ import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.query.MergeQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
@@ -119,7 +118,7 @@ class RdbEngineOracle extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     // ORA-01920: user name 'string' conflicts with another user or role name
     return e.getErrorCode() == 1920;
   }
@@ -127,12 +126,6 @@ class RdbEngineOracle extends AbstractRdbEngine {
   @Override
   public String dropNamespaceSql(String namespace) {
     return "DROP USER " + enclose(namespace);
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException {
-    throw new ExecutionException("Dropping the user failed: " + namespace, e);
   }
 
   @Override
@@ -163,8 +156,8 @@ class RdbEngineOracle extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT 1 FROM " + fullTableName + " FETCH FIRST 1 ROWS ONLY";
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM ALL_TABLES" + " WHERE OWNER = ? AND TABLE_NAME = ?";
   }
 
   @Override
@@ -227,12 +220,6 @@ class RdbEngineOracle extends AbstractRdbEngine {
     }
     // Integrity constraint violation
     return e.getSQLState().equals("23000");
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    // ORA-00942: Table or view does not exist
-    return e.getErrorCode() == 942;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -4,7 +4,6 @@ import static com.scalar.db.storage.jdbc.JdbcUtils.shortenIndexNameIfNeeded;
 
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.query.InsertOnConflictDoUpdateQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
@@ -91,19 +90,13 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     return false;
   }
 
   @Override
   public String dropNamespaceSql(String namespace) {
     return "DROP SCHEMA " + enclose(namespace);
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException {
-    throw new ExecutionException("Dropping the schema failed: " + namespace, e);
   }
 
   @Override
@@ -137,8 +130,8 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT 1 FROM " + fullTableName + " LIMIT 1";
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM information_schema.tables" + " WHERE table_schema = ? AND table_name = ?";
   }
 
   @Override
@@ -175,15 +168,6 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
     }
     // 23505: unique_violation
     return e.getSQLState().equals("23505");
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    if (e.getSQLState() == null) {
-      return false;
-    }
-    // 42P01: undefined_table
-    return e.getSQLState().equals("42P01");
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSpanner.java
@@ -108,7 +108,7 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     // Since the "IF NOT EXISTS" syntax is used to create a schema, we always return false
     return false;
   }
@@ -116,11 +116,6 @@ class RdbEngineSpanner extends RdbEnginePostgresql {
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
     return e.getErrorCode() == Code.ALREADY_EXISTS_VALUE;
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    return e.getErrorCode() == Code.INVALID_ARGUMENT_VALUE;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.query.MergeQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
@@ -80,7 +79,7 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     // 2714: There is already an object named '%.*ls' in the database.
     return e.getErrorCode() == 2714;
   }
@@ -88,12 +87,6 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   @Override
   public String dropNamespaceSql(String namespace) {
     return "DROP SCHEMA " + enclose(namespace);
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException {
-    throw new ExecutionException("Dropping the schema failed: " + namespace, e);
   }
 
   @Override
@@ -144,8 +137,8 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT TOP 1 1 FROM " + fullTableName;
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM INFORMATION_SCHEMA.TABLES" + " WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
   }
 
   @Override
@@ -188,13 +181,6 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
     // SQL state: 23000
     // Message: Integrity constraint violation
     return e.getSQLState().equals("23000");
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    // Error code: 208
-    // Message: Invalid object name '%.*ls'.
-    return e.getErrorCode() == 208;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -16,6 +16,7 @@ import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.JDBCType;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -64,18 +65,6 @@ class RdbEngineSqlite extends AbstractRdbEngine {
 
     return ((SQLiteException) e).getResultCode() == SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY
         || ((SQLiteException) e).getResultCode() == SQLiteErrorCode.SQLITE_CONSTRAINT_UNIQUE;
-  }
-
-  @Override
-  public boolean isUndefinedTableError(SQLException e) {
-    // Error code: SQLITE_ERROR (1)
-    // Message: SQL error or missing database (no such table: XXX)
-
-    // Error code: SQLITE_SCHEMA (17)
-    // Message: The database schema changed (no such table: XXX)
-
-    return (e.getErrorCode() == 1 || e.getErrorCode() == 17)
-        && e.getMessage().contains("no such table:");
   }
 
   @Override
@@ -244,7 +233,7 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+  public boolean isDuplicateSchemaError(SQLException e) {
     // Namespace is never created
     return false;
   }
@@ -259,11 +248,6 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   public String truncateTableSql(String namespace, String table) {
     // SQLite does not support TRUNCATE TABLE statement.
     return "DELETE FROM " + encloseFullTableName(namespace, table);
-  }
-
-  @Override
-  public void dropNamespaceTranslateSQLException(SQLException e, String namespace) {
-    throw new AssertionError("DropNamespace never happen in SQLite implementation");
   }
 
   @Override
@@ -296,8 +280,14 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public String internalTableExistsCheckSql(String fullTableName) {
-    return "SELECT 1 FROM " + fullTableName + " LIMIT 1";
+  public String internalTableExistsCheckSql() {
+    return "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?";
+  }
+
+  @Override
+  public void bindInternalTableExistsCheckParams(
+      PreparedStatement preparedStatement, String schema, String table) throws SQLException {
+    preparedStatement.setString(1, schema + NAMESPACE_SEPARATOR + table);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -4,7 +4,6 @@ import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DateColumn;
 import com.scalar.db.io.TimeColumn;
@@ -40,8 +39,6 @@ public interface RdbEngineStrategy {
   boolean isDuplicateTableError(SQLException e);
 
   boolean isDuplicateKeyError(SQLException e);
-
-  boolean isUndefinedTableError(SQLException e);
 
   boolean isConflict(SQLException e);
 
@@ -89,16 +86,13 @@ public interface RdbEngineStrategy {
 
   String tryAddIfNotExistsToCreateTableSql(String createTableSql);
 
-  boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e);
+  boolean isDuplicateSchemaError(SQLException e);
 
   String dropNamespaceSql(String namespace);
 
   default String truncateTableSql(String namespace, String table) {
     return "TRUNCATE TABLE " + encloseFullTableName(namespace, table);
   }
-
-  void dropNamespaceTranslateSQLException(SQLException e, String namespace)
-      throws ExecutionException;
 
   String namespaceExistsStatement();
 
@@ -133,7 +127,36 @@ public interface RdbEngineStrategy {
 
   String[] alterColumnTypeSql(String namespace, String table, String columnName, String columnType);
 
-  String internalTableExistsCheckSql(String fullTableName);
+  /**
+   * Returns a parameterized SQL that checks whether the specified table exists by querying the
+   * database's system catalog. The returned SQL uses {@code ?} placeholders for the schema and
+   * table name; use {@link #bindInternalTableExistsCheckParams(PreparedStatement, String, String)}
+   * to bind them. Unlike a direct {@code SELECT} against the target table, the returned SQL
+   * succeeds (returning zero rows) when the table does not exist, so it avoids the noisy
+   * server-side error log that the underlying driver/database emits for an undefined-table error.
+   *
+   * @return a SQL string with {@code ?} placeholders whose result set is non-empty iff the table
+   *     exists
+   */
+  String internalTableExistsCheckSql();
+
+  /**
+   * Binds the schema and table parameters of the SQL returned by {@link
+   * #internalTableExistsCheckSql()}. The default binds {@code schema} to parameter 1 and {@code
+   * table} to parameter 2. Engines whose SQL has a different parameter shape (e.g., SQLite, which
+   * keys on a composite {@code schema$table} name) override this.
+   *
+   * @param preparedStatement the prepared statement built from {@link
+   *     #internalTableExistsCheckSql()}
+   * @param schema the schema (namespace) name
+   * @param table the table name
+   * @throws SQLException if a database access error occurs while binding parameters
+   */
+  default void bindInternalTableExistsCheckParams(
+      PreparedStatement preparedStatement, String schema, String table) throws SQLException {
+    preparedStatement.setString(1, schema);
+    preparedStatement.setString(2, table);
+  }
 
   default String createIndexSql(
       String schema, String table, String indexName, String indexedColumn) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
@@ -200,61 +200,56 @@ public class TableMetadataService {
 
   TableMetadata getTableMetadata(Connection connection, String namespace, String table)
       throws SQLException {
-    try {
-      return executeQuery(
-          connection,
-          getSelectColumnsStatement(),
-          requiresExplicitCommit,
-          ps -> ps.setString(1, getFullTableName(namespace, table)),
-          resultSet -> {
-            TableMetadata.Builder builder = TableMetadata.newBuilder();
-            boolean tableExists = false;
-
-            while (resultSet.next()) {
-              tableExists = true;
-
-              String columnName = resultSet.getString(COL_COLUMN_NAME);
-              DataType dataType = DataType.valueOf(resultSet.getString(COL_DATA_TYPE));
-              builder.addColumn(columnName, dataType);
-
-              boolean indexed = resultSet.getBoolean(COL_INDEXED);
-              if (indexed) {
-                builder.addSecondaryIndex(columnName);
-              }
-
-              String keyType = resultSet.getString(COL_KEY_TYPE);
-              if (keyType == null) {
-                continue;
-              }
-
-              switch (KeyType.valueOf(keyType)) {
-                case PARTITION:
-                  builder.addPartitionKey(columnName);
-                  break;
-                case CLUSTERING:
-                  Scan.Ordering.Order clusteringOrder =
-                      Scan.Ordering.Order.valueOf(resultSet.getString(COL_CLUSTERING_ORDER));
-                  builder.addClusteringKey(columnName, clusteringOrder);
-                  break;
-                default:
-                  throw new AssertionError("Invalid key type: " + keyType);
-              }
-            }
-
-            if (!tableExists) {
-              return null;
-            }
-
-            return builder.build();
-          });
-    } catch (SQLException e) {
-      // An exception will be thrown if the namespace table does not exist when executing the select
-      // query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return null;
-      }
-      throw e;
+    if (!internalTableExists(connection, metadataSchema, TABLE_NAME)) {
+      return null;
     }
+
+    return executeQuery(
+        connection,
+        getSelectColumnsStatement(),
+        requiresExplicitCommit,
+        ps -> ps.setString(1, getFullTableName(namespace, table)),
+        resultSet -> {
+          TableMetadata.Builder builder = TableMetadata.newBuilder();
+          boolean tableExists = false;
+
+          while (resultSet.next()) {
+            tableExists = true;
+
+            String columnName = resultSet.getString(COL_COLUMN_NAME);
+            DataType dataType = DataType.valueOf(resultSet.getString(COL_DATA_TYPE));
+            builder.addColumn(columnName, dataType);
+
+            boolean indexed = resultSet.getBoolean(COL_INDEXED);
+            if (indexed) {
+              builder.addSecondaryIndex(columnName);
+            }
+
+            String keyType = resultSet.getString(COL_KEY_TYPE);
+            if (keyType == null) {
+              continue;
+            }
+
+            switch (KeyType.valueOf(keyType)) {
+              case PARTITION:
+                builder.addPartitionKey(columnName);
+                break;
+              case CLUSTERING:
+                Scan.Ordering.Order clusteringOrder =
+                    Scan.Ordering.Order.valueOf(resultSet.getString(COL_CLUSTERING_ORDER));
+                builder.addClusteringKey(columnName, clusteringOrder);
+                break;
+              default:
+                throw new AssertionError("Invalid key type: " + keyType);
+            }
+          }
+
+          if (!tableExists) {
+            return null;
+          }
+
+          return builder.build();
+        });
   }
 
   private String getSelectColumnsStatement() {
@@ -300,6 +295,10 @@ public class TableMetadataService {
   }
 
   Set<String> getNamespaceTableNames(Connection connection, String namespace) throws SQLException {
+    if (!internalTableExists(connection, metadataSchema, TABLE_NAME)) {
+      return Collections.emptySet();
+    }
+
     String selectTablesOfNamespaceStatement =
         "SELECT DISTINCT "
             + enclose(COL_FULL_TABLE_NAME)
@@ -309,61 +308,47 @@ public class TableMetadataService {
             + enclose(COL_FULL_TABLE_NAME)
             + " LIKE ?";
     String prefix = namespace + ".";
-    try {
-      return executeQuery(
-          connection,
-          selectTablesOfNamespaceStatement,
-          requiresExplicitCommit,
-          ps -> ps.setString(1, prefix + "%"),
-          results -> {
-            Set<String> tableNames = new HashSet<>();
-            while (results.next()) {
-              String tableName = results.getString(COL_FULL_TABLE_NAME).substring(prefix.length());
-              tableNames.add(tableName);
-            }
-            return tableNames;
-          });
-    } catch (SQLException e) {
-      // An exception will be thrown if the metadata table does not exist when executing the select
-      // query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return Collections.emptySet();
-      }
-      throw e;
-    }
+    return executeQuery(
+        connection,
+        selectTablesOfNamespaceStatement,
+        requiresExplicitCommit,
+        ps -> ps.setString(1, prefix + "%"),
+        results -> {
+          Set<String> tableNames = new HashSet<>();
+          while (results.next()) {
+            String tableName = results.getString(COL_FULL_TABLE_NAME).substring(prefix.length());
+            tableNames.add(tableName);
+          }
+          return tableNames;
+        });
   }
 
   Set<String> getNamespaceNames(Connection connection) throws SQLException {
+    if (!internalTableExists(connection, metadataSchema, TABLE_NAME)) {
+      return Collections.singleton(metadataSchema);
+    }
+
     String selectAllTableNames =
         "SELECT DISTINCT "
             + enclose(COL_FULL_TABLE_NAME)
             + " FROM "
             + encloseFullTableName(metadataSchema, TABLE_NAME);
-    try {
-      Set<String> namespaceOfExistingTables =
-          executeQuery(
-              connection,
-              selectAllTableNames,
-              requiresExplicitCommit,
-              rs -> {
-                Set<String> namespaces = new HashSet<>();
-                while (rs.next()) {
-                  String fullTableName = rs.getString(COL_FULL_TABLE_NAME);
-                  String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
-                  namespaces.add(namespaceName);
-                }
-                return namespaces;
-              });
-      namespaceOfExistingTables.add(metadataSchema);
-      return namespaceOfExistingTables;
-    } catch (SQLException e) {
-      // An exception will be thrown if the namespace table does not exist when executing the select
-      // query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return Collections.singleton(metadataSchema);
-      }
-      throw e;
-    }
+    Set<String> namespaceOfExistingTables =
+        executeQuery(
+            connection,
+            selectAllTableNames,
+            requiresExplicitCommit,
+            rs -> {
+              Set<String> namespaces = new HashSet<>();
+              while (rs.next()) {
+                String fullTableName = rs.getString(COL_FULL_TABLE_NAME);
+                String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
+                namespaces.add(namespaceName);
+              }
+              return namespaces;
+            });
+    namespaceOfExistingTables.add(metadataSchema);
+    return namespaceOfExistingTables;
   }
 
   private String computeBooleanValue(boolean value) {
@@ -392,6 +377,12 @@ public class TableMetadataService {
         throw e;
       }
     }
+  }
+
+  private boolean internalTableExists(Connection connection, String namespace, String table)
+      throws SQLException {
+    return JdbcAdmin.internalTableExists(
+        connection, rdbEngine, namespace, table, requiresExplicitCommit);
   }
 
   private void deleteTable(Connection connection, String fullTableName) throws SQLException {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/VirtualTableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/VirtualTableMetadataService.java
@@ -315,18 +315,8 @@ public class VirtualTableMetadataService {
 
   private boolean internalTableExists(Connection connection, String namespace, String table)
       throws SQLException {
-    String fullTableName = encloseFullTableName(namespace, table);
-    String sql = rdbEngine.internalTableExistsCheckSql(fullTableName);
-    try {
-      execute(connection, sql, requiresExplicitCommit);
-      return true;
-    } catch (SQLException e) {
-      // An exception will be thrown if the table does not exist when executing the select query
-      if (rdbEngine.isUndefinedTableError(e)) {
-        return false;
-      }
-      throw e;
-    }
+    return JdbcAdmin.internalTableExists(
+        connection, rdbEngine, namespace, table, requiresExplicitCommit);
   }
 
   private void deleteTable(Connection connection, String fullTableName) throws SQLException {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +32,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.rpc.Code;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
@@ -138,37 +138,6 @@ public class JdbcAdminTest {
     }
   }
 
-  private void mockUndefinedTableError(RdbEngine rdbEngine, SQLException sqlException) {
-    switch (rdbEngine) {
-      case MYSQL:
-      case MARIADB:
-        when(sqlException.getErrorCode()).thenReturn(1049);
-        break;
-      case POSTGRESQL:
-      case YUGABYTE:
-        when(sqlException.getSQLState()).thenReturn("42P01");
-        break;
-      case SPANNER:
-        when(sqlException.getErrorCode()).thenReturn(Code.INVALID_ARGUMENT_VALUE);
-        break;
-      case ORACLE:
-        when(sqlException.getErrorCode()).thenReturn(942);
-        break;
-      case SQL_SERVER:
-        when(sqlException.getErrorCode()).thenReturn(208);
-        break;
-      case SQLITE:
-        when(sqlException.getErrorCode()).thenReturn(1);
-        when(sqlException.getMessage()).thenReturn("no such table: ");
-        break;
-      case DB2:
-        when(sqlException.getErrorCode()).thenReturn(-204);
-        break;
-      default:
-        throw new AssertionError("Unsupported rdbEngine " + rdbEngine);
-    }
-  }
-
   private ResultSet mockResultSet(SelectAllFromMetadataTableResultSetMocker.Row... rows)
       throws SQLException {
     ResultSet resultSet = mock(ResultSet.class);
@@ -268,6 +237,11 @@ public class JdbcAdminTest {
     String namespace = "ns";
     String table = "table";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -294,7 +268,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 "c11", DataType.TIMESTAMPTZ.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -344,13 +318,13 @@ public class JdbcAdminTest {
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
     Connection connection = mock(Connection.class);
-    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
 
     when(dataSource.getConnection()).thenReturn(connection);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
-    SQLException sqlException = mock(SQLException.class);
-    mockUndefinedTableError(rdbEngine, sqlException);
-    when(selectStatement.executeQuery()).thenThrow(sqlException);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     // Act
     TableMetadata actual = admin.getTableMetadata("my_ns", "my_tbl");
@@ -1488,7 +1462,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.MYSQL,
-        "SELECT 1 FROM `my_ns`.`foo_table` LIMIT 1",
+        prepareSqlForTableCheck(RdbEngine.MYSQL),
         "CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`",
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
@@ -1514,7 +1488,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.ORACLE,
-        "SELECT 1 FROM \"my_ns\".\"foo_table\" FETCH FIRST 1 ROWS ONLY",
+        prepareSqlForTableCheck(RdbEngine.ORACLE),
         "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
         "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS",
         "CREATE TABLE \""
@@ -1541,7 +1515,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.POSTGRESQL,
-        "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1",
+        prepareSqlForTableCheck(RdbEngine.POSTGRESQL),
         "CREATE SCHEMA IF NOT EXISTS \"" + METADATA_SCHEMA + "\"",
         "CREATE TABLE IF NOT EXISTS \""
             + METADATA_SCHEMA
@@ -1567,7 +1541,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.SQL_SERVER,
-        "SELECT TOP 1 1 FROM [my_ns].[foo_table]",
+        prepareSqlForTableCheck(RdbEngine.SQL_SERVER),
         "CREATE SCHEMA [" + METADATA_SCHEMA + "]",
         "CREATE TABLE ["
             + METADATA_SCHEMA
@@ -1593,7 +1567,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.SQLITE,
-        "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1",
+        prepareSqlForTableCheck(RdbEngine.SQLITE),
         "CREATE TABLE IF NOT EXISTS \""
             + METADATA_SCHEMA
             + "$metadata\"("
@@ -1618,7 +1592,7 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.DB2,
-        "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1",
+        prepareSqlForTableCheck(RdbEngine.DB2),
         "CREATE SCHEMA \"" + METADATA_SCHEMA + "\"",
         "CREATE TABLE IF NOT EXISTS \""
             + METADATA_SCHEMA
@@ -1640,13 +1614,20 @@ public class JdbcAdminTest {
   }
 
   private void repairTable_ForX_shouldCreateMetadataTableAndAddMetadataForTable(
-      RdbEngine rdbEngine, String... expectedSqlStatements)
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement, String... expectedSqlStatements)
       throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
     TableMetadata metadata =
         TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+
+    // Mock the table existence check to indicate that the table exists.
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
     List<Statement> mockedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
@@ -1665,6 +1646,7 @@ public class JdbcAdminTest {
     admin.repairTable(namespace, table, metadata, new HashMap<>());
 
     // Assert
+    verify(connection).prepareStatement(expectedCheckTableExistStatement);
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(mockedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
@@ -1674,7 +1656,7 @@ public class JdbcAdminTest {
   public void repairTable_WithNonExistingTableToRepairForMysql_shouldThrowIllegalArgumentException()
       throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.MYSQL, "SELECT 1 FROM `my_ns`.`foo_table` LIMIT 1");
+        RdbEngine.MYSQL, prepareSqlForTableCheck(RdbEngine.MYSQL));
   }
 
   @Test
@@ -1682,7 +1664,7 @@ public class JdbcAdminTest {
       repairTable_WithNonExistingTableToRepairForOracle_shouldThrowIllegalArgumentException()
           throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.ORACLE, "SELECT 1 FROM \"my_ns\".\"foo_table\" FETCH FIRST 1 ROWS ONLY");
+        RdbEngine.ORACLE, prepareSqlForTableCheck(RdbEngine.ORACLE));
   }
 
   @Test
@@ -1690,7 +1672,7 @@ public class JdbcAdminTest {
       repairTable_WithNonExistingTableToRepairForPostgresql_shouldThrowIllegalArgumentException()
           throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.POSTGRESQL, "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1");
+        RdbEngine.POSTGRESQL, prepareSqlForTableCheck(RdbEngine.POSTGRESQL));
   }
 
   @Test
@@ -1698,7 +1680,7 @@ public class JdbcAdminTest {
       repairTable_WithNonExistingTableToRepairForSqlServer_shouldThrowIllegalArgumentException()
           throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.SQL_SERVER, "SELECT TOP 1 1 FROM [my_ns].[foo_table]");
+        RdbEngine.SQL_SERVER, prepareSqlForTableCheck(RdbEngine.SQL_SERVER));
   }
 
   @Test
@@ -1706,14 +1688,14 @@ public class JdbcAdminTest {
       repairTable_WithNonExistingTableToRepairForSqlite_shouldThrowIllegalArgumentException()
           throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.SQLITE, "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1");
+        RdbEngine.SQLITE, prepareSqlForTableCheck(RdbEngine.SQLITE));
   }
 
   @Test
   public void repairTable_WithNonExistingTableToRepairForDb2_shouldThrowIllegalArgumentException()
       throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.DB2, "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1");
+        RdbEngine.DB2, prepareSqlForTableCheck(RdbEngine.DB2));
   }
 
   private void repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
@@ -1724,21 +1706,21 @@ public class JdbcAdminTest {
     TableMetadata metadata =
         TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
 
-    Statement checkTableExistStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
-    SQLException sqlException = mock(SQLException.class);
-    mockUndefinedTableError(rdbEngine, sqlException);
-    when(checkTableExistStatement.execute(any())).thenThrow(sqlException);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     // Act
     assertThatThrownBy(() -> admin.repairTable(namespace, table, metadata, new HashMap<>()))
         .isInstanceOf(IllegalArgumentException.class);
 
     // Assert
-    verify(checkTableExistStatement).execute(expectedCheckTableExistStatement);
+    verify(connection).prepareStatement(expectedCheckTableExistStatement);
   }
 
   @Test
@@ -2024,6 +2006,11 @@ public class JdbcAdminTest {
     String namespace = "my_ns";
     String table = "foo_table";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(false);
 
@@ -2053,7 +2040,8 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 "c1", DataType.TEXT.toString(), "PARTITION", null, false));
     when(metadataSelectStatement.executeQuery()).thenReturn(metadataResultSet);
-    when(connection.prepareStatement(any())).thenReturn(metadataSelectStatement);
+    when(connection.prepareStatement(any()))
+        .thenReturn(checkPreparedStatement, metadataSelectStatement);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
@@ -2168,6 +2156,11 @@ public class JdbcAdminTest {
     String namespace = "my_ns";
     String table = "foo_table";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true, false);
 
@@ -2197,7 +2190,8 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 "c1", DataType.TEXT.toString(), "PARTITION", null, false));
     when(metadataSelectStatement.executeQuery()).thenReturn(metadataResultSet);
-    when(connection.prepareStatement(any())).thenReturn(metadataSelectStatement);
+    when(connection.prepareStatement(any()))
+        .thenReturn(checkPreparedStatement, metadataSelectStatement);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
@@ -2400,8 +2394,8 @@ public class JdbcAdminTest {
   }
 
   @Test
-  public void dropNamespace_WithNonScalarDBTableLeftForSqlite_ShouldThrowIllegalArgumentException()
-      throws Exception {
+  public void
+      dropNamespace_WithNonScalarDBTableLeftForSqlite_ShouldThrowIllegalArgumentException() {
     // Do nothing. SQLite does not have a concept of namespaces.
   }
 
@@ -2507,6 +2501,12 @@ public class JdbcAdminTest {
     String namespace = "ns1";
     String table1 = "t1";
     String table2 = "t2";
+
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     ResultSet resultSet = mock(ResultSet.class);
 
     // Everytime the ResultSet.next() method will be called, the ResultSet.getXXX methods call be
@@ -2521,7 +2521,7 @@ public class JdbcAdminTest {
         .next();
     PreparedStatement preparedStatement = mock(PreparedStatement.class);
     when(preparedStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, preparedStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -2538,6 +2538,32 @@ public class JdbcAdminTest {
     verify(connection).prepareStatement(expectedSelectStatement);
     assertThat(actualTableNames).containsExactly(table1, table2);
     verify(preparedStatement).setString(1, namespace + ".%");
+  }
+
+  @ParameterizedTest
+  @EnumSource(RdbEngine.class)
+  public void getNamespaceTableNames_WhenMetadataTableDoesNotExist_ShouldReturnEmptySet(
+      RdbEngine rdbEngine) throws Exception {
+    // Arrange
+    String namespace = "ns1";
+
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false); // metadata table does not exist
+
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    // Act
+    Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
+
+    // Assert
+    assertThat(actualTableNames).isEmpty();
+    verify(selectStatement, never()).executeQuery();
   }
 
   @Test
@@ -2771,6 +2797,31 @@ public class JdbcAdminTest {
     assertThat(adminForDb2.namespaceExists(METADATA_SCHEMA)).isTrue();
   }
 
+  @ParameterizedTest
+  @EnumSource(RdbEngine.class)
+  public void namespaceExists_WithNonExistingNamespace_ShouldReturnFalse(RdbEngine rdbEngine)
+      throws Exception {
+    // Arrange
+    String namespace = "my_ns";
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    Connection connection = mock(Connection.class);
+    PreparedStatement selectStatement = mock(PreparedStatement.class);
+    ResultSet results = mock(ResultSet.class);
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(selectStatement.executeQuery()).thenReturn(results);
+    when(results.next()).thenReturn(false); // the namespace does not exist
+
+    // Act
+    boolean exists = admin.namespaceExists(namespace);
+
+    // Assert
+    assertThat(exists).isFalse();
+    verify(selectStatement).executeQuery();
+  }
+
   @Test
   public void createIndex_ForColumnTypeWithoutRequiredAlterationForMysql_ShouldCreateIndexProperly()
       throws Exception {
@@ -2871,6 +2922,11 @@ public class JdbcAdminTest {
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -2879,7 +2935,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.BOOLEAN.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     Statement statement = mock(Statement.class);
 
     when(dataSource.getConnection()).thenReturn(connection);
@@ -2988,6 +3044,11 @@ public class JdbcAdminTest {
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -2996,7 +3057,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.TEXT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -3358,6 +3419,12 @@ public class JdbcAdminTest {
     String table = "my_tbl";
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -3366,7 +3433,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.BOOLEAN.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -3467,6 +3534,12 @@ public class JdbcAdminTest {
     String table = "my_tbl";
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -3475,7 +3548,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.TEXT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -3509,6 +3582,11 @@ public class JdbcAdminTest {
     String longColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -3517,7 +3595,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 longColumn, DataType.BOOLEAN.toString(), null, null, true));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
     when(dataSource.getConnection()).thenReturn(connection);
@@ -3909,6 +3987,11 @@ public class JdbcAdminTest {
     String currentColumn = "c1";
     String newColumn = "c2";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -3916,11 +3999,10 @@ public class JdbcAdminTest {
                 currentColumn, DataType.TEXT.toString(), "PARTITION", null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
 
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
-      Statement expectedStatement = mock(Statement.class);
-      expectedStatements.add(expectedStatement);
+      expectedStatements.add(mock(Statement.class));
     }
     when(connection.createStatement())
         .thenReturn(
@@ -4047,6 +4129,11 @@ public class JdbcAdminTest {
     String column1 = "c1";
     String column2 = "c2";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -4056,11 +4143,10 @@ public class JdbcAdminTest {
                 column2, DataType.INT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
 
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
-      Statement expectedStatement = mock(Statement.class);
-      expectedStatements.add(expectedStatement);
+      expectedStatements.add(mock(Statement.class));
     }
     when(connection.createStatement())
         .thenReturn(
@@ -4201,6 +4287,11 @@ public class JdbcAdminTest {
     String columnName2 = "c2";
     String columnName3 = "c3";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -4210,11 +4301,10 @@ public class JdbcAdminTest {
                 columnName2, DataType.INT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
 
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
-      Statement expectedStatement = mock(Statement.class);
-      expectedStatements.add(expectedStatement);
+      expectedStatements.add(mock(Statement.class));
     }
     when(connection.createStatement())
         .thenReturn(
@@ -4245,6 +4335,11 @@ public class JdbcAdminTest {
     String newColumn = "new_col";
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     // Mock table metadata with a secondary index on the long column
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
@@ -4254,7 +4349,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 oldColumn, DataType.BOOLEAN.toString(), null, null, true));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
     when(dataSource.getConnection()).thenReturn(connection);
@@ -4378,6 +4473,11 @@ public class JdbcAdminTest {
     String columnName1 = "c1";
     String columnName2 = "c2";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -4386,7 +4486,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 columnName2, DataType.INT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     when(dataSource.getConnection()).thenReturn(connection);
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.SQLITE);
 
@@ -4425,6 +4525,11 @@ public class JdbcAdminTest {
     String columnName1 = "c1";
     String columnName2 = "c2";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -4434,11 +4539,10 @@ public class JdbcAdminTest {
                 columnName2, DataType.INT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
 
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
-      Statement expectedStatement = mock(Statement.class);
-      expectedStatements.add(expectedStatement);
+      expectedStatements.add(mock(Statement.class));
     }
     when(connection.createStatement())
         .thenReturn(
@@ -4578,6 +4682,11 @@ public class JdbcAdminTest {
     String columnName1 = "c1";
     String columnName2 = "c2";
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet1 =
         mockResultSet(
@@ -4586,7 +4695,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 columnName2, DataType.INT.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet1);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (String expectedSqlStatement : expectedSqlStatements) {
       Statement mock = mock(Statement.class);
@@ -4630,6 +4739,11 @@ public class JdbcAdminTest {
     String longColumn = "a_very_long_column_name_that_exceeds_the_maximum_index_name_length";
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.POSTGRESQL);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     // Mock table metadata with a secondary index on the long column
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
@@ -4639,7 +4753,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 longColumn, DataType.BOOLEAN.toString(), null, null, true));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
 
     Statement statement = mock(Statement.class);
     when(dataSource.getConnection()).thenReturn(connection);
@@ -4738,8 +4852,15 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     // Arrange
     Statement getTableMetadataNamespacesStatementMock = mock(Statement.class);
-
     when(connection.createStatement()).thenReturn(getTableMetadataNamespacesStatementMock);
+
+    // The metadata table existence check (internalTableExists) runs before the namespace query.
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+
     when(dataSource.getConnection()).thenReturn(connection);
 
     ResultSet resultSet =
@@ -4818,23 +4939,27 @@ public class JdbcAdminTest {
       throws SQLException, ExecutionException {
     // Arrange
     Statement getTableMetadataNamespacesStatementMock = mock(Statement.class);
-
     when(connection.createStatement()).thenReturn(getTableMetadataNamespacesStatementMock);
+
+    // The metadata table existence check (internalTableExists) returns false, so the metadata
+    // table is treated as non-existent.
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+
     when(dataSource.getConnection()).thenReturn(connection);
 
-    SQLException sqlException = mock(SQLException.class);
-    mockUndefinedTableError(rdbEngine, sqlException);
-    when(getTableMetadataNamespacesStatementMock.executeQuery(anyString())).thenThrow(sqlException);
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
     // Act
     Set<String> actual = admin.getNamespaceNames();
 
     // Assert
-    verify(connection).createStatement();
-    verify(getTableMetadataNamespacesStatementMock)
-        .executeQuery(getTableMetadataNamespacesStatement);
     assertThat(actual).containsOnly(METADATA_SCHEMA);
+    verify(getTableMetadataNamespacesStatementMock, never())
+        .executeQuery(getTableMetadataNamespacesStatement);
   }
 
   @ParameterizedTest
@@ -4846,16 +4971,19 @@ public class JdbcAdminTest {
       })
   public void getImportTableMetadata_ForXBesidesSqlite_ShouldWorkProperly(RdbEngine rdbEngine)
       throws SQLException, ExecutionException {
-    String expectedCheckTableExistStatement = prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE);
+    String expectedCheckTableExistStatement = prepareSqlForTableCheck(rdbEngine);
 
     // Arrange
-    Statement checkTableExistStatement = mock(Statement.class);
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     ResultSet primaryKeyResults = mock(ResultSet.class);
     ResultSet columnResults = mock(ResultSet.class);
     when(dataSource.getConnection()).thenReturn(connection);
-    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
     when(connection.getMetaData()).thenReturn(metadata);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
     when(primaryKeyResults.next()).thenReturn(true).thenReturn(true).thenReturn(false);
     when(primaryKeyResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn("pk1").thenReturn("pk2");
     when(columnResults.next())
@@ -4911,8 +5039,7 @@ public class JdbcAdminTest {
     TableMetadata actual = admin.getImportTableMetadata(NAMESPACE, TABLE, overrideColumnsType);
 
     // Assert
-    verify(checkTableExistStatement, description(description))
-        .execute(expectedCheckTableExistStatement);
+    verify(connection, description(description)).prepareStatement(expectedCheckTableExistStatement);
     assertThat(actual.getPartitionKeyNames()).hasSameElementsAs(ImmutableSet.of("pk1", "pk2"));
     assertThat(actual.getColumnDataTypes()).containsExactlyEntriesOf(expectedColumns);
     verify(connection).setReadOnly(true);
@@ -4948,7 +5075,7 @@ public class JdbcAdminTest {
     for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
       if (!rdbEngine.equals(RdbEngine.SQLITE)) {
         getImportTableMetadata_PrimaryKeyNotExistsForX_ShouldThrowIllegalStateException(
-            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+            rdbEngine, prepareSqlForTableCheck(rdbEngine));
       }
     }
   }
@@ -4959,7 +5086,7 @@ public class JdbcAdminTest {
     for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
       if (!rdbEngine.equals(RdbEngine.SQLITE)) {
         getImportTableMetadata_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
-            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+            rdbEngine, prepareSqlForTableCheck(rdbEngine));
       }
     }
   }
@@ -4967,34 +5094,37 @@ public class JdbcAdminTest {
   private void getImportTableMetadata_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
       RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
     // Arrange
-    Statement checkTableExistStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    reset(connection);
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
-    SQLException sqlException = mock(SQLException.class);
-    mockUndefinedTableError(rdbEngine, sqlException);
-    when(checkTableExistStatement.execute(any())).thenThrow(sqlException);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(() -> admin.getImportTableMetadata(NAMESPACE, TABLE, Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
-    verify(
-            checkTableExistStatement,
-            description("database engine specific test failed: " + rdbEngine))
-        .execute(expectedCheckTableExistStatement);
+    verify(connection, description("database engine specific test failed: " + rdbEngine))
+        .prepareStatement(expectedCheckTableExistStatement);
   }
 
   private void getImportTableMetadata_PrimaryKeyNotExistsForX_ShouldThrowIllegalStateException(
       RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
     // Arrange
-    Statement checkTableExistStatement = mock(Statement.class);
+    reset(connection);
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     ResultSet primaryKeyResults = mock(ResultSet.class);
     when(dataSource.getConnection()).thenReturn(connection);
-    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
     when(connection.getMetaData()).thenReturn(metadata);
     when(primaryKeyResults.next()).thenReturn(false);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
     RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
     if (rdbEngineStrategy instanceof RdbEngineMysql) {
       when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
@@ -5011,8 +5141,7 @@ public class JdbcAdminTest {
             () -> admin.getImportTableMetadata(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
-    verify(checkTableExistStatement, description(description))
-        .execute(expectedCheckTableExistStatement);
+    verify(connection, description(description)).prepareStatement(expectedCheckTableExistStatement);
     assertThat(thrown).as(description).isInstanceOf(IllegalStateException.class);
   }
 
@@ -5022,7 +5151,7 @@ public class JdbcAdminTest {
     for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
       if (!rdbEngine.equals(RdbEngine.SQLITE)) {
         getImportTableMetadata_UnsupportedDataTypeGivenForX_ShouldThrowExecutionException(
-            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+            rdbEngine, prepareSqlForTableCheck(rdbEngine));
       }
     }
   }
@@ -5030,13 +5159,17 @@ public class JdbcAdminTest {
   private void getImportTableMetadata_UnsupportedDataTypeGivenForX_ShouldThrowExecutionException(
       RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
     // Arrange
-    Statement checkTableExistStatement = mock(Statement.class);
+    reset(connection);
+    PreparedStatement checkTableExistStatement = mock(PreparedStatement.class);
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     ResultSet primaryKeyResults = mock(ResultSet.class);
     ResultSet columnResults = mock(ResultSet.class);
     when(dataSource.getConnection()).thenReturn(connection);
-    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.prepareStatement(anyString())).thenReturn(checkTableExistStatement);
     when(connection.getMetaData()).thenReturn(metadata);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkTableExistStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
     when(primaryKeyResults.next()).thenReturn(true).thenReturn(false);
     when(primaryKeyResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn("pk1");
     when(columnResults.next()).thenReturn(true).thenReturn(false);
@@ -5064,8 +5197,7 @@ public class JdbcAdminTest {
             () -> admin.getImportTableMetadata(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
-    verify(checkTableExistStatement, description(description))
-        .execute(expectedCheckTableExistStatement);
+    verify(connection, description(description)).prepareStatement(expectedCheckTableExistStatement);
     assertThat(thrown).as(description).isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -5115,25 +5247,8 @@ public class JdbcAdminTest {
     assertThat(thrown).isInstanceOf(UnsupportedOperationException.class);
   }
 
-  private String prepareSqlForTableCheck(RdbEngine rdbEngine, String namespace, String table) {
-    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
-    StringBuilder sql =
-        new StringBuilder("SELECT ")
-            .append(rdbEngine.equals(RdbEngine.SQL_SERVER) ? "TOP 1 1" : "1")
-            .append(" FROM ")
-            .append(rdbEngineStrategy.encloseFullTableName(namespace, table));
-
-    switch (rdbEngine) {
-      case ORACLE:
-        sql.append(" FETCH FIRST 1 ROWS ONLY");
-        break;
-      case SQL_SERVER:
-        break;
-      default:
-        sql.append(" LIMIT 1");
-    }
-
-    return sql.toString();
+  private String prepareSqlForTableCheck(RdbEngine rdbEngine) {
+    return getRdbEngineStrategy(rdbEngine).internalTableExistsCheckSql();
   }
 
   private RdbEngineStrategy getRdbEngineStrategy(RdbEngine rdbEngine) {
@@ -5255,6 +5370,11 @@ public class JdbcAdminTest {
     String indexColumn = "index_col";
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.DB2);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -5263,7 +5383,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.BLOB.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     Statement statement = mock(Statement.class);
 
     when(dataSource.getConnection()).thenReturn(connection);
@@ -5319,6 +5439,11 @@ public class JdbcAdminTest {
     String indexColumn = "index_col";
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.ORACLE);
 
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
+
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -5327,7 +5452,7 @@ public class JdbcAdminTest {
             new SelectAllFromMetadataTableResultSetMocker.Row(
                 indexColumn, DataType.BLOB.toString(), null, null, false));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkPreparedStatement, selectStatement);
     Statement statement = mock(Statement.class);
 
     when(dataSource.getConnection()).thenReturn(connection);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSpannerTest.java
@@ -181,11 +181,11 @@ public class RdbEngineSpannerTest {
   }
 
   @Test
-  void isCreateMetadataSchemaDuplicateSchemaError_ShouldAlwaysReturnFalse() {
+  void isDuplicateSchemaError_ShouldAlwaysReturnFalse() {
     SQLException e = mock(SQLException.class);
     when(e.getErrorCode()).thenReturn(Code.ALREADY_EXISTS_VALUE);
 
-    assertThat(rdbEngine.isCreateMetadataSchemaDuplicateSchemaError(e)).isFalse();
+    assertThat(rdbEngine.isDuplicateSchemaError(e)).isFalse();
   }
 
   @Test
@@ -202,22 +202,6 @@ public class RdbEngineSpannerTest {
     when(e.getErrorCode()).thenReturn(Code.NOT_FOUND_VALUE);
 
     assertThat(rdbEngine.isDuplicateKeyError(e)).isFalse();
-  }
-
-  @Test
-  void isUndefinedTableError_InvalidArgumentCode_ShouldReturnTrue() {
-    SQLException e = mock(SQLException.class);
-    when(e.getErrorCode()).thenReturn(Code.INVALID_ARGUMENT_VALUE);
-
-    assertThat(rdbEngine.isUndefinedTableError(e)).isTrue();
-  }
-
-  @Test
-  void isUndefinedTableError_OtherCode_ShouldReturnFalse() {
-    SQLException e = mock(SQLException.class);
-    when(e.getErrorCode()).thenReturn(Code.NOT_FOUND_VALUE);
-
-    assertThat(rdbEngine.isUndefinedTableError(e)).isFalse();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
@@ -86,18 +86,6 @@ class RdbEngineSqliteTest {
   }
 
   @Test
-  void isUndefinedTableError_True() {
-    SQLException e =
-        (SQLException) catchThrowable(() -> statement.executeUpdate("select 1 from t404"));
-    assertTrue(rdbEngine.isUndefinedTableError(e));
-  }
-
-  @Test
-  void isUndefinedTableError_False() {
-    assertFalse(rdbEngine.isUndefinedTableError(causeSyntaxError()));
-  }
-
-  @Test
   void isConflict_True_SQLITE_BUSY_WhenUpdatingBeingDeletedTableInSeparateConnection()
       throws SQLException {
     statement.executeUpdate("create table t (c integer)");

--- a/core/src/test/java/com/scalar/db/storage/jdbc/VirtualTableMetadataServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/VirtualTableMetadataServiceTest.java
@@ -30,12 +30,14 @@ public class VirtualTableMetadataServiceTest {
 
   private RdbEngineStrategy rdbEngine;
   private VirtualTableMetadataService service;
+  private String checkTableExistsSql;
 
   @BeforeEach
   public void setUp() {
     MockitoAnnotations.openMocks(this);
     rdbEngine = new RdbEngineMysql();
     service = new VirtualTableMetadataService(METADATA_SCHEMA, rdbEngine, false);
+    checkTableExistsSql = rdbEngine.internalTableExistsCheckSql();
   }
 
   @Test
@@ -196,11 +198,14 @@ public class VirtualTableMetadataServiceTest {
   public void getVirtualTableInfo_VirtualTableExists_ShouldReturnVirtualTableInfo()
       throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
     PreparedStatement preparedStatement = mock(PreparedStatement.class);
-    when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+    when(connection.prepareStatement(anyString()))
+        .thenReturn(checkPreparedStatement, preparedStatement);
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true);
     when(resultSet.getString("full_table_name")).thenReturn("ns.vtable");
@@ -225,26 +230,25 @@ public class VirtualTableMetadataServiceTest {
     assertThat(virtualTableInfo.getRightSourceTableName()).isEqualTo("right_table");
     assertThat(virtualTableInfo.getJoinType()).isEqualTo(VirtualTableJoinType.INNER);
 
-    ArgumentCaptor<String> checkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(checkCaptor.capture());
-    assertThat(checkCaptor.getValue())
-        .isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
-
-    ArgumentCaptor<String> selectCaptor = ArgumentCaptor.forClass(String.class);
-    verify(connection).prepareStatement(selectCaptor.capture());
-    assertThat(selectCaptor.getValue())
-        .isEqualTo("SELECT * FROM `scalardb`.`virtual_tables` WHERE `full_table_name` = ?");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
+    verify(connection)
+        .prepareStatement("SELECT * FROM `scalardb`.`virtual_tables` WHERE `full_table_name` = ?");
     verify(preparedStatement).setString(1, "ns.vtable");
   }
 
   @Test
   public void getVirtualTableInfo_VirtualTableDoesNotExist_ShouldReturnNull() throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
     PreparedStatement preparedStatement = mock(PreparedStatement.class);
-    when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+    when(connection.prepareStatement(anyString()))
+        .thenReturn(checkPreparedStatement, preparedStatement);
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(false);
     when(preparedStatement.executeQuery()).thenReturn(resultSet);
@@ -258,25 +262,22 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(virtualTableInfo).isNull();
 
-    ArgumentCaptor<String> checkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(checkCaptor.capture());
-    assertThat(checkCaptor.getValue())
-        .isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
-
-    ArgumentCaptor<String> selectCaptor = ArgumentCaptor.forClass(String.class);
-    verify(connection).prepareStatement(selectCaptor.capture());
-    assertThat(selectCaptor.getValue())
-        .isEqualTo("SELECT * FROM `scalardb`.`virtual_tables` WHERE `full_table_name` = ?");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
+    verify(connection)
+        .prepareStatement("SELECT * FROM `scalardb`.`virtual_tables` WHERE `full_table_name` = ?");
     verify(preparedStatement).setString(1, "ns.vtable");
   }
 
   @Test
   public void getVirtualTableInfo_MetadataTableDoesNotExist_ShouldReturnNull() throws Exception {
     // Arrange
-    Statement statement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(statement);
-    SQLException sqlException = new SQLException("Table doesn't exist", "42S02", 1146);
-    when(statement.execute(anyString())).thenThrow(sqlException);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     String namespace = "ns";
     String table = "vtable";
@@ -287,19 +288,22 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(virtualTableInfo).isNull();
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    verify(statement).execute(captor.capture());
-    assertThat(captor.getValue()).isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
   }
 
   @Test
   public void getVirtualTableInfosBySourceTable_ShouldReturnVirtualTableInfos() throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
     PreparedStatement preparedStatement = mock(PreparedStatement.class);
-    when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+    when(connection.prepareStatement(anyString()))
+        .thenReturn(checkPreparedStatement, preparedStatement);
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true, true, false);
     when(resultSet.getString("full_table_name")).thenReturn("ns.vtable1", "ns.vtable2");
@@ -327,15 +331,11 @@ public class VirtualTableMetadataServiceTest {
     assertThat(virtualTableInfos.get(1).getRightSourceTableName()).isEqualTo("source_table");
     assertThat(virtualTableInfos.get(1).getJoinType()).isEqualTo(VirtualTableJoinType.LEFT_OUTER);
 
-    ArgumentCaptor<String> checkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(checkCaptor.capture());
-    assertThat(checkCaptor.getValue())
-        .isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
-
-    ArgumentCaptor<String> selectCaptor = ArgumentCaptor.forClass(String.class);
-    verify(connection).prepareStatement(selectCaptor.capture());
-    assertThat(selectCaptor.getValue())
-        .isEqualTo(
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
+    verify(connection)
+        .prepareStatement(
             "SELECT * FROM `scalardb`.`virtual_tables` WHERE `left_source_table_full_table_name` = ? OR `right_source_table_full_table_name` = ?");
     verify(preparedStatement).setString(1, "ns.source_table");
     verify(preparedStatement).setString(2, "ns.source_table");
@@ -345,10 +345,11 @@ public class VirtualTableMetadataServiceTest {
   public void getVirtualTableInfosBySourceTable_MetadataTableDoesNotExist_ShouldReturnEmptyList()
       throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    SQLException sqlException = new SQLException("Table doesn't exist", "42S02", 1146);
-    when(checkStatement.execute(anyString())).thenThrow(sqlException);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     String sourceNamespace = "ns";
     String sourceTable = "source_table";
@@ -360,19 +361,22 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(virtualTableInfos).isEmpty();
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(captor.capture());
-    assertThat(captor.getValue()).isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
   }
 
   @Test
   public void getNamespaceTableNames_ShouldReturnTableNames() throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
     PreparedStatement preparedStatement = mock(PreparedStatement.class);
-    when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+    when(connection.prepareStatement(anyString()))
+        .thenReturn(checkPreparedStatement, preparedStatement);
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true, true, false);
     when(resultSet.getString("full_table_name")).thenReturn("ns.table1", "ns.table2");
@@ -386,15 +390,11 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(tableNames).containsExactlyInAnyOrder("table1", "table2");
 
-    ArgumentCaptor<String> checkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(checkCaptor.capture());
-    assertThat(checkCaptor.getValue())
-        .isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
-
-    ArgumentCaptor<String> selectCaptor = ArgumentCaptor.forClass(String.class);
-    verify(connection).prepareStatement(selectCaptor.capture());
-    assertThat(selectCaptor.getValue())
-        .isEqualTo(
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
+    verify(connection)
+        .prepareStatement(
             "SELECT `full_table_name` FROM `scalardb`.`virtual_tables` WHERE `full_table_name` LIKE ?");
     verify(preparedStatement).setString(1, "ns.%");
   }
@@ -403,10 +403,11 @@ public class VirtualTableMetadataServiceTest {
   public void getNamespaceTableNames_MetadataTableDoesNotExist_ShouldReturnEmptySet()
       throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    SQLException sqlException = new SQLException("Table doesn't exist", "42S02", 1146);
-    when(checkStatement.execute(anyString())).thenThrow(sqlException);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     String namespace = "ns";
 
@@ -416,18 +417,22 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(tableNames).isEmpty();
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(captor.capture());
-    assertThat(captor.getValue()).isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
   }
 
   @Test
   public void getNamespaceNamesOfExistingTables_ShouldReturnNamespaceNames() throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    Statement selectStatement = mock(Statement.class);
-    when(connection.createStatement()).thenReturn(checkStatement, selectStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(true);
 
+    Statement selectStatement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(selectStatement);
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true, true, true, false);
     when(resultSet.getString("full_table_name"))
@@ -440,10 +445,9 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(namespaceNames).containsExactlyInAnyOrder("ns1", "ns2");
 
-    ArgumentCaptor<String> checkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(checkCaptor.capture());
-    assertThat(checkCaptor.getValue())
-        .isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
 
     ArgumentCaptor<String> selectCaptor = ArgumentCaptor.forClass(String.class);
     verify(selectStatement).executeQuery(selectCaptor.capture());
@@ -455,10 +459,11 @@ public class VirtualTableMetadataServiceTest {
   public void getNamespaceNamesOfExistingTables_MetadataTableDoesNotExist_ShouldReturnEmptySet()
       throws Exception {
     // Arrange
-    Statement checkStatement = mock(Statement.class);
-    SQLException sqlException = new SQLException("Table doesn't exist", "42S02", 1146);
-    when(checkStatement.execute(anyString())).thenThrow(sqlException);
-    when(connection.createStatement()).thenReturn(checkStatement);
+    PreparedStatement checkPreparedStatement = mock(PreparedStatement.class);
+    when(connection.prepareStatement(anyString())).thenReturn(checkPreparedStatement);
+    ResultSet checkResultSet = mock(ResultSet.class);
+    when(checkPreparedStatement.executeQuery()).thenReturn(checkResultSet);
+    when(checkResultSet.next()).thenReturn(false);
 
     // Act
     Set<String> namespaceNames = service.getNamespaceNamesOfExistingTables(connection);
@@ -466,8 +471,8 @@ public class VirtualTableMetadataServiceTest {
     // Assert
     assertThat(namespaceNames).isEmpty();
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    verify(checkStatement).execute(captor.capture());
-    assertThat(captor.getValue()).isEqualTo("SELECT 1 FROM `scalardb`.`virtual_tables` LIMIT 1");
+    verify(connection).prepareStatement(checkTableExistsSql);
+    verify(checkPreparedStatement).setString(1, METADATA_SCHEMA);
+    verify(checkPreparedStatement).setString(2, "virtual_tables");
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3579
- **Commit to backport:** cc79aa76833cdde8bf738cb9d3cf6bfcb8999416

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.18-pull-3579 &&
git cherry-pick --no-rerere-autoupdate -m1 cc79aa76833cdde8bf738cb9d3cf6bfcb8999416
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!