### PR TITLE
Restore the Coordinator.State(id, childIds, state) constructor

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -427,6 +427,10 @@ public class Coordinator {
       this(id, state, System.currentTimeMillis());
     }
 
+    public State(String id, List<String> childIds, TransactionState state) {
+      this(id, childIds, null, state, System.currentTimeMillis());
+    }
+
     public State(String id, @Nullable WriteSet writeSet, TransactionState state) {
       this(id, EMPTY_CHILD_IDS, writeSet, state, System.currentTimeMillis());
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -988,6 +988,21 @@ public class CoordinatorTest {
   }
 
   @Test
+  public void state_WithChildIds_ShouldHoldChildIdsAndEmptyWriteSet() {
+    // Arrange
+    List<String> childIds = Arrays.asList("child-1", "child-2");
+
+    // Act
+    State state = new State(ANY_ID_1, childIds, TransactionState.COMMITTED);
+
+    // Assert
+    assertThat(state.getId()).isEqualTo(ANY_ID_1);
+    assertThat(state.getChildIds()).containsExactlyElementsOf(childIds);
+    assertThat(state.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(state.getWriteSet()).isEmpty();
+  }
+
+  @Test
   public void state_EmptyWriteSet_ShouldPersistColumnWithNonEmptyBytes()
       throws CoordinatorException {
     // Arrange — State with an empty (but non-null) WriteSet that explicitly carries

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -988,7 +988,7 @@ public class CoordinatorTest {
   }
 
   @Test
-  public void state_WithChildIds_ShouldHoldChildIdsAndEmptyWriteSet() {
+  public void state_WithChildIds_ShouldHoldChildIdsAndNoWriteSet() {
     // Arrange
     List<String> childIds = Arrays.asList("child-1", "child-2");
 


### PR DESCRIPTION
## Description

This PR is an addendum to #3564.

`Coordinator.State` is a public class consumed externally by other ScalarDB components. In #2612 ("Relax visibility of Coordinator's methods for use by other ScalarDB components"), the `State(String id, List<String> childIds, TransactionState state)` constructor was added specifically for that external use.

While adding the `tx_write_set` column in #3564, that constructor was replaced with a `WriteSet`-based one (`State(String id, @Nullable WriteSet writeSet, TransactionState state)`). As a result, the `(id, childIds, state)` constructor that those external components depend on no longer exists, breaking them. This PR restores it.

## Related issues and/or PRs

- Addendum to #3564 

## Changes made

- Restored `public State(String id, List<String> childIds, TransactionState state)` on `Coordinator.State`, delegating to the canonical private constructor with a `null` write set and the current timestamp.
- This is purely additive: the existing `(id, writeSet, state)` constructor is unchanged. `(String, List<String>, TransactionState)` and `(String, WriteSet, TransactionState)` differ in parameter types, so overload resolution remains unambiguous.
- Added a unit test (`CoordinatorTest#state_WithChildIds_ShouldHoldChildIdsAndEmptyWriteSet`) covering the restored constructor.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The external consumer uses `(id, state)` in production code and `(id, childIds, state)` in tests; restoring this constructor lets its build/tests pass again with no change required on its side.
- The `(id, writeSet, state)` constructor exposes the protobuf `WriteSet` type on the public API. That is out of scope here and left as-is.

## Release notes

N/A
