### PR TITLE
Override isGroupCommitEnabled in ConsensusCommitAdminIntegrationTestWithObjectStorage on branch 3.17

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
@@ -38,6 +38,12 @@ public class ConsensusCommitAdminIntegrationTestWithObjectStorage
   }
 
   @Override
+  protected boolean isGroupCommitEnabled(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
+        .isCoordinatorGroupCommitEnabled();
+  }
+
+  @Override
   @Disabled("Object Storage does not support index-related operations")
   public void createIndex_ForAllDataTypesWithExistingData_ShouldCreateIndexesCorrectly() {}
 


### PR DESCRIPTION
## Description

The Blob Storage group commit integration test job has been failing on branch 3.17 because `ConsensusCommitAdminIntegrationTestWithObjectStorage` does not override `isGroupCommitEnabled(String testName)`. The base class's default implementation returns `false`, while the actual `admin.createCoordinatorTables(...)` creates a Coordinator table with the `tx_child_ids` column when group commit is enabled. The resulting assertion failure in `createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()` (via `extraCheckOnCoordinatorTable()`) blocks CI on this branch:

```
expected: TableMetadata{columnNames=[tx_id, tx_state, tx_created_at], ...}
 but was: TableMetadata{columnNames=[tx_created_at, tx_id, tx_state, tx_child_ids], ...}
```

The override has been missing since the test class was first added, but stayed dormant because `getProps` returned properties from `ObjectStorageEnv.getProperties` — which does not load ConsensusCommit-related system properties (notably `scalardb.consensus_commit.coordinator.group_commit.enabled=true` set by the CI), so group commit was never actually exercised on this storage. #3576 switched `getProps` to `ConsensusCommitObjectStorageEnv.getProperties`, finally enabling group commit mode for this test and exposing the missing override.

## Related issues and/or PRs

- Surfaced by #3576 (`Backport to branch(3.17) : Apply test-name suffix to coordinator namespace exactly once in Consensus Commit integration tests`)
- The same fix is being applied to branches `3` and `3.18` as additional commits on #3599 and #3598 respectively

## Changes made

- Override `isGroupCommitEnabled(String testName)` in `ConsensusCommitAdminIntegrationTestWithObjectStorage` to return the actual value from `ConsensusCommitConfig.isCoordinatorGroupCommitEnabled()`, matching the pattern already used by `ConsensusCommitAdminIntegrationTestWith{Cassandra,Cosmos,Dynamo,JdbcDatabase}`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This is a test-only fix. There is no production code change.

## Release notes

N/A
