### PR TITLE
Backport to branch(3) : Restore the Coordinator.State(id, childIds, state) constructor

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -438,6 +438,10 @@ public class Coordinator {
       this(id, state, System.currentTimeMillis());
     }
 
+    public State(String id, List<String> childIds, TransactionState state) {
+      this(id, childIds, null, state, System.currentTimeMillis());
+    }
+
     public State(String id, @Nullable WriteSet writeSet, TransactionState state) {
       this(id, EMPTY_CHILD_IDS, writeSet, state, System.currentTimeMillis());
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -1493,7 +1493,8 @@ public class CommitHandlerTest {
     handlerWithoutWriteSetLogging.commitState(context);
 
     // Assert
-    verify(coordinator).putState(new Coordinator.State(anyId(), null, TransactionState.COMMITTED));
+    verify(coordinator)
+        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.COMMITTED));
   }
 
   @Test
@@ -1510,7 +1511,8 @@ public class CommitHandlerTest {
     handlerWithoutWriteSetLogging.abortState(context);
 
     // Assert
-    verify(coordinator).putState(new Coordinator.State(anyId(), null, TransactionState.ABORTED));
+    verify(coordinator)
+        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.ABORTED));
   }
 
   @Test
@@ -1533,9 +1535,10 @@ public class CommitHandlerTest {
         .isInstanceOf(CommitException.class);
 
     // Assert
-    verify(coordinator).putState(new Coordinator.State(anyId(), null, TransactionState.ABORTED));
+    verify(coordinator)
+        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.ABORTED));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), null, TransactionState.COMMITTED));
+        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.COMMITTED));
     verify(handlerWithoutWriteSetLogging).rollbackRecords(context);
     verify(handlerWithoutWriteSetLogging).onFailureBeforeCommit(context);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -1011,6 +1011,21 @@ public class CoordinatorTest {
   }
 
   @Test
+  public void state_WithChildIds_ShouldHoldChildIdsAndNoWriteSet() {
+    // Arrange
+    List<String> childIds = Arrays.asList("child-1", "child-2");
+
+    // Act
+    State state = new State(ANY_ID_1, childIds, TransactionState.COMMITTED);
+
+    // Assert
+    assertThat(state.getId()).isEqualTo(ANY_ID_1);
+    assertThat(state.getChildIds()).containsExactlyElementsOf(childIds);
+    assertThat(state.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(state.getWriteSet()).isEmpty();
+  }
+
+  @Test
   public void state_EmptyWriteSet_ShouldPersistColumnWithNonEmptyBytes()
       throws CoordinatorException {
     // Arrange — State with an empty (but non-null) WriteSet that explicitly carries


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3605
- **Commit to backport:** 3a46eb760d6c14c4e5eb8ff9699c834f29717830

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3605 &&
git cherry-pick --no-rerere-autoupdate -m1 3a46eb760d6c14c4e5eb8ff9699c834f29717830
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!