### PR TITLE
Backport to branch(3.16) : Return the before-image only after the lazy-recovery rollback is written on a read

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -79,21 +79,62 @@ public class RecoveryExecutor implements AutoCloseable {
       case RETURN_LATEST_RESULT_AND_RECOVER:
         Optional<Coordinator.State> state = getCoordinatorState(result.getId());
 
+        if (state.isPresent()) {
+          rolledBack = state.get().getState() == TransactionState.ABORTED;
+          recoveredResult = createRecoveredResult(state, selection, result, transactionId);
+          future =
+              executorService.submit(
+                  () -> {
+                    recovery.recover(selection, result, state);
+                    return null;
+                  });
+          break;
+        }
+
+        // The coordinator state is absent. Throw if the transaction that wrote the record has not
+        // expired (it may still be in flight); otherwise it has expired and must be aborted.
         throwUncommittedRecordExceptionIfTransactionNotExpired(
             state, selection, result, transactionId);
 
-        rolledBack = !state.isPresent() || state.get().getState() == TransactionState.ABORTED;
+        // The transaction that wrote the record has expired and has no coordinator state. The
+        // before-image is only the correct value to return once that transaction is confirmed
+        // aborted, so abort it synchronously (write its ABORTED coordinator state) first.
+        boolean aborted;
+        try {
+          aborted = recovery.tryAbortExpiredTransaction(result.getId());
+        } catch (CoordinatorException e) {
+          throw new CrudException(
+              CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+              e,
+              transactionId);
+        }
 
-        // Return the latest result
-        recoveredResult = createRecoveredResult(state, selection, result, transactionId);
-
-        // Recover the record
-        future =
-            executorService.submit(
-                () -> {
-                  recovery.recover(selection, result, state);
-                  return null;
-                });
+        if (aborted) {
+          // The transaction that wrote the record is now aborted (its ABORTED coordinator state was
+          // written). Return the before-image and roll the record back in the background.
+          rolledBack = true;
+          recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
+          future =
+              executorService.submit(
+                  () -> {
+                    recovery.rollbackRecord(selection, result);
+                    return null;
+                  });
+        } else {
+          // Writing the ABORTED state conflicted: a concurrent actor resolved the transaction (e.g.
+          // it committed). Re-read the coordinator state and resolve the read from that outcome
+          // instead of returning a stale before-image.
+          Optional<Coordinator.State> winnerState = getCoordinatorState(result.getId());
+          assert winnerState.isPresent();
+          rolledBack = winnerState.get().getState() == TransactionState.ABORTED;
+          recoveredResult = createRecoveredResult(winnerState, selection, result, transactionId);
+          future =
+              executorService.submit(
+                  () -> {
+                    recovery.recover(selection, result, winnerState);
+                    return null;
+                  });
+        }
 
         break;
       case RETURN_COMMITTED_RESULT_AND_RECOVER:

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -50,7 +50,6 @@ public class RecoveryHandler {
     }
   }
 
-  @VisibleForTesting
   void rollbackRecord(Selection selection, TransactionResult result) throws ExecutionException {
     logger.debug(
         "Rollback for {}, {} mutated by {}",
@@ -104,6 +103,36 @@ public class RecoveryHandler {
     return composer;
   }
 
+  /**
+   * Aborts the transaction that wrote a record, for the read path, when that transaction has
+   * expired and has no coordinator state, by writing its ABORTED coordinator state (the
+   * lazy-recovery rollback). The before-image of such a record is only the correct value to return
+   * once that transaction is known to be aborted, which this confirms.
+   *
+   * @param id the transaction id of the transaction that wrote the record. The caller must have
+   *     already confirmed the transaction is expired and has no coordinator state; this method does
+   *     not check either condition
+   * @return {@code true} if the ABORTED state was written — the transaction is now aborted, so
+   *     returning the before-image is correct; {@code false} if writing it conflicted because a
+   *     concurrent actor resolved the transaction (e.g. it committed), in which case the caller
+   *     must re-read the coordinator state and resolve the read from that outcome instead of
+   *     returning a stale before-image
+   * @throws CoordinatorException if writing the ABORTED state fails for a reason other than a
+   *     conflict
+   */
+  boolean tryAbortExpiredTransaction(String id) throws CoordinatorException {
+    try {
+      coordinator.putStateForLazyRecoveryRollback(id);
+      return true;
+    } catch (CoordinatorConflictException e) {
+      logger.info(
+          "Putting state in coordinator for a record conflicted; a concurrent actor resolved the transaction. Transaction ID: {}",
+          id,
+          e);
+      return false;
+    }
+  }
+
   private void abortIfExpired(Selection selection, TransactionResult result)
       throws CoordinatorException, ExecutionException {
     if (!isTransactionExpired(result)) {
@@ -128,7 +157,7 @@ public class RecoveryHandler {
     storage.mutate(mutations);
   }
 
-  public boolean isTransactionExpired(TransactionResult result) {
+  boolean isTransactionExpired(TransactionResult result) {
     long current = System.currentTimeMillis();
     return current > result.getPreparedAt() + TRANSACTION_LIFETIME_MILLIS;
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -370,12 +370,13 @@ public class RecoveryExecutorTest {
 
   @Test
   public void
-      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_ShouldRollback()
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerWritten_ShouldReturnBeforeImageAndRollback()
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
 
     // Act
     RecoveryExecutor.Result result =
@@ -389,21 +390,23 @@ public class RecoveryExecutorTest {
     // Wait for recovery to complete
     result.recoveryFuture.get();
 
-    // Assert
+    // Assert: only after the ABORTED state is written do we return the before-image and roll back
     assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+    verify(recovery).rollbackRecord(selection, transactionResult);
+    verify(recovery, never()).recover(any(), any(), any());
   }
 
   @Test
   public void
-      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordWithoutBeforeImage_ShouldRollback()
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerWritten_RecordWithoutBeforeImage_ShouldReturnEmptyAndRollback()
           throws Exception {
     // Arrange
     TransactionResult transactionResult =
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
 
     // Act
     RecoveryExecutor.Result result =
@@ -420,7 +423,91 @@ public class RecoveryExecutorTest {
     // Assert
     assertThat(result.recoveredResult).isEmpty();
     assertThat(result.rolledBack).isTrue();
-    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+    verify(recovery).rollbackRecord(selection, transactionResult);
+    verify(recovery, never()).recover(any(), any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerConflictAndWinnerCommitted_ShouldReturnAfterImage()
+          throws Exception {
+    // Arrange: writing the ABORTED state conflicts because the transaction committed concurrently
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    Coordinator.State committedState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(committedState));
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(false);
+
+    executor = spy(executor);
+    doReturn(ANY_TIME_MILLIS_4).when(executor).getCommittedAt();
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: the committed after-image is returned -- not the stale before-image
+    assertThat(result.recoveredResult).hasValue(prepareRolledForwardResult());
+    assertThat(result.rolledBack).isFalse();
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(committedState)));
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerConflictAndWinnerAborted_ShouldReturnBeforeImage()
+          throws Exception {
+    // Arrange: writing the ABORTED state conflicts because another actor aborted the transaction
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(abortedState));
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(false);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    assertThat(result.rolledBack).isTrue();
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_TryAbortThrowsCoordinatorException_ShouldThrowCrudException()
+          throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenThrow(CoordinatorException.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    transactionResult,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOf(CrudException.class);
+
+    // Verify no recovery attempted
+    verify(recovery, never()).rollbackRecord(any(), any());
+    verify(recovery, never()).recover(any(), any(), any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -282,5 +283,42 @@ public class RecoveryHandlerTest {
     // Assert
     verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
     verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void tryAbortExpiredTransaction_MarkerWritten_ShouldReturnTrue()
+      throws CoordinatorException {
+    // Act
+    boolean aborted = handler.tryAbortExpiredTransaction(ANY_ID_1);
+
+    // Assert
+    assertThat(aborted).isTrue();
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+  }
+
+  @Test
+  public void tryAbortExpiredTransaction_Conflict_ShouldReturnFalse() throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putStateForLazyRecoveryRollback(ANY_ID_1);
+
+    // Act
+    boolean aborted = handler.tryAbortExpiredTransaction(ANY_ID_1);
+
+    // Assert
+    assertThat(aborted).isFalse();
+    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+  }
+
+  @Test
+  public void tryAbortExpiredTransaction_CoordinatorException_ShouldThrow()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.tryAbortExpiredTransaction(ANY_ID_1))
+        .isInstanceOf(CoordinatorException.class);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -689,9 +689,13 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    // With the default isolation, the read path aborts the expired transaction synchronously (its
+    // ABORTED coordinator state is written) before returning the result, then rolls the record back
+    // in the background. recover() is not used on this path.
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test
@@ -883,9 +887,13 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     ((ConsensusCommit) transaction).waitForRecoveryCompletion();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    // With the default isolation, the read path aborts the expired transaction synchronously (its
+    // ABORTED coordinator state is written) before returning the result, then rolls the record back
+    // in the background. recover() is not used on this path.
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1730,12 +1730,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator, never()).putState(any(Coordinator.State.class));
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    } else {
-      // In other cases, recovery should occur
-
+    } else if (isolation == Isolation.READ_COMMITTED) {
+      // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
+      // via recover()
       verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    } else {
+      // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
+      // (its ABORTED coordinator state is written) before the before-image is returned, then the
+      // record is rolled back in the background. recover() is not used on this path.
+      verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -2318,11 +2326,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
       verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    } else {
-      // In other cases, recovery should occur
+    } else if (isolation == Isolation.READ_COMMITTED) {
+      // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
+      // via recover()
       verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
       verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    } else {
+      // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
+      // (its ABORTED coordinator state is written) before the before-image is returned, then the
+      // record is rolled back in the background. recover() is not used on this path.
+      verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     }
   }
 
@@ -2510,10 +2527,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     waitForRecoveryCompletion(transaction);
 
-    // Recovery should occur (abort due to expiry, then roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
+    // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
+    // before the result is returned, then the record is rolled back in the background. recover() is
+    // not used on this path.
+    verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @ParameterizedTest
@@ -3216,10 +3237,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     waitForRecoveryCompletion(transaction);
 
-    // Recovery should occur (abort due to expiry, then roll-back)
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
+    // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
+    // before the records are returned, then the record is rolled back in the background. recover()
+    // is not used on this path.
+    verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
   }
 
   @ParameterizedTest
@@ -3596,6 +3621,158 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     storage.put(put);
   }
 
+  // Sets up the lazy-recovery-rollback race for the transaction that wrote a record: the read path
+  // first looks up the coordinator state and finds none, so it tries to abort the expired
+  // transaction. Intercept only that first lookup to return empty while writing the COMMITTED
+  // coordinator state (the winner) as a side effect. The real lazy-recovery rollback that follows
+  // then genuinely conflicts against this committed state, and the real re-read resolves the read
+  // from the winner's outcome (the after-image).
+  private void simulateLazyRecoveryRollbackConflict(String ongoingTxId)
+      throws CoordinatorException {
+    doAnswer(
+            invocation -> {
+              coordinator.putState(new Coordinator.State(ongoingTxId, TransactionState.COMMITTED));
+              return Optional.empty();
+            })
+        .doCallRealMethod()
+        .when(coordinator)
+        .getState(ongoingTxId);
+  }
+
+  private void assertPreparedRecordAfterLazyRecoveryRollbackConflict(
+      TransactionResult result, Isolation isolation, String ongoingTxId)
+      throws ExecutionException, CoordinatorException {
+    if (isolation == Isolation.READ_COMMITTED) {
+      // READ_COMMITTED uses RETURN_COMMITTED_RESULT_AND_RECOVER: it always returns the committed
+      // (before-image) result and recovers the record in the background. It does not perform the
+      // lazy-recovery-rollback conflict resolution, so the winner's after-image is not surfaced on
+      // this path.
+      assertThat(result.getId()).isEqualTo(ANY_ID_1);
+      assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+      assertThat(result.getVersion()).isEqualTo(1);
+      assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+      verify(recovery, never()).tryAbortExpiredTransaction(anyString());
+      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    } else {
+      // SNAPSHOT/SERIALIZABLE use RETURN_LATEST_RESULT_AND_RECOVER. The lazy-recovery rollback
+      // loses the race, so the read resolves from the winner's COMMITTED outcome. The after-image
+      // is returned (not the before-image), and the record is rolled forward instead of back.
+      assertThat(result.getId()).isEqualTo(ongoingTxId);
+      assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+      assertThat(result.getVersion()).isEqualTo(2);
+      assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+
+      verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+      verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    }
+  }
+
+  private void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldReturnAllRecords(
+          boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    // Three records in partition 0: (0,0) and (0,2) are COMMITTED, while (0,1) is an expired
+    // PREPARED record with no coordinator state (the conflict target).
+    String ongoingTxId =
+        populateRecordsForBeforeIndexTest(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+    simulateLazyRecoveryRollbackConflict(ongoingTxId);
+
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    List<Result> results;
+    if (!useScanner) {
+      results = transaction.scan(scan);
+    } else {
+      try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+        results = scanner.all();
+      }
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert
+    // All three records are returned, ordered by clustering key.
+    assertThat(results.size()).isEqualTo(3);
+
+    // The committed records (0,0) and (0,2) are returned unchanged.
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(results.get(0).getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(results.get(2).getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    // The expired PREPARED record (0,1) is resolved according to the isolation level.
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    TransactionResult result =
+        (TransactionResult) ((FilteredResult) results.get(1)).getOriginalResult();
+    assertPreparedRecordAfterLazyRecoveryRollbackConflict(result, isolation, ongoingTxId);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldBehaveCorrectly(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            prepared_at,
+            null,
+            CommitType.NORMAL_COMMIT);
+    simulateLazyRecoveryRollbackConflict(ongoingTxId);
+
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Optional<Result> r = transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(r).isPresent();
+    TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert
+    assertPreparedRecordAfterLazyRecoveryRollbackConflict(result, isolation, ongoingTxId);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldBehaveCorrectly(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldReturnAllRecords(
+        false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldBehaveCorrectly(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButLazyRecoveryRollbackConflicts_ShouldReturnAllRecords(
+        true, isolation);
+  }
+
   // Writes a PREPARED/DELETED record at the given account_type with the given after-image BALANCE
   // and writer transaction id, so that two records with different primary keys but the same BALANCE
   // index value reproduce a transient index duplicate.
@@ -3895,10 +4072,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.isPresent()).isTrue();
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
-    // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    if (isolation == Isolation.READ_COMMITTED) {
+      // In READ_COMMITTED isolation, the record is recovered in the background via recover()
+      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    } else {
+      // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
+      // (its ABORTED coordinator state is written) before the before-image is returned, then the
+      // record is rolled back in the background. recover() is not used on this path.
+      verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    }
   }
 
   @ParameterizedTest
@@ -4137,10 +4324,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.isPresent()).isTrue();
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE + 100);
 
-    // In all isolations, recovery should occur
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    if (isolation == Isolation.READ_COMMITTED) {
+      // In READ_COMMITTED isolation, the record is recovered in the background via recover()
+      verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    } else {
+      // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
+      // (its ABORTED coordinator state is written) before the before-image is returned, then the
+      // record is rolled back in the background. recover() is not used on this path.
+      verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+      verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3621
- **Commit to backport:** bd155d1884a62f503903738fc95b466134238134

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-3621 &&
git cherry-pick --no-rerere-autoupdate -m1 bd155d1884a62f503903738fc95b466134238134
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!