### PR TITLE
Backport to branch(3.15) : Abort in-flight group-committed transactions correctly on the manager rollback/abort-by-ID path

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -254,25 +254,32 @@ public class CommitHandler {
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
-      try {
-        Optional<Coordinator.State> state = coordinator.getState(id);
-        if (state.isPresent()) {
-          // successfully COMMITTED or ABORTED
-          return state.get().getState();
-        }
-        throw new UnknownTransactionStatusException(
-            CoreError
-                .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-                .buildMessage(),
-            e,
-            id);
-      } catch (CoordinatorException e1) {
-        throw new UnknownTransactionStatusException(
-            CoreError.CONSENSUS_COMMIT_CANNOT_GET_STATE.buildMessage(), e1, id);
-      }
+      return resolveAbortStateConflict(id, e);
     } catch (CoordinatorException e) {
       throw new UnknownTransactionStatusException(
           CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(), e, id);
+    }
+  }
+
+  // Resolves the final transaction state after a conflict while writing the ABORTED state: a
+  // concurrent writer beat us, so follow whatever state is already persisted.
+  private TransactionState resolveAbortStateConflict(String id, CoordinatorConflictException e)
+      throws UnknownTransactionStatusException {
+    try {
+      Optional<Coordinator.State> state = coordinator.getState(id);
+      if (state.isPresent()) {
+        // successfully COMMITTED or ABORTED
+        return state.get().getState();
+      }
+      throw new UnknownTransactionStatusException(
+          CoreError
+              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
+              .buildMessage(),
+          e,
+          id);
+    } catch (CoordinatorException e1) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_CANNOT_GET_STATE.buildMessage(), e1, id);
     }
   }
 
@@ -293,6 +300,36 @@ public class CommitHandler {
     } catch (Exception e) {
       logger.warn("Rolling back records failed. Transaction ID: {}", snapshot.getId(), e);
       // ignore since records are recovered lazily
+    }
+  }
+
+  /**
+   * Writes the ABORTED state for a manager-level rollback/abort by transaction ID (the {@code
+   * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
+   * transaction ID is known.
+   *
+   * <p>This delegates to {@link Coordinator#putStateForLazyRecoveryRollback(String)}, which
+   * branches on the given ID: for a group commit full key it uses the same two-step protocol as
+   * lazy recovery, writing the parent-ID conflict marker before the full-ID ABORTED record so the
+   * abort wins against an in-flight normal group commit (which writes the COMMITTED state under the
+   * parent ID); for a non-group-commit ID it just writes the ABORTED record.
+   *
+   * @param id the transaction ID
+   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
+   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
+   *     TransactionState#ABORTED}) is already persisted
+   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
+   */
+  public TransactionState abortStateForRollback(String id)
+      throws UnknownTransactionStatusException {
+    try {
+      coordinator.putStateForLazyRecoveryRollback(id);
+      return TransactionState.ABORTED;
+    } catch (CoordinatorConflictException e) {
+      return resolveAbortStateConflict(id, e);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(), e, id);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -386,7 +386,7 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
   public TransactionState rollback(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
-      return commit.abortState(txId);
+      return commit.abortStateForRollback(txId);
     } catch (UnknownTransactionStatusException ignored) {
       return TransactionState.UNKNOWN;
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -308,6 +308,73 @@ public class CommitHandlerTest {
   }
 
   @Test
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // The abort delegates to Coordinator#putStateForLazyRecoveryRollback rather than a plain
+    // putState. That method branches on the ID: it writes the parent-ID conflict marker before the
+    // full-ID record for a group commit full key (so the abort wins against an in-flight group
+    // commit), and falls back to a single putState for a non-group-commit ID. Which branch runs
+    // here depends on anyId(): a non-group-commit ID in this base class, a group commit full key in
+    // the group commit subclass that overrides anyId().
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).putStateForLazyRecoveryRollback(anyId());
+    verify(coordinator, never()).putState(any());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateForRollback(anyId());
+
+    // Assert
+    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(anyId());
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
           throws ExecutionException, CoordinatorException {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -11,10 +11,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import com.scalar.db.api.TransactionState;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.util.groupcommit.GroupCommitConfig;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
@@ -91,5 +93,41 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     List<String> fullIds = groupCommitFullIdsArgumentCaptor.getValue();
     assertThat(fullIds.size()).isEqualTo(1);
     assertThat(fullIds.get(0)).isEqualTo(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted();
+
+    // abortStateForRollback(id) only writes the coordinator rollback marker; it never goes through
+    // the group commit path, so the slot reserved by extraInitialize() is not released. Release it
+    // here so the @AfterEach groupCommitter.close() does not block on the slot-abort timeout.
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    super.abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    super.abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown();
+    groupCommitter.remove(anyId());
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -451,7 +451,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -465,7 +465,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -478,7 +478,8 @@ public class ConsensusCommitManagerTest {
   public void rollback_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
+    when(commit.abortStateForRollback(ANY_TX_ID))
+        .thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -491,7 +492,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerReturnsAborted_ShouldReturnTheState() throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -505,7 +506,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortState(ANY_TX_ID)).thenReturn(expected);
+    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -518,7 +519,8 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
+    when(commit.abortStateForRollback(ANY_TX_ID))
+        .thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -44,6 +45,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -732,10 +734,15 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record. This way the
+    // abort conflicts with, and wins against, an in-flight normal group commit, which writes the
+    // COMMITTED state under the parent ID.
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @Test
@@ -838,10 +845,14 @@ public class CoordinatorTest {
     spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 
   @ParameterizedTest
@@ -879,9 +890,13 @@ public class CoordinatorTest {
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
-    verify(spiedCoordinator)
+    // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
+    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder
+        .verify(spiedCoordinator)
         .putStateForGroupCommit(
             eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -3694,6 +3696,39 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .isEqualTo(TransactionState.ABORTED);
     assertThat(coordinator.getState(failingTxn2.getId()).get().getState())
         .isEqualTo(TransactionState.ABORTED);
+  }
+
+  @Test
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      rollback_forOngoingGroupCommitTransactionWhenNormalGroupCommitInFlight_ShouldRollbackCorrectly()
+          throws Exception {
+    // Rolling back an in-flight, group-committed transaction by ID must win against the in-flight
+    // normal group commit, which writes the COMMITTED state under the parent ID. The race is made
+    // deterministic by rolling the transaction back by ID just before the group commit writes its
+    // COMMITTED state under the parent ID, so the two writes genuinely conflict.
+
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+    transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1));
+    String ongoingTxId = transaction.getId();
+    String parentId =
+        new CoordinatorGroupCommitKeyManipulator().keysFromFullKey(ongoingTxId).parentKey;
+
+    doAnswer(
+            invocation -> {
+              // The rollback writes the parent-ID ABORTED marker (not a COMMITTED state), so it
+              // does not match this stub and runs against the real coordinator.
+              manager.rollback(ongoingTxId);
+              return invocation.callRealMethod();
+            })
+        .when(coordinator)
+        .putStateForGroupCommit(eq(parentId), anyList(), eq(TransactionState.COMMITTED), anyLong());
+
+    // Act Assert
+    assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
+    assertThat(manager.getState(ongoingTxId)).isEqualTo(TransactionState.ABORTED);
   }
 
   private DistributedTransaction prepareTransfer(


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3619
- **Commit to backport:** 098253c5cec3bd7c85e39ed4276cf7e28a70bca5

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.15-pull-3619 &&
git cherry-pick --no-rerere-autoupdate -m1 098253c5cec3bd7c85e39ed4276cf7e28a70bca5
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!