### PR TITLE
Backport to branch(3.18) : Fix read-only handling in coordinator write omission commit paths

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -407,28 +407,36 @@ public class CommitHandler {
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
-      try {
-        Optional<Coordinator.State> state = coordinator.getState(id);
-        if (state.isPresent()) {
-          // successfully COMMITTED or ABORTED
-          return state.get().getState();
-        }
-        throw new UnknownTransactionStatusException(
-            CoreError
-                .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-                .buildMessage(e.getMessage()),
-            e,
-            id);
-      } catch (CoordinatorException e1) {
-        throw new UnknownTransactionStatusException(
-            CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
-            e1,
-            id);
-      }
+      return resolveAbortStateConflict(id, e);
     } catch (CoordinatorException e) {
       throw new UnknownTransactionStatusException(
           CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
           e,
+          id);
+    }
+  }
+
+  // Resolves the final transaction state after a conflict while writing the ABORTED state: a
+  // concurrent writer beat us, so follow whatever state is already persisted.
+  private TransactionState resolveAbortStateConflict(String id, CoordinatorConflictException e)
+      throws UnknownTransactionStatusException {
+    try {
+      Optional<Coordinator.State> state = coordinator.getState(id);
+      if (state.isPresent()) {
+        // successfully COMMITTED or ABORTED
+        return state.get().getState();
+      }
+      throw new UnknownTransactionStatusException(
+          CoreError
+              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
+              .buildMessage(e.getMessage()),
+          e,
+          id);
+    } catch (CoordinatorException e1) {
+      e1.addSuppressed(e);
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
+          e1,
           id);
     }
   }
@@ -449,6 +457,38 @@ public class CommitHandler {
     } catch (Exception e) {
       logger.info("Rolling back records failed. Transaction ID: {}", context.transactionId, e);
       // ignore since records are recovered lazily
+    }
+  }
+
+  /**
+   * Writes the ABORTED state for a manager-level rollback/abort by transaction ID (the {@code
+   * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
+   * transaction ID is known.
+   *
+   * <p>This delegates to {@link Coordinator#putStateForLazyRecoveryRollback(String)}, which
+   * branches on the given ID: for a group commit full key it uses the same two-step protocol as
+   * lazy recovery, writing the parent-ID conflict marker before the full-ID ABORTED record so the
+   * abort wins against an in-flight normal group commit (which writes the COMMITTED state under the
+   * parent ID); for a non-group-commit ID it just writes the ABORTED record.
+   *
+   * @param id the transaction ID
+   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
+   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
+   *     TransactionState#ABORTED}) is already persisted
+   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
+   */
+  public TransactionState abortStateForRollback(String id)
+      throws UnknownTransactionStatusException {
+    try {
+      coordinator.putStateForLazyRecoveryRollback(id);
+      return TransactionState.ABORTED;
+    } catch (CoordinatorConflictException e) {
+      return resolveAbortStateConflict(id, e);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
+          e,
+          id);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -91,7 +91,7 @@ public class CommitHandler {
       TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
       throws UnknownTransactionStatusException {
     if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
-      abortState(context.transactionId);
+      abortState(context);
     }
     if (hasWritesOrDeletesInSnapshot) {
       rollbackRecords(context);
@@ -167,7 +167,7 @@ public class CommitHandler {
         prepareRecords(context);
       } catch (PreparationException e) {
         safelyCallOnFailureBeforeCommit(context);
-        abortState(context.transactionId);
+        abortState(context);
         rollbackRecords(context);
         if (e instanceof PreparationConflictException) {
           throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
@@ -399,6 +399,24 @@ public class CommitHandler {
       logger.info("Committing records failed. Transaction ID: {}", context.transactionId, e);
       // ignore since records are recovered lazily
     }
+  }
+
+  /**
+   * Writes the ABORTED state for the given transaction context.
+   *
+   * <p>Subclasses can override this to perform context-aware cleanup (e.g., releasing a reserved
+   * group commit slot, which requires the {@link TransactionContext#groupCommitSlotReserved} flag
+   * that a bare transaction ID does not carry) before delegating to {@link #abortState(String)}.
+   *
+   * @param context the transaction context
+   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
+   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
+   *     TransactionState#ABORTED}) is already persisted
+   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
+   */
+  public TransactionState abortState(TransactionContext context)
+      throws UnknownTransactionStatusException {
+    return abortState(context.transactionId);
   }
 
   public TransactionState abortState(String id) throws UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -81,7 +81,25 @@ public class CommitHandler {
     }
   }
 
-  private Optional<Future<Void>> invokeBeforePreparationHook(TransactionContext context)
+  // Aborts the coordinator state and rolls back records as needed after a pre-commit failure. When
+  // the transaction has no writes and deletes, there are no records to roll back. In that case the
+  // coordinator state is still aborted unless coordinator write omission on read-only is enabled:
+  // when it is, a write-less transaction (a read-only one, or a non-read-only one with an empty
+  // write set) writes no coordinator state row on the commit path either, so there is nothing to
+  // abort.
+  private void abortStateAndRollbackRecordsIfNeeded(
+      TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
+      throws UnknownTransactionStatusException {
+    if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
+      abortState(context.transactionId);
+    }
+    if (hasWritesOrDeletesInSnapshot) {
+      rollbackRecords(context);
+    }
+  }
+
+  private Optional<Future<Void>> invokeBeforePreparationHook(
+      TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
       throws UnknownTransactionStatusException, CommitException {
     if (beforePreparationHook == null) {
       return Optional.empty();
@@ -91,8 +109,9 @@ public class CommitHandler {
       return Optional.of(beforePreparationHook.handle(tableMetadataManager, context));
     } catch (Exception e) {
       safelyCallOnFailureBeforeCommit(context);
-      abortState(context.transactionId);
-      rollbackRecords(context);
+
+      abortStateAndRollbackRecordsIfNeeded(context, hasWritesOrDeletesInSnapshot);
+
       throw new CommitException(
           CoreError.CONSENSUS_COMMIT_HANDLING_BEFORE_PREPARATION_HOOK_FAILED.buildMessage(
               e.getMessage()),
@@ -102,7 +121,9 @@ public class CommitHandler {
   }
 
   private void waitBeforePreparationHookFuture(
-      TransactionContext context, @Nullable Future<Void> beforePreparationHookFuture)
+      TransactionContext context,
+      @Nullable Future<Void> beforePreparationHookFuture,
+      boolean hasWritesOrDeletesInSnapshot)
       throws UnknownTransactionStatusException, CommitException {
     if (beforePreparationHookFuture == null) {
       return;
@@ -112,8 +133,9 @@ public class CommitHandler {
       beforePreparationHookFuture.get();
     } catch (Exception e) {
       safelyCallOnFailureBeforeCommit(context);
-      abortState(context.transactionId);
-      rollbackRecords(context);
+
+      abortStateAndRollbackRecordsIfNeeded(context, hasWritesOrDeletesInSnapshot);
+
       throw new CommitException(
           CoreError.CONSENSUS_COMMIT_HANDLING_BEFORE_PREPARATION_HOOK_FAILED.buildMessage(
               e.getMessage()),
@@ -127,7 +149,8 @@ public class CommitHandler {
     boolean hasWritesOrDeletesInSnapshot =
         !context.readOnly && context.snapshot.hasWritesOrDeletes();
 
-    Optional<Future<Void>> beforePreparationHookFuture = invokeBeforePreparationHook(context);
+    Optional<Future<Void>> beforePreparationHookFuture =
+        invokeBeforePreparationHook(context, hasWritesOrDeletesInSnapshot);
 
     if (canOnePhaseCommit(context)) {
       try {
@@ -161,14 +184,7 @@ public class CommitHandler {
     } catch (ValidationException e) {
       safelyCallOnFailureBeforeCommit(context);
 
-      // If the transaction has no writes and deletes, we don't need to abort-state and
-      // rollback-records since there are no changes to be made.
-      if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
-        abortState(context.transactionId);
-      }
-      if (hasWritesOrDeletesInSnapshot) {
-        rollbackRecords(context);
-      }
+      abortStateAndRollbackRecordsIfNeeded(context, hasWritesOrDeletesInSnapshot);
 
       if (e instanceof ValidationConflictException) {
         throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
@@ -179,7 +195,8 @@ public class CommitHandler {
       throw e;
     }
 
-    waitBeforePreparationHookFuture(context, beforePreparationHookFuture.orElse(null));
+    waitBeforePreparationHookFuture(
+        context, beforePreparationHookFuture.orElse(null), hasWritesOrDeletesInSnapshot);
 
     if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
       commitState(context);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -145,17 +145,15 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   }
 
   @Override
-  public TransactionState abortState(String id) throws UnknownTransactionStatusException {
-    // This abort path only carries the transaction ID (e.g., lazy recovery or an explicit abort via
-    // the manager), so there is no TransactionContext to consult for slot reservation. Removing the
-    // slot by ID is idempotent and safe even when no slot was reserved.
-    try {
-      groupCommitter.remove(id);
-    } catch (Exception e) {
-      logger.warn(
-          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}", id, e);
-    }
-    return super.abortState(id);
+  public TransactionState abortState(TransactionContext context)
+      throws UnknownTransactionStatusException {
+    // Release the reserved group commit slot before writing the ABORTED state. The context carries
+    // the groupCommitSlotReserved flag, so cancelGroupCommitIfNeeded() only removes the slot when
+    // one was actually reserved (and the transaction ID is a full key). The manager-level
+    // abort/rollback-by-ID path goes through abortStateForRollback(String) instead, which is not
+    // overridden here, so a bare transaction ID never reaches groupCommitter.remove().
+    cancelGroupCommitIfNeeded(context);
+    return super.abortState(context);
   }
 
   private static class Emitter implements Emittable<String, String, TransactionContext> {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -53,7 +53,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
     if (!context.readOnly
         && !context.snapshot.hasWritesOrDeletes()
         && coordinatorWriteOmissionOnReadOnlyEnabled) {
-      cancelGroupCommitIfNeeded(context.transactionId);
+      cancelGroupCommitIfNeeded(context);
     }
 
     super.commit(context);
@@ -64,7 +64,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
     try {
       return super.canOnePhaseCommit(context);
     } catch (CommitException e) {
-      cancelGroupCommitIfNeeded(context.transactionId);
+      cancelGroupCommitIfNeeded(context);
       throw e;
     }
   }
@@ -72,13 +72,13 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   @Override
   void onePhaseCommitRecords(TransactionContext context)
       throws CommitConflictException, UnknownTransactionStatusException {
-    cancelGroupCommitIfNeeded(context.transactionId);
+    cancelGroupCommitIfNeeded(context);
     super.onePhaseCommitRecords(context);
   }
 
   @Override
   protected void onFailureBeforeCommit(TransactionContext context) {
-    cancelGroupCommitIfNeeded(context.transactionId);
+    cancelGroupCommitIfNeeded(context);
   }
 
   private void commitStateViaGroupCommit(TransactionContext context)
@@ -90,11 +90,11 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       logger.debug(
           "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
     } catch (GroupCommitConflictException e) {
-      cancelGroupCommitIfNeeded(id);
+      cancelGroupCommitIfNeeded(context);
       // Throw a proper exception from this method if needed.
       handleCommitConflict(context, e);
     } catch (GroupCommitException e) {
-      cancelGroupCommitIfNeeded(id);
+      cancelGroupCommitIfNeeded(context);
       Throwable cause = e.getCause();
       if (cause instanceof CoordinatorConflictException) {
         // Throw a proper exception from this method if needed.
@@ -105,17 +105,36 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       }
     } catch (Exception e) {
       // This is an unexpected exception, but clean up resources just in case.
-      cancelGroupCommitIfNeeded(id);
+      cancelGroupCommitIfNeeded(context);
       throw new AssertionError("Group commit unexpectedly failed. TransactionID: " + id, e);
     }
   }
 
-  private void cancelGroupCommitIfNeeded(String id) {
+  private void cancelGroupCommitIfNeeded(TransactionContext context) {
+    // A transaction only holds a group commit slot when one was reserved at begin time (e.g., a
+    // read-only transaction does not reserve a slot when coordinator write omission is enabled).
+    // When no slot was reserved there is nothing to release.
+    if (!context.groupCommitSlotReserved) {
+      return;
+    }
+
+    // FIXME: When a slot was reserved (so the early return above did not fire), this can run more
+    // than once on a single failure path, because several cleanup callbacks each release the slot:
+    //   - onFailureBeforeCommit() runs on every failure path (via safelyCallOnFailureBeforeCommit);
+    //   - abortState() additionally runs from abortStateAndRollbackRecordsIfNeeded() when the
+    //     transaction has writes/deletes, or coordinator write omission on read-only is disabled;
+    //   - onePhaseCommitRecords() pre-cancels the slot before its body, so a one-phase-commit
+    //     failure followed by onFailureBeforeCommit() also cancels twice.
+    // It is currently safe only because groupCommitter.remove() is idempotent. The cleanup paths
+    // should be reworked so the slot is released exactly once instead of relying on that
+    // idempotency.
     try {
-      groupCommitter.remove(id);
+      groupCommitter.remove(context.transactionId);
     } catch (Exception e) {
       logger.warn(
-          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}", id);
+          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}",
+          context.transactionId,
+          e);
     }
   }
 
@@ -127,7 +146,15 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
 
   @Override
   public TransactionState abortState(String id) throws UnknownTransactionStatusException {
-    cancelGroupCommitIfNeeded(id);
+    // This abort path only carries the transaction ID (e.g., lazy recovery or an explicit abort via
+    // the manager), so there is no TransactionContext to consult for slot reservation. Removing the
+    // slot by ID is idempotent and safe even when no slot was reserved.
+    try {
+      groupCommitter.remove(id);
+    } catch (Exception e) {
+      logger.warn(
+          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}", id, e);
+    }
     return super.abortState(id);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -226,8 +226,18 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
       logger.warn("Failed to close the scanner. Transaction ID: {}", getId(), e);
     }
 
-    if (groupCommitter != null && !context.readOnly) {
-      groupCommitter.remove(getId());
+    // Release the reserved group commit slot if this transaction holds one.
+    if (groupCommitter != null && context.groupCommitSlotReserved) {
+      // This is best-effort cleanup; never let a failure here mask the rollback or propagate out of
+      // this cleanup path.
+      try {
+        groupCommitter.remove(getId());
+      } catch (Exception e) {
+        logger.warn(
+            "Failed to remove the transaction ID from the group committer. Transaction ID: {}",
+            getId(),
+            e);
+      }
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -571,7 +571,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   public TransactionState rollback(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
-      return commit.abortState(txId);
+      return commit.abortStateForRollback(txId);
     } catch (UnknownTransactionStatusException ignored) {
       return TransactionState.UNKNOWN;
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -63,6 +63,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   private final Isolation isolation;
   private final ConsensusCommitOperationChecker operationChecker;
   @Nullable private final CoordinatorGroupCommitter groupCommitter;
+  private final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
@@ -80,6 +81,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(config).orElse(null);
+    coordinatorWriteOmissionOnReadOnlyEnabled =
+        config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
     crud =
         new CrudHandler(
             storage,
@@ -118,6 +121,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(config).orElse(null);
+    coordinatorWriteOmissionOnReadOnlyEnabled =
+        config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
     crud =
         new CrudHandler(
             storage,
@@ -167,6 +172,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     this.crud = crud;
     this.commit = commit;
     this.groupCommitter = groupCommitter;
+    this.coordinatorWriteOmissionOnReadOnlyEnabled =
+        config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
     this.isolation = isolation;
     VirtualTableInfoManager virtualTableInfoManager =
         new VirtualTableInfoManager(admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
@@ -278,13 +285,22 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       String txId, Isolation isolation, boolean readOnly, boolean oneOperation) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkNotNull(isolation);
-    if (!readOnly && isGroupCommitEnabled()) {
+    // Reserve a group commit slot for every non-read-only transaction, and for a read-only
+    // transaction only when coordinator write omission is disabled. Such a read-only transaction
+    // writes a coordinator state row, so without a slot it would reach the group commit path with a
+    // bare (unreserved) transaction ID and fail. A non-read-only transaction that turns out to be
+    // write-less under write omission still reserves a slot here but cancels it later on the commit
+    // path.
+    boolean groupCommitSlotReserved = false;
+    if (isGroupCommitEnabled() && (!readOnly || !coordinatorWriteOmissionOnReadOnlyEnabled)) {
       assert groupCommitter != null;
       txId = groupCommitter.reserve(txId);
+      groupCommitSlotReserved = true;
     }
     Snapshot snapshot = new Snapshot(txId, tableMetadataManager, parallelExecutor);
     TransactionContext context =
-        new TransactionContext(txId, snapshot, isolation, readOnly, oneOperation);
+        new TransactionContext(
+            txId, snapshot, isolation, readOnly, oneOperation, groupCommitSlotReserved);
     DistributedTransaction transaction =
         new ConsensusCommit(context, crud, commit, operationChecker, groupCommitter);
     if (readOnly) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -55,9 +55,11 @@ public class Coordinator {
   private static final int MAX_RETRY_COUNT = 5;
   private static final long SLEEP_BASE_MILLIS = 50;
   private static final Logger logger = LoggerFactory.getLogger(Coordinator.class);
+  private static final CoordinatorGroupCommitKeyManipulator KEY_MANIPULATOR =
+      new CoordinatorGroupCommitKeyManipulator();
+
   private final DistributedStorage storage;
   private final String coordinatorNamespace;
-  private final CoordinatorGroupCommitKeyManipulator keyManipulator;
 
   /**
    * @param storage a storage
@@ -68,14 +70,12 @@ public class Coordinator {
   public Coordinator(DistributedStorage storage) {
     this.storage = storage;
     coordinatorNamespace = NAMESPACE;
-    keyManipulator = new CoordinatorGroupCommitKeyManipulator();
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public Coordinator(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(NAMESPACE);
-    keyManipulator = new CoordinatorGroupCommitKeyManipulator();
   }
 
   /**
@@ -88,7 +88,7 @@ public class Coordinator {
    * @throws CoordinatorException if the coordinator state cannot be retrieved
    */
   public Optional<Coordinator.State> getState(String id) throws CoordinatorException {
-    if (keyManipulator.isFullKey(id)) {
+    if (KEY_MANIPULATOR.isFullKey(id)) {
       return getStateForGroupCommit(id);
     }
 
@@ -107,7 +107,7 @@ public class Coordinator {
   @VisibleForTesting
   Optional<Coordinator.State> getStateForGroupCommit(String fullId) throws CoordinatorException {
     // Scan with the parent ID for a normal group that contains multiple transactions.
-    Keys<String, String, String> idForGroupCommit = keyManipulator.keysFromFullKey(fullId);
+    Keys<String, String, String> idForGroupCommit = KEY_MANIPULATOR.keysFromFullKey(fullId);
 
     String parentId = idForGroupCommit.parentKey;
     String childId = idForGroupCommit.childKey;
@@ -174,7 +174,7 @@ public class Coordinator {
       String parentId, List<String> fullIds, TransactionState transactionState, long createdAt)
       throws CoordinatorException {
 
-    if (keyManipulator.isFullKey(parentId)) {
+    if (KEY_MANIPULATOR.isFullKey(parentId)) {
       throw new AssertionError(
           "This method is only for normal group commits that use a parent ID as the key");
     }
@@ -182,7 +182,7 @@ public class Coordinator {
     // Put the state that contains a parent ID as the key and multiple child transaction IDs.
     List<String> childIds = new ArrayList<>(fullIds.size());
     for (String fullId : fullIds) {
-      Keys<String, String, String> keys = keyManipulator.keysFromFullKey(fullId);
+      Keys<String, String, String> keys = KEY_MANIPULATOR.keysFromFullKey(fullId);
       childIds.add(keys.childKey);
     }
     State state = new State(parentId, childIds, transactionState, createdAt);
@@ -192,7 +192,7 @@ public class Coordinator {
   }
 
   public void putStateForLazyRecoveryRollback(String id) throws CoordinatorException {
-    if (keyManipulator.isFullKey(id)) {
+    if (KEY_MANIPULATOR.isFullKey(id)) {
       putStateForLazyRecoveryRollbackForGroupCommit(id);
       return;
     }
@@ -258,7 +258,7 @@ public class Coordinator {
     // - `lazy-recovery-abort-with-full-id` succeeds
     // - The original commit with `tx_id: <full tx ID>` fails
     // - The transaction is treated as aborted because of `lazy-recovery-abort-with-full-id`
-    Keys<String, String, String> keys = keyManipulator.keysFromFullKey(id);
+    Keys<String, String, String> keys = KEY_MANIPULATOR.keysFromFullKey(id);
     try {
       // This record is to prevent a group commit that has the same parent ID considering case #a
       // regardless if the transaction is actually in a group commit (case #a) or a delayed commit

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.exception.transaction.CrudException;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,12 @@ public class TransactionContext {
   // a transaction.
   public final boolean oneOperation;
 
+  // Whether a group commit slot was reserved for this transaction at begin time. It is true only
+  // when the group commit feature is enabled and a slot was actually reserved (see
+  // ConsensusCommitManager.begin()). The rollback and commit paths check this flag to decide
+  // whether the reserved slot must be released.
+  public final boolean groupCommitSlotReserved;
+
   // A list of scanners opened in the transaction
   public final List<ConsensusCommitScanner> scanners = new ArrayList<>();
 
@@ -36,12 +43,24 @@ public class TransactionContext {
       Snapshot snapshot,
       Isolation isolation,
       boolean readOnly,
-      boolean oneOperation) {
+      boolean oneOperation,
+      boolean groupCommitSlotReserved) {
     this.transactionId = transactionId;
     this.snapshot = snapshot;
     this.isolation = isolation;
     this.readOnly = readOnly;
     this.oneOperation = oneOperation;
+    this.groupCommitSlotReserved = groupCommitSlotReserved;
+  }
+
+  @VisibleForTesting
+  TransactionContext(
+      String transactionId,
+      Snapshot snapshot,
+      Isolation isolation,
+      boolean readOnly,
+      boolean oneOperation) {
+    this(transactionId, snapshot, isolation, readOnly, oneOperation, false);
   }
 
   public boolean isSnapshotReadRequired() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -235,7 +235,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
       String txId, Isolation isolation, boolean readOnly, boolean oneOperation) {
     Snapshot snapshot = new Snapshot(txId, tableMetadataManager, parallelExecutor);
     TransactionContext context =
-        new TransactionContext(txId, snapshot, isolation, readOnly, oneOperation);
+        new TransactionContext(txId, snapshot, isolation, readOnly, oneOperation, false);
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(context, crud, commit, operationChecker);
     getNamespace().ifPresent(transaction::withNamespace);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -76,6 +76,13 @@ public class CommitHandlerTest {
     return ANY_ID;
   }
 
+  // Creates a TransactionContext for tests. Overridden by the group commit test to mark the context
+  // as holding a reserved group commit slot, mirroring what ConsensusCommitManager.begin() does.
+  protected TransactionContext createTransactionContext(
+      String id, Snapshot snapshot, Isolation isolation, boolean readOnly, boolean oneOperation) {
+    return new TransactionContext(id, snapshot, isolation, readOnly, oneOperation);
+  }
+
   protected void extraInitialize() {}
 
   protected void extraCleanup() {}
@@ -206,7 +213,7 @@ public class CommitHandlerTest {
     return snapshot;
   }
 
-  private Snapshot prepareSnapshotWithoutWrites() {
+  protected Snapshot prepareSnapshotWithoutWrites() {
     Snapshot snapshot = prepareSnapshot();
 
     Get get = prepareGet();
@@ -238,7 +245,7 @@ public class CommitHandlerTest {
     doNothingWhenCoordinatorPutState();
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -263,7 +270,7 @@ public class CommitHandlerTest {
     doNothingWhenCoordinatorPutState();
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -286,7 +293,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
 
     // Act
     handler.commit(context);
@@ -310,7 +317,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -335,7 +342,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -359,7 +366,7 @@ public class CommitHandlerTest {
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
@@ -384,7 +391,7 @@ public class CommitHandlerTest {
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
@@ -409,7 +416,7 @@ public class CommitHandlerTest {
     doNothingWhenCoordinatorPutState();
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -436,7 +443,7 @@ public class CommitHandlerTest {
     doNothingWhenCoordinatorPutState();
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     handler.commit(context);
@@ -457,7 +464,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     // With SNAPSHOT isolation, validation is not required
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.validateRecords(context);
@@ -474,7 +481,7 @@ public class CommitHandlerTest {
     doNothing().when(snapshot).toSerializable(storage);
     // With SERIALIZABLE isolation, validation is required when there are reads
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     handler.validateRecords(context);
@@ -492,7 +499,7 @@ public class CommitHandlerTest {
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
@@ -517,7 +524,7 @@ public class CommitHandlerTest {
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
@@ -542,7 +549,7 @@ public class CommitHandlerTest {
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -573,7 +580,7 @@ public class CommitHandlerTest {
         .getState(anyId());
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -602,7 +609,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -632,7 +639,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -661,7 +668,7 @@ public class CommitHandlerTest {
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -688,7 +695,7 @@ public class CommitHandlerTest {
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -714,7 +721,7 @@ public class CommitHandlerTest {
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -747,7 +754,7 @@ public class CommitHandlerTest {
         .getState(anyId());
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -778,7 +785,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -810,7 +817,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -841,7 +848,7 @@ public class CommitHandlerTest {
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -872,7 +879,7 @@ public class CommitHandlerTest {
         .when(coordinator)
         .getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -898,7 +905,7 @@ public class CommitHandlerTest {
         .when(coordinator)
         .getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -922,7 +929,7 @@ public class CommitHandlerTest {
         TransactionState.COMMITTED, CoordinatorConflictException.class);
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -947,7 +954,7 @@ public class CommitHandlerTest {
         TransactionState.COMMITTED, CoordinatorConflictException.class);
     doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -969,7 +976,7 @@ public class CommitHandlerTest {
     doNothing().when(storage).mutate(anyList());
     doThrowExceptionWhenCoordinatorPutState(TransactionState.COMMITTED, CoordinatorException.class);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
@@ -1004,7 +1011,7 @@ public class CommitHandlerTest {
             });
     handler.setBeforePreparationHook(delayedBeforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     Instant start = Instant.now();
@@ -1033,7 +1040,7 @@ public class CommitHandlerTest {
         .handle(any(), any());
     handler.setBeforePreparationHook(beforePreparationHook);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -1057,7 +1064,7 @@ public class CommitHandlerTest {
     doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
     setBeforePreparationHookIfNeeded(true);
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
@@ -1072,11 +1079,161 @@ public class CommitHandlerTest {
   }
 
   @Test
+  public void
+      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws ExecutionException, CoordinatorException, CrudException,
+              UnknownTransactionStatusException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong"))
+        .when(beforePreparationHook)
+        .handle(any(), any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    // With coordinator write omission enabled, a read-only transaction must not write any
+    // coordinator row even when the before-preparation hook fails.
+    verify(storage, never()).mutate(anyList());
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).abortState(any());
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(any());
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
+              InterruptedException, UnknownTransactionStatusException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
+    setBeforePreparationHookIfNeeded(true);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).abortState(any());
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
+          throws ExecutionException, CoordinatorException, CrudException {
+    // Arrange
+    handler = spy(createCommitHandler(false));
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong"))
+        .when(beforePreparationHook)
+        .handle(any(), any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    // With coordinator write omission disabled, the ABORTED state is written even for a read-only
+    // transaction, but record rollback is still skipped since there are no writes.
+    verify(storage, never()).mutate(anyList());
+    verify(coordinator).putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(any());
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
+          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
+              InterruptedException, UnknownTransactionStatusException {
+    // Arrange
+    handler = spy(createCommitHandler(false));
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
+    setBeforePreparationHookIfNeeded(true);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    // With coordinator write omission disabled, the ABORTED state is written even for a read-only
+    // transaction, but record rollback is still skipped since there are no writes.
+    verify(storage, never()).mutate(anyList());
+    verify(coordinator).putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(any());
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookGiven_InNonReadOnlyModeWithoutWritesAndWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws ExecutionException, CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong"))
+        .when(beforePreparationHook)
+        .handle(any(), any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    // A non-read-only transaction without writes and deletes writes no coordinator row when
+    // coordinator write omission is enabled, so the before-preparation hook failure must not abort
+    // the state. There are also no records to roll back.
+    verify(storage, never()).mutate(anyList());
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).abortState(any());
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(any());
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookFutureGiven_InNonReadOnlyModeWithoutWritesAndWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws CoordinatorException, java.util.concurrent.ExecutionException,
+              InterruptedException, UnknownTransactionStatusException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
+    setBeforePreparationHookIfNeeded(true);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    // Same as above for the before-preparation hook future failure path.
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).abortState(any());
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
   public void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() throws Exception {
     // Arrange
     Snapshot snapshot = prepareSnapshot();
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1103,7 +1260,7 @@ public class CommitHandlerTest {
     snapshot.putIntoGetSet(get, Optional.empty());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1133,7 +1290,7 @@ public class CommitHandlerTest {
     doReturn(true).when(mutationsGrouper).canBeGroupedAltogether(anyList());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1150,7 +1307,7 @@ public class CommitHandlerTest {
     CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
     Snapshot snapshot = prepareSnapshotWithoutWrites();
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1173,7 +1330,7 @@ public class CommitHandlerTest {
     snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.empty());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1197,7 +1354,7 @@ public class CommitHandlerTest {
     doReturn(true).when(mutationsGrouper).canBeGroupedAltogether(anyList());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1221,7 +1378,7 @@ public class CommitHandlerTest {
     doReturn(false).when(mutationsGrouper).canBeGroupedAltogether(anyList());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     boolean actual = handler.canOnePhaseCommit(context);
@@ -1247,7 +1404,7 @@ public class CommitHandlerTest {
     doThrow(ExecutionException.class).when(mutationsGrouper).canBeGroupedAltogether(anyList());
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.canOnePhaseCommit(context))
@@ -1263,7 +1420,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = spy(prepareSnapshotWithSamePartitionPut());
     doNothing().when(storage).mutate(anyList());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.onePhaseCommitRecords(context);
@@ -1281,7 +1438,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
     doThrow(NoMutationException.class).when(storage).mutate(anyList());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
@@ -1297,7 +1454,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
     doThrow(RetriableExecutionException.class).when(storage).mutate(anyList());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
@@ -1313,7 +1470,7 @@ public class CommitHandlerTest {
     Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
     doThrow(ExecutionException.class).when(storage).mutate(anyList());
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
@@ -1332,7 +1489,7 @@ public class CommitHandlerTest {
     doNothing().when(handler).onePhaseCommitRecords(any(TransactionContext.class));
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
 
     // Act
     handler.commit(context);
@@ -1356,7 +1513,7 @@ public class CommitHandlerTest {
         .onePhaseCommitRecords(any(TransactionContext.class));
 
     TransactionContext context =
-        new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.commit(context))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -598,6 +598,73 @@ public class CommitHandlerTest {
   }
 
   @Test
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // The abort delegates to Coordinator#putStateForLazyRecoveryRollback rather than a plain
+    // putState. That method branches on the ID: it writes the parent-ID conflict marker before the
+    // full-ID record for a group commit full key (so the abort wins against an in-flight group
+    // commit), and falls back to a single putState for a non-group-commit ID. Which branch runs
+    // here depends on anyId(): a non-group-commit ID in this base class, a group commit full key in
+    // the group commit subclass that overrides anyId().
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).putStateForLazyRecoveryRollback(anyId());
+    verify(coordinator, never()).putState(any());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
           throws ExecutionException, CoordinatorException, CrudException {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -1167,7 +1167,7 @@ public class CommitHandlerTest {
     // coordinator row even when the before-preparation hook fails.
     verify(storage, never()).mutate(anyList());
     verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
+    verify(handler, never()).abortState(any(TransactionContext.class));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
   }
@@ -1189,7 +1189,7 @@ public class CommitHandlerTest {
 
     // Assert
     verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
+    verify(handler, never()).abortState(any(TransactionContext.class));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -1267,7 +1267,7 @@ public class CommitHandlerTest {
     // the state. There are also no records to roll back.
     verify(storage, never()).mutate(anyList());
     verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
+    verify(handler, never()).abortState(any(TransactionContext.class));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
   }
@@ -1290,7 +1290,7 @@ public class CommitHandlerTest {
     // Assert
     // Same as above for the before-preparation hook future failure path.
     verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
+    verify(handler, never()).abortState(any(TransactionContext.class));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(context);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -317,7 +317,7 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     verify(coordinator, never()).putState(any());
     verify(coordinator, never())
         .putStateForGroupCommit(anyString(), anyList(), any(TransactionState.class), anyLong());
-    verify(handler, never()).abortState(any());
+    verify(handler, never()).abortState(any(TransactionContext.class));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
     // The bare ID never reserved a slot, so cancelGroupCommitIfNeeded skips remove() entirely.

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.scalar.db.api.TransactionState;
@@ -49,6 +51,16 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
   @Override
   protected String anyId() {
     return keyManipulator.fullKey(parentKey, childKey);
+  }
+
+  @Override
+  protected TransactionContext createTransactionContext(
+      String id, Snapshot snapshot, Isolation isolation, boolean readOnly, boolean oneOperation) {
+    // In the group commit tests a slot is reserved for the transaction (extraInitialize() and the
+    // per-test reserve() calls), so mark the context as holding a reserved slot. Tests that
+    // intentionally model an unreserved transaction build the context with the raw constructor.
+    return new TransactionContext(
+        id, snapshot, isolation, readOnly, oneOperation, /* groupCommitSlotReserved= */ true);
   }
 
   @Override
@@ -203,6 +215,142 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
 
     // Assert
     verify(groupCommitter, never()).remove(anyId());
+  }
+
+  @Test
+  public void commit_InReadOnlyModeWithWriteOmissionDisabled_ShouldCommitStateViaGroupCommit()
+      throws CommitException, UnknownTransactionStatusException, CoordinatorException,
+          ExecutionException {
+    // Arrange
+    // With coordinator write omission disabled, a read-only transaction writes a coordinator state
+    // row. ConsensusCommitManager.begin() reserves a group commit slot for it (so its transaction
+    // ID is a group commit full key), and the state must be committed through the group commit path
+    // like any other state-writing transaction.
+    CommitHandler handler = spy(createCommitHandler(false));
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doNothingWhenCoordinatorPutState();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act
+    handler.commit(context);
+
+    // Assert
+    verify(storage, never()).mutate(anyList());
+    // The COMMITTED state is written via the group commit path (putStateForGroupCommit).
+    verifyCoordinatorPutState(TransactionState.COMMITTED);
+    verify(groupCommitter, never()).remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void
+      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws ExecutionException, CoordinatorException, CrudException,
+              UnknownTransactionStatusException {
+    super
+        .commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords();
+
+    // Assert
+    // abortState is skipped (omission enabled), but the reserved group commit slot is still
+    // released once via onFailureBeforeCommit, so it does not leak.
+    verify(groupCommitter).remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void
+      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
+          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
+              InterruptedException, UnknownTransactionStatusException {
+    super
+        .commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords();
+
+    // Assert
+    // abortState is skipped (omission enabled), but the reserved group commit slot is still
+    // released once via onFailureBeforeCommit, so it does not leak.
+    verify(groupCommitter).remove(anyId());
+  }
+
+  @Test
+  public void
+      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabledAndBareTransactionId_ShouldNotWriteCoordinatorRowNorTouchGroupCommitter()
+          throws ExecutionException, CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    // With coordinator write omission enabled, ConsensusCommitManager.begin() does not reserve a
+    // group commit slot for a read-only transaction, so the context's groupCommitSlotReserved stays
+    // false. This reproduces that production case (the inherited tests use
+    // createTransactionContext()
+    // which marks the slot as reserved instead). When the before-preparation hook fails, commit()
+    // must still fail with CommitException, write no coordinator row, and leave the group committer
+    // untouched: cancelGroupCommitIfNeeded skips remove() because no slot was reserved.
+    // Release the slot reserved by extraInitialize(); it is unrelated to this test's bare
+    // transaction ID, and leaving it outstanding would make groupCommitter.close() block on it
+    // during teardown. clearInvocations() then lets the remove() assertion count only the act
+    // phase.
+    groupCommitter.remove(anyId());
+    clearInvocations(groupCommitter);
+    String bareId = UUID.randomUUID().toString();
+    CommitHandler handler = spy(createCommitHandler(true));
+    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
+    doThrow(new RuntimeException("Something is wrong"))
+        .when(beforePreparationHook)
+        .handle(any(), any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    // This context deliberately did not reserve a group commit slot (groupCommitSlotReserved stays
+    // false), so it is built with the raw constructor rather than the createTransactionContext()
+    // helper that marks the slot as reserved.
+    TransactionContext context =
+        new TransactionContext(
+            bareId,
+            snapshot,
+            Isolation.SNAPSHOT,
+            true,
+            false,
+            /* groupCommitSlotReserved= */ false);
+
+    // Act
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    // Assert
+    verify(storage, never()).mutate(anyList());
+    verify(coordinator, never()).putState(any());
+    verify(coordinator, never())
+        .putStateForGroupCommit(anyString(), anyList(), any(TransactionState.class), anyLong());
+    verify(handler, never()).abortState(any());
+    verify(handler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(any());
+    // The bare ID never reserved a slot, so cancelGroupCommitIfNeeded skips remove() entirely.
+    verify(groupCommitter, never()).remove(anyString());
+  }
+
+  @Test
+  @Override
+  public void
+      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
+          throws ExecutionException, CoordinatorException, CrudException {
+    super
+        .commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords();
+
+    // Assert
+    // The reserved group commit slot is released twice — once via onFailureBeforeCommit and once
+    // via abortState (omission disabled) — both routing through cancelGroupCommitIfNeeded.
+    verify(groupCommitter, times(2)).remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void
+      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
+          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
+              InterruptedException, UnknownTransactionStatusException {
+    super
+        .commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords();
+
+    // Assert
+    // The reserved group commit slot is released twice — once via onFailureBeforeCommit and once
+    // via abortState (omission disabled) — both routing through cancelGroupCommitIfNeeded.
+    verify(groupCommitter, times(2)).remove(anyId());
   }
 
   @ParameterizedTest

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -521,4 +521,40 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
         .commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException();
     groupCommitter.remove(anyId());
   }
+
+  @Test
+  @Override
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted();
+
+    // abortStateForRollback(id) only writes the coordinator rollback marker; it never goes through
+    // the group commit path, so the slot reserved by extraInitialize() is not released. Release it
+    // here so the @AfterEach groupCommitter.close() does not block on the slot-abort timeout.
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -158,14 +158,18 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction.getCrudHandler()).isEqualTo(crud);
     assertThat(transaction.getCommitHandler()).isEqualTo(commit);
     assertThat(keyManipulator.isFullKey(transaction.getId())).isTrue();
+    assertThat(transaction.getTransactionContext().groupCommitSlotReserved).isTrue();
     verify(groupCommitter).reserve(ANY_TX_ID);
   }
 
   @Test
   public void
-      beginReadOnly_TxIdGivenWithGroupCommitter_ReturnWithSpecifiedTxIdAndSnapshotIsolation()
+      beginReadOnly_TxIdGivenWithGroupCommitterAndWriteOmissionEnabled_ShouldNotReserveGroupCommitSlot()
           throws TransactionException {
     // Arrange
+    // With coordinator write omission enabled (default), a read-only transaction writes no
+    // coordinator state row, so it must not reserve a group commit slot and keeps its bare tx ID.
+    when(consensusCommitConfig.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
@@ -196,7 +200,53 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction.getCrudHandler()).isEqualTo(crud);
     assertThat(transaction.getCommitHandler()).isEqualTo(commit);
     assertThat(keyManipulator.isFullKey(transaction.getId())).isFalse();
+    assertThat(transaction.getTransactionContext().groupCommitSlotReserved).isFalse();
     verify(groupCommitter, never()).reserve(ANY_TX_ID);
+  }
+
+  @Test
+  public void
+      beginReadOnly_TxIdGivenWithGroupCommitterAndWriteOmissionDisabled_ShouldReserveGroupCommitSlot()
+          throws TransactionException {
+    // Arrange
+    // With coordinator write omission disabled, a read-only transaction writes a coordinator state
+    // row, so it must reserve a group commit slot just like a writing transaction and get a group
+    // commit full key. Otherwise its state would be committed via the non-group-commit path with a
+    // bare (unreserved) transaction ID, which crashes the group committer.
+    when(consensusCommitConfig.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(false);
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
+    String parentKey = keyManipulator.generateParentKey();
+    String fullKey = keyManipulator.fullKey(parentKey, ANY_TX_ID);
+    doReturn(fullKey).when(groupCommitter).reserve(anyString());
+    ConsensusCommitManager managerWithGroupCommit =
+        new ConsensusCommitManager(
+            storage,
+            admin,
+            consensusCommitConfig,
+            databaseConfig,
+            coordinator,
+            parallelExecutor,
+            recoveryExecutor,
+            crud,
+            commit,
+            Isolation.SNAPSHOT,
+            groupCommitter);
+
+    // Act
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((DecoratedDistributedTransaction) managerWithGroupCommit.beginReadOnly(ANY_TX_ID))
+                .getOriginalTransaction();
+
+    // Assert
+    assertThat(transaction.getTransactionContext().transactionId).isEqualTo(fullKey);
+    assertThat(transaction.getTransactionContext().isolation).isEqualTo(Isolation.SNAPSHOT);
+    assertThat(transaction.getTransactionContext().readOnly).isTrue();
+    assertThat(keyManipulator.isFullKey(transaction.getId())).isTrue();
+    assertThat(transaction.getTransactionContext().groupCommitSlotReserved).isTrue();
+    verify(groupCommitter).reserve(ANY_TX_ID);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -695,7 +695,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -709,7 +709,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -722,7 +722,8 @@ public class ConsensusCommitManagerTest {
   public void rollback_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
+    when(commit.abortStateForRollback(ANY_TX_ID))
+        .thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -735,7 +736,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerReturnsAborted_ShouldReturnTheState() throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -749,7 +750,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -762,7 +763,8 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
+    when(commit.abortStateForRollback(ANY_TX_ID))
+        .thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -33,6 +33,7 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.io.Key;
+import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -853,6 +854,16 @@ public class ConsensusCommitTest {
   public void rollback_WithGroupCommitter_ShouldRemoveTxFromGroupCommitter()
       throws CrudException, UnknownTransactionStatusException {
     // Arrange
+    // begin() reserved a group commit slot for this transaction, so rollback() must release it.
+    context =
+        spy(
+            new TransactionContext(
+                ANY_ID,
+                snapshot,
+                Isolation.SNAPSHOT,
+                false,
+                false,
+                /* groupCommitSlotReserved= */ true));
     CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
     ConsensusCommit consensusWithGroupCommit =
         new ConsensusCommit(context, crud, commit, operationChecker, groupCommitter);
@@ -868,9 +879,13 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void rollback_WithGroupCommitter_InReadOnlyMode_ShouldNotRemoveTxFromGroupCommitter()
-      throws CrudException, UnknownTransactionStatusException {
+  public void
+      rollback_WithGroupCommitter_InReadOnlyModeWithoutReservedSlot_ShouldNotRemoveTxFromGroupCommitter()
+          throws CrudException, UnknownTransactionStatusException {
     // Arrange
+    // A read-only transaction that never reserved a group commit slot (this is the
+    // coordinator-write-omission-enabled case, where begin() skips the reservation) has
+    // groupCommitSlotReserved left false, so rollback() must not call remove().
     context = spy(new TransactionContext(ANY_ID, snapshot, Isolation.SNAPSHOT, true, false));
     CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
     ConsensusCommit consensusWithGroupCommit =
@@ -882,6 +897,42 @@ public class ConsensusCommitTest {
     // Assert
     verify(context).closeScanners();
     verify(groupCommitter, never()).remove(anyString());
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+    verify(commit, never()).abortState(anyString());
+  }
+
+  @Test
+  public void
+      rollback_WithGroupCommitter_InReadOnlyModeWithReservedSlot_ShouldRemoveTxFromGroupCommitter()
+          throws CrudException, UnknownTransactionStatusException {
+    // Arrange
+    // A read-only transaction with coordinator write omission disabled writes a coordinator state
+    // row, so begin() reserves a group commit slot (groupCommitSlotReserved is true) and its ID is
+    // a
+    // full key. rollback() must release that slot; otherwise it leaks and stalls co-batched
+    // transactions until the group commit timeout reclaims it.
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String fullKey = keyManipulator.fullKey(keyManipulator.generateParentKey(), ANY_ID);
+    context =
+        spy(
+            new TransactionContext(
+                fullKey,
+                snapshot,
+                Isolation.SNAPSHOT,
+                true,
+                false,
+                /* groupCommitSlotReserved= */ true));
+    CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
+    ConsensusCommit consensusWithGroupCommit =
+        new ConsensusCommit(context, crud, commit, operationChecker, groupCommitter);
+
+    // Act
+    consensusWithGroupCommit.rollback();
+
+    // Assert
+    verify(context).closeScanners();
+    verify(groupCommitter).remove(fullKey);
     verify(commit, never()).rollbackRecords(any(TransactionContext.class));
     verify(commit, never()).abortState(anyString());
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -42,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -768,10 +770,15 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record. This way the
+    // abort conflicts with, and wins against, an in-flight normal group commit, which writes the
+    // COMMITTED state under the parent ID.
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @Test
@@ -874,10 +881,14 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @ParameterizedTest
@@ -915,9 +926,13 @@ public class CoordinatorTest {
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -398,7 +398,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     TwoPhaseCommitTransactionManager manager =
         new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
 
-    doThrow(UnknownTransactionStatusException.class).when(commit).abortState(any());
+    doThrow(UnknownTransactionStatusException.class).when(commit).abortState(anyString());
 
     TwoPhaseCommitTransaction transaction1 = manager.begin(ANY_TX_ID);
     try {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -16,6 +16,7 @@ import com.scalar.db.io.Key;
 import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public abstract class ConsensusCommitIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -33,6 +34,35 @@ public abstract class ConsensusCommitIntegrationTestBase
   }
 
   protected abstract Properties getProps(String testName);
+
+  @SuppressWarnings("unused") // Referenced by @DisabledIf below.
+  private boolean isGroupCommitEnabled() {
+    return Boolean.parseBoolean(
+        getProperties(getTestName())
+            .getProperty(ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "false"));
+  }
+
+  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
+  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. With group
+  // commit enabled, aborting an ongoing transaction by ID writes the ABORTED state under the full
+  // transaction ID, while a normal group commit writes the COMMITTED state under the parent ID.
+  // The two do not conflict, so the abort is lost and the transaction can still commit.
+  @Test
+  @Override
+  @DisabledIf("isGroupCommitEnabled")
+  public void abort_forOngoingTransaction_ShouldAbortCorrectly() throws TransactionException {
+    super.abort_forOngoingTransaction_ShouldAbortCorrectly();
+  }
+
+  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
+  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. See the note
+  // on abort_forOngoingTransaction_ShouldAbortCorrectly above.
+  @Test
+  @Override
+  @DisabledIf("isGroupCommitEnabled")
+  public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() throws TransactionException {
+    super.rollback_forOngoingTransaction_ShouldRollbackCorrectly();
+  }
 
   @Test
   public void

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -16,7 +16,6 @@ import com.scalar.db.io.Key;
 import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 public abstract class ConsensusCommitIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -34,35 +33,6 @@ public abstract class ConsensusCommitIntegrationTestBase
   }
 
   protected abstract Properties getProps(String testName);
-
-  @SuppressWarnings("unused") // Referenced by @DisabledIf below.
-  private boolean isGroupCommitEnabled() {
-    return Boolean.parseBoolean(
-        getProperties(getTestName())
-            .getProperty(ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "false"));
-  }
-
-  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
-  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. With group
-  // commit enabled, aborting an ongoing transaction by ID writes the ABORTED state under the full
-  // transaction ID, while a normal group commit writes the COMMITTED state under the parent ID.
-  // The two do not conflict, so the abort is lost and the transaction can still commit.
-  @Test
-  @Override
-  @DisabledIf("isGroupCommitEnabled")
-  public void abort_forOngoingTransaction_ShouldAbortCorrectly() throws TransactionException {
-    super.abort_forOngoingTransaction_ShouldAbortCorrectly();
-  }
-
-  // TODO: Re-enable this test for coordinator group commit in the follow-up PR that fixes
-  // manager.abort(txId)/rollback(txId) for an in-flight group-committed transaction. See the note
-  // on abort_forOngoingTransaction_ShouldAbortCorrectly above.
-  @Test
-  @Override
-  @DisabledIf("isGroupCommitEnabled")
-  public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() throws TransactionException {
-    super.rollback_forOngoingTransaction_ShouldRollbackCorrectly();
-  }
 
   @Test
   public void

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -12,6 +12,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -48,9 +50,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
-import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
-import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
@@ -8055,9 +8055,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   @EnumSource(Isolation.class)
   void
       commit_ConflictingExternalUpdate_DifferentGetButSameRecordReturned_ShouldThrowShouldBehaveCorrectly(
-          Isolation isolation)
-          throws UnknownTransactionStatusException, CrudException, RollbackException,
-              CommitException, TransactionException {
+          Isolation isolation) throws TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     manager.insert(
@@ -9693,6 +9691,40 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Act Assert
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      rollback_forOngoingGroupCommitTransactionWhenNormalGroupCommitInFlight_ShouldRollbackCorrectly()
+          throws Exception {
+    // Rolling back an in-flight, group-committed transaction by ID must win against the in-flight
+    // normal group commit, which writes the COMMITTED state under the parent ID. The race is made
+    // deterministic by rolling the transaction back by ID just before the group commit writes its
+    // COMMITTED state under the parent ID, so the two writes genuinely conflict.
+
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
+    DistributedTransaction transaction = manager.begin();
+    transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1));
+    String ongoingTxId = transaction.getId();
+    String parentId =
+        new CoordinatorGroupCommitKeyManipulator().keysFromFullKey(ongoingTxId).parentKey;
+
+    doAnswer(
+            invocation -> {
+              // The rollback writes the parent-ID ABORTED marker (not a COMMITTED state), so it
+              // does not match this stub and runs against the real coordinator.
+              manager.rollback(ongoingTxId);
+              return invocation.callRealMethod();
+            })
+        .when(coordinator)
+        .putStateForGroupCommit(eq(parentId), anyList(), eq(TransactionState.COMMITTED), anyLong());
+
+    // Act Assert
+    assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
+    assertThat(manager.getState(ongoingTxId)).isEqualTo(TransactionState.ABORTED);
   }
 
   private DistributedTransaction prepareTransfer(


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3614
- **Commit to backport:** a3a2e953247b8dcafdfc5672836caae91eb3de5e

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.18-pull-3614 &&
git cherry-pick --no-rerere-autoupdate -m1 a3a2e953247b8dcafdfc5672836caae91eb3de5e
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!