### PR TITLE
Harden DynamoAdmin.repairTable (address PR #3610 review feedback)

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -307,10 +307,14 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ProvisionedThroughput.builder().readCapacityUnits(ru).writeCapacityUnits(ru).build());
     requestBuilder.tableName(getFullTableName(namespace, table));
 
+    boolean tableCreated;
     try {
       if (!(ifNotExists && internalTableExists(namespace, table))) {
         client.createTable(requestBuilder.build());
         waitForTableCreation(namespace, table);
+        tableCreated = true;
+      } else {
+        tableCreated = false;
       }
     } catch (Exception e) {
       throw new ExecutionException(
@@ -319,7 +323,14 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
     boolean noScaling = Boolean.parseBoolean(options.getOrDefault(NO_SCALING, DEFAULT_NO_SCALING));
     if (!noScaling) {
-      enableAutoScaling(namespace, table, metadata.getSecondaryIndexNames(), ru);
+      // Only enable auto scaling for the secondary indexes when the table is newly created. When an
+      // existing table is repaired, its existing indexes already have auto scaling, and any missing
+      // index gets its auto scaling when it is created by createIndex. Registering a scalable
+      // target
+      // for a not-yet-created index would otherwise fail.
+      Set<String> secondaryIndexesToScale =
+          tableCreated ? metadata.getSecondaryIndexNames() : Collections.emptySet();
+      enableAutoScaling(namespace, table, secondaryIndexesToScale, ru);
     }
 
     boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
@@ -1411,7 +1422,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
           createIndex(nonPrefixedNamespace, table, indexColumnName, options);
         }
       }
-    } catch (RuntimeException e) {
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
       throw new ExecutionException(
           String.format(
               "Repairing the %s table failed",

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -307,14 +307,12 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ProvisionedThroughput.builder().readCapacityUnits(ru).writeCapacityUnits(ru).build());
     requestBuilder.tableName(getFullTableName(namespace, table));
 
-    boolean tableCreated;
+    boolean tableCreated = false;
     try {
       if (!(ifNotExists && internalTableExists(namespace, table))) {
         client.createTable(requestBuilder.build());
         waitForTableCreation(namespace, table);
         tableCreated = true;
-      } else {
-        tableCreated = false;
       }
     } catch (Exception e) {
       throw new ExecutionException(
@@ -323,11 +321,10 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
     boolean noScaling = Boolean.parseBoolean(options.getOrDefault(NO_SCALING, DEFAULT_NO_SCALING));
     if (!noScaling) {
-      // Only enable auto scaling for the secondary indexes when the table is newly created. When an
-      // existing table is repaired, its existing indexes already have auto scaling, and any missing
-      // index gets its auto scaling when it is created by createIndex. Registering a scalable
-      // target
-      // for a not-yet-created index would otherwise fail.
+      // Enable auto scaling for the secondary indexes only when the table is newly created. For an
+      // existing table being repaired, its indexes already have auto scaling, and any missing index
+      // gets its auto scaling when createIndex creates it. Enabling it here for a missing index
+      // would fail because its scaling target does not exist yet.
       Set<String> secondaryIndexesToScale =
           tableCreated ? metadata.getSecondaryIndexNames() : Collections.emptySet();
       enableAutoScaling(namespace, table, secondaryIndexesToScale, ru);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1222,6 +1222,73 @@ public abstract class DynamoAdminTestBase {
   }
 
   @Test
+  public void repairTable_WhenMetadataIsInvalid_ShouldThrowIllegalArgumentException() {
+    // Arrange: a BOOLEAN secondary index is rejected by checkMetadata with an
+    // IllegalArgumentException, which repairTable must let propagate (not wrap in
+    // ExecutionException), consistent with the other storage admins.
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.BOOLEAN)
+            .addSecondaryIndex("c2")
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      repairTable_WhenExistingTableHasSecondaryIndex_ShouldNotRegisterAutoScalingForThatIndex()
+          throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.TEXT)
+            .addSecondaryIndex("c2")
+            .build();
+
+    // The table exists and already has the c2 global secondary index (ACTIVE).
+    // The index name format is "<fullTableName>.global_index.<column>".
+    String globalIndexName = getFullTableName() + ".global_index.c2";
+    GlobalSecondaryIndexDescription gsiDescription =
+        GlobalSecondaryIndexDescription.builder()
+            .indexName(globalIndexName)
+            .indexStatus(IndexStatus.ACTIVE)
+            .build();
+    TableDescription tableDescription = mock(TableDescription.class);
+    when(tableDescription.tableStatus()).thenReturn(TableStatus.ACTIVE);
+    when(tableDescription.globalSecondaryIndexes()).thenReturn(ImmutableList.of(gsiDescription));
+    DescribeTableResponse tableResponse = mock(DescribeTableResponse.class);
+    when(tableResponse.table()).thenReturn(tableDescription);
+
+    when(client.describeTable(DescribeTableRequest.builder().tableName(getFullTableName()).build()))
+        .thenReturn(tableResponse);
+    when(client.describeTable(
+            DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
+    when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
+        .thenReturn(backupIsEnabledResponse);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert: auto scaling is registered only for the table, never for the existing index's GSI.
+    // (Before the fix, createTableInternal registered scaling for the index even though the table
+    // already existed, which would fail against a real DynamoDB for a not-yet-created index.)
+    ArgumentCaptor<RegisterScalableTargetRequest> captor =
+        ArgumentCaptor.forClass(RegisterScalableTargetRequest.class);
+    verify(applicationAutoScalingClient, times(2)).registerScalableTarget(captor.capture());
+    assertThat(captor.getAllValues())
+        .allSatisfy(
+            request -> assertThat(request.resourceId()).isEqualTo("table/" + getFullTableName()));
+  }
+
+  @Test
   public void repairTable_WithNonExistingTableAndMetadataTables_shouldCreateBothTables()
       throws ExecutionException {
     // Arrange


### PR DESCRIPTION
## Description

PR #3610 (the backport of the `repairTable` behavior alignment to branch `3.18`) received automated review comments (Gemini Code Assist / Copilot). The flagged code is identical to `master`, so per our backport policy the fixes belong on `master` first and are then backported. This PR applies the two `DynamoAdmin` behavior fixes from that feedback on `master`.

## Related issues and/or PRs

- Addresses automated review feedback on #3610
- Related to #3561 (the original `master` change backported by #3610)

## Changes made

- **Exception handling in `DynamoAdmin#repairTable`**: previously only `RuntimeException` was caught, so an `ExecutionException` thrown by `createTableInternal` / `createIndex` propagated without the `"Repairing the %s table failed"` context, and an `IllegalArgumentException` from `checkMetadata` was wrapped in `ExecutionException`. Now `IllegalArgumentException` is rethrown as-is and other exceptions are wrapped, consistent with the other storage admins (e.g. `CosmosAdmin`).
- **Secondary-index auto scaling in `DynamoAdmin#createTableInternal`**: auto scaling was enabled for all of the metadata's secondary indexes even when the table already existed. During `repairTable`, this ran before a missing index was (re)created, so registering a scalable target for a not-yet-created index could fail. Auto scaling for secondary indexes is now enabled only when the table is newly created; a missing index gets its auto scaling when `createIndex` creates it.
- Added unit tests for both behaviors.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This is the `master`-side fix; it should be backported to `3.18` (and any other affected maintenance branches) afterwards. Once merged, the corresponding bot comments on #3610 can be resolved with a pointer here.
- The auto-scaling behavior is most meaningfully verified against a real DynamoDB / via integration tests. The added unit tests assert the call pattern (no scalable-target registration for an already-existing index during repair).

## Release notes

N/A
