### PR TITLE
Add DistributedTransactionManager#recoverRecord

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -2,10 +2,12 @@ package com.scalar.db.api;
 
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.io.Key;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 public interface DistributedTransactionManager
     extends TransactionManagerCrudOperable, AutoCloseable {
@@ -479,12 +481,12 @@ public interface DistributedTransactionManager
   }
 
   /**
-   * Finishes a given terminated transaction by performing any remaining post-termination work and
-   * cleaning up the Coordinator state row. The transaction must already be in a terminal state
+   * Finishes a given terminated transaction by completing any remaining post-termination work and
+   * performing the Coordinator state cleanup. The transaction must already be in a terminal state
    * ({@code COMMITTED} or {@code ABORTED}); this method completes the per-record work that was
    * otherwise deferred to lazy recovery — rolling forward {@code PREPARED} or {@code DELETED}
    * records of a committed transaction, or rolling back {@code PREPARED} or {@code DELETED} records
-   * of an aborted one — and then removes the Coordinator state row.
+   * of an aborted one — and then performs the cleanup.
    *
    * <p>This is a best-effort, retryable cleanup API intended to be called after a transaction
    * terminates so that ScalarDB can complete per-record post-termination work eagerly and reclaim
@@ -524,6 +526,64 @@ public interface DistributedTransactionManager
    *     coordinator-level cleanup
    */
   boolean finishTransaction(String txId) throws TransactionException;
+
+  /**
+   * Recovers a single record left in an uncommitted physical state ({@code PREPARED} or {@code
+   * DELETED}) by a transaction that did not finish cleanly, identified by its key. The record is
+   * rolled forward to its after-image if the transaction that wrote it committed, or rolled back to
+   * its before-image if it aborted.
+   *
+   * <p>This is the key-scoped counterpart to {@link #finishTransaction(String)}. Unlike {@code
+   * finishTransaction}, which is transaction-ID-scoped and recovers every record of a transaction
+   * from its persisted write set, {@code recoverRecord} targets one record and does not require a
+   * write set — so it can repair records left behind by transactions that never persisted one (for
+   * example, transactions that crashed before {@link DistributedTransaction#commit()}, or that
+   * originated from binaries pre-dating the write-set column), which {@code finishTransaction}
+   * cannot reach.
+   *
+   * <p><b>Note:</b> This is a low-level operational API specific to the Consensus Commit
+   * transaction manager. Most applications should not call it directly — it is intended for
+   * advanced use cases. Callers are expected to understand the underlying transaction lifecycle and
+   * the implications of invoking this method directly.
+   *
+   * <p><b>Return value:</b> this method returns whether the record is resolved, not which terminal
+   * state it resolved to — the writer that committed (rolled forward) and the writer that aborted
+   * (rolled back) both return {@code true}. Callers that need the actual outcome should read the
+   * record after this method returns {@code true}. Reporting only resolved-or-not keeps the
+   * contract accurate in races where the writer's true outcome cannot be determined cheaply (for
+   * example, when a concurrent cleanup already removed the Coordinator state row).
+   *
+   * <p><b>Already-resolved records:</b> if the record does not exist or is already committed (no
+   * uncommitted metadata), this method is a no-op and returns {@code true}.
+   *
+   * <p><b>Expiration guard:</b> when the writer transaction has no Coordinator state row (so it
+   * cannot be told apart from a still-in-flight transaction), this method aborts the writer and
+   * rolls the record back only if the writer has expired; otherwise it performs no recovery and
+   * returns {@code false}, signaling that the writer may still be in flight and the call can be
+   * retried later. This matches the behavior of lazy recovery and prevents aborting a healthy,
+   * mid-commit transaction.
+   *
+   * <p><b>Partial recovery:</b> this method makes only the targeted record physically consistent.
+   * When it aborts a writer that spans multiple records, it writes a transaction-wide {@code
+   * ABORTED} Coordinator state, so the writer's other records are rolled back by lazy recovery on
+   * their next read — the outcome is eventually consistent (all-rollback), never a torn
+   * commit/rollback split.
+   *
+   * @param namespace the namespace of the record
+   * @param table the table of the record
+   * @param partitionKey the partition key of the record
+   * @param clusteringKey the clustering key of the record, or {@code null} if the table has no
+   *     clustering key
+   * @return {@code true} if the record was recovered (rolled forward or back, or already resolved),
+   *     or {@code false} if the writer is not yet recoverable (no Coordinator state and not
+   *     expired) and the call should be retried later
+   * @throws TransactionException if recovering the record fails
+   * @throws UnsupportedOperationException if the underlying transaction manager does not support
+   *     record-level recovery
+   */
+  boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey)
+      throws TransactionException;
 
   /**
    * Closes connections to the cluster. The connections are shared among multiple services such as

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1089,6 +1089,18 @@ public enum CoreError implements ScalarDbError {
       "Finishing a transaction is not supported in single CRUD operation transactions",
       "",
       ""),
+  JDBC_TRANSACTION_RECOVERING_RECORD_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0291",
+      "Recovering a record is not supported in JDBC transactions",
+      "",
+      ""),
+  SINGLE_CRUD_OPERATION_TRANSACTION_RECOVERING_RECORD_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0292",
+      "Recovering a record is not supported in single CRUD operation transactions",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -1438,7 +1450,13 @@ public enum CoreError implements ScalarDbError {
   CONSENSUS_COMMIT_FINISHING_TRANSACTION_FAILED(
       Category.INTERNAL_ERROR,
       "0068",
-      "Finishing the transaction failed. Transaction ID: %s, Details: %s",
+      "Finishing the transaction failed. Transaction ID: %s; Details: %s",
+      "",
+      ""),
+  CONSENSUS_COMMIT_RECOVERING_RECORD_FAILED(
+      Category.INTERNAL_ERROR,
+      "0069",
+      "Recovering the record failed. Table: %s; Partition Key: %s; Clustering Key: %s; Details: %s",
       "",
       ""),
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -19,9 +19,11 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 public abstract class DecoratedDistributedTransactionManager
     implements DistributedTransactionManager {
@@ -300,6 +302,13 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public boolean finishTransaction(String txId) throws TransactionException {
     return transactionManager.finishTransaction(txId);
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey)
+      throws TransactionException {
+    return transactionManager.recoverRecord(namespace, table, partitionKey, clusteringKey);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -20,10 +20,12 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
@@ -228,6 +230,13 @@ public class TransactionService implements DistributedTransactionManager {
   @Override
   public boolean finishTransaction(String txId) throws TransactionException {
     return manager.finishTransaction(txId);
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey)
+      throws TransactionException {
+    return manager.recoverRecord(namespace, table, partitionKey, clusteringKey);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -6,11 +6,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
+import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
 import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
@@ -36,12 +38,14 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.ThrowableFunction;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
@@ -610,19 +614,6 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
 
     State state = stateOpt.get();
 
-    // Only COMMITTED or ABORTED states are expected here. Anything else indicates an internal
-    // invariant violation, not a runtime condition. This is checked before the write-set presence
-    // check so that a persisted non-terminal state (which should never exist) always surfaces as
-    // the invariant violation rather than being misreported as a missing write set.
-    TransactionState txState = state.getState();
-    if (txState != TransactionState.COMMITTED && txState != TransactionState.ABORTED) {
-      throw new AssertionError(
-          "Unexpected non-terminal transaction state at finishTransaction. State: "
-              + txState
-              + ", Transaction ID: "
-              + txId);
-    }
-
     // The transaction did not commit through DistributedTransaction#commit() (e.g., it was
     // terminated via DistributedTransactionManager#rollback()/abort(), aborted by lazy recovery, or
     // originated from a pre-feature binary) and so carries no write set. Note that a commit() that
@@ -679,9 +670,10 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       }
     }
 
-    // Delete the state row. state.getId() is the parent ID for group-commit rows because
-    // Coordinator#getState(fullChildId) routes through getStateForGroupCommit() and returns the
-    // parent row, so the delete targets the right row in both single and group cases.
+    // Perform the Coordinator state cleanup (delete the state row). state.getId() is the parent ID
+    // for group-commit rows because Coordinator#getState(fullChildId) routes through
+    // getStateForGroupCommit() and returns the parent row, so the delete targets the right row in
+    // both single and group cases.
     // Coordinator#deleteState is unconditional and benign on a concurrent delete.
     try {
       coordinator.deleteState(state.getId());
@@ -716,6 +708,95 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       return false;
     }
     return expectedTxId.equals(result.getId());
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey)
+      throws TransactionException {
+    checkArgument(!Strings.isNullOrEmpty(namespace));
+    checkArgument(!Strings.isNullOrEmpty(table));
+    checkNotNull(partitionKey);
+
+    // Read the current physical state of the record.
+    Get get = buildRecordGet(namespace, table, partitionKey, clusteringKey);
+    Optional<Result> resultOpt;
+    try {
+      resultOpt = storage.get(get);
+    } catch (ExecutionException e) {
+      throw new TransactionException(
+          CoreError.CONSENSUS_COMMIT_RECOVERING_RECORD_FAILED.buildMessage(
+              ScalarDbUtils.getFullTableName(namespace, table),
+              partitionKey,
+              clusteringKey,
+              e.getMessage()),
+          e,
+          null);
+    }
+
+    // Nothing to recover if the record does not exist or is already committed. isCommitted() also
+    // covers a record with no transaction metadata (tx_state absent), which is deemed as committed.
+    // The record is already resolved in both cases, so report it as recovered.
+    if (!resultOpt.isPresent()) {
+      return true;
+    }
+    TransactionResult txResult = new TransactionResult(resultOpt.get());
+    if (txResult.isCommitted()) {
+      return true;
+    }
+
+    // The record is uncommitted (PREPARED or DELETED). A record written by ScalarDB always carries
+    // both tx_id and tx_state together, so tx_id is non-null here; the isCommitted() check above
+    // already handled the no-metadata case where tx_state — and thus tx_id — is absent.
+    String txId = txResult.getId();
+    assert txId != null;
+
+    Optional<State> stateOpt;
+    try {
+      stateOpt = coordinator.getState(txId);
+    } catch (CoordinatorException e) {
+      throw new TransactionException(
+          CoreError.CONSENSUS_COMMIT_RECOVERING_RECORD_FAILED.buildMessage(
+              ScalarDbUtils.getFullTableName(namespace, table),
+              partitionKey,
+              clusteringKey,
+              e.getMessage()),
+          e,
+          txId);
+    }
+
+    // Recover the single record and report whether it was resolved. The Coordinator state cleanup
+    // is deliberately not performed: the writer may span other records that still need the state
+    // row, and the transaction-wide ABORTED row written for the no-state case keeps those records
+    // consistent via lazy recovery.
+    try {
+      return recoveryExecutor.executeSynchronously(get, txResult, stateOpt);
+    } catch (ExecutionException | CoordinatorException e) {
+      throw new TransactionException(
+          CoreError.CONSENSUS_COMMIT_RECOVERING_RECORD_FAILED.buildMessage(
+              ScalarDbUtils.getFullTableName(namespace, table),
+              partitionKey,
+              clusteringKey,
+              e.getMessage()),
+          e,
+          txId);
+    }
+  }
+
+  private static Get buildRecordGet(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey) {
+    // Read all columns (no projections) with linearizable consistency so the before-image and the
+    // transaction metadata needed for recovery are available.
+    GetBuilder.BuildableGetWithPartitionKey builder =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(partitionKey)
+            .consistency(Consistency.LINEARIZABLE);
+    if (clusteringKey != null) {
+      builder.clusteringKey(clusteringKey);
+    }
+    return builder.build();
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -398,9 +398,8 @@ public class Coordinator {
 
   /**
    * Deletes the coordinator state row for the given transaction id. The delete is unconditional —
-   * if the row was already removed (e.g., by a concurrent {@code finishTransaction} call), this is
-   * a benign no-op at the storage layer and no exception is propagated. Storage errors surface as
-   * {@link CoordinatorException}; the caller (typically {@code finishTransaction}) is itself a
+   * if the row was already removed, this is a benign no-op at the storage layer and no exception is
+   * propagated. Storage errors surface as {@link CoordinatorException}; the caller is itself a
    * retryable API, so no internal retry is performed here.
    *
    * @param id the transaction id whose state row should be deleted

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -62,6 +62,48 @@ public class RecoveryExecutor implements AutoCloseable {
                 .build());
   }
 
+  /**
+   * Resolves the value to return for an uncommitted record encountered during a read and recovers
+   * the record asynchronously.
+   *
+   * <p>The record recovery runs on a background thread, exposed through {@link
+   * Result#recoveryFuture}, and delegates to the best-effort {@link
+   * RecoveryHandler#tryRecover(Selection, TransactionResult, Optional)}. <b>The record is not
+   * guaranteed to be recovered, even after {@link Result#recoveryFuture} completes</b>: a completed
+   * future only means the recovery attempt ran, not that the record reached a resolved physical
+   * state. Recovery is intentionally skipped when the writer has no coordinator state and has not
+   * expired (it may still be in flight), and a roll that conflicts with a concurrent actor is
+   * deferred to a subsequent read. This is acceptable on the lazy-recovery read path because a
+   * later read retries recovery. Callers that require the record to be resolved before proceeding
+   * must use {@link #executeSynchronously(Selection, TransactionResult, Optional)} instead, which
+   * guarantees the record is recovered when it returns {@code true}.
+   *
+   * <p>The {@code recoveryType} controls what value is returned and whether recovery is attempted:
+   *
+   * <ul>
+   *   <li>{@code RETURN_LATEST_RESULT_AND_RECOVER}: read the coordinator state and return the
+   *       latest result — the after-image if the writer committed, otherwise the before-image —
+   *       then recover the record. Throws {@link UncommittedRecordException} when the writer has no
+   *       coordinator state and has not expired (it may still be in flight).
+   *   <li>{@code RETURN_COMMITTED_RESULT_AND_RECOVER}: return the committed (before-image) result
+   *       immediately and recover the record on the background thread, where the coordinator state
+   *       is read and the not-expired guard is applied.
+   *   <li>{@code RETURN_COMMITTED_RESULT_AND_NOT_RECOVER}: return the committed (before-image)
+   *       result without attempting any recovery (the future completes immediately).
+   * </ul>
+   *
+   * @param key the snapshot key identifying the record
+   * @param selection the selection that read the record
+   * @param result the latest known uncommitted {@link TransactionResult} for the record
+   * @param transactionId the ID of the reading transaction (used for error reporting)
+   * @param recoveryType the recovery strategy to apply (see above)
+   * @return a {@link Result} holding the value to return, the future that completes when the
+   *     background recovery attempt finishes (completion does not imply the record was recovered;
+   *     see above), and whether the record was rolled back
+   * @throws CrudException if reading the coordinator state or table metadata fails, or if the
+   *     record is uncommitted by a writer that is still potentially in flight ({@link
+   *     UncommittedRecordException})
+   */
   public Result execute(
       Snapshot.Key key,
       Selection selection,
@@ -85,7 +127,7 @@ public class RecoveryExecutor implements AutoCloseable {
           future =
               executorService.submit(
                   () -> {
-                    recovery.recover(selection, result, state);
+                    recovery.tryRecover(selection, result, state);
                     return null;
                   });
           break;
@@ -131,7 +173,7 @@ public class RecoveryExecutor implements AutoCloseable {
           future =
               executorService.submit(
                   () -> {
-                    recovery.recover(selection, result, winnerState);
+                    recovery.tryRecover(selection, result, winnerState);
                     return null;
                   });
         }
@@ -154,7 +196,7 @@ public class RecoveryExecutor implements AutoCloseable {
                   throwUncommittedRecordExceptionIfTransactionNotExpired(
                       s, selection, result, transactionId);
 
-                  recovery.recover(selection, result, s);
+                  recovery.tryRecover(selection, result, s);
                   return null;
                 });
 
@@ -357,15 +399,13 @@ public class RecoveryExecutor implements AutoCloseable {
   }
 
   /**
-   * Recovers a single record synchronously by delegating to the underlying {@link RecoveryHandler}.
-   * The synchronous counterpart of {@link #execute(Snapshot.Key, Selection, TransactionResult,
-   * String, RecoveryType)}; callers that already know the coordinator state and want the recovery
-   * to complete inline (e.g., {@code finishTransaction}) use this entry point without leaking the
-   * {@code RecoveryHandler} dependency itself.
+   * Recovers a single record synchronously when the coordinator state is already known to be
+   * present. This is the entry point for callers that always hold a terminal coordinator state.
    *
-   * <p>Rollforward vs. rollback is decided by the supplied coordinator state, and the underlying
-   * composers absorb {@link com.scalar.db.exception.storage.NoMutationException} when the record
-   * has already been recovered by a concurrent actor.
+   * <p>It delegates to {@link RecoveryHandler#recover(Selection, TransactionResult,
+   * Coordinator.State)}, the present-state overload that always rolls the record and never touches
+   * the coordinator — so the record is guaranteed to be recovered and {@link CoordinatorException}
+   * cannot be thrown. That overload returns nothing, so this method does too.
    *
    * @param selection the selection that identifies the user record
    * @param result the latest known TransactionResult for the record
@@ -374,15 +414,30 @@ public class RecoveryExecutor implements AutoCloseable {
    */
   void executeSynchronously(Selection selection, TransactionResult result, Coordinator.State state)
       throws ExecutionException {
-    try {
-      recovery.recover(selection, result, Optional.of(state));
-    } catch (CoordinatorException e) {
-      // recover only throws CoordinatorException via abortIfExpired, which runs solely when the
-      // coordinator state is empty. This entry point requires a non-null state, so the branch is
-      // unreachable.
-      throw new AssertionError(
-          "CoordinatorException from recover with a present state should be impossible", e);
-    }
+    recovery.recover(selection, result, state);
+  }
+
+  /**
+   * Recovers a single record synchronously, blocking until the recovery completes, and reports
+   * whether the record was recovered.
+   *
+   * <p>This delegates to {@link RecoveryHandler#recover(Selection, TransactionResult, Optional)},
+   * which guarantees that when {@code true} is returned the record has been physically resolved —
+   * the entry point for the {@code recoverRecord} API. See that method for the full semantics and
+   * the meaning of the returned value.
+   *
+   * @param selection the selection that identifies the user record
+   * @param result the latest known TransactionResult for the record
+   * @param state the coordinator state for the transaction that wrote the record, if any
+   * @return {@code true} if the record was recovered (resolved to a terminal state), {@code false}
+   *     if the writer may still be in flight and the call should be retried later
+   * @throws ExecutionException if the underlying storage read or mutation fails
+   * @throws CoordinatorException if reading or updating the coordinator state fails
+   */
+  boolean executeSynchronously(
+      Selection selection, TransactionResult result, Optional<Coordinator.State> state)
+      throws ExecutionException, CoordinatorException {
+    return recovery.recover(selection, result, state);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -37,17 +37,117 @@ public class RecoveryHandler {
     this.tableMetadataManager = checkNotNull(tableMetadataManager);
   }
 
-  public void recover(
+  /**
+   * Best-effort recovery of the given record according to the writer transaction's coordinator
+   * state. This is the entry point for lazy recovery on the read path: it advances recovery as far
+   * as it cheaply can but does not guarantee the record reaches its resolved physical state, and it
+   * returns nothing.
+   *
+   * <ul>
+   *   <li>State present {@code COMMITTED}: roll the record forward.
+   *   <li>State present otherwise (i.e. {@code ABORTED}): roll the record back.
+   *   <li>State absent and the writer expired: abort the writer and roll the record back; if a
+   *       concurrent actor already resolved the writer (the abort is conflict-absorbed), the record
+   *       is left for that actor / a subsequent lazy recovery — a later read will recover it.
+   *   <li>State absent and the writer not expired: perform no recovery, since the writer may still
+   *       be in flight.
+   * </ul>
+   *
+   * <p>Use {@link #recover(Selection, TransactionResult, Optional)} instead when the caller needs a
+   * guarantee that the record has been physically resolved on return (e.g. the synchronous {@code
+   * recoverRecord} API).
+   *
+   * @param selection the selection that identifies the record to recover
+   * @param result the latest known {@link TransactionResult} for the record
+   * @param state the coordinator state of the writer transaction, or empty if it has no state row
+   * @throws ExecutionException if the underlying storage read or mutation fails
+   * @throws CoordinatorException if reading or updating the coordinator state fails
+   */
+  public void tryRecover(
       Selection selection, TransactionResult result, Optional<Coordinator.State> state)
       throws ExecutionException, CoordinatorException {
     if (state.isPresent()) {
-      if (state.get().getState().equals(TransactionState.COMMITTED)) {
-        rollforwardRecord(selection, result);
-      } else {
-        rollbackRecord(selection, result);
-      }
+      rollRecordToState(selection, result, state.get().getState());
     } else {
-      abortIfExpired(selection, result);
+      abortIfExpired(selection, result, false);
+    }
+  }
+
+  /**
+   * Recovers the given record according to the writer transaction's coordinator state, guaranteeing
+   * that when {@code true} is returned the record has been physically resolved (rolled forward or
+   * back). This is the entry point for callers that must be able to rely on the record being
+   * recovered once the call succeeds.
+   *
+   * <ul>
+   *   <li>State present {@code COMMITTED}: roll the record forward; returns {@code true}.
+   *   <li>State present otherwise (i.e. {@code ABORTED}): roll the record back; returns {@code
+   *       true}.
+   *   <li>State absent and the writer expired: abort the writer and roll the record back; returns
+   *       {@code true}. If a concurrent actor already resolved the writer (the abort is
+   *       conflict-absorbed), the record is rolled to the winner's terminal outcome. If the
+   *       writer's state row is already gone, {@code true} is still returned — the Coordinator
+   *       state cleanup process removed the state row after the winner committed, which also
+   *       resolved this record, so the record is already consistent.
+   *   <li>State absent and the writer not expired: perform no recovery and return {@code false},
+   *       since the writer may still be in flight. This is a "not yet recoverable" outcome; the
+   *       caller can retry later.
+   * </ul>
+   *
+   * @param selection the selection that identifies the record to recover
+   * @param result the latest known {@link TransactionResult} for the record
+   * @param state the coordinator state of the writer transaction, or empty if it has no state row
+   * @return {@code true} if the record was recovered (resolved to a terminal state), {@code false}
+   *     if the writer may still be in flight and the call should be retried later
+   * @throws ExecutionException if the underlying storage read or mutation fails
+   * @throws CoordinatorException if reading or updating the coordinator state fails
+   */
+  public boolean recover(
+      Selection selection, TransactionResult result, Optional<Coordinator.State> state)
+      throws ExecutionException, CoordinatorException {
+    if (state.isPresent()) {
+      recover(selection, result, state.get());
+      return true;
+    } else {
+      return abortIfExpired(selection, result, true);
+    }
+  }
+
+  /**
+   * Recovers the given record when the writer's coordinator state is already known to be present.
+   * With a present state the record is always rolled (forward if {@code COMMITTED}, back
+   * otherwise); the coordinator is never read or written, so — unlike {@link #recover(Selection,
+   * TransactionResult, Optional)} — this neither defers the roll nor throws {@link
+   * CoordinatorException}. This is the entry point for callers that already hold a terminal
+   * coordinator state.
+   *
+   * @param selection the selection that identifies the record to recover
+   * @param result the latest known {@link TransactionResult} for the record
+   * @param state the present terminal coordinator state of the writer transaction
+   * @throws ExecutionException if the underlying storage read or mutation fails
+   */
+  public void recover(Selection selection, TransactionResult result, Coordinator.State state)
+      throws ExecutionException {
+    rollRecordToState(selection, result, state.getState());
+  }
+
+  /**
+   * Rolls the record forward (if {@code state} is {@code COMMITTED}) or back (if {@code ABORTED}).
+   *
+   * <p>{@code state} must be a terminal state. The coordinator only ever persists terminal states,
+   * so every caller passes a {@code COMMITTED} or {@code ABORTED} state. The {@code assert}
+   * documents that invariant for developers and trips on a corrupt non-terminal state when
+   * assertions are enabled (e.g. in tests); in production, where assertions are disabled, a
+   * non-terminal state is treated as a rollback.
+   */
+  private void rollRecordToState(
+      Selection selection, TransactionResult result, TransactionState state)
+      throws ExecutionException {
+    if (state.equals(TransactionState.COMMITTED)) {
+      rollforwardRecord(selection, result);
+    } else {
+      assert state.equals(TransactionState.ABORTED);
+      rollbackRecord(selection, result);
     }
   }
 
@@ -168,12 +268,29 @@ public class RecoveryHandler {
     }
   }
 
-  private void abortIfExpired(Selection selection, TransactionResult result)
+  /**
+   * Aborts the writer of an uncommitted record if it has expired, and reports whether the record
+   * was resolved.
+   *
+   * @param ensureRecordResolved when {@code true}, the targeted record is guaranteed to be
+   *     physically resolved on return even when the abort conflicts with a concurrent actor (the
+   *     {@code recover} path); when {@code false}, a conflicting abort leaves the record for the
+   *     winning actor / a subsequent lazy recovery (the best-effort {@code tryRecover} path).
+   * @return {@code true} if the record was definitely recovered (the writer was aborted and the
+   *     record rolled, or a concurrent actor's outcome was applied), {@code false} if recovery
+   *     could not be guaranteed — either the writer has not expired and may still be in flight, or
+   *     the abort conflicted in the best-effort path and the targeted record was left for the
+   *     winning actor / a subsequent lazy recovery
+   */
+  private boolean abortIfExpired(
+      Selection selection, TransactionResult result, boolean ensureRecordResolved)
       throws CoordinatorException, ExecutionException {
     assert selection.forFullTableName().isPresent();
 
     if (!isTransactionExpired(result)) {
-      return;
+      // The writer may still be in flight; do not abort it. Report that the record is not yet
+      // recoverable so callers can retry later.
+      return false;
     }
 
     try {
@@ -194,12 +311,36 @@ public class RecoveryHandler {
           result.getId(),
           e);
 
-      // This can happen when the record has already been rolled back by another transaction. In
-      // this case, we just ignore it.
-      return;
+      if (!ensureRecordResolved) {
+        // Best-effort path (tryRecover): the targeted record is left for the winning actor / a
+        // subsequent lazy recovery, so this call did not resolve it. Skip the coordinator re-read
+        // entirely — it would be wasted work — and report that recovery is not guaranteed. The
+        // return value is discarded by the caller (tryRecover is void), so this only documents the
+        // honest outcome of the best-effort path.
+        return false;
+      }
+
+      // Guaranteed path (recover): a concurrent actor already resolved the writer. Re-read the
+      // coordinator state and roll the record to the winner's outcome so it is physically resolved
+      // on return.
+      Optional<TransactionState> rereadState =
+          coordinator.getState(result.getId()).map(Coordinator.State::getState);
+
+      if (rereadState.isPresent()) {
+        // Roll the targeted record to the winner's outcome. This is idempotent: the underlying
+        // composers absorb NoMutationException if the winner already rolled the record.
+        rollRecordToState(selection, result, rereadState.get());
+        return true;
+      }
+
+      // The writer's state row is already gone — which only happens after the Coordinator state
+      // cleanup process removes the state row, and that process also resolves this record before
+      // the cleanup. The record is therefore already consistent.
+      return true;
     }
 
     rollbackRecord(selection, result);
+    return true;
   }
 
   private void mutate(List<Mutation> mutations) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -141,6 +141,16 @@ public class TransactionResult extends AbstractResult {
     return getText(Attribute.ID);
   }
 
+  /**
+   * Returns the transaction state ({@code tx_state}) of this record.
+   *
+   * <p>When {@code tx_state} is null, the record is deemed as committed and {@code COMMITTED} is
+   * returned: a record imported into a table initially has no transaction metadata, which is a
+   * legitimate state (see {@link #isCommitted()} and {@link #isDeemedAsCommitted()}).
+   *
+   * @return the transaction state, or {@code COMMITTED} when this record has no transaction
+   *     metadata
+   */
   public TransactionState getState() {
     if (isNull(Attribute.STATE)) {
       // To handle existing databases that do not have transaction metadata, the record is deemed as
@@ -162,10 +172,37 @@ public class TransactionResult extends AbstractResult {
     return getBigInt(Attribute.COMMITTED_AT);
   }
 
+  /**
+   * Returns whether this record is in the committed state.
+   *
+   * <p>This returns {@code true} when the transaction state ({@code tx_state}) is {@code
+   * COMMITTED}. It also returns {@code true} when the record has no transaction metadata (i.e.
+   * {@code tx_state} is null): when a table is imported, its existing records initially have no
+   * transaction metadata. That is a legitimate state and such a record is deemed as committed (see
+   * {@link #getState()}).
+   *
+   * @return {@code true} if this record is committed, including records that are deemed as
+   *     committed
+   */
   public boolean isCommitted() {
     return getState().equals(TransactionState.COMMITTED);
   }
 
+  /**
+   * Returns whether this record is deemed as committed because it carries no transaction metadata.
+   *
+   * <p>When a table is imported, its existing records initially have no transaction metadata. This
+   * is a legitimate state, and such a record is deemed as committed.
+   *
+   * <p>Both this method and {@link #isCommitted()} capture the "deemed as committed" notion of a
+   * record without transaction metadata, but inspect different columns: this method keys off the
+   * absence of the transaction ID ({@code tx_id}), while {@code isCommitted()} keys off the
+   * transaction state ({@code tx_state}, via {@link #getState()}). They agree for a record without
+   * transaction metadata because such a record has both {@code tx_id} and {@code tx_state} absent —
+   * a record written by ScalarDB always carries both together.
+   *
+   * @return {@code true} if this record has no transaction ID and is therefore deemed as committed
+   */
   public boolean isDeemedAsCommitted() {
     return getId() == null;
   }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -33,6 +33,7 @@ import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
 import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcCrudService;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -435,6 +437,13 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
   public boolean finishTransaction(String txId) {
     throw new UnsupportedOperationException(
         CoreError.JDBC_TRANSACTION_FINISHING_TRANSACTION_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey) {
+    throw new UnsupportedOperationException(
+        CoreError.JDBC_TRANSACTION_RECOVERING_RECORD_NOT_SUPPORTED.buildMessage());
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -40,6 +40,7 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -447,6 +449,13 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
     throw new UnsupportedOperationException(
         CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_FINISHING_TRANSACTION_NOT_SUPPORTED
             .buildMessage());
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey) {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_RECOVERING_RECORD_NOT_SUPPORTED.buildMessage());
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.Consistency;
 import com.scalar.db.api.CrudOperable;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -54,6 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -1982,7 +1984,7 @@ public class ConsensusCommitManagerTest {
 
     // Assert — the state row is already gone, so finishing is a no-op that reports success.
     assertThat(finished).isTrue();
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator, never()).deleteState(anyString());
   }
 
@@ -2001,20 +2003,7 @@ public class ConsensusCommitManagerTest {
     // Assert — the transaction is not applicable (no write set), so the call reports false and
     // leaves the state row for lazy recovery instead of throwing.
     assertThat(finished).isFalse();
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
-    verify(coordinator, never()).deleteState(anyString());
-  }
-
-  @Test
-  public void finishTransaction_NonTerminalState_ShouldThrowAssertionError() throws Exception {
-    // Arrange — A persisted State should never be PREPARED. If it is, that's an internal
-    // invariant violation that finishTransaction must surface loudly.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.PREPARED);
-    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
-
-    // Act + Assert
-    assertThatThrownBy(() -> manager.finishTransaction(ANY_TX_ID))
-        .isInstanceOf(AssertionError.class);
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator, never()).deleteState(anyString());
   }
 
@@ -2062,7 +2051,7 @@ public class ConsensusCommitManagerTest {
     // Assert — record was missing, so recovery is not invoked, but the state row is still cleaned
     // up because the transaction itself is terminal.
     assertThat(finished).isTrue();
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator).deleteState(ANY_TX_ID);
   }
 
@@ -2084,7 +2073,7 @@ public class ConsensusCommitManagerTest {
     // Assert
     assertThat(finished).isTrue();
     verify(storage, never()).get(any(Get.class));
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator).deleteState(ANY_TX_ID);
   }
 
@@ -2106,7 +2095,7 @@ public class ConsensusCommitManagerTest {
 
     // Assert
     assertThat(finished).isTrue();
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator).deleteState(ANY_TX_ID);
   }
 
@@ -2126,7 +2115,7 @@ public class ConsensusCommitManagerTest {
 
     // Assert
     assertThat(finished).isTrue();
-    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator).deleteState(ANY_TX_ID);
   }
 
@@ -2189,7 +2178,7 @@ public class ConsensusCommitManagerTest {
         .hasCause(firstAttemptCause);
     verify(coordinator, never()).deleteState(anyString());
 
-    // Second call recovers and deletes the state row
+    // Second call recovers and cleans up the state row
     boolean finished = manager.finishTransaction(ANY_TX_ID);
     assertThat(finished).isTrue();
     verify(recoveryExecutor)
@@ -2247,5 +2236,256 @@ public class ConsensusCommitManagerTest {
     verify(recoveryExecutor)
         .executeSynchronously(any(Get.class), any(TransactionResult.class), eq(state));
     verify(coordinator).deleteState(ANY_TX_ID);
+  }
+
+  // ------------------------------------------------------------
+  // recoverRecord
+  // ------------------------------------------------------------
+
+  // Key-shape and table-existence validation is delegated to the storage-layer OperationChecker
+  // invoked by storage.get, so it is not re-tested here (covered by OperationChecker's own tests
+  // and the integration tests).
+
+  private Result committedRecord(String txId) {
+    Result record = mock(Result.class);
+    when(record.getText(Attribute.ID)).thenReturn(txId);
+    when(record.isNull(Attribute.STATE)).thenReturn(false);
+    when(record.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
+    return record;
+  }
+
+  @Test
+  public void recoverRecord_UncommittedRecordGiven_ShouldRecoverWithStateAndReturnTrue()
+      throws Exception {
+    // Arrange
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    State state = new State(ANY_TX_ID, TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
+    when(recoveryExecutor.executeSynchronously(
+            any(Get.class), any(TransactionResult.class), eq(Optional.of(state))))
+        .thenReturn(true);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv"));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator).getState(ANY_TX_ID);
+    verify(recoveryExecutor)
+        .executeSynchronously(any(Get.class), any(TransactionResult.class), eq(Optional.of(state)));
+    // recoverRecord must never perform Coordinator state cleanup (delete the state row).
+    verify(coordinator, never()).deleteState(anyString());
+
+    // The Get is built with linearizable consistency and the supplied keys (no projections).
+    ArgumentCaptor<Get> getCaptor = ArgumentCaptor.forClass(Get.class);
+    verify(storage).get(getCaptor.capture());
+    Get get = getCaptor.getValue();
+    assertThat(get.forNamespace()).hasValue(ANY_NAMESPACE);
+    assertThat(get.forTable()).hasValue(ANY_TABLE);
+    assertThat((Object) get.getPartitionKey()).isEqualTo(Key.ofText("pk", "pv"));
+    assertThat(get.getClusteringKey()).hasValue(Key.ofText("ck", "cv"));
+    assertThat(get.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(get.getProjections()).isEmpty();
+  }
+
+  @Test
+  public void recoverRecord_PartitionKeyOnly_ShouldBuildGetWithoutClusteringKey() throws Exception {
+    // Arrange
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    State state = new State(ANY_TX_ID, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
+    when(recoveryExecutor.executeSynchronously(
+            any(Get.class), any(TransactionResult.class), eq(Optional.of(state))))
+        .thenReturn(true);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), null);
+
+    // Assert
+    assertThat(recovered).isTrue();
+    ArgumentCaptor<Get> getCaptor = ArgumentCaptor.forClass(Get.class);
+    verify(storage).get(getCaptor.capture());
+    Get get = getCaptor.getValue();
+    assertThat((Object) get.getPartitionKey()).isEqualTo(Key.ofText("pk", "pv"));
+    assertThat(get.getClusteringKey()).isEmpty();
+    assertThat(get.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+  }
+
+  @Test
+  public void recoverRecord_StateAbsent_ShouldDelegateWithEmptyStateAndReturnResult()
+      throws Exception {
+    // Arrange
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.empty());
+    when(recoveryExecutor.executeSynchronously(
+            any(Get.class), any(TransactionResult.class), eq(Optional.empty())))
+        .thenReturn(true);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv"));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(recoveryExecutor)
+        .executeSynchronously(any(Get.class), any(TransactionResult.class), eq(Optional.empty()));
+    verify(coordinator, never()).deleteState(anyString());
+  }
+
+  @Test
+  public void recoverRecord_RecordAbsent_ShouldReturnTrueWithoutRecovery() throws Exception {
+    // Arrange
+    when(storage.get(any(Get.class))).thenReturn(Optional.empty());
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv"));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).getState(anyString());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(Optional.class));
+  }
+
+  @Test
+  public void recoverRecord_AlreadyCommittedRecord_ShouldReturnTrueWithoutRecovery()
+      throws Exception {
+    // Arrange
+    Result record = committedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv"));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).getState(anyString());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(Optional.class));
+  }
+
+  @Test
+  public void recoverRecord_DeemedAsCommittedRecord_ShouldReturnTrueWithoutRecovery()
+      throws Exception {
+    // Arrange — an imported-table row with no transaction metadata (tx_state is null). getState()
+    // deems such a record COMMITTED, so recoverRecord must no-op without consulting the
+    // coordinator.
+    Result record = mock(Result.class);
+    when(record.isNull(Attribute.STATE)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv"));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).getState(anyString());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(Optional.class));
+  }
+
+  @Test
+  public void recoverRecord_CoordinatorGetStateFails_ShouldThrowTransactionException()
+      throws Exception {
+    // Arrange
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    CoordinatorException toThrow = mock(CoordinatorException.class);
+    when(toThrow.getMessage()).thenReturn("coordinator down");
+    doThrow(toThrow).when(coordinator).getState(ANY_TX_ID);
+
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                manager.recoverRecord(
+                    ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(TransactionException.class)
+        .hasMessageStartingWith("DB-CORE-30069:");
+    verify(coordinator, never()).deleteState(anyString());
+  }
+
+  @Test
+  public void recoverRecord_StorageGetFails_ShouldThrowTransactionException() throws Exception {
+    // Arrange
+    com.scalar.db.exception.storage.ExecutionException cause =
+        new com.scalar.db.exception.storage.ExecutionException("storage down");
+    when(storage.get(any(Get.class))).thenThrow(cause);
+
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                manager.recoverRecord(
+                    ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(TransactionException.class)
+        .hasCause(cause)
+        .hasMessageStartingWith("DB-CORE-30069:");
+    // The record could not be read, so neither the coordinator nor the recovery executor is
+    // touched.
+    verify(coordinator, never()).getState(anyString());
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(Optional.class));
+    verify(coordinator, never()).deleteState(anyString());
+  }
+
+  @Test
+  public void recoverRecord_RecoveryExecutorFails_ShouldThrowTransactionException()
+      throws Exception {
+    // Arrange
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    State state = new State(ANY_TX_ID, TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
+    com.scalar.db.exception.storage.ExecutionException cause =
+        new com.scalar.db.exception.storage.ExecutionException("recovery storage down");
+    doThrow(cause)
+        .when(recoveryExecutor)
+        .executeSynchronously(any(Get.class), any(TransactionResult.class), eq(Optional.of(state)));
+
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                manager.recoverRecord(
+                    ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(TransactionException.class)
+        .hasCause(cause)
+        .hasMessageStartingWith("DB-CORE-30069:");
+    // recoverRecord must never perform Coordinator state cleanup, even on failure.
+    verify(coordinator, never()).deleteState(anyString());
+  }
+
+  @Test
+  public void
+      recoverRecord_RecoveryExecutorThrowsCoordinatorException_ShouldThrowTransactionException()
+          throws Exception {
+    // Arrange — no coordinator state, and the no-state recovery path throws CoordinatorException
+    // (the second arm of recoverRecord's ExecutionException | CoordinatorException multicatch).
+    Result record = preparedRecord(ANY_TX_ID);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.empty());
+    CoordinatorException cause = mock(CoordinatorException.class);
+    when(cause.getMessage()).thenReturn("coordinator down");
+    doThrow(cause)
+        .when(recoveryExecutor)
+        .executeSynchronously(any(Get.class), any(TransactionResult.class), eq(Optional.empty()));
+
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                manager.recoverRecord(
+                    ANY_NAMESPACE, ANY_TABLE, Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(TransactionException.class)
+        .hasCause(cause)
+        .hasMessageStartingWith("DB-CORE-30069:");
+    // recoverRecord must never perform Coordinator state cleanup, even on failure.
+    verify(coordinator, never()).deleteState(anyString());
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -340,7 +340,7 @@ public class RecoveryExecutorTest {
         .isInstanceOf(CrudException.class);
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -364,7 +364,7 @@ public class RecoveryExecutorTest {
         .isInstanceOf(UncommittedRecordException.class);
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -393,7 +393,7 @@ public class RecoveryExecutorTest {
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
     verify(recovery).rollbackRecord(selection, transactionResult);
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -423,7 +423,7 @@ public class RecoveryExecutorTest {
     assertThat(result.recoveredResult).isEmpty();
     assertThat(result.rolledBack).isTrue();
     verify(recovery).rollbackRecord(selection, transactionResult);
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -453,7 +453,8 @@ public class RecoveryExecutorTest {
     // Assert: the committed after-image is returned -- not the stale before-image
     assertThat(result.recoveredResult).hasValue(prepareRolledForwardResult());
     assertThat(result.rolledBack).isFalse();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(committedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(committedState)));
   }
 
   @Test
@@ -480,7 +481,8 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
   @Test
@@ -506,7 +508,7 @@ public class RecoveryExecutorTest {
 
     // Verify no recovery attempted
     verify(recovery, never()).rollbackRecord(any(), any());
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -532,7 +534,8 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
   @Test
@@ -560,7 +563,8 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).isEmpty();
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
   @Test
@@ -590,7 +594,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledForwardResult());
     assertThat(result.rolledBack).isFalse();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
   @Test
@@ -617,7 +621,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).isNotPresent();
     assertThat(result.rolledBack).isFalse();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
   @Test
@@ -646,7 +650,7 @@ public class RecoveryExecutorTest {
     assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -676,7 +680,7 @@ public class RecoveryExecutorTest {
     assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -703,7 +707,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
   @Test
@@ -731,7 +735,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).isEmpty();
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.empty()));
   }
 
   @Test
@@ -757,7 +761,8 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
   @Test
@@ -785,7 +790,8 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).isEmpty();
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+    verify(recovery)
+        .tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
   }
 
   @Test
@@ -815,7 +821,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
   @Test
@@ -842,7 +848,7 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+    verify(recovery).tryRecover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
   }
 
   @Test
@@ -870,7 +876,7 @@ public class RecoveryExecutorTest {
     assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -897,7 +903,7 @@ public class RecoveryExecutorTest {
     assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
@@ -924,19 +930,55 @@ public class RecoveryExecutorTest {
     assertThat(result.rolledBack).isTrue();
 
     // Verify no recovery attempted
-    verify(recovery, never()).recover(any(), any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
   }
 
   @Test
-  public void executeSynchronously_ShouldDelegateToRecoveryHandler() throws Exception {
+  public void
+      executeSynchronously_WithOptionalPresentState_ShouldDelegateToRecoverAndReturnItsResult()
+          throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED);
+    Optional<Coordinator.State> state =
+        Optional.of(new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED));
+    when(recovery.recover(selection, transactionResult, state)).thenReturn(true);
 
     // Act
-    executor.executeSynchronously(selection, transactionResult, state);
+    boolean actual = executor.executeSynchronously(selection, transactionResult, state);
 
     // Assert
-    verify(recovery).recover(selection, transactionResult, Optional.of(state));
+    assertThat(actual).isTrue();
+    verify(recovery).recover(selection, transactionResult, state);
+  }
+
+  @Test
+  public void
+      executeSynchronously_WithOptionalEmptyState_ShouldDelegateToRecoverAndReturnItsResult()
+          throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(recovery.recover(selection, transactionResult, Optional.empty())).thenReturn(false);
+
+    // Act
+    boolean actual = executor.executeSynchronously(selection, transactionResult, Optional.empty());
+
+    // Assert
+    assertThat(actual).isFalse();
+    verify(recovery).recover(selection, transactionResult, Optional.empty());
+  }
+
+  @Test
+  public void executeSynchronously_WithNonOptionalPresentState_ShouldDelegateToRecover()
+      throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    Coordinator.State state = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+
+    // Act — the present-state overload is used by finishTransaction and returns nothing.
+    executor.executeSynchronously(selection, transactionResult, state);
+
+    // Assert — it delegates to the present-state recover overload (which never touches the
+    // coordinator and cannot throw CoordinatorException).
+    verify(recovery).recover(selection, transactionResult, state);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -102,9 +102,10 @@ public class RecoveryHandlerTest {
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
-    handler.recover(selection, result, state);
+    boolean recovered = handler.recover(selection, result, state);
 
     // Assert
+    assertThat(recovered).isTrue();
     verify(handler).rollforwardRecord(selection, result);
   }
 
@@ -163,9 +164,10 @@ public class RecoveryHandlerTest {
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
-    handler.recover(selection, result, state);
+    boolean recovered = handler.recover(selection, result, state);
 
     // Assert
+    assertThat(recovered).isTrue();
     verify(handler).rollbackRecord(selection, result);
   }
 
@@ -218,7 +220,7 @@ public class RecoveryHandlerTest {
 
   @Test
   public void
-      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndNotExpired_ShouldDoNothing()
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndNotExpired_ShouldDoNothingAndReturnFalse()
           throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(System.currentTimeMillis());
@@ -226,17 +228,19 @@ public class RecoveryHandlerTest {
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
-    handler.recover(selection, result, state);
+    boolean recovered = handler.recover(selection, result, state);
 
-    // Assert
+    // Assert — the writer may still be in flight, so the record is not recovered.
+    assertThat(recovered).isFalse();
     verify(coordinator, never())
         .putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(handler, never()).rollbackRecord(selection, result);
   }
 
   @Test
-  public void recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_ShouldAbort()
-      throws CoordinatorException, ExecutionException {
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_ShouldAbortAndReturnTrue()
+          throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result =
         preparePreparedResult(
@@ -246,16 +250,17 @@ public class RecoveryHandlerTest {
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
-    handler.recover(selection, result, state);
+    boolean recovered = handler.recover(selection, result, state);
 
     // Assert
+    assertThat(recovered).isTrue();
     verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
     verify(handler).rollbackRecord(selection, result);
   }
 
   @Test
   public void
-      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_CoordinatorConflictExceptionByCoordinator_ShouldNotThrowAnyException()
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_CoordinatorConflictExceptionByCoordinator_ShouldRollbackToRereadAbortedAndReturnTrue()
           throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result =
@@ -265,13 +270,75 @@ public class RecoveryHandlerTest {
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putStateForLazyRecoveryRollback(anyString());
+    // A concurrent actor already aborted the writer; the re-read returns that ABORTED state.
+    when(coordinator.getState(ANY_ID_1))
+        .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED)));
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
-    assertThatCode(() -> handler.recover(selection, result, state)).doesNotThrowAnyException();
+    boolean recovered = handler.recover(selection, result, state);
+
+    // Assert — recover guarantees the record is resolved: it is rolled back to match the winner's
+    // ABORTED outcome.
+    assertThat(recovered).isTrue();
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(handler).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_RacingCommitWon_ShouldRollforwardToRereadCommittedAndReturnTrue()
+          throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyString());
+    // A concurrent commit won the race; the re-read sees COMMITTED, which must be reported
+    // instead of a false ABORTED.
+    when(coordinator.getState(ANY_ID_1))
+        .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED)));
+    doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    boolean recovered = handler.recover(selection, result, state);
+
+    // Assert — recover guarantees the record is resolved: it is rolled forward to match the
+    // winner's COMMITTED outcome.
+    assertThat(recovered).isTrue();
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(handler).rollforwardRecord(selection, result);
+    verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_CoordinatorConflictExceptionAndRereadEmpty_ShouldReturnTrueWithoutRoll()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — the abort conflicts and the re-read finds no state row: the winner committed and
+    // the Coordinator state cleanup process (finishTransaction) then removed the state row, which
+    // also resolved this record. recover reports the record as recovered and does not touch the
+    // (already consistent) record.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyString());
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
+
+    // Act
+    boolean recovered = handler.recover(selection, result, state);
 
     // Assert
+    assertThat(recovered).isTrue();
     verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
     verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
   }
 
   @Test
@@ -331,5 +398,141 @@ public class RecoveryHandlerTest {
     // Act Assert
     assertThatThrownBy(() -> handler.tryAbortExpiredTransaction(ANY_ID_1))
         .isInstanceOf(CoordinatorException.class);
+  }
+
+  // ------------------------------------------------------------
+  // recover with a present (non-Optional) state
+  // ------------------------------------------------------------
+
+  @Test
+  public void recover_WithPresentStateCommitted_ShouldRollforwardWithoutCoordinatorAccess()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED);
+    doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    handler.recover(selection, result, state);
+
+    // Assert — rolled forward, and the coordinator is never touched.
+    verify(handler).rollforwardRecord(selection, result);
+    verify(coordinator, never()).getState(anyString());
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+  }
+
+  @Test
+  public void recover_WithPresentStateAborted_ShouldRollbackWithoutCoordinatorAccess()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    handler.recover(selection, result, state);
+
+    // Assert — rolled back, and the coordinator is never touched.
+    verify(handler).rollbackRecord(selection, result);
+    verify(coordinator, never()).getState(anyString());
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+  }
+
+  // ------------------------------------------------------------
+  // tryRecover (best-effort; used by lazy recovery)
+  // ------------------------------------------------------------
+
+  @Test
+  public void tryRecover_WhenCoordinatorStateCommitted_ShouldRollforward()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    Optional<Coordinator.State> state =
+        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED));
+    doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(handler).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void tryRecover_WhenCoordinatorStateAborted_ShouldRollback()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    Optional<Coordinator.State> state =
+        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(handler).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void
+      tryRecover_WhenCoordinatorStateNotExistsAndExpired_CoordinatorConflictException_ShouldDeferWithoutRereadingStateOrRollingTheRecord()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — unlike recover, the best-effort tryRecover does NOT resolve the record on conflict;
+    // it leaves it for the winning actor / a subsequent lazy recovery. Because its return value is
+    // discarded, it must not even re-read the coordinator state.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyString());
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert — no coordinator re-read and no roll.
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator, never()).getState(anyString());
+    verify(handler, never()).rollforwardRecord(selection, result);
+    verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void tryRecover_WhenCoordinatorStateNotExistsAndNotExpired_ShouldDoNothing()
+      throws CoordinatorException, ExecutionException {
+    // Arrange — the writer has no coordinator state and has not expired, so it may still be in
+    // flight; best-effort recovery must leave it untouched.
+    TransactionResult result = preparePreparedResult(System.currentTimeMillis());
+    Optional<Coordinator.State> state = Optional.empty();
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollforwardRecord(selection, result);
+    verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void tryRecover_WhenCoordinatorStateNotExistsAndExpired_ShouldAbortAndRollback()
+      throws CoordinatorException, ExecutionException {
+    // Arrange — the writer has no coordinator state and has expired, so best-effort recovery aborts
+    // it and rolls the record back.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyString());
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(handler).rollbackRecord(selection, result);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -1597,4 +1597,14 @@ public class JdbcTransactionManagerTest {
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageStartingWith("DB-CORE-10289:");
   }
+
+  @Test
+  public void recoverRecord_ShouldThrowUnsupportedOperationException() {
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                manager.recoverRecord("ns", "tbl", Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageStartingWith("DB-CORE-10291:");
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManagerTest.java
@@ -1121,4 +1121,15 @@ public class SingleCrudOperationTransactionManagerTest {
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageStartingWith("DB-CORE-10290:");
   }
+
+  @Test
+  public void recoverRecord_ShouldThrowUnsupportedOperationException() {
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                transactionManager.recoverRecord(
+                    "ns", "tbl", Key.ofText("pk", "pv"), Key.ofText("ck", "cv")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageStartingWith("DB-CORE-10292:");
+  }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -499,7 +499,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -548,7 +548,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -588,7 +588,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     transaction.rollback();
 
     // Assert
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -645,11 +645,11 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // Assert
     // With the default isolation, the read path aborts the expired transaction synchronously (its
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
-    // in the background. recover() is not used on this path.
+    // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test
@@ -691,7 +691,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -740,7 +740,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -780,7 +780,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     transaction.rollback();
 
     // Assert
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -837,11 +837,11 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // Assert
     // With the default isolation, the read path aborts the expired transaction synchronously (its
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
-    // in the background. recover() is not used on this path.
+    // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -550,7 +550,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -606,7 +606,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -654,7 +654,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     transaction.rollback();
 
     // Assert
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -720,11 +720,11 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // Assert
     // With the default isolation, the read path aborts the expired transaction synchronously (its
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
-    // in the background. recover() is not used on this path.
+    // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test
@@ -780,7 +780,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -836,7 +836,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -884,7 +884,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     transaction.rollback();
 
     // Assert
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -950,11 +950,11 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // Assert
     // With the default isolation, the read path aborts the expired transaction synchronously (its
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
-    // in the background. recover() is not used on this path.
+    // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1292,12 +1292,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       if (readOnly) {
         // In read-only mode, recovery should not occur
         verify(recovery, never())
-            .recover(any(Selection.class), any(TransactionResult.class), any());
+            .tryRecover(any(Selection.class), any(TransactionResult.class), any());
         verify(recovery, never())
             .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
       } else {
         // In read-write mode, recovery should occur
-        verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+        verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
         verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
       }
     } else {
@@ -1310,7 +1310,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       assertThat(result.getCommittedAt()).isGreaterThan(0);
 
       // Recovery should occur
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     }
   }
@@ -1414,11 +1414,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     if (isolation == Isolation.READ_COMMITTED && readOnly) {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In other cases, recovery should occur
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     }
   }
@@ -1549,7 +1550,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     // In all cases, recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(coordinator, never()).putState(any(Coordinator.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -1655,23 +1656,25 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     if (isolation == Isolation.READ_COMMITTED && readOnly) {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator, never()).putState(any(Coordinator.State.class));
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else if (isolation == Isolation.READ_COMMITTED) {
       // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
-      // via recover()
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      // via tryRecover()
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
-      // record is rolled back in the background. recover() is not used on this path.
+      // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -1790,12 +1793,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       if (readOnly) {
         // In read-only mode, recovery should not occur
         verify(recovery, never())
-            .recover(any(Selection.class), any(TransactionResult.class), any());
+            .tryRecover(any(Selection.class), any(TransactionResult.class), any());
         verify(recovery, never())
             .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
       } else {
         // In read-write mode, recovery should occur
-        verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+        verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
         verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
       }
     } else {
@@ -1805,7 +1808,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       assertThat(result).isNull();
 
       // Recovery should occur
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     }
   }
@@ -1909,11 +1912,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     if (isolation == Isolation.READ_COMMITTED && readOnly) {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In other cases, recovery should occur
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     }
   }
@@ -2044,7 +2048,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     // In all cases, recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(coordinator, never()).putState(any(Coordinator.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -2151,22 +2155,24 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     if (isolation == Isolation.READ_COMMITTED && readOnly) {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else if (isolation == Isolation.READ_COMMITTED) {
       // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
-      // via recover()
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      // via tryRecover()
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
-      // record is rolled back in the background. recover() is not used on this path.
+      // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -2255,7 +2261,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-forward)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2292,7 +2298,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2331,12 +2337,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
     // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
-    // before the result is returned, then the record is rolled back in the background. recover() is
+    // before the result is returned, then the record is rolled back in the background. tryRecover()
+    // is
     // not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @ParameterizedTest
@@ -2365,7 +2372,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.rollback();
 
     // Recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(coordinator, never()).putState(any(Coordinator.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -2402,7 +2409,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-forward = delete committed)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2437,7 +2444,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2476,7 +2483,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2548,7 +2555,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Recovery should occur for both transient rows (DELETED old + PREPARED new) and roll them
     // FORWARD (writer committed); nothing is rolled back.
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, times(2))
+        .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, times(2))
         .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -2608,7 +2616,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Recovery should occur for both transient rows (DELETED old + PREPARED new) and roll them BACK
     // (writer aborted); nothing is rolled forward.
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, times(2))
+        .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -2663,7 +2672,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Recovery should occur once for the aborted in-flight record and roll it BACK; nothing is
     // rolled forward (the surviving record is genuinely committed and needs no recovery).
-    verify(recovery, times(1)).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, times(1))
+        .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, times(1)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -2749,7 +2759,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2861,7 +2871,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-forward)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2951,7 +2961,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3041,12 +3051,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
     // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
-    // before the records are returned, then the record is rolled back in the background. recover()
+    // before the records are returned, then the record is rolled back in the background.
+    // tryRecover()
     // is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @ParameterizedTest
@@ -3122,7 +3133,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.rollback();
 
     // Recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(coordinator, never()).putState(any(Coordinator.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
@@ -3216,7 +3227,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-forward = delete committed)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3305,7 +3316,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     waitForRecoveryCompletion(transaction);
 
     // Recovery should occur (roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3455,7 +3466,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
 
       verify(recovery, never()).tryAbortExpiredTransaction(anyString());
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     } else {
       // SNAPSHOT/SERIALIZABLE use RETURN_LATEST_RESULT_AND_RECOVER. The lazy-recovery rollback
       // loses the race, so the read resolves from the winner's COMMITTED outcome. The after-image
@@ -3466,7 +3477,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
 
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     }
@@ -3697,7 +3708,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3753,7 +3764,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
     // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3799,7 +3810,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     // In all isolations, recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -3851,18 +3862,19 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
     if (isolation == Isolation.READ_COMMITTED) {
-      // In READ_COMMITTED isolation, the record is recovered in the background via recover()
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      // In READ_COMMITTED isolation, the record is recovered in the background via tryRecover()
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
-      // record is rolled back in the background. recover() is not used on this path.
+      // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -3925,7 +3937,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
 
     // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3981,7 +3993,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
     // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -4027,7 +4039,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     // In all isolations, recovery should not occur
-    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
   }
@@ -4079,18 +4091,19 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
     if (isolation == Isolation.READ_COMMITTED) {
-      // In READ_COMMITTED isolation, the record is recovered in the background via recover()
-      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      // In READ_COMMITTED isolation, the record is recovered in the background via tryRecover()
+      verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
-      // record is rolled back in the background. recover() is not used on this path.
+      // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -9743,6 +9756,41 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      rollback_forOngoingGroupCommitTransactionWhenNormalGroupCommitInFlight_ShouldRollbackCorrectly()
+          throws Exception {
+    // Rolling back an in-flight, group-committed transaction by ID must win against the in-flight
+    // normal group commit, which writes the COMMITTED state under the parent ID. The race is made
+    // deterministic by rolling the transaction back by ID just before the group commit writes its
+    // COMMITTED state under the parent ID, so the two writes genuinely conflict.
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    DistributedTransaction transaction = manager.begin();
+    transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1));
+    String ongoingTxId = transaction.getId();
+    String parentId =
+        new CoordinatorGroupCommitKeyManipulator().keysFromFullKey(ongoingTxId).parentKey;
+
+    doAnswer(
+            invocation -> {
+              // The rollback writes the parent-ID ABORTED marker (not a COMMITTED state), so it
+              // does not match this stub and runs against the real coordinator.
+              manager.rollback(ongoingTxId);
+              return invocation.callRealMethod();
+            })
+        .when(coordinator)
+        .putStateForGroupCommit(
+            eq(parentId), anyList(), any(), eq(TransactionState.COMMITTED), anyLong());
+
+    // Act Assert
+    assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
+    assertThat(manager.getState(ongoingTxId)).isEqualTo(TransactionState.ABORTED);
+  }
+
+  @Test
   void finishTransaction_CommittedWithSomeRecordsStillPrepared_ShouldRollForwardAndDeleteState()
       throws Exception {
     // Scenario 1: a transaction wrote two records, the Coordinator state row says COMMITTED, but
@@ -10036,38 +10084,268 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
+  void recoverRecord_PreparedRecordWhenCoordinatorStateCommitted_ShouldRollForwardAndReturnTrue()
+      throws Exception {
+    // Arrange — record (0,0) is PREPARED at storage but its writer committed.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            System.currentTimeMillis(),
+            TransactionState.COMMITTED,
+            CommitType.NORMAL_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — rolled forward to the after-image; the Coordinator state row is NOT deleted (unlike
+    // finishTransaction).
+    assertThat(recovered).isTrue();
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(raw.get().getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+    assertThat(coordinator.getState(txId)).isPresent();
+  }
+
+  @Test
+  void recoverRecord_PreparedRecordWhenCoordinatorStateAborted_ShouldRollBackAndReturnTrue()
+      throws Exception {
+    // Arrange — record (0,0) is PREPARED at storage but its writer aborted.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            System.currentTimeMillis(),
+            TransactionState.ABORTED,
+            CommitType.NORMAL_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — rolled back to the before-image; the Coordinator state row is NOT deleted.
+    assertThat(recovered).isTrue();
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getText(Attribute.ID)).isEqualTo(ANY_ID_1);
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(raw.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(coordinator.getState(txId)).isPresent();
+  }
+
+  @Test
+  void recoverRecord_DeletedRecordWhenCoordinatorStateCommitted_ShouldRollForwardRemovingRecord()
+      throws Exception {
+    // Arrange — record (0,0) is DELETED at storage and its writer committed; rolling forward must
+    // physically remove the record.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    populatePreparedRecordAndCoordinatorStateRecord(
+        originalStorage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        System.currentTimeMillis(),
+        TransactionState.COMMITTED,
+        CommitType.NORMAL_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — the call reports the record recovered and the record is physically gone.
+    assertThat(recovered).isTrue();
+    assertThat(originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1))).isEmpty();
+  }
+
+  @Test
+  void recoverRecord_PreparedRecordWithNoCoordinatorStateAndExpired_ShouldAbortAndReturnTrue()
+      throws Exception {
+    // Arrange — record (0,0) is PREPARED with no Coordinator state and the writer has expired.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            1, // a long-past prepared-at, so the writer is considered expired
+            null,
+            CommitType.NORMAL_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — the writer is aborted and the record rolled back to the before-image.
+    assertThat(recovered).isTrue();
+    Optional<Coordinator.State> state = coordinator.getState(txId);
+    assertThat(state).isPresent();
+    assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getText(Attribute.ID)).isEqualTo(ANY_ID_1);
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(raw.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @Test
+  void recoverRecord_PreparedRecordWithNoCoordinatorStateAndNotExpired_ShouldReturnFalse()
+      throws Exception {
+    // Arrange — record (0,0) is PREPARED with no Coordinator state and the writer is NOT expired,
+    // so it may still be in flight and must not be aborted.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            System.currentTimeMillis(),
+            null,
+            CommitType.NORMAL_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — no recovery performed; the record is untouched and no Coordinator state was written.
+    assertThat(recovered).isFalse();
+    assertThat(coordinator.getState(txId)).isEmpty();
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getText(Attribute.ID)).isEqualTo(txId);
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.PREPARED.get());
+  }
+
+  @Test
   @EnabledIf("isGroupCommitEnabled")
   void
-      rollback_forOngoingGroupCommitTransactionWhenNormalGroupCommitInFlight_ShouldRollbackCorrectly()
+      recoverRecord_PreparedGroupCommitRecordWithNoCoordinatorStateAndNotExpired_ShouldNotAbortLiveGroupAndReturnFalse()
           throws Exception {
-    // Rolling back an in-flight, group-committed transaction by ID must win against the in-flight
-    // normal group commit, which writes the COMMITTED state under the parent ID. The race is made
-    // deterministic by rolling the transaction back by ID just before the group commit writes its
-    // COMMITTED state under the parent ID, so the two writes genuinely conflict.
+    // Arrange — record (0,0) is PREPARED by a group-commit transaction (its tx_id is a full
+    // group-commit key) with no Coordinator state and a recent prepared-at. This represents a
+    // healthy, in-flight group whose parent Coordinator row has not been written yet. recoverRecord
+    // must not abort it (which would write a conflicting ABORTED row and take down the whole live
+    // group); it reuses the exact abortIfExpired path that lazy recovery uses, so the expiration
+    // guard protects the live group identically.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            System.currentTimeMillis(),
+            null,
+            CommitType.GROUP_COMMIT);
 
-    // Arrange
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — the live group is left untouched: no recovery performed, no Coordinator state (not
+    // even the lazy-recovery-abort-with-parent-id row) was written, and the record is unchanged.
+    assertThat(recovered).isFalse();
+    assertThat(coordinator.getState(txId)).isEmpty();
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getText(Attribute.ID)).isEqualTo(txId);
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.PREPARED.get());
+  }
+
+  @Test
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      recoverRecord_PreparedGroupCommitRecordWithNoCoordinatorStateAndExpired_ShouldAbortViaGroupCommitPathAndReturnTrue()
+          throws Exception {
+    // Arrange — record (0,0) is PREPARED by a group-commit transaction (its tx_id is a full
+    // group-commit key) with no Coordinator state and an expired prepared-at. This is an abandoned
+    // group-commit writer (the group never reached commit). recoverRecord must abort it through the
+    // group-commit-aware path (Coordinator.putStateForLazyRecoveryRollbackForGroupCommit), which
+    // writes both the lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same
+    // rows that conflict-protect against a racing real group commit. This is the expired
+    // counterpart
+    // of the not-expired test above and confirms recoverRecord drives the no-state group-commit
+    // branch identically to lazy recovery.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    String txId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            originalStorage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            1, // a long-past prepared-at, so the writer is considered expired
+            null,
+            CommitType.GROUP_COMMIT);
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert — the writer is aborted via the group-commit path and the record rolled back to the
+    // before-image. getState on the full key resolves to ABORTED (it falls through to the full-id
+    // ABORTED row written by the group-commit abort path).
+    assertThat(recovered).isTrue();
+    Optional<Coordinator.State> state = coordinator.getState(txId);
+    assertThat(state).isPresent();
+    assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getText(Attribute.ID)).isEqualTo(ANY_ID_1);
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(raw.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @Test
+  void recoverRecord_AlreadyCommittedRecord_ShouldBeNoOpAndReturnTrue() throws Exception {
+    // Arrange — a normally committed record.
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
     DistributedTransaction transaction = manager.begin();
-    transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1));
-    String ongoingTxId = transaction.getId();
-    String parentId =
-        new CoordinatorGroupCommitKeyManipulator().keysFromFullKey(ongoingTxId).parentKey;
+    transaction.insert(prepareInsert(0, 0, namespace1, TABLE_1, NEW_BALANCE));
+    transaction.commit();
 
-    doAnswer(
-            invocation -> {
-              // The rollback writes the parent-ID ABORTED marker (not a COMMITTED state), so it
-              // does not match this stub and runs against the real coordinator.
-              manager.rollback(ongoingTxId);
-              return invocation.callRealMethod();
-            })
-        .when(coordinator)
-        .putStateForGroupCommit(
-            eq(parentId), anyList(), any(), eq(TransactionState.COMMITTED), anyLong());
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
 
-    // Act Assert
-    assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
-    assertThat(manager.getState(ongoingTxId)).isEqualTo(TransactionState.ABORTED);
+    // Assert — no-op; the record stays COMMITTED.
+    assertThat(recovered).isTrue();
+    Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(raw).isPresent();
+    assertThat(raw.get().getInt(Attribute.STATE)).isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(raw.get().getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+  }
+
+  @Test
+  void recoverRecord_AbsentRecord_ShouldBeNoOpAndReturnTrue() throws Exception {
+    // Arrange — no record at (0,0).
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    assertThat(originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1))).isEmpty();
+
+    // Act
+    boolean recovered =
+        manager.recoverRecord(
+            namespace1, TABLE_1, Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0));
+
+    // Assert
+    assertThat(recovered).isTrue();
+    assertThat(originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1))).isEmpty();
   }
 
   private DistributedTransaction prepareTransfer(


### PR DESCRIPTION
## Description

When a Consensus Commit transaction crashes, it can leave a record in an uncommitted physical state (`PREPARED` or `DELETED`). Today such records are cleaned up either by lazy recovery (on the next read, and only after the writer is considered expired for the no-coordinator-state case) or by `finishTransaction(txId)`. However, `finishTransaction` is transaction-ID-scoped and write-set-driven: it only works for transactions that reached `DistributedTransaction#commit()` and therefore persisted a write set. Records left behind by a writer that has **no write set** (e.g. a transaction that crashed before `commit()`, or one from a binary that pre-dates the write-set column) cannot be repaired on demand and must wait for lazy recovery to happen to read them.

This PR adds `recoverRecord`, a key-scoped operational API that lets an operator deterministically repair a single such record on demand.

## Related issues and/or PRs

N/A

## Changes made

- Added `boolean recoverRecord(String namespace, String table, Key partitionKey, @Nullable Key clusteringKey)` to `DistributedTransactionManager`, documented as a low-level operational API (mirroring `finishTransaction`/`getState`/`rollback`).
- Implemented it in `ConsensusCommitManager`: reads the record, derives the writer transaction ID from it, and recovers via the existing `Coordinator`/`RecoveryHandler` machinery. It rolls the record forward or back based on the writer's coordinator state, keeps the expiration guard for the no-coordinator-state case (so a healthy in-flight writer is not aborted), and does **not** delete the Coordinator state row (other records of the same writer may still need it). Key-shape and table validation are delegated to the storage-layer `OperationChecker` invoked by `storage.get`.
- **Return value is a `boolean`, not a `TransactionState`.** It reports *whether* the record was recovered: `true` means the record was resolved (rolled forward/back, or already resolved), and `false` signals the writer may still be in flight, so the call can be retried later. It deliberately does not return the resolved terminal state because that cannot always be determined accurately in races (e.g. a concurrent `finishTransaction` that already cleaned up the Coordinator state row). Callers that need the actual outcome should read the record after a `true` return.
- Refactored `RecoveryHandler` to separate best-effort from guaranteed recovery:
  - Renamed the existing best-effort `recover` to `tryRecover` (still `void`; used by lazy recovery on the read path — a conflicting record is left for the winning actor or a later lazy read).
  - Added a new synchronous `recover` that physically resolves the record, overloaded to take either an `Optional<Coordinator.State>` (returning whether the record was recovered) or a concrete `Coordinator.State` (`void`).
  - Centralized the terminal-state dispatch (roll forward on `COMMITTED`, back on `ABORTED`) in a single helper.
- Generalized `RecoveryExecutor.executeSynchronously` with an `Optional<Coordinator.State>` overload returning whether the record was recovered, giving `finishTransaction` and `recoverRecord` a single guaranteed synchronous recovery entry point.
- Wired the cross-cutting surface: `DecoratedDistributedTransactionManager` and `TransactionService` delegate; `JdbcTransactionManager` and `SingleCrudOperationTransactionManager` throw `UnsupportedOperationException` with dedicated `CoreError` messages.
- Added unit tests (`ConsensusCommitManagerTest`, `RecoveryHandlerTest`, `RecoveryExecutorTest`, and the JDBC/single-CRUD manager tests) and Consensus Commit integration tests (`ConsensusCommitSpecificIntegrationTestBase`), including group-commit cases and the not-expired `false`-return case. Added Javadoc to `TransactionResult#getState`/`#isCommitted`/`#isDeemedAsCommitted`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR is stacked on #3621 ("Return the before-image only after the lazy-recovery rollback is written on a read") and targets its branch `fix-stale-read-on-lazy-recovery-abort-conflict`. It has been rebased onto that branch, so the diff against the base contains only the `recoverRecord` changes plus the supporting `RecoveryHandler`/`RecoveryExecutor` refactor; the best-effort lazy-recovery path (renamed `tryRecover`) coexists with the base branch's synchronous lazy-recovery-rollback fix. Once #3621 is merged, this PR will be retargeted to `master`.

## Release notes

Added the `DistributedTransactionManager#recoverRecord` API for recovering a single record left in an uncommitted state by a crashed transaction. Note that this is a low-level operational API specific to the Consensus Commit transaction manager. Most applications should not call it directly; it is intended for advanced use cases. Callers are expected to understand the underlying transaction lifecycle and the implications of invoking this method directly.

