### PR TITLE
Abort in-flight group-committed transactions correctly on the manager rollback/abort-by-ID path

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -528,11 +528,11 @@ public class CommitHandler {
    * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
    * transaction ID is known.
    *
-   * <p>For a group commit full key, it uses the same two-step protocol as lazy recovery (see {@link
-   * Coordinator#putStateForLazyRecoveryRollback(String)}): it writes the parent-ID conflict marker
-   * before the full-ID ABORTED record, so the abort wins against an in-flight normal group commit
-   * (which writes the COMMITTED state under the parent ID). For a non-group-commit ID it just
-   * writes the ABORTED record.
+   * <p>This delegates to {@link Coordinator#putStateForLazyRecoveryRollback(String)}, which
+   * branches on the given ID: for a group commit full key it uses the same two-step protocol as
+   * lazy recovery, writing the parent-ID conflict marker before the full-ID ABORTED record so the
+   * abort wins against an in-flight normal group commit (which writes the COMMITTED state under the
+   * parent ID); for a non-group-commit ID it just writes the ABORTED record.
    *
    * @param id the transaction ID
    * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -449,9 +449,8 @@ public class CommitHandler {
   }
 
   /**
-   * Writes the ABORTED state without persisting a {@code tx_write_set}. Intended for callers that
-   * don't have the originating transaction context (lazy recovery, manager-level rollback) or that
-   * don't want per-transaction write-set logging.
+   * Writes the ABORTED state without persisting a {@code tx_write_set} using a single {@code
+   * putState}. Intended for callers that don't want per-transaction write-set logging.
    *
    * @param id the transaction ID
    * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
@@ -471,28 +470,36 @@ public class CommitHandler {
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
-      try {
-        Optional<Coordinator.State> state = coordinator.getState(id);
-        if (state.isPresent()) {
-          // successfully COMMITTED or ABORTED
-          return state.get().getState();
-        }
-        throw new UnknownTransactionStatusException(
-            CoreError
-                .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-                .buildMessage(e.getMessage()),
-            e,
-            id);
-      } catch (CoordinatorException e1) {
-        throw new UnknownTransactionStatusException(
-            CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
-            e1,
-            id);
-      }
+      return resolveAbortStateConflict(id, e);
     } catch (CoordinatorException e) {
       throw new UnknownTransactionStatusException(
           CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
           e,
+          id);
+    }
+  }
+
+  // Resolves the final transaction state after a conflict while writing the ABORTED state: a
+  // concurrent writer beat us, so follow whatever state is already persisted.
+  private TransactionState resolveAbortStateConflict(String id, CoordinatorConflictException e)
+      throws UnknownTransactionStatusException {
+    try {
+      Optional<Coordinator.State> state = coordinator.getState(id);
+      if (state.isPresent()) {
+        // successfully COMMITTED or ABORTED
+        return state.get().getState();
+      }
+      throw new UnknownTransactionStatusException(
+          CoreError
+              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
+              .buildMessage(e.getMessage()),
+          e,
+          id);
+    } catch (CoordinatorException e1) {
+      e1.addSuppressed(e);
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
+          e1,
           id);
     }
   }
@@ -513,6 +520,38 @@ public class CommitHandler {
     } catch (Exception e) {
       logger.info("Rolling back records failed. Transaction ID: {}", context.transactionId, e);
       // ignore since records are recovered lazily
+    }
+  }
+
+  /**
+   * Writes the ABORTED state for a manager-level rollback/abort by transaction ID (the {@code
+   * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
+   * transaction ID is known.
+   *
+   * <p>For a group commit full key, it uses the same two-step protocol as lazy recovery (see {@link
+   * Coordinator#putStateForLazyRecoveryRollback(String)}): it writes the parent-ID conflict marker
+   * before the full-ID ABORTED record, so the abort wins against an in-flight normal group commit
+   * (which writes the COMMITTED state under the parent ID). For a non-group-commit ID it just
+   * writes the ABORTED record.
+   *
+   * @param id the transaction ID
+   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
+   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
+   *     TransactionState#ABORTED}) is already persisted
+   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
+   */
+  public TransactionState abortStateForRollback(String id)
+      throws UnknownTransactionStatusException {
+    try {
+      coordinator.putStateForLazyRecoveryRollback(id);
+      return TransactionState.ABORTED;
+    } catch (CoordinatorConflictException e) {
+      return resolveAbortStateConflict(id, e);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
+          e,
+          id);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -579,7 +579,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   public TransactionState rollback(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
-      return commit.abortStateWithoutWriteSet(txId);
+      return commit.abortStateForRollback(txId);
     } catch (UnknownTransactionStatusException ignored) {
       return TransactionState.UNKNOWN;
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -643,8 +643,12 @@ public class CommitHandlerTest {
     TransactionState result = handler.abortStateForRollback(anyId());
 
     // Assert
-    // The abort goes through the lazy-recovery two-step protocol (which writes the parent-ID
-    // conflict marker before the full-ID record for a group commit full key), not a plain putState.
+    // The abort delegates to Coordinator#putStateForLazyRecoveryRollback rather than a plain
+    // putState. That method branches on the ID: it writes the parent-ID conflict marker before the
+    // full-ID record for a group commit full key (so the abort wins against an in-flight group
+    // commit), and falls back to a single putState for a non-group-commit ID. Which branch runs
+    // here depends on anyId(): a non-group-commit ID in this base class, a group commit full key in
+    // the group commit subclass that overrides anyId().
     assertThat(result).isEqualTo(TransactionState.ABORTED);
     verify(coordinator).putStateForLazyRecoveryRollback(anyId());
     verify(coordinator, never()).putState(any());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -634,6 +634,69 @@ public class CommitHandlerTest {
   }
 
   @Test
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // The abort goes through the lazy-recovery two-step protocol (which writes the parent-ID
+    // conflict marker before the full-ID record for a group commit full key), not a plain putState.
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).putStateForLazyRecoveryRollback(anyId());
+    verify(coordinator, never()).putState(any());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
           throws ExecutionException, CoordinatorException, CrudException {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -533,6 +533,42 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
   }
 
   @Test
+  @Override
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted();
+
+    // abortStateForRollback(id) only writes the coordinator rollback marker; it never goes through
+    // the group commit path, so the slot reserved by extraInitialize() is not released. Release it
+    // here so the @AfterEach groupCommitter.close() does not block on the slot-abort timeout.
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
   void emitter_emitNormalGroup_WithMultipleWritingChildren_ShouldAggregatePerChild()
       throws Exception {
     // The slot reserved by extraInitialize is unused here — these emitter tests bypass the group

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -695,7 +695,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -709,7 +709,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -722,7 +722,7 @@ public class ConsensusCommitManagerTest {
   public void rollback_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID))
+    when(commit.abortStateForRollback(ANY_TX_ID))
         .thenThrow(UnknownTransactionStatusException.class);
 
     // Act
@@ -736,7 +736,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerReturnsAborted_ShouldReturnTheState() throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -750,7 +750,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -763,7 +763,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortStateWithoutWriteSet(ANY_TX_ID))
+    when(commit.abortStateForRollback(ANY_TX_ID))
         .thenThrow(UnknownTransactionStatusException.class);
 
     // Act

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -48,6 +49,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -783,10 +785,15 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record. This way the
+    // abort conflicts with, and wins against, an in-flight normal group commit, which writes the
+    // COMMITTED state under the parent ID.
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @Test
@@ -889,10 +896,14 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @ParameterizedTest
@@ -930,10 +941,14 @@ public class CoordinatorTest {
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -16,7 +16,6 @@ import com.scalar.db.io.Key;
 import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 public abstract class ConsensusCommitIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -34,35 +33,6 @@ public abstract class ConsensusCommitIntegrationTestBase
   }
 
   protected abstract Properties getProps(String testName);
-
-  @SuppressWarnings("unused") // Referenced by @DisabledIf below.
-  private boolean isGroupCommitEnabled() {
-    return Boolean.parseBoolean(
-        getProperties(getTestName())
-            .getProperty(ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "false"));
-  }
-
-  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
-  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. With group
-  // commit enabled, aborting an ongoing transaction by ID writes the ABORTED state under the full
-  // transaction ID, while a normal group commit writes the COMMITTED state under the parent ID.
-  // The two do not conflict, so the abort is lost and the transaction can still commit.
-  @Test
-  @Override
-  @DisabledIf("isGroupCommitEnabled")
-  public void abort_forOngoingTransaction_ShouldAbortCorrectly() throws TransactionException {
-    super.abort_forOngoingTransaction_ShouldAbortCorrectly();
-  }
-
-  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
-  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. See the note
-  // on abort_forOngoingTransaction_ShouldAbortCorrectly above.
-  @Test
-  @Override
-  @DisabledIf("isGroupCommitEnabled")
-  public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() throws TransactionException {
-    super.rollback_forOngoingTransaction_ShouldRollbackCorrectly();
-  }
 
   @Test
   public void

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -12,6 +12,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -48,9 +50,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
-import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
-import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
@@ -7809,9 +7809,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   @EnumSource(Isolation.class)
   void
       commit_ConflictingExternalUpdate_DifferentGetButSameRecordReturned_ShouldThrowShouldBehaveCorrectly(
-          Isolation isolation)
-          throws UnknownTransactionStatusException, CrudException, RollbackException,
-              CommitException, TransactionException {
+          Isolation isolation) throws TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     manager.insert(
@@ -9838,6 +9836,41 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                         .setName(ACCOUNT_TYPE)
                         .setIntValue(Column.IntValue.newBuilder().setValue(clusteringKeyValue))))
         .build();
+  }
+
+  @Test
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      rollback_forOngoingGroupCommitTransactionWhenNormalGroupCommitInFlight_ShouldRollbackCorrectly()
+          throws Exception {
+    // Rolling back an in-flight, group-committed transaction by ID must win against the in-flight
+    // normal group commit, which writes the COMMITTED state under the parent ID. The race is made
+    // deterministic by rolling the transaction back by ID just before the group commit writes its
+    // COMMITTED state under the parent ID, so the two writes genuinely conflict.
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    DistributedTransaction transaction = manager.begin();
+    transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1));
+    String ongoingTxId = transaction.getId();
+    String parentId =
+        new CoordinatorGroupCommitKeyManipulator().keysFromFullKey(ongoingTxId).parentKey;
+
+    doAnswer(
+            invocation -> {
+              // The rollback writes the parent-ID ABORTED marker (not a COMMITTED state), so it
+              // does not match this stub and runs against the real coordinator.
+              manager.rollback(ongoingTxId);
+              return invocation.callRealMethod();
+            })
+        .when(coordinator)
+        .putStateForGroupCommit(
+            eq(parentId), anyList(), any(), eq(TransactionState.COMMITTED), anyLong());
+
+    // Act Assert
+    assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
+    assertThat(manager.getState(ongoingTxId)).isEqualTo(TransactionState.ABORTED);
   }
 
   private DistributedTransaction prepareTransfer(


### PR DESCRIPTION
## Description

When coordinator group commit is enabled, `DistributedTransactionManager.rollback(String)` / `abort(String)` could fail to abort an in-flight, group-committed transaction. The by-ID abort path wrote the `ABORTED` coordinator state under the full transaction ID only, which never conflicts with the parent-ID `COMMITTED` state that a normal group commit writes. As a result the abort was silently lost: the transaction still committed and `getState()` returned `COMMITTED`.

This issue was surfaced by #3614, where removing a same-instance-only slot-cancel band-aid made it visible as failing integration tests. #3614 temporarily disabled those tests for group commit; this PR fixes the behavior and re-enables them.

## Related issues and/or PRs

- #3614

## Changes made

- Add `CommitHandler.abortStateForRollback(String)` for the manager-level rollback/abort-by-ID path. For a group commit full key it uses the same two-step protocol as lazy recovery (`Coordinator.putStateForLazyRecoveryRollback`): it writes the parent-ID conflict marker before the full-ID `ABORTED` record, so the abort wins against an in-flight normal group commit. For a non-group-commit ID it just writes the `ABORTED` record.
- Route `ConsensusCommitManager.rollback(String)` through `abortStateForRollback`. `abortStateWithoutWriteSet` keeps its single-`putState` behavior for the two-phase commit rollback path. Conflict resolution is extracted into `resolveAbortStateConflict` and shared.
- Re-enable `abort_forOngoingTransaction_ShouldAbortCorrectly` and `rollback_forOngoingTransaction_ShouldRollbackCorrectly` for coordinator group commit.
- Add unit tests for `abortStateForRollback`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

For a same-instance abort of an in-flight transaction that is batched with other transactions under the same parent, the parent-ID conflict marker also makes those co-batched transactions fail their commit with a (retryable) conflict. This is acceptable because aborting an in-flight transaction by ID is an out-of-band operation rather than the normal `transaction.rollback()` path.

## Release notes

Fixed a bug where aborting an in-flight, group-committed transaction by ID via `DistributedTransactionManager.rollback(String)` / `abort(String)` could be lost when the Coordinator group commit feature was enabled.