### PR TITLE
Handle coordinator state row deletion in Consensus Commit recovery and read paths

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -438,8 +438,21 @@ public interface DistributedTransactionManager
    * advanced use cases. Callers are expected to understand the underlying transaction lifecycle and
    * the implications of invoking this method directly.
    *
+   * <p><b>Finished or unknown transactions:</b> the state is read from the transaction's
+   * Coordinator state row. Once that row has been removed — by {@link #finishTransaction(String)}
+   * or another Coordinator state cleanup — the transaction's terminal outcome is no longer
+   * persisted and cannot be read, so this method returns {@link TransactionState#UNKNOWN}. A
+   * committed-and-cleaned-up transaction, a transaction ID that never existed, and a transaction
+   * whose state row could not be read are therefore indistinguishable through this method: all
+   * return {@link TransactionState#UNKNOWN}.
+   *
+   * <p>Relatedly, calling {@link #rollback(String)} or {@link #abort(String)} on a finished,
+   * cleaned-up transaction ID records a fresh ABORTED state, after which this method returns {@link
+   * TransactionState#ABORTED} for that ID even if the transaction had committed.
+   *
    * @param txId a transaction ID
-   * @return {@link TransactionState}
+   * @return the transaction's {@link TransactionState}, or {@link TransactionState#UNKNOWN} if its
+   *     state can no longer be determined (see above)
    * @throws TransactionException if getting the state of a given transaction fails
    * @throws UnsupportedOperationException if the underlying transaction manager does not support
    *     getting a transaction state
@@ -453,6 +466,15 @@ public interface DistributedTransactionManager
    * transaction manager. Most applications should not call it directly — it is intended for
    * advanced use cases. Callers are expected to understand the underlying transaction lifecycle and
    * the implications of invoking this method directly.
+   *
+   * <p><b>Limitation for finished transactions:</b> if the given transaction ID has already
+   * finished and been cleaned up (its Coordinator state row removed by {@link
+   * #finishTransaction(String)} or another Coordinator state cleanup), this method writes a fresh
+   * ABORTED Coordinator state and returns {@link TransactionState#ABORTED} — even if that
+   * transaction had actually committed. (If a Coordinator state row is still present, that existing
+   * state is returned and no new row is written.) A subsequent {@link #getState(String)} for the
+   * same ID then returns {@link TransactionState#ABORTED}, masking the true (possibly committed)
+   * outcome. Do not roll back a transaction ID that may already have finished.
    *
    * @param txId a transaction ID
    * @return {@link TransactionState}
@@ -469,6 +491,8 @@ public interface DistributedTransactionManager
    * transaction manager. Most applications should not call it directly — it is intended for
    * advanced use cases. Callers are expected to understand the underlying transaction lifecycle and
    * the implications of invoking this method directly.
+   *
+   * <p>The finished-transaction limitation described on {@link #rollback(String)} applies here too.
    *
    * @param txId a transaction ID
    * @return {@link TransactionState}
@@ -512,6 +536,10 @@ public interface DistributedTransactionManager
    * <p><b>Idempotency:</b> calling this method on a transaction ID whose state row is absent
    * (already finished, never started, or already cleaned up by a concurrent caller) returns {@code
    * true}. Callers may safely re-invoke this method on the same transaction ID.
+   *
+   * <p><b>Effect on {@link #getState(String)}:</b> once this method finishes a transaction and
+   * reclaims its Coordinator state row, {@link #getState(String)} for that transaction ID returns
+   * {@link TransactionState#UNKNOWN}, since the terminal outcome is no longer persisted.
    *
    * <p><b>Group commit:</b> when the transaction ID belongs to a child of a group commit, the call
    * processes the write sets of all sibling children in a single pass and then deletes the shared

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1246,6 +1246,12 @@ public enum CoreError implements ScalarDbError {
       "Records that need recovery were found during the before-image index check when closing the scanner. Transaction ID: %s",
       "",
       ""),
+  CONSENSUS_COMMIT_RESOLVING_UNCOMMITTED_RECORD_RETRY_LIMIT_EXCEEDED(
+      Category.CONCURRENCY_ERROR,
+      "0030",
+      "Resolving an uncommitted record exceeded the retry limit during recovery. Transaction ID: %s",
+      "",
+      ""),
 
   //
   // Errors for the internal error category

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1475,12 +1475,6 @@ public enum CoreError implements ScalarDbError {
       "Rolling back the transaction failed. Details: %s",
       "",
       ""),
-  CONSENSUS_COMMIT_COMMITTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST(
-      Category.UNKNOWN_TRANSACTION_STATUS_ERROR,
-      "0001",
-      "Committing state failed with NoMutationException, but the coordinator status does not exist. Details: %s",
-      "",
-      ""),
   CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS(
       Category.UNKNOWN_TRANSACTION_STATUS_ERROR,
       "0002",

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -84,12 +84,14 @@ public class CommitHandler {
     }
   }
 
-  // Aborts the coordinator state and rolls back records as needed after a pre-commit failure. When
-  // the transaction has no writes and deletes, there are no records to roll back. In that case the
-  // coordinator state is still aborted unless coordinator write omission on read-only is enabled:
-  // when it is, a write-less transaction (a read-only one, or a non-read-only one with an empty
-  // write set) writes no coordinator state row on the commit path either, so there is nothing to
-  // abort.
+  /**
+   * Aborts the coordinator state and rolls back records as needed after a pre-commit failure. When
+   * the transaction has no writes and deletes, there are no records to roll back. In that case the
+   * coordinator state is still aborted unless coordinator write omission on read-only is enabled:
+   * when it is, a write-less transaction (a read-only one, or a non-read-only one with an empty
+   * write set) writes no coordinator state row on the commit path either, so there is nothing to
+   * abort.
+   */
   private void abortStateAndRollbackRecordsIfNeeded(
       TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
       throws UnknownTransactionStatusException {
@@ -274,11 +276,54 @@ public class CommitHandler {
               cause,
               context.transactionId);
         }
+        // Otherwise the coordinator state is present and COMMITTED, which means this transaction
+        // has already committed. Only Two-phase Commit I/F reaches this branch: there the same
+        // transaction's commit can be driven more than once -- re-invoked for recovery, or
+        // committed by multiple participants -- so an earlier or concurrent commit of this
+        // transaction may have already written its COMMITTED state, and this commit then loses the
+        // putIfNotExists race and observes it here. With One-phase Commit I/F this is unreachable:
+        // this commit is the only writer of the COMMITTED state and it just lost the race, so the
+        // conflicting row was an ABORTED from a lazy recovery, handled above. The transaction is
+        // committed, so return normally and let the caller commit the records.
+        //
+        // TODO: revisit this if/when the Two-phase Commit I/F is removed -- it would
+        // then be unreachable (a COMMITTED state could never be observed after a conflict here).
       } else {
-        throw new UnknownTransactionStatusException(
-            CoreError
-                .CONSENSUS_COMMIT_COMMITTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-                .buildMessage(cause.getMessage()),
+        // The coordinator state is absent: a row existed when our putIfNotExists lost the race, but
+        // it is gone now. In both interfaces this means the conflicting row was an ABORTED written
+        // by a lazy recovery (which also rolled the records back) and later removed by the
+        // Coordinator state cleanup process, so the transaction is definitively aborted. Roll the
+        // records back and report a conflict -- the same outcome as the present-ABORTED case above.
+        //
+        // A COMMITTED row can be ruled out here in both interfaces:
+        //   - One-phase Commit I/F: this commit is the only writer of this transaction's COMMITTED
+        //     state, and it just lost the race, so the conflicting row could only have been an
+        //     ABORTED from a lazy recovery -- a COMMITTED for this transaction never existed.
+        //   - Two-phase Commit I/F: other participants or re-driven commits of the same transaction
+        //     can also write COMMITTED, so the conflict could in principle have been against a
+        //     COMMITTED row. But the Two-phase Commit I/F does not assume finishTransaction,
+        //     and a COMMITTED coordinator row is only ever removed by finishTransaction (the
+        //     periodic cleanup removes only ABORTED rows). So a COMMITTED row never disappears
+        //     here: had the conflict been against one, it would still be present and handled by
+        //     the present-COMMITTED branch above. An absent row therefore means the conflict was
+        //     an ABORTED.
+        //
+        // Group commit reaches an absent state by a second, more common route, and the outcome is
+        // still correct. There the conflicting putIfNotExists is keyed on the parent ID (the group
+        // emitter writes the parent-ID COMMITTED row), so the row it conflicts with -- a lazy
+        // recovery's empty-tx_child_ids ABORTED parent row -- can still be present. getState then
+        // resolves by full ID: it finds the parent row, sees it does not list this child, and finds
+        // no full-ID row, so it returns empty. That empty does not mean a cleaned-up row; it means
+        // this child was never committed (a committed child would either be listed in the parent
+        // row or have its own full-ID COMMITTED row, and getState would return it). Rolling back
+        // and reporting a retryable conflict is the correct outcome for such an uncommitted child.
+        //
+        // TODO: revisit this if/when the Two-phase Commit I/F is removed.
+
+        rollbackRecords(context);
+        throw new CommitConflictException(
+            CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
+                cause.getMessage()),
             cause,
             context.transactionId);
       }
@@ -452,9 +497,19 @@ public class CommitHandler {
    * Writes the ABORTED state without persisting a {@code tx_write_set} using a single {@code
    * putState}. Intended for callers that don't want per-transaction write-set logging.
    *
+   * <p>On a {@code putIfNotExists} conflict this resolves a now-absent coordinator state as {@link
+   * TransactionState#ABORTED} (see {@link #abortStateInternal}). That is only sound for callers
+   * that cannot be racing a real, deletable COMMITTED row: the self-abort path (which provably
+   * never committed) and all Two-phase Commit I/F aborts (the Two-phase Commit I/F does not assume
+   * {@code finishTransaction}, so a COMMITTED coordinator row is never removed). A One-phase Commit
+   * I/F abort-by-id, which can target a transaction that actually committed and whose COMMITTED row
+   * {@code finishTransaction} can remove, must NOT use this method — use {@link
+   * #abortStateForRollback} instead, which honestly reports {@code UNKNOWN} for an absent row.
+   *
    * @param id the transaction ID
-   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
-   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
+   * @return the resulting transaction state — {@link TransactionState#ABORTED} (including when a
+   *     concurrent writer's row is absent on re-read), or, if a concurrent writer beat us and its
+   *     state is still present, whatever state ({@link TransactionState#COMMITTED} or {@link
    *     TransactionState#ABORTED}) is already persisted
    * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
    */
@@ -470,7 +525,22 @@ public class CommitHandler {
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
-      return resolveAbortStateConflict(id, e);
+      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
+      // the self-abort path and all Two-phase Commit I/F aborts. Follows the persisted state when
+      // present; an absent row is determinable as ABORTED here:
+      //   - One-phase Commit I/F self-abort (abortState from a commit-path failure, before
+      //     commitState runs): the transaction provably never committed, so the conflicting row
+      //     could only have been a lazy-recovery ABORTED, later removed by the cleanup process.
+      //   - Two-phase Commit I/F (rollback and abort-by-id): other participants can write
+      //     COMMITTED, but the Two-phase Commit I/F does not assume finishTransaction, and a
+      //     COMMITTED coordinator row is only ever removed by finishTransaction (the periodic
+      //     cleanup removes only ABORTED rows). So a COMMITTED never disappears: had the conflict
+      //     been against one, it would still be present and returned above. An absent row therefore
+      //     means the conflict was an ABORTED.
+      //
+      // TODO: revisit this if/when the Two-phase Commit I/F is removed
+
+      return readCoordinatorStateAfterAbortConflict(id, e).orElse(TransactionState.ABORTED);
     } catch (CoordinatorException e) {
       throw new UnknownTransactionStatusException(
           CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
@@ -479,22 +549,18 @@ public class CommitHandler {
     }
   }
 
-  // Resolves the final transaction state after a conflict while writing the ABORTED state: a
-  // concurrent writer beat us, so follow whatever state is already persisted.
-  private TransactionState resolveAbortStateConflict(String id, CoordinatorConflictException e)
-      throws UnknownTransactionStatusException {
+  /**
+   * Reads the persisted coordinator state after our ABORTED putIfNotExists lost the race. Returns
+   * the already-persisted COMMITTED/ABORTED state when present, or empty when the row is absent
+   * (already removed by the Coordinator state cleanup process). The two resolvers below interpret
+   * an absent row differently, because whether it is determinable depends on the calling path. A
+   * coordinator read failure is undeterminable regardless of path, so it surfaces as
+   * UnknownTransactionStatusException with the original conflict preserved as the cause.
+   */
+  private Optional<TransactionState> readCoordinatorStateAfterAbortConflict(
+      String id, CoordinatorConflictException e) throws UnknownTransactionStatusException {
     try {
-      Optional<Coordinator.State> state = coordinator.getState(id);
-      if (state.isPresent()) {
-        // successfully COMMITTED or ABORTED
-        return state.get().getState();
-      }
-      throw new UnknownTransactionStatusException(
-          CoreError
-              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-              .buildMessage(e.getMessage()),
-          e,
-          id);
+      return coordinator.getState(id).map(Coordinator.State::getState);
     } catch (CoordinatorException e1) {
       e1.addSuppressed(e);
       throw new UnknownTransactionStatusException(
@@ -546,7 +612,28 @@ public class CommitHandler {
       coordinator.putStateForLazyRecoveryRollback(id);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
-      return resolveAbortStateConflict(id, e);
+      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
+      // the One-phase Commit I/F abort-by-id path (DistributedTransactionManager.rollback(String) /
+      // abort(String)). Follows the persisted state when present. Unlike the self-abort and
+      // Two-phase Commit I/F aborts, an absent row here is genuinely undeterminable: abort-by-id
+      // can target a transaction that actually committed, and in One-phase Commit I/F
+      // finishTransaction can remove that COMMITTED row, so an absent row may be a cleaned-up
+      // COMMITTED rather than a cleaned-up ABORTED. Report an honest
+      // UnknownTransactionStatusException preserving the original conflict, rather than fabricating
+      // a terminal state.
+      //
+      // TODO: revisit this if/when the Two-phase Commit I/F is removed
+
+      Optional<TransactionState> persisted = readCoordinatorStateAfterAbortConflict(id, e);
+      if (persisted.isPresent()) {
+        return persisted.get();
+      }
+      throw new UnknownTransactionStatusException(
+          CoreError
+              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
+              .buildMessage(e.getMessage()),
+          e,
+          id);
     } catch (CoordinatorException e) {
       throw new UnknownTransactionStatusException(
           CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -91,7 +91,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(config).orElse(null);
     coordinatorWriteOmissionOnReadOnlyEnabled =
         config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
@@ -131,7 +131,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(config).orElse(null);
     coordinatorWriteOmissionOnReadOnlyEnabled =
         config.isCoordinatorWriteOmissionOnReadOnlyEnabled();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -575,7 +575,9 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     } catch (CoordinatorException ignored) {
       // ignored
     }
-    // Either no state exists or the exception is thrown
+
+    // The Coordinator state row is absent (the transaction never existed, or it was finished and
+    // cleaned up) or could not be read. These are indistinguishable here, so report UNKNOWN.
     return TransactionState.UNKNOWN;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -6,6 +6,7 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionSetBuilder;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
+import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.GetBuilder;
@@ -15,6 +16,7 @@ import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.ScanBuilder;
@@ -37,6 +39,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -450,6 +453,49 @@ public final class ConsensusCommitUtils {
           CoreError.TABLE_NOT_FOUND.buildMessage(operation.forFullTableName().get()));
     }
     return metadata;
+  }
+
+  /**
+   * Re-reads the record physically (with linearizable consistency). This is used to determine the
+   * record's current state when the writer's coordinator state is absent: since a Coordinator state
+   * cleanup process can run, an absent state no longer implies the writer never committed, so a
+   * previously observed (uncommitted) result may be stale.
+   *
+   * @param storage the storage to read from
+   * @param tableMetadataManager the metadata manager used to resolve the table metadata
+   * @param selection the selection that identifies the record (provides namespace/table/metadata)
+   * @param observed the previously observed, uncommitted {@link TransactionResult} for the record
+   * @return the freshly re-read record, or empty if the record no longer exists
+   * @throws ExecutionException if the underlying storage read fails
+   */
+  static Optional<TransactionResult> rereadRecord(
+      DistributedStorage storage,
+      TransactionTableMetadataManager tableMetadataManager,
+      Selection selection,
+      TransactionResult observed)
+      throws ExecutionException {
+    TransactionTableMetadata transactionTableMetadata =
+        getTransactionTableMetadata(tableMetadataManager, selection);
+    TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
+    Key partitionKey = ScalarDbUtils.getPartitionKey(observed, tableMetadata);
+    Optional<Key> clusteringKey = ScalarDbUtils.getClusteringKey(observed, tableMetadata);
+    Optional<Result> result = storage.get(buildReReadGet(selection, partitionKey, clusteringKey));
+    return result.map(TransactionResult::new);
+  }
+
+  private static Get buildReReadGet(
+      Selection selection, Key partitionKey, Optional<Key> clusteringKey) {
+    assert selection.forNamespace().isPresent() && selection.forTable().isPresent();
+    // Read all columns (no projections) with linearizable consistency so the before-image and the
+    // transaction metadata are available.
+    GetBuilder.BuildableGetWithPartitionKey builder =
+        Get.newBuilder()
+            .namespace(selection.forNamespace().get())
+            .table(selection.forTable().get())
+            .partitionKey(partitionKey)
+            .consistency(Consistency.LINEARIZABLE);
+    clusteringKey.ifPresent(builder::clusteringKey);
+    return builder.build();
   }
 
   static Get prepareGetForStorage(Get get, TableMetadata metadata) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -256,8 +256,7 @@ public class Coordinator {
     // - The original commit with `tx_id: <full tx ID>` succeeds
     // - `lazy-recovery-abort-with-parent-id` succeeds
     // - `lazy-recovery-abort-with-full-id` fails
-    // - The transaction is treated as committed since the commit `tx_id` is the transaction full
-    // ID
+    // - The transaction is treated as committed since the commit `tx_id` is the transaction full ID
     //
     // D. The original commit with `tx_id: <full tx ID>` is in-progress in case #b, and lazy
     // recovery happens first
@@ -282,20 +281,35 @@ public class Coordinator {
 
       // If the group commit contains the transaction, follow the state.
       // Otherwise, continue to insert a record with the full ID.
+      //
+      // The parent row can also be absent here: the Coordinator state cleanup process removed an
+      // already-finished group-commit row in the small window after our insert conflicted (the row
+      // existed at insert time, which is why the insert conflicted). This is no longer an invariant
+      // violation, so we fall through to insert the full-ID record -- the same path taken when the
+      // parent row is present but does not contain this child. If the transaction actually
+      // committed via a full-ID record (a delayed, standalone commit), that insert conflicts and
+      // the caller re-reads the committed outcome instead of treating the transaction as aborted.
+      // If instead it committed via the parent row (a normal group commit) whose row was then
+      // cleaned up, no full-ID record exists, so the insert succeeds and writes a now-spurious
+      // full-ID ABORTED. This is non-corrupting -- the record was already finalized to its
+      // committed value, so a subsequent rollback is a conditional no-op -- and is the same
+      // accepted residual as the read path's pre-abort/abort cleanup race (the spurious ABORTED is
+      // reclaimed later by the Coordinator state cleanup process). getState for such a finished,
+      // cleaned-up transaction is already documented as indeterminate.
       Optional<State> optState = getState(keys.parentKey);
-      if (!optState.isPresent()) {
-        throw new AssertionError();
-      }
-      State state = optState.get();
-      if (state.getChildIds().contains(keys.childKey)) {
-        if (state.getState() == TransactionState.ABORTED) {
-          return;
-        } else {
-          // Conflicted.
-          throw e;
+      if (optState.isPresent()) {
+        State state = optState.get();
+        if (state.getChildIds().contains(keys.childKey)) {
+          if (state.getState() == TransactionState.ABORTED) {
+            return;
+          } else {
+            // Conflicted.
+            throw e;
+          }
         }
       }
     }
+
     // This record is to intend the transaction is aborted.
     putState(new Coordinator.State(id, TransactionState.ABORTED));
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -187,7 +187,12 @@ public class RecoveryExecutor implements AutoCloseable {
       throws CrudException {
     TransactionResult current = result;
     for (int attempt = 0; ; attempt++) {
-      Optional<Coordinator.State> state = getCoordinatorState(current.getId());
+      // current is always an uncommitted record, so its tx_id is non-null here; getId() is
+      // @Nullable only for deemed-committed records, which are never recovered.
+      String txId = current.getId();
+      assert txId != null;
+
+      Optional<Coordinator.State> state = getCoordinatorState(txId);
 
       if (state.isPresent()) {
         boolean rolledBack = state.get().getState() == TransactionState.ABORTED;
@@ -230,7 +235,7 @@ public class RecoveryExecutor implements AutoCloseable {
         // The transaction committed and was cleaned up; the record carries the committed value.
         return new Result(key, fresh, Futures.immediateFuture(null), false);
       }
-      if (!current.getId().equals(fresh.get().getId())) {
+      if (!txId.equals(fresh.get().getId())) {
         // A different transaction re-prepared the record. Re-resolve against it.
         checkReadRetryLimit(attempt, transactionId);
         current = fresh.get();
@@ -242,7 +247,7 @@ public class RecoveryExecutor implements AutoCloseable {
       // aborted, so abort it synchronously (write its ABORTED coordinator state) first.
       boolean aborted;
       try {
-        aborted = recovery.tryAbortExpiredTransaction(current.getId());
+        aborted = recovery.tryAbortExpiredTransaction(txId);
       } catch (CoordinatorException e) {
         throw new CrudException(
             CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
@@ -277,7 +282,7 @@ public class RecoveryExecutor implements AutoCloseable {
           // The writer committed and was cleaned up; the record carries the committed value.
           return new Result(key, afterAbort, Futures.immediateFuture(null), false);
         }
-        if (!current.getId().equals(afterAbort.get().getId())) {
+        if (!txId.equals(afterAbort.get().getId())) {
           // A different transaction re-prepared the record after we aborted the writer (the writer
           // was rolled back and, possibly through one or more intervening commits, a new writer
           // re-prepared it). current's before-image is no longer guaranteed to be the latest

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
@@ -13,6 +14,7 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
@@ -41,6 +43,13 @@ import java.util.concurrent.Future;
 
 public class RecoveryExecutor implements AutoCloseable {
 
+  // The maximum number of re-resolution passes in resolveLatestResultAndRecover. Each pass is
+  // driven by a real concurrent change (a different transaction re-prepared the record, or the
+  // writer was resolved while we tried to abort it), so the loop terminates quickly in practice;
+  // this is only a backstop against pathological contention.
+  @VisibleForTesting static final int MAX_RESOLUTION_ATTEMPTS = 5;
+
+  private final DistributedStorage storage;
   private final Coordinator coordinator;
   private final RecoveryHandler recovery;
   private final TransactionTableMetadataManager tableMetadataManager;
@@ -48,9 +57,11 @@ public class RecoveryExecutor implements AutoCloseable {
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public RecoveryExecutor(
+      DistributedStorage storage,
       Coordinator coordinator,
       RecoveryHandler recovery,
       TransactionTableMetadataManager tableMetadataManager) {
+    this.storage = Objects.requireNonNull(storage);
     this.coordinator = Objects.requireNonNull(coordinator);
     this.recovery = Objects.requireNonNull(recovery);
     this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
@@ -100,9 +111,10 @@ public class RecoveryExecutor implements AutoCloseable {
    * @return a {@link Result} holding the value to return, the future that completes when the
    *     background recovery attempt finishes (completion does not imply the record was recovered;
    *     see above), and whether the record was rolled back
-   * @throws CrudException if reading the coordinator state or table metadata fails, or if the
-   *     record is uncommitted by a writer that is still potentially in flight ({@link
-   *     UncommittedRecordException})
+   * @throws UncommittedRecordException if the record is uncommitted by a writer that has no
+   *     coordinator state and has not expired (it may still be in flight)
+   * @throws CrudConflictException if resolving an uncommitted record exceeds the retry limit
+   * @throws CrudException if reading the coordinator state or table metadata fails
    */
   public Result execute(
       Snapshot.Key key,
@@ -113,82 +125,13 @@ public class RecoveryExecutor implements AutoCloseable {
       throws CrudException {
     assert !result.isCommitted();
 
-    Optional<TransactionResult> recoveredResult;
-    Future<Void> future;
-    boolean rolledBack;
-
     switch (recoveryType) {
       case RETURN_LATEST_RESULT_AND_RECOVER:
-        Optional<Coordinator.State> state = getCoordinatorState(result.getId());
-
-        if (state.isPresent()) {
-          rolledBack = state.get().getState() == TransactionState.ABORTED;
-          recoveredResult = createRecoveredResult(state, selection, result, transactionId);
-          future =
-              executorService.submit(
-                  () -> {
-                    recovery.tryRecover(selection, result, state);
-                    return null;
-                  });
-          break;
-        }
-
-        // The coordinator state is absent. Throw if the transaction that wrote the record has not
-        // expired (it may still be in flight); otherwise it has expired and must be aborted.
-        throwUncommittedRecordExceptionIfTransactionNotExpired(
-            state, selection, result, transactionId);
-
-        // The transaction that wrote the record has expired and has no coordinator state. The
-        // before-image is only the correct value to return once that transaction is confirmed
-        // aborted, so abort it synchronously (write its ABORTED coordinator state) first.
-        boolean aborted;
-        try {
-          aborted = recovery.tryAbortExpiredTransaction(result.getId());
-        } catch (CoordinatorException e) {
-          throw new CrudException(
-              CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
-              e,
-              transactionId);
-        }
-
-        if (aborted) {
-          // The transaction that wrote the record is now aborted (its ABORTED coordinator state was
-          // written). Return the before-image and roll the record back in the background.
-          rolledBack = true;
-          recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
-          future =
-              executorService.submit(
-                  () -> {
-                    recovery.rollbackRecord(selection, result);
-                    return null;
-                  });
-        } else {
-          // Writing the ABORTED state conflicted: a concurrent actor resolved the transaction (e.g.
-          // it committed). Re-read the coordinator state and resolve the read from that outcome
-          // instead of returning a stale before-image.
-          Optional<Coordinator.State> winnerState = getCoordinatorState(result.getId());
-          assert winnerState.isPresent();
-          rolledBack = winnerState.get().getState() == TransactionState.ABORTED;
-          recoveredResult = createRecoveredResult(winnerState, selection, result, transactionId);
-          future =
-              executorService.submit(
-                  () -> {
-                    recovery.tryRecover(selection, result, winnerState);
-                    return null;
-                  });
-        }
-
-        break;
+        return resolveLatestResultAndRecover(key, selection, result, transactionId);
       case RETURN_COMMITTED_RESULT_AND_RECOVER:
-        // Return the committed result
-        recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
-
-        // The rollback/rollforward decision is deferred to the recovery thread, but since we
-        // return the committed (before-image) result, we treat this as rolled back
-        rolledBack = true;
-
-        // Recover the record
-        future =
+        // Return the committed (before-image) result, and recover the record on the background
+        // thread, where the coordinator state is read and the not-expired guard is applied.
+        Future<Void> future =
             executorService.submit(
                 () -> {
                   Optional<Coordinator.State> s = getCoordinatorState(result.getId());
@@ -200,23 +143,184 @@ public class RecoveryExecutor implements AutoCloseable {
                   return null;
                 });
 
-        break;
+        // The rollback/rollforward decision is deferred to the recovery thread, but since we
+        // return the committed (before-image) result, we treat this as rolled back.
+        return new Result(
+            key, createRecordFromBeforeImage(selection, result, transactionId), future, true);
       case RETURN_COMMITTED_RESULT_AND_NOT_RECOVER:
-        // Return the committed result
-        recoveredResult = createRecordFromBeforeImage(selection, result, transactionId);
-
-        // No recovery is performed, but the committed (before-image) result is returned
-        rolledBack = true;
-
-        // No need to recover the record
-        future = Futures.immediateFuture(null);
-
-        break;
+        // Return the committed (before-image) result without attempting any recovery.
+        return new Result(
+            key,
+            createRecordFromBeforeImage(selection, result, transactionId),
+            Futures.immediateFuture(null),
+            true);
       default:
         throw new AssertionError("Unknown recovery type: " + recoveryType);
     }
+  }
 
-    return new Result(key, recoveredResult, future, rolledBack);
+  /**
+   * Resolves the value to return for an uncommitted record read under {@code
+   * RETURN_LATEST_RESULT_AND_RECOVER} and recovers the record.
+   *
+   * <p>When the writer transaction has a coordinator state, the latest result is returned (after-
+   * or before-image) and the record is recovered in the background. When it does not, the
+   * transaction may either still be in flight (not expired — the read is blocked with {@link
+   * UncommittedRecordException}) or have left a stale record. Because a Coordinator state cleanup
+   * process can run, an absent state no longer implies the transaction never committed, so the
+   * record is physically re-read to decide:
+   *
+   * <ul>
+   *   <li>record gone — a committed delete or rolled-back insert: return empty.
+   *   <li>record committed — the transaction committed and was cleaned up: return its value.
+   *   <li>record re-prepared by a different transaction: re-resolve against that transaction.
+   *   <li>record still uncommitted by the same expired transaction: it is genuinely dead, so abort
+   *       it (write its ABORTED coordinator state) and, only once that succeeds, return the
+   *       before-image and roll the record back in the background. If the abort conflicts (the
+   *       transaction was concurrently resolved), re-resolve from the top.
+   * </ul>
+   *
+   * The re-resolution loop is bounded by {@link #MAX_RESOLUTION_ATTEMPTS}.
+   */
+  private Result resolveLatestResultAndRecover(
+      Snapshot.Key key, Selection selection, TransactionResult result, String transactionId)
+      throws CrudException {
+    TransactionResult current = result;
+    for (int attempt = 0; ; attempt++) {
+      Optional<Coordinator.State> state = getCoordinatorState(current.getId());
+
+      if (state.isPresent()) {
+        boolean rolledBack = state.get().getState() == TransactionState.ABORTED;
+        Optional<TransactionResult> recoveredResult =
+            createRecoveredResult(state.get(), selection, current, transactionId);
+        TransactionResult recovered = current;
+        Future<Void> future =
+            executorService.submit(
+                () -> {
+                  recovery.tryRecover(selection, recovered, state);
+                  return null;
+                });
+        return new Result(key, recoveredResult, future, rolledBack);
+      }
+
+      // The coordinator state is absent. Throw if the transaction has not expired (it may still be
+      // in flight); otherwise it has expired and must be aborted.
+      throwUncommittedRecordExceptionIfTransactionNotExpired(
+          state, selection, current, transactionId);
+
+      // The transaction has expired with no coordinator state. Re-read the record physically:
+      // because a Coordinator state cleanup process can run, the previously observed uncommitted
+      // result may be stale.
+      Optional<TransactionResult> fresh;
+      try {
+        fresh =
+            ConsensusCommitUtils.rereadRecord(storage, tableMetadataManager, selection, current);
+      } catch (ExecutionException e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+            e,
+            transactionId);
+      }
+
+      if (!fresh.isPresent()) {
+        // The record is gone (a committed delete, or a rolled-back insert). Return empty.
+        return new Result(key, Optional.empty(), Futures.immediateFuture(null), true);
+      }
+      if (fresh.get().isCommitted()) {
+        // The transaction committed and was cleaned up; the record carries the committed value.
+        return new Result(key, fresh, Futures.immediateFuture(null), false);
+      }
+      if (!current.getId().equals(fresh.get().getId())) {
+        // A different transaction re-prepared the record. Re-resolve against it.
+        checkReadRetryLimit(attempt, transactionId);
+        current = fresh.get();
+        continue;
+      }
+
+      // The record is still uncommitted by the same expired transaction: it is genuinely dead. The
+      // before-image is only the correct value to return once that transaction is confirmed
+      // aborted, so abort it synchronously (write its ABORTED coordinator state) first.
+      boolean aborted;
+      try {
+        aborted = recovery.tryAbortExpiredTransaction(current.getId());
+      } catch (CoordinatorException e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+            e,
+            transactionId);
+      }
+
+      if (aborted) {
+        // The ABORTED coordinator state was written with putIfNotExists, which also succeeds when
+        // the row is absent. So the writer may actually have committed, been finalized, and had its
+        // COMMITTED state removed by a Coordinator state cleanup process in the window between the
+        // pre-abort re-read above and this abort. In that race the ABORTED we just wrote is
+        // spurious and the record carries the committed value, so re-read once more and return the
+        // record's actual state instead of a possibly stale before-image. (The spurious ABORTED is
+        // non-corrupting -- the record stays committed and the background rollback below is a
+        // conditional no-op -- and is reclaimed by the Coordinator state cleanup process.)
+        Optional<TransactionResult> afterAbort;
+        try {
+          afterAbort =
+              ConsensusCommitUtils.rereadRecord(storage, tableMetadataManager, selection, current);
+        } catch (ExecutionException e) {
+          throw new CrudException(
+              CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+              e,
+              transactionId);
+        }
+        if (!afterAbort.isPresent()) {
+          // The record is gone (a committed delete that raced the cleanup). Return empty.
+          return new Result(key, Optional.empty(), Futures.immediateFuture(null), true);
+        }
+        if (afterAbort.get().isCommitted()) {
+          // The writer committed and was cleaned up; the record carries the committed value.
+          return new Result(key, afterAbort, Futures.immediateFuture(null), false);
+        }
+        if (!current.getId().equals(afterAbort.get().getId())) {
+          // A different transaction re-prepared the record after we aborted the writer (the writer
+          // was rolled back and, possibly through one or more intervening commits, a new writer
+          // re-prepared it). current's before-image is no longer guaranteed to be the latest
+          // committed value, so re-resolve against the new writer instead of returning a stale
+          // before-image -- the same ABA handling as the pre-abort re-read above.
+          checkReadRetryLimit(attempt, transactionId);
+          current = afterAbort.get();
+          continue;
+        }
+
+        // The record is still uncommitted by the same expired writer (the genuine-abort case): the
+        // writer is now aborted, so return the before-image and roll the record back in the
+        // background. The before-image is built from current (the pre-abort snapshot), not
+        // afterAbort: only a coordinator write happened between the two physical reads, so the
+        // record (and thus its before-image) is unchanged, and the branches above already ruled out
+        // the record having been committed, removed, or re-prepared by a different transaction.
+        Optional<TransactionResult> recoveredResult =
+            createRecordFromBeforeImage(selection, current, transactionId);
+        TransactionResult recovered = current;
+        Future<Void> future =
+            executorService.submit(
+                () -> {
+                  recovery.rollbackRecord(selection, recovered);
+                  return null;
+                });
+        return new Result(key, recoveredResult, future, true);
+      }
+
+      // Writing the ABORTED state conflicted: a concurrent actor resolved the transaction (e.g. it
+      // committed) or a cleanup raced. Re-resolve from the top.
+      checkReadRetryLimit(attempt, transactionId);
+    }
+  }
+
+  private void checkReadRetryLimit(int attempt, String transactionId) throws CrudConflictException {
+    // attempt is the current 0-based pass index, checked at the end of a pass before retrying, so
+    // the last allowed pass is MAX_RESOLUTION_ATTEMPTS - 1.
+    if (attempt >= MAX_RESOLUTION_ATTEMPTS - 1) {
+      throw new CrudConflictException(
+          CoreError.CONSENSUS_COMMIT_RESOLVING_UNCOMMITTED_RECORD_RETRY_LIMIT_EXCEEDED.buildMessage(
+              transactionId),
+          transactionId);
+    }
   }
 
   private Optional<Coordinator.State> getCoordinatorState(String transactionId)
@@ -232,17 +336,13 @@ public class RecoveryExecutor implements AutoCloseable {
   }
 
   private Optional<TransactionResult> createRecoveredResult(
-      Optional<Coordinator.State> state,
-      Selection selection,
-      TransactionResult result,
-      String transactionId)
+      Coordinator.State state, Selection selection, TransactionResult result, String transactionId)
       throws CrudException {
-    if (!state.isPresent() || state.get().getState() == TransactionState.ABORTED) {
+    if (state.getState() == TransactionState.ABORTED) {
       return createRecordFromBeforeImage(selection, result, transactionId);
-    } else {
-      assert state.get().getState() == TransactionState.COMMITTED;
-      return createResultFromAfterImage(selection, result, transactionId);
     }
+    assert state.getState() == TransactionState.COMMITTED;
+    return createResultFromAfterImage(selection, result, transactionId);
   }
 
   private void throwUncommittedRecordExceptionIfTransactionNotExpired(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -293,6 +293,23 @@ public class RecoveryHandler {
       return false;
     }
 
+    // Before writing the ABORTED state, physically re-read the record. A Coordinator state cleanup
+    // process can finalize the record and remove the writer's state row, so an expired writer with
+    // no coordinator state no longer implies the record is still uncommitted: the writer may have
+    // committed and been cleaned up. Only abort when the record is still uncommitted by this
+    // writer; otherwise writing the ABORTED state would leave a spurious tombstone for an
+    // already-resolved (possibly committed) transaction.
+    Optional<TransactionResult> latest =
+        ConsensusCommitUtils.rereadRecord(storage, tableMetadataManager, selection, result);
+    if (!latest.isPresent()
+        || latest.get().isCommitted()
+        || !result.getId().equals(latest.get().getId())) {
+      // The record is gone, already committed, or re-prepared by a different transaction — this
+      // writer's record has already been resolved (rolled and possibly replaced), so the record is
+      // consistent and no ABORTED state should be written.
+      return true;
+    }
+
     try {
       coordinator.putStateForLazyRecoveryRollback(result.getId());
     } catch (CoordinatorConflictException e) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -293,6 +293,11 @@ public class RecoveryHandler {
       return false;
     }
 
+    // result is the expired uncommitted writer being recovered, so its tx_id is non-null here;
+    // getId() is @Nullable only for deemed-committed records, which are never recovered.
+    String txId = result.getId();
+    assert txId != null;
+
     // Before writing the ABORTED state, physically re-read the record. A Coordinator state cleanup
     // process can finalize the record and remove the writer's state row, so an expired writer with
     // no coordinator state no longer implies the record is still uncommitted: the writer may have
@@ -301,9 +306,7 @@ public class RecoveryHandler {
     // already-resolved (possibly committed) transaction.
     Optional<TransactionResult> latest =
         ConsensusCommitUtils.rereadRecord(storage, tableMetadataManager, selection, result);
-    if (!latest.isPresent()
-        || latest.get().isCommitted()
-        || !result.getId().equals(latest.get().getId())) {
+    if (!latest.isPresent() || latest.get().isCommitted() || !txId.equals(latest.get().getId())) {
       // The record is gone, already committed, or re-prepared by a different transaction — this
       // writer's record has already been resolved (rolled and possibly replaced), so the record is
       // consistent and no ABORTED state should be written.
@@ -311,7 +314,7 @@ public class RecoveryHandler {
     }
 
     try {
-      coordinator.putStateForLazyRecoveryRollback(result.getId());
+      coordinator.putStateForLazyRecoveryRollback(txId);
     } catch (CoordinatorConflictException e) {
       TransactionTableMetadata tableMetadata =
           getTransactionTableMetadata(tableMetadataManager, selection);
@@ -325,7 +328,7 @@ public class RecoveryHandler {
           selection.forFullTableName().get(),
           partitionKey,
           clusteringKey,
-          result.getId(),
+          txId,
           e);
 
       if (!ensureRecordResolved) {
@@ -341,7 +344,7 @@ public class RecoveryHandler {
       // coordinator state and roll the record to the winner's outcome so it is physically resolved
       // on return.
       Optional<TransactionState> rereadState =
-          coordinator.getState(result.getId()).map(Coordinator.State::getState);
+          coordinator.getState(txId).map(Coordinator.State::getState);
 
       if (rereadState.isPresent()) {
         // Roll the targeted record to the winner's outcome. This is idempotent: the underlying

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -136,6 +136,19 @@ public class TransactionResult extends AbstractResult {
     return result.getColumns();
   }
 
+  /**
+   * Returns the ID of the transaction that last wrote this record ({@code tx_id}).
+   *
+   * <p>This is {@code null} when the record has no transaction metadata, i.e. when the record is
+   * deemed as committed (see {@link #isDeemedAsCommitted()} and {@link #getState()}). That happens
+   * when a record imported into a table initially has no transaction metadata. A record written by
+   * a ScalarDB transaction otherwise always carries {@code tx_id} and {@code tx_state} together, so
+   * a non-null {@code tx_id} implies the record is prepared, deleted, or committed by a known
+   * transaction.
+   *
+   * @return the transaction ID that last wrote this record, or {@code null} when the record is
+   *     deemed as committed (no transaction metadata)
+   */
   @Nullable
   public String getId() {
     return getText(Attribute.ID);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -484,7 +484,9 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     } catch (CoordinatorException ignored) {
       // ignored
     }
-    // Either no state exists or the exception is thrown
+
+    // The Coordinator state row is absent (the transaction never existed, or it was finished and
+    // cleaned up) or could not be read. These are indistinguishable here, so report UNKNOWN.
     return TransactionState.UNKNOWN;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -78,7 +78,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     crud =
         new CrudHandler(
             storage,
@@ -121,7 +121,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     crud =
         new CrudHandler(
             storage,

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -677,6 +677,10 @@ public class CommitHandlerTest {
   @Test
   public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
       throws CoordinatorException {
+    // The conflicting state row is absent on re-read, which is reachable once the Coordinator state
+    // cleanup process removes a finished row. The outcome cannot be recovered, so an honest
+    // UnknownTransactionStatusException is thrown, preserving the original conflict as the cause.
+
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
@@ -685,7 +689,8 @@ public class CommitHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
-        .isInstanceOf(UnknownTransactionStatusException.class);
+        .isInstanceOf(UnknownTransactionStatusException.class)
+        .hasCauseInstanceOf(CoordinatorConflictException.class);
     verify(coordinator).getState(anyId());
   }
 
@@ -702,7 +707,47 @@ public class CommitHandlerTest {
 
   @Test
   public void
-      commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
+      abortStateWithoutWriteSet_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+          throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class).when(coordinator).putState(any());
+    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
+
+    // Assert
+    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void abortStateWithoutWriteSet_WhenConflictAndNoStatePersisted_ShouldReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Unlike abortStateForRollback (the One-phase Commit I/F abort-by-id path), this method is used
+    // by the self-abort path and all Two-phase Commit I/F aborts, which cannot be racing a real,
+    // deletable COMMITTED row. A conflicting-then-absent coordinator state is therefore
+    // determinable as ABORTED (the conflict was a lazy-recovery ABORTED later removed by the
+    // Coordinator state cleanup process), not an honest UNKNOWN.
+
+    // Arrange
+    doThrow(CoordinatorConflictException.class).when(coordinator).putState(any());
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  public void
+      commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitException()
           throws ExecutionException, CoordinatorException, CrudException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
@@ -717,8 +762,13 @@ public class CommitHandlerTest {
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
+
+    // The self-abort path provably never committed, so a conflicting-then-absent coordinator state
+    // resolves to ABORTED rather than UNKNOWN. The commit then surfaces the original preparation
+    // failure (a CommitException) instead of masking it with an UnknownTransactionStatusException.
     assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
+        .isInstanceOf(CommitException.class)
+        .isNotInstanceOf(UnknownTransactionStatusException.class);
 
     // Assert
 
@@ -733,7 +783,7 @@ public class CommitHandlerTest {
             new Coordinator.State(
                 anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
+    verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
 
@@ -909,7 +959,7 @@ public class CommitHandlerTest {
 
   @Test
   public void
-      commit_ExceptionThrownInValidationAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
+      commit_ExceptionThrownInValidationAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitException()
           throws ExecutionException, CoordinatorException, ValidationConflictException,
               CrudException {
     // Arrange
@@ -925,8 +975,13 @@ public class CommitHandlerTest {
         createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act
+
+    // The self-abort path provably never committed, so a conflicting-then-absent coordinator state
+    // resolves to ABORTED rather than UNKNOWN. The commit then surfaces the original validation
+    // failure (a CommitException) instead of masking it with an UnknownTransactionStatusException.
     assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
+        .isInstanceOf(CommitException.class)
+        .isNotInstanceOf(UnknownTransactionStatusException.class);
 
     // Assert
 
@@ -937,7 +992,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), writeSet, TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
+    verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
 
@@ -1068,8 +1123,14 @@ public class CommitHandlerTest {
 
   @Test
   public void
-      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenNothingReturnedInGetState_ShouldThrowUnknown()
+      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitConflict()
           throws ExecutionException, CoordinatorException, CrudException {
+    // Writing the COMMITTED state conflicts, and the conflicting row is absent on re-read. The only
+    // concurrent writer of this transaction's state is a lazy recovery, which only ever writes
+    // ABORTED, so the conflicting row was an ABORTED state that the Coordinator state cleanup
+    // process then removed. The transaction is therefore aborted, so the records are rolled back
+    // and a conflict is reported -- the same outcome as when the ABORTED state is still present.
+
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     doNothing().when(storage).mutate(anyList());
@@ -1081,13 +1142,14 @@ public class CommitHandlerTest {
 
     // Act
     assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(CoordinatorConflictException.class);
 
     // Assert
     verify(storage, times(2)).mutate(anyList());
     verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
     verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
+    verify(handler).rollbackRecords(context);
     verify(handler, never()).onFailureBeforeCommit(any());
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -27,9 +28,11 @@ import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.GroupCommitConfig;
+import com.scalar.db.util.groupcommit.GroupCommitConflictException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -332,6 +335,40 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     verify(handler).onFailureBeforeCommit(any());
     // The bare ID never reserved a slot, so cancelGroupCommitIfNeeded skips remove() entirely.
     verify(groupCommitter, never()).remove(anyString());
+  }
+
+  @Test
+  public void
+      handleCommitConflict_GroupCommitConflictExceptionGivenAndNoStatePersisted_ShouldRollbackRecordsAndThrowCommitConflict()
+          throws Exception {
+    // The group-commit conflict route (commitStateViaGroupCommit catches
+    // GroupCommitConflictException and calls handleCommitConflict) must, when the coordinator state
+    // is absent on re-read, resolve to a definitive conflict -- roll the records back and throw
+    // CommitConflictException -- the same outcome as the normal-commit conflict route. getState for
+    // a group-commit child checks both the parent and full-ID rows, so an absent state genuinely
+    // means the transaction never committed.
+
+    // Arrange
+    // This test resolves the conflict by calling handleCommitConflict directly and never emits or
+    // removes the group, so release the slot reserved by extraInitialize() up front. Leaving it
+    // outstanding would make groupCommitter.close() block on it during teardown.
+    groupCommitter.remove(anyId());
+    clearInvocations(groupCommitter);
+
+    CommitHandler handler = spy(createCommitHandler(true));
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
+    when(coordinator.getState(anyId())).thenReturn(Optional.empty());
+    GroupCommitConflictException cause = new GroupCommitConflictException("conflict");
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCause(cause);
+    verify(handler).rollbackRecords(context);
+    verify(coordinator).getState(anyId());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -952,6 +952,72 @@ public class CoordinatorTest {
   }
 
   @Test
+  void
+      putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord_ShouldInsertRecordWithFullId()
+          throws CoordinatorException {
+    // The parent-id insert conflicts because a finished group-commit row existed, but the
+    // Coordinator state cleanup process removed it before we re-read it. With no full-ID record,
+    // this transaction is genuinely uncommitted (e.g. a delayed group commit that never landed), so
+    // we fall through to insert the full-ID ABORTED record instead of crashing with AssertionError.
+
+    // Arrange
+    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String fullId = keyManipulator.fullKey(parentId, ANY_ID_1);
+
+    doThrow(CoordinatorConflictException.class)
+        .when(spiedCoordinator)
+        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+    doReturn(Optional.empty()).when(spiedCoordinator).getState(parentId);
+
+    // Act
+    spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
+
+    // Assert
+    verify(spiedCoordinator)
+        .putStateForGroupCommit(
+            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
+    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+  }
+
+  @Test
+  void
+      putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndTransactionCommittedWithFullId_ShouldThrowCoordinatorConflictException()
+          throws CoordinatorException {
+    // The parent row was cleaned up after our parent-id insert conflicted, but this transaction
+    // actually committed via a full-ID record (a delayed, standalone commit). Falling through to
+    // insert the full-ID ABORTED record conflicts with that committed record, which propagates so
+    // the caller re-reads the committed outcome instead of treating the transaction as aborted.
+
+    // Arrange
+    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String fullId = keyManipulator.fullKey(parentId, ANY_ID_1);
+
+    doThrow(CoordinatorConflictException.class)
+        .when(spiedCoordinator)
+        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+    doReturn(Optional.empty()).when(spiedCoordinator).getState(parentId);
+    doThrow(CoordinatorConflictException.class)
+        .when(spiedCoordinator)
+        .putState(new State(fullId, TransactionState.ABORTED));
+
+    // Act
+    assertThatThrownBy(() -> spiedCoordinator.putStateForLazyRecoveryRollback(fullId))
+        .isInstanceOf(CoordinatorConflictException.class);
+
+    // Assert
+    verify(spiedCoordinator)
+        .putStateForGroupCommit(
+            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
+    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+  }
+
+  @Test
   public void state_WriteSetSerializationRoundTrip_ShouldPreserveContent()
       throws CoordinatorException {
     // Arrange — build a State that carries a populated WriteSet.

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -19,15 +19,19 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
@@ -122,6 +126,7 @@ public class RecoveryExecutorTest {
               .addClusteringKey(ANY_NAME_2)
               .build());
 
+  @Mock private DistributedStorage storage;
   @Mock private Coordinator coordinator;
   @Mock private RecoveryHandler recovery;
   @Mock private TransactionTableMetadataManager tableMetadataManager;
@@ -134,7 +139,7 @@ public class RecoveryExecutorTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    executor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    executor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
 
     // Arrange
     when(tableMetadataManager.getTransactionTableMetadata(selection))
@@ -147,6 +152,10 @@ public class RecoveryExecutorTest {
   }
 
   private TransactionResult prepareResult(TransactionState state) {
+    return prepareResult(state, ANY_ID_2);
+  }
+
+  private TransactionResult prepareResult(TransactionState state, String id) {
     ImmutableMap<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
             .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
@@ -162,7 +171,7 @@ public class RecoveryExecutorTest {
             .put(ANY_NAME_11, TimeColumn.of(ANY_NAME_11, ANY_TIME_2))
             .put(ANY_NAME_12, TimestampColumn.of(ANY_NAME_12, ANY_TIMESTAMP_2))
             .put(ANY_NAME_13, TimestampTZColumn.of(ANY_NAME_13, ANY_TIMESTAMPTZ_2))
-            .put(ID, TextColumn.of(ID, ANY_ID_2))
+            .put(ID, TextColumn.of(ID, id))
             .put(PREPARED_AT, BigIntColumn.of(PREPARED_AT, ANY_TIME_MILLIS_3))
             .put(STATE, IntColumn.of(STATE, state.get()))
             .put(VERSION, IntColumn.of(VERSION, 1))
@@ -375,6 +384,7 @@ public class RecoveryExecutorTest {
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
     when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
 
     // Act
@@ -405,6 +415,7 @@ public class RecoveryExecutorTest {
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
     when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
 
     // Act
@@ -435,6 +446,7 @@ public class RecoveryExecutorTest {
     Coordinator.State committedState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(committedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
     when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(false);
 
     executor = spy(executor);
@@ -466,6 +478,7 @@ public class RecoveryExecutorTest {
     Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(abortedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
     when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(false);
 
     // Act
@@ -493,6 +506,7 @@ public class RecoveryExecutorTest {
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
     when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenThrow(CoordinatorException.class);
 
     // Act Assert
@@ -509,6 +523,377 @@ public class RecoveryExecutorTest {
     // Verify no recovery attempted
     verify(recovery, never()).rollbackRecord(any(), any());
     verify(recovery, never()).tryRecover(any(), any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordReReadCommitted_ShouldReturnCommittedValue()
+          throws Exception {
+    // Arrange: the coordinator state was cleaned up after the transaction committed; re-reading the
+    // record shows it is now committed.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    TransactionResult committedRecord = prepareResult(TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(committedRecord));
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: the committed value is returned (not a stale before-image), and nothing is recovered
+    assertThat(result.recoveredResult).hasValue(committedRecord);
+    assertThat(result.rolledBack).isFalse();
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
+    verify(recovery, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordReReadAbsent_ShouldReturnEmpty()
+          throws Exception {
+    // Arrange: the record is gone (a committed delete or a rolled-back insert).
+    TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.empty());
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: a committed delete returns empty, never a stale before-image
+    assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
+    verify(recovery, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerWrittenButRecordCommitted_ShouldReturnCommittedValue()
+          throws Exception {
+    // Arrange: the pre-abort re-read still sees the record PREPARED by the same writer, so the
+    // ABORTED state is written. But the writer actually committed and was cleaned up in the race,
+    // so the post-abort re-read sees the record committed. The committed value is returned, not a
+    // stale before-image.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    TransactionResult committedRecord = prepareResult(TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    // First (pre-abort) re-read sees PREPARED; second (post-abort) re-read sees committed.
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(transactionResult), Optional.of(committedRecord));
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: the committed value is returned and the record is not rolled back
+    assertThat(result.recoveredResult).hasValue(committedRecord);
+    assertThat(result.rolledBack).isFalse();
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_2);
+    verify(recovery, never()).rollbackRecord(any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerWrittenButRecordAbsent_ShouldReturnEmpty()
+          throws Exception {
+    // Arrange: the pre-abort re-read sees the record PREPARED by the same writer, so the ABORTED
+    // state is written. But the writer's delete committed and was cleaned up in the race, so the
+    // post-abort re-read finds the record gone. Empty is returned, not a stale before-image.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    // First (pre-abort) re-read sees PREPARED; second (post-abort) re-read finds the record gone.
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult), Optional.empty());
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            transactionResult,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: empty is returned and the record is not rolled back
+    assertThat(result.recoveredResult).isEmpty();
+    assertThat(result.rolledBack).isTrue();
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_2);
+    verify(recovery, never()).rollbackRecord(any(), any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortMarkerWrittenButRecordRePreparedByDifferentTransaction_ShouldReResolveAgainstIt()
+          throws Exception {
+    // Arrange: the pre-abort re-read sees the record PREPARED by the same writer, so the ABORTED
+    // state is written for it. In the race the writer is rolled back and a DIFFERENT transaction
+    // re-prepares the record, so the post-abort re-read sees a different writer. Because an
+    // intervening commit may have advanced the latest committed value, the loop must NOT return the
+    // original writer's (now stale) before-image -- it must re-resolve against the new writer. The
+    // new writer's coordinator state is ABORTED, so the record is resolved (rolled back) for it.
+    TransactionResult original = prepareResult(TransactionState.PREPARED);
+    TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
+    Coordinator.State abortedState = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
+    when(recovery.isTransactionExpired(original)).thenReturn(true);
+    // First (pre-abort) re-read sees the same writer PREPARED; second (post-abort) re-read sees a
+    // different writer's PREPARED record.
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(original), Optional.of(rePrepared));
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            original,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: resolved against the re-preparing transaction (ANY_ID_1), not by returning the
+    // original writer's before-image. The original writer was aborted, but the new writer is the
+    // one the record is recovered for.
+    assertThat(result.rolledBack).isTrue();
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_2);
+    verify(recovery, never()).tryAbortExpiredTransaction(ANY_ID_1);
+    verify(coordinator).getState(ANY_ID_1);
+    verify(recovery).tryRecover(eq(selection), eq(rePrepared), eq(Optional.of(abortedState)));
+    verify(recovery, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_AbortKeepsConflicting_ShouldThrowCrudConflictExceptionAfterRetryLimit()
+          throws Exception {
+    // Arrange: the coordinator state stays absent and every abort attempt conflicts (a concurrent
+    // actor keeps racing), so the re-resolution loop spins until MAX_RESOLUTION_ATTEMPTS is reached
+    // and a CrudConflictException is thrown.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    transactionResult,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOf(CrudConflictException.class);
+
+    // The loop runs exactly MAX_RESOLUTION_ATTEMPTS passes, attempting the abort on each.
+    verify(recovery, times(RecoveryExecutor.MAX_RESOLUTION_ATTEMPTS))
+        .tryAbortExpiredTransaction(ANY_ID_2);
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordRePreparedByDifferentTransaction_ShouldReResolveAgainstIt()
+          throws Exception {
+    // Arrange: the original writer's coordinator state is absent and it has expired; the re-read
+    // shows a DIFFERENT transaction re-prepared the record. The loop re-resolves against that
+    // transaction, whose coordinator state is ABORTED, so the record is rolled back for it.
+    TransactionResult original = prepareResult(TransactionState.PREPARED);
+    TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
+    Coordinator.State abortedState = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
+    when(recovery.isTransactionExpired(original)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(rePrepared));
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(
+            snapshotKey,
+            selection,
+            original,
+            ANY_ID_3,
+            RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER);
+    result.recoveryFuture.get();
+
+    // Assert: resolved against the re-preparing transaction (ANY_ID_1), not aborted as the original
+    assertThat(result.rolledBack).isTrue();
+    verify(coordinator).getState(ANY_ID_2);
+    verify(coordinator).getState(ANY_ID_1);
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
+    verify(recovery).tryRecover(eq(selection), eq(rePrepared), eq(Optional.of(abortedState)));
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordRePreparedByDifferentTransactionNotExpired_ShouldThrowUncommittedRecordException()
+          throws Exception {
+    // Arrange: the original writer's coordinator state is absent and it has expired; the re-read
+    // shows a DIFFERENT, still-in-flight transaction re-prepared the record (its coordinator state
+    // is absent AND it has NOT expired). The re-resolution must re-apply the expiry guard to the
+    // new
+    // writer rather than aborting it or returning the original writer's before-image: a live second
+    // writer must not be killed, so the loop throws UncommittedRecordException for it (retry).
+    TransactionResult original = prepareResult(TransactionState.PREPARED);
+    TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(original)).thenReturn(true);
+    when(recovery.isTransactionExpired(rePrepared)).thenReturn(false);
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(rePrepared));
+
+    // Act Assert: the exception is raised for the re-preparing (new) writer, not the original.
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    original,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOfSatisfying(
+            UncommittedRecordException.class,
+            e -> assertThat(e.getResults()).containsExactly(rePrepared));
+
+    // The expiry guard was re-applied to the new writer (ANY_ID_1), and the live writer was neither
+    // aborted nor rolled back.
+    verify(coordinator).getState(ANY_ID_2);
+    verify(coordinator).getState(ANY_ID_1);
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
+    verify(recovery, never()).tryRecover(any(), any(), any());
+    verify(recovery, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_PreAbortReReadThrowsExecutionException_ShouldThrowCrudException()
+          throws Exception {
+    // Arrange: the coordinator state is absent and the writer expired, but the pre-abort physical
+    // re-read fails with an ExecutionException, which must surface as a CrudException.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class))).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    transactionResult,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOf(CrudException.class);
+
+    // The abort is never attempted because the pre-abort re-read failed first.
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_PostAbortReReadThrowsExecutionException_ShouldThrowCrudException()
+          throws Exception {
+    // Arrange: the pre-abort re-read sees the same writer PREPARED, so the ABORTED state is
+    // written.
+    // The post-abort re-read then fails with an ExecutionException, which must surface as a
+    // CrudException.
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(transactionResult))
+        .thenThrow(ExecutionException.class);
+    when(recovery.tryAbortExpiredTransaction(ANY_ID_2)).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    transactionResult,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOf(CrudException.class);
+
+    verify(recovery).tryAbortExpiredTransaction(ANY_ID_2);
+    verify(recovery, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void
+      execute_ReturnLatestResultAndRecoverType_TransactionExpiredAndNoCoordinatorState_RecordKeepsBeingRePreparedByDifferentTransactions_ShouldThrowCrudConflictExceptionAfterRetryLimit()
+          throws Exception {
+    // Arrange: the coordinator state stays absent and expired, and every physical re-read shows a
+    // DIFFERENT transaction has re-prepared the record (modeled by ping-ponging between two ids),
+    // so
+    // the loop keeps taking the re-prepare branch until MAX_RESOLUTION_ATTEMPTS is reached and a
+    // CrudConflictException is thrown. This exercises the retry limit via the re-prepare branch
+    // (the
+    // abort-conflict branch is covered by AbortKeepsConflicting above).
+    TransactionResult original = prepareResult(TransactionState.PREPARED);
+    TransactionResult rePreparedAs1 = prepareResult(TransactionState.PREPARED, ANY_ID_1);
+    TransactionResult rePreparedAs2 = prepareResult(TransactionState.PREPARED, ANY_ID_2);
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(any(TransactionResult.class))).thenReturn(true);
+    // current starts as ANY_ID_2; each re-read returns the opposite id so the re-prepare branch is
+    // taken on every pass.
+    when(storage.get(any(Get.class)))
+        .thenReturn(
+            Optional.of(rePreparedAs1),
+            Optional.of(rePreparedAs2),
+            Optional.of(rePreparedAs1),
+            Optional.of(rePreparedAs2),
+            Optional.of(rePreparedAs1));
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    snapshotKey,
+                    selection,
+                    original,
+                    ANY_ID_3,
+                    RecoveryExecutor.RecoveryType.RETURN_LATEST_RESULT_AND_RECOVER))
+        .isInstanceOf(CrudConflictException.class);
+
+    // The loop runs exactly MAX_RESOLUTION_ATTEMPTS passes, re-reading on each, and never aborts
+    // (it
+    // always takes the re-prepare branch).
+    verify(storage, times(RecoveryExecutor.MAX_RESOLUTION_ATTEMPTS)).get(any(Get.class));
+    verify(recovery, never()).tryAbortExpiredTransaction(any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
@@ -43,6 +44,7 @@ public class RecoveryHandlerTest {
   private static final String ANY_NAME_1 = "name1";
   private static final String ANY_TEXT_1 = "text1";
   private static final String ANY_ID_1 = "id1";
+  private static final String ANY_ID_2 = "id2";
   private static final long ANY_TIME_1 = 100;
 
   private static final TableMetadata TABLE_METADATA =
@@ -74,13 +76,24 @@ public class RecoveryHandlerTest {
     when(transactionTableMetadataManager.getTransactionTableMetadata(selection))
         .thenReturn(transactionTableMetadata);
     when(transactionTableMetadata.getTableMetadata()).thenReturn(TABLE_METADATA);
+
+    // By default the re-read in abortIfExpired sees the same record still uncommitted by the
+    // same writer (the no-race case), so the expired-abort tests behave as before. Tests for the
+    // cleanup race override this stub with a committed, absent, or re-prepared record.
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.PREPARED, ANY_ID_1)));
   }
 
   private TransactionResult prepareResult(long preparedAt, TransactionState transactionState) {
+    return prepareResult(preparedAt, transactionState, ANY_ID_1);
+  }
+
+  private TransactionResult prepareResult(
+      long preparedAt, TransactionState transactionState, String id) {
     ImmutableMap<String, Column<?>> columns =
         ImmutableMap.<String, Column<?>>builder()
             .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
-            .put(Attribute.ID, TextColumn.of(Attribute.ID, ANY_ID_1))
+            .put(Attribute.ID, TextColumn.of(Attribute.ID, id))
             .put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, preparedAt))
             .put(Attribute.STATE, IntColumn.of(Attribute.STATE, transactionState.get()))
             .put(Attribute.VERSION, IntColumn.of(Attribute.VERSION, 1))
@@ -360,6 +373,180 @@ public class RecoveryHandlerTest {
 
     // Assert
     verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_RecordRereadCommitted_ShouldReturnTrueWithoutAborting()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — the writer committed and was finalized, then the Coordinator state cleanup process
+    // removed its state row. The abort-before re-read sees the record already committed, so no
+    // spurious ABORTED state is written and the record is not rolled.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.COMMITTED, ANY_ID_1)));
+
+    // Act
+    boolean recovered = handler.recover(selection, result, state);
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_RecordRereadAbsent_ShouldReturnTrueWithoutAborting()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — the record is gone (a committed delete that was finalized and cleaned up). The
+    // abort-before re-read finds nothing, so no spurious ABORTED state is written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class))).thenReturn(Optional.empty());
+
+    // Act
+    boolean recovered = handler.recover(selection, result, state);
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_RecordRereadRePreparedByDifferentTransaction_ShouldReturnTrueWithoutAborting()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — this writer's record was already resolved and a different transaction re-prepared
+    // the record. The abort-before re-read sees a different writer, so this writer's ABORTED state
+    // is not written (it would be a spurious tombstone for an already-resolved transaction).
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.PREPARED, ANY_ID_2)));
+
+    // Act
+    boolean recovered = handler.recover(selection, result, state);
+
+    // Assert
+    assertThat(recovered).isTrue();
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void
+      tryRecover_WhenCoordinatorStateNotExistsAndExpired_RecordRereadCommitted_ShouldNotAbort()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — best-effort path: the writer committed and was cleaned up, so the abort-before
+    // re-read sees the record committed and no spurious ABORTED state is written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.COMMITTED, ANY_ID_1)));
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void tryRecover_WhenCoordinatorStateNotExistsAndExpired_RecordRereadAbsent_ShouldNotAbort()
+      throws CoordinatorException, ExecutionException {
+    // Arrange — best-effort path: the record is gone (a committed delete that was finalized and
+    // cleaned up), so the abort-before re-read finds nothing and no spurious ABORTED state is
+    // written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class))).thenReturn(Optional.empty());
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void
+      tryRecover_WhenCoordinatorStateNotExistsAndExpired_RecordRereadRePreparedByDifferentTransaction_ShouldNotAbort()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — best-effort path: this writer's record was already resolved and a different
+    // transaction re-prepared the record, so the abort-before re-read sees a different writer and
+    // no spurious ABORTED state is written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class)))
+        .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.PREPARED, ANY_ID_2)));
+
+    // Act
+    handler.tryRecover(selection, result, state);
+
+    // Assert
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+    verify(handler, never()).rollforwardRecord(selection, result);
+  }
+
+  @Test
+  public void
+      recover_WhenCoordinatorStateNotExistsAndExpired_ReReadThrowsExecutionException_ShouldPropagateAndNotAbort()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — the abort-before re-read in abortIfExpired fails with an ExecutionException, which
+    // must propagate and prevent any ABORTED state from being written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class))).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.recover(selection, result, state))
+        .isInstanceOf(ExecutionException.class);
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(handler, never()).rollbackRecord(selection, result);
+  }
+
+  @Test
+  public void
+      tryRecover_WhenCoordinatorStateNotExistsAndExpired_ReReadThrowsExecutionException_ShouldPropagateAndNotAbort()
+          throws CoordinatorException, ExecutionException {
+    // Arrange — best-effort path: the abort-before re-read in abortIfExpired fails with an
+    // ExecutionException, which must propagate and prevent any ABORTED state from being written.
+    TransactionResult result =
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    Optional<Coordinator.State> state = Optional.empty();
+    when(storage.get(any(Get.class))).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.tryRecover(selection, result, state))
+        .isInstanceOf(ExecutionException.class);
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -127,7 +127,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(consensusCommitConfig).orElse(null);
     CrudHandler crud =
         new CrudHandler(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -635,9 +635,9 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
           Selection s) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -690,9 +690,9 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
           Selection s) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -865,9 +865,9 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
           Selection s) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null);
+        storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act
@@ -920,9 +920,9 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
           Selection s) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null);
+        storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -139,7 +139,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(consensusCommitConfig).orElse(null);
     CrudHandler crud =
         new CrudHandler(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -2337,9 +2337,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
     // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
-    // before the result is returned, then the record is rolled back in the background. tryRecover()
-    // is
-    // not used on this path.
+    // before the result is returned, then the record is rolled back in the background.
+    // tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -3052,8 +3051,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // The index read path always uses RETURN_LATEST_RESULT_AND_RECOVER regardless of isolation, so
     // the expired transaction is aborted synchronously (its ABORTED coordinator state is written)
     // before the records are returned, then the record is rolled back in the background.
-    // tryRecover()
-    // is not used on this path.
+    // tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -10675,7 +10673,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
-    recoveryExecutor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager);
+    recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
     groupCommitter = CoordinatorGroupCommitter.from(consensusCommitConfig).orElse(null);
     CrudHandler crud =
         new CrudHandler(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -100,6 +101,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   protected static final String SOME_COLUMN = "some_column";
   private static final int INITIAL_BALANCE = 1000;
   private static final int NEW_BALANCE = 2000;
+
+  // A value committed by an intervening transaction, distinct from INITIAL_BALANCE and NEW_BALANCE,
+  // used to detect a stale before-image read in the post-abort ABA cleanup-race test.
+  private static final int INTERVENING_BALANCE = 3000;
+  private static final String INTERVENING_TX_ID = "intervening-tx-id";
+  private static final String REPREPARING_TX_ID = "repreparing-tx-id";
+
   private static final int NUM_ACCOUNTS = 4;
   private static final int NUM_TYPES = 4;
   private static final String ANY_ID_1 = "id1";
@@ -1484,9 +1492,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
     DistributedTransaction transaction = begin(manager, readOnly);
 
     // Act Assert
@@ -1617,10 +1625,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
-            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
     DistributedTransaction transaction = begin(manager, readOnly);
 
     // Act
@@ -1982,9 +1990,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+        storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null, commitType);
     DistributedTransaction transaction = begin(manager, readOnly);
 
     // Act Assert
@@ -2115,10 +2123,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
-            storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+            storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null, commitType);
     DistributedTransaction transaction = begin(manager, readOnly);
 
     // Act
@@ -2310,14 +2318,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
             storage,
             namespace1,
             TABLE_1,
             TransactionState.PREPARED,
-            prepared_at,
+            preparedAt,
             null,
             CommitType.NORMAL_COMMIT);
     DistributedTransaction transaction = manager.begin();
@@ -2353,13 +2361,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
         storage,
         namespace1,
         TABLE_1,
         TransactionState.PREPARED,
-        prepared_at,
+        preparedAt,
         null,
         CommitType.NORMAL_COMMIT);
     DistributedTransaction transaction = manager.begin();
@@ -2675,6 +2683,51 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, times(1)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  // Writes a PREPARED/DELETED record at the given account_type with the given after-image BALANCE
+  // and writer transaction id, so that two records with different primary keys but the same BALANCE
+  // index value reproduce a transient index duplicate.
+  private void populatePreparedIndexRecord(
+      DistributedStorage storage,
+      String namespace,
+      String table,
+      int accountType,
+      TransactionState recordState,
+      int balance,
+      int beforeBalance,
+      String txId,
+      long preparedAt)
+      throws ExecutionException {
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(table)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, accountType))
+            .intValue(BALANCE, balance)
+            .textValue(Attribute.ID, txId)
+            .intValue(Attribute.STATE, recordState.get())
+            .intValue(Attribute.VERSION, 2)
+            .bigIntValue(Attribute.PREPARED_AT, preparedAt)
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, beforeBalance)
+            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 1)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+
+    // When using Oracle, a RetriableExecutionException may occur even without any conflicts. So, we
+    // retry the put operation in such a case.
+    while (true) {
+      try {
+        storage.put(put);
+        break;
+      } catch (RetriableExecutionException e) {
+        // retry
+      }
+    }
   }
 
   @ParameterizedTest
@@ -3014,10 +3067,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populateRecordsForBeforeIndexTest(
-            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act Assert
@@ -3108,9 +3161,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populateRecordsForBeforeIndexTest(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null);
     DistributedTransaction transaction = manager.begin();
 
     // Act Assert
@@ -3487,12 +3540,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     // Three records in partition 0: (0,0) and (0,2) are COMMITTED, while (0,1) is an expired
     // PREPARED record with no coordinator state (the conflict target).
     String ongoingTxId =
         populateRecordsForBeforeIndexTest(
-            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null);
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null);
     simulateLazyRecoveryRollbackConflict(ongoingTxId);
 
     DistributedTransaction transaction = manager.begin();
@@ -3537,14 +3590,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
             storage,
             namespace1,
             TABLE_1,
             TransactionState.PREPARED,
-            prepared_at,
+            preparedAt,
             null,
             CommitType.NORMAL_COMMIT);
     simulateLazyRecoveryRollbackConflict(ongoingTxId);
@@ -3584,49 +3637,799 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         true, isolation);
   }
 
-  // Writes a PREPARED/DELETED record at the given account_type with the given after-image BALANCE
-  // and writer transaction id, so that two records with different primary keys but the same BALANCE
-  // index value reproduce a transient index duplicate.
-  private void populatePreparedIndexRecord(
-      DistributedStorage storage,
-      String namespace,
-      String table,
-      int accountType,
-      TransactionState recordState,
-      int balance,
-      int beforeBalance,
-      String txId,
-      long preparedAt)
-      throws ExecutionException {
+  // Sets up the cleanup race for the transaction that wrote a record: the read path looks up the
+  // coordinator state and finds none. Intercept only that first lookup to roll the record forward
+  // to its committed after-image (a real write) as a side effect, modeling the writer committing,
+  // being finalized, and its coordinator state row removed by the cleanup process. The coordinator
+  // row stays absent, so the subsequent physical re-read observes the committed record, and the
+  // read resolves to it without writing a spurious ABORTED state.
+  private void simulateRecordFinalizedAndCleanedUp(String ongoingTxId) throws CoordinatorException {
+    doAnswer(
+            invocation -> {
+              rollRecordForwardToCommitted();
+              return Optional.empty();
+            })
+        .doCallRealMethod()
+        .when(coordinator)
+        .getState(ongoingTxId);
+  }
+
+  // Flips the prepared record (0, 0) to its committed after-image with a real write
+  // (STATE=COMMITTED, committed_at set), leaving the after-image columns (balance, id, version)
+  // that the writer prepared. This is what a real rollforward + finalize leaves behind.
+  private void rollRecordForwardToCommitted() throws ExecutionException {
     Put put =
         Put.newBuilder()
-            .namespace(namespace)
-            .table(table)
+            .namespace(namespace1)
+            .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, accountType))
-            .intValue(BALANCE, balance)
-            .textValue(Attribute.ID, txId)
-            .intValue(Attribute.STATE, recordState.get())
-            .intValue(Attribute.VERSION, 2)
-            .bigIntValue(Attribute.PREPARED_AT, preparedAt)
-            .intValue(Attribute.BEFORE_PREFIX + BALANCE, beforeBalance)
-            .textValue(Attribute.BEFORE_ID, ANY_ID_1)
-            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
-            .intValue(Attribute.BEFORE_VERSION, 1)
-            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
-            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(Attribute.STATE, TransactionState.COMMITTED.get())
+            .bigIntValue(Attribute.COMMITTED_AT, 1)
             .build();
-
-    // When using Oracle, a RetriableExecutionException may occur even without any conflicts. So, we
-    // retry the put operation in such a case.
     while (true) {
       try {
         storage.put(put);
         break;
       } catch (RetriableExecutionException e) {
-        // retry
+        // retry (Oracle may throw without a real conflict)
       }
     }
+  }
+
+  private void assertRecordAfterCleanupFinalizedAndCommitted(
+      TransactionResult result, Isolation isolation, boolean readOnly, String ongoingTxId)
+      throws CoordinatorException, ExecutionException {
+    if (isolation == Isolation.READ_COMMITTED) {
+      // READ_COMMITTED returns the committed before-image immediately. In read-write mode it also
+      // recovers in the background, but the abort-before re-read sees the record already committed,
+      // so no spurious ABORTED coordinator state is written. In read-only mode no recovery runs.
+      assertThat(result.getId()).isEqualTo(ANY_ID_1);
+      assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+      assertThat(result.getVersion()).isEqualTo(1);
+      assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+      if (readOnly) {
+        verify(recovery, never())
+            .tryRecover(any(Selection.class), any(TransactionResult.class), any());
+      } else {
+        verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
+      }
+      verify(recovery, never()).tryAbortExpiredTransaction(anyString());
+      verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+      verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    } else {
+      // SNAPSHOT/SERIALIZABLE resolve from the physical re-read, which sees the committed
+      // after-image, so the after-image is returned -- not a stale before-image. No abort is
+      // attempted and no spurious ABORTED coordinator state is written.
+      assertThat(result.getId()).isEqualTo(ongoingTxId);
+      assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+      assertThat(result.getVersion()).isEqualTo(2);
+      assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+
+      verify(recovery, never()).tryAbortExpiredTransaction(anyString());
+      verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
+      verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    }
+  }
+
+  private void
+      selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Selection s,
+          boolean useScanner,
+          Isolation isolation,
+          boolean readOnly,
+          CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
+    simulateRecordFinalizedAndCleanedUp(ongoingTxId);
+
+    DistributedTransaction transaction = begin(manager, readOnly);
+
+    // Act
+    TransactionResult result;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      assertThat(r).isPresent();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(1);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert
+    assertRecordAfterCleanupFinalizedAndCommitted(result, isolation, readOnly, ongoingTxId);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+        get, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+        scan, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+        scan, true, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+        scanAll, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUp_ShouldReturnCommittedValue(
+        scanAll, true, isolation, readOnly, commitType);
+  }
+
+  // Models the cleanup race that strikes *after* the read path has decided to abort the writer
+  // (SNAPSHOT/SERIALIZABLE synchronous resolution): the pre-abort re-read still sees the record
+  // PREPARED by the writer, so the read path calls tryAbortExpiredTransaction; but the writer then
+  // commits, is finalized, and its coordinator state is cleaned up -- modeled here as a side effect
+  // of the abort attempt, after which the real abort still writes a (now spurious) ABORTED
+  // coordinator state. The post-abort re-read then observes the committed record, so the read must
+  // resolve to the committed value rather than a stale before-image. The spurious ABORTED is the
+  // accepted, non-corrupting residual (reclaimed later by Coordinator state cleanup).
+  private void simulateRecordFinalizedAndCleanedUpDuringAbort(String ongoingTxId)
+      throws CoordinatorException {
+    doAnswer(
+            invocation -> {
+              rollRecordForwardToCommitted();
+              return invocation.callRealMethod();
+            })
+        .when(recovery)
+        .tryAbortExpiredTransaction(ongoingTxId);
+  }
+
+  private void
+      selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Selection s, boolean useScanner, Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange — a prepared record with no coordinator state, expired. The cleanup race is injected
+    // into the abort attempt itself (see simulateRecordFinalizedAndCleanedUpDuringAbort).
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
+    simulateRecordFinalizedAndCleanedUpDuringAbort(ongoingTxId);
+
+    DistributedTransaction transaction = begin(manager, false);
+
+    // Act
+    TransactionResult result;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      assertThat(r).isPresent();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(1);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert — the committed after-image is returned (not a stale before-image). The abort was
+    // attempted and the (accepted, non-corrupting) spurious ABORTED coordinator state was written,
+    // but the record is not rolled back and stays committed.
+    assertThat(result.getId()).isEqualTo(ongoingTxId);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getVersion()).isEqualTo(2);
+    assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+
+    verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+        get, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+        scan, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+        scan, true, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+        scanAll, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
+        scanAll, true, isolation, commitType);
+  }
+
+  // Models the group-commit-specific cleanup race that strikes *during* the lazy-recovery-rollback
+  // attempt: the record is still physically PREPARED, the writer already committed via group commit
+  // (a COMMITTED parent row with this child's ID existed), and the coordinator cleanup process
+  // removed the parent row in the small window between our parent-id insert conflicting and the
+  // subsequent re-read inside putStateForLazyRecoveryRollbackForGroupCommit. The fall-through then
+  // writes a spurious full-ID ABORTED coordinator state -- the same outcome as the unit test
+  // putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord.
+  // Crucially, the record is already rolled forward at conflict time (rollRecordForwardToCommitted
+  // models the writer's commit), so the background rollback is a conditional no-op and the data
+  // record stays committed despite the spurious ABORTED.
+  private void simulateGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback(String ongoingTxId)
+      throws CoordinatorException {
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    Keys<String, String, String> keys = keyManipulator.keysFromFullKey(ongoingTxId);
+    String parentKey = keys.parentKey;
+
+    // The parent-id insert conflicts because a finished group-commit row existed (the writer
+    // committed). Roll the record forward as a side effect to model the writer's commit, then
+    // throw to simulate the conflict with the already-committed parent row.
+    doAnswer(
+            invocation -> {
+              rollRecordForwardToCommitted();
+              throw new CoordinatorConflictException(
+                  "simulated conflict: group-commit parent row was committed");
+            })
+        .when(coordinator)
+        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+
+    // The coordinator cleanup process removed the parent row in the window between the conflict
+    // and the re-read -- return empty to model the cleaned-up state. The fall-through then writes
+    // the spurious full-ID ABORTED record instead of re-throwing the conflict exception.
+    doReturn(Optional.empty()).when(coordinator).getState(parentKey);
+  }
+
+  private void
+      selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Selection s, boolean useScanner, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange — a prepared record under a group-commit full ID with no coordinator state, expired.
+    // The group-commit parent-row cleanup race is injected via
+    // simulateGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback.
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage,
+            namespace1,
+            TABLE_1,
+            TransactionState.PREPARED,
+            preparedAt,
+            null,
+            CommitType.GROUP_COMMIT);
+    simulateGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback(ongoingTxId);
+
+    DistributedTransaction transaction = begin(manager, false);
+
+    // Act
+    TransactionResult result;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      assertThat(r).isPresent();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(1);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert — the committed after-image is returned (not a stale before-image). The
+    // group-commit abort path wrote a spurious full-ID ABORTED coordinator state (accepted,
+    // non-corrupting residual: reclaimed later by coordinator cleanup), but the record stays
+    // committed and is not rolled back.
+    assertThat(result.getId()).isEqualTo(ongoingTxId);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getVersion()).isEqualTo(2);
+    assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+
+    verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Isolation.class,
+      names = {"SNAPSHOT", "SERIALIZABLE"})
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      get_GetGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+        get, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Isolation.class,
+      names = {"SNAPSHOT", "SERIALIZABLE"})
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      scan_ScanGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+        scan, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Isolation.class,
+      names = {"SNAPSHOT", "SERIALIZABLE"})
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      getScanner_ScanGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+        scan, true, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Isolation.class,
+      names = {"SNAPSHOT", "SERIALIZABLE"})
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      scan_ScanAllGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+        scanAll, false, isolation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Isolation.class,
+      names = {"SNAPSHOT", "SERIALIZABLE"})
+  @EnabledIf("isGroupCommitEnabled")
+  void
+      getScanner_ScanAllGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+          Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
+        scanAll, true, isolation);
+  }
+
+  // Models the ABA cleanup race that strikes *during* the abort: the pre-abort re-read still sees
+  // the record PREPARED by the writer, so the read path calls tryAbortExpiredTransaction. As a side
+  // effect of that abort we model the full chain that can happen in the window before the
+  // post-abort re-read: the writer is rolled back, an intervening transaction commits a new value
+  // (INTERVENING_BALANCE), and yet another transaction re-prepares the record on top of that
+  // committed value. The post-abort re-read therefore sees a DIFFERENT writer, so the read must
+  // re-resolve against it and ultimately return the intervening committed value -- never the
+  // original writer's now-stale before-image (INITIAL_BALANCE).
+  private void simulateRecordRePreparedByDifferentTxDuringAbort(String ongoingTxId)
+      throws CoordinatorException {
+    // The re-preparing transaction is aborted, so resolving it rolls the record back to its
+    // before-image, restoring the intervening committed value as the record's committed image.
+    coordinator.putState(new Coordinator.State(REPREPARING_TX_ID, TransactionState.ABORTED));
+    doAnswer(
+            invocation -> {
+              rePrepareRecordByDifferentTransaction();
+              return invocation.callRealMethod();
+            })
+        .when(recovery)
+        .tryAbortExpiredTransaction(ongoingTxId);
+  }
+
+  // Writes the record (0, 0) as PREPARED by a different transaction whose before-image is the
+  // intervening committed value. Models: original writer rolled back -> intervening commit
+  // (INTERVENING_BALANCE, version 2) -> different transaction re-prepares on top (version 3).
+  private void rePrepareRecordByDifferentTransaction() throws ExecutionException {
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, NEW_BALANCE) // re-preparing tx's after-image; discarded on its abort
+            .textValue(Attribute.ID, REPREPARING_TX_ID)
+            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
+            .intValue(Attribute.VERSION, 3)
+            .bigIntValue(Attribute.PREPARED_AT, System.currentTimeMillis())
+            .intValue(Attribute.BEFORE_PREFIX + BALANCE, INTERVENING_BALANCE)
+            .textValue(Attribute.BEFORE_ID, INTERVENING_TX_ID)
+            .intValue(Attribute.BEFORE_STATE, TransactionState.COMMITTED.get())
+            .intValue(Attribute.BEFORE_VERSION, 2)
+            .bigIntValue(Attribute.BEFORE_PREPARED_AT, 1)
+            .bigIntValue(Attribute.BEFORE_COMMITTED_AT, 1)
+            .build();
+    while (true) {
+      try {
+        storage.put(put);
+        break;
+      } catch (RetriableExecutionException e) {
+        // retry (Oracle may throw without a real conflict)
+      }
+    }
+  }
+
+  private void
+      selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Selection s, boolean useScanner, Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange — a prepared record with no coordinator state, expired. The ABA cleanup race is
+    // injected into the abort attempt itself (see
+    // simulateRecordRePreparedByDifferentTxDuringAbort).
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
+    simulateRecordRePreparedByDifferentTxDuringAbort(ongoingTxId);
+
+    DistributedTransaction transaction = begin(manager, false);
+
+    // Act
+    TransactionResult result;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      assertThat(r).isPresent();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(1);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert — the read re-resolved against the re-preparing transaction and returned the
+    // intervening committed value (INTERVENING_BALANCE), NOT the original writer's stale before-
+    // image (INITIAL_BALANCE) nor its after-image (NEW_BALANCE). The original writer was aborted,
+    // but the record is recovered for the re-preparing transaction (rolled back to the intervening
+    // committed value).
+    assertThat(result.getInt(BALANCE)).isEqualTo(INTERVENING_BALANCE);
+    assertThat(result.getId()).isEqualTo(INTERVENING_TX_ID);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getVersion()).isEqualTo(2);
+
+    verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
+    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(recovery, never()).tryAbortExpiredTransaction(REPREPARING_TX_ID);
+    verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+        get, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+        scan, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+        scan, true, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+        scanAll, false, isolation, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("snapshotOrSerializableIsolationAndCommitType")
+  void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+          Isolation isolation, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
+        scanAll, true, isolation, commitType);
+  }
+
+  // Like simulateRecordFinalizedAndCleanedUp, but models a committed delete: the writer's delete
+  // committed and was finalized (the record physically removed) and its coordinator state row was
+  // cleaned up. Intercept the first coordinator-state lookup to delete the record with a real
+  // write, then report the coordinator row absent so the re-read finds the record gone.
+  private void simulateRecordDeleteFinalizedAndCleanedUp(String ongoingTxId)
+      throws CoordinatorException {
+    doAnswer(
+            invocation -> {
+              deleteRecordPhysically();
+              return Optional.empty();
+            })
+        .doCallRealMethod()
+        .when(coordinator)
+        .getState(ongoingTxId);
+  }
+
+  private void deleteRecordPhysically() throws ExecutionException {
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+    while (true) {
+      try {
+        storage.delete(delete);
+        break;
+      } catch (RetriableExecutionException e) {
+        // retry (Oracle may throw without a real conflict)
+      }
+    }
+  }
+
+  private void
+      selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Selection s,
+          boolean useScanner,
+          Isolation isolation,
+          boolean readOnly,
+          CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange — a prepared DELETE with no coordinator state, expired.
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null, commitType);
+    simulateRecordDeleteFinalizedAndCleanedUp(ongoingTxId);
+
+    DistributedTransaction transaction = begin(manager, readOnly);
+    boolean readCommitted = isolation == Isolation.READ_COMMITTED;
+
+    // Act
+    TransactionResult result = null;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      if (readCommitted) {
+        // READ_COMMITTED returns the committed before-image without the physical re-read.
+        assertThat(r).isPresent();
+        result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      } else {
+        // SNAPSHOT/SERIALIZABLE re-read the record physically and find it gone, so empty is
+        // returned instead of a stale before-image.
+        assertThat(r).isEmpty();
+      }
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      if (readCommitted) {
+        assertThat(results.size()).isEqualTo(1);
+        result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      } else {
+        assertThat(results).isEmpty();
+      }
+    }
+
+    transaction.commit();
+
+    waitForRecoveryCompletion(transaction);
+
+    // Assert — no spurious ABORTED coordinator state is written in any isolation.
+    if (readCommitted) {
+      assertThat(result.getId()).isEqualTo(ANY_ID_1);
+      assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+      assertThat(result.getVersion()).isEqualTo(1);
+      assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+      if (readOnly) {
+        verify(recovery, never())
+            .tryRecover(any(Selection.class), any(TransactionResult.class), any());
+      } else {
+        verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
+      }
+    } else {
+      verify(recovery, never())
+          .tryRecover(any(Selection.class), any(TransactionResult.class), any());
+    }
+    verify(recovery, never()).tryAbortExpiredTransaction(anyString());
+    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+        get, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+        scan, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+        scan, true, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      scan_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+        scanAll, false, isolation, readOnly, commitType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("isolationAndReadOnlyModeAndCommitType")
+  void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+          Isolation isolation, boolean readOnly, CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButDeleteFinalizedAndCleanedUp_ShouldBehaveCorrectly(
+        scanAll, true, isolation, readOnly, commitType);
   }
 
   @ParameterizedTest
@@ -3773,9 +4576,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
 
     DistributedTransaction transaction = manager.begin();
 
@@ -3820,10 +4623,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
-            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, preparedAt, null, commitType);
 
     Get get =
         Get.newBuilder()
@@ -4002,9 +4805,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis();
+    long preparedAt = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+        storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null, commitType);
 
     DistributedTransaction transaction = manager.begin();
 
@@ -4049,10 +4852,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
-    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
-            storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+            storage, namespace1, TABLE_1, TransactionState.DELETED, preparedAt, null, commitType);
 
     Get get =
         Get.newBuilder()
@@ -10755,6 +11558,18 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   static Stream<Arguments> isolationAndCommitType() {
     return Arrays.stream(Isolation.values())
+        .flatMap(
+            isolation ->
+                Arrays.stream(CommitType.values())
+                    .map(commitType -> Arguments.of(isolation, commitType)));
+  }
+
+  // SNAPSHOT/SERIALIZABLE only: the synchronous read-path resolution
+  // (resolveLatestResultAndRecover, which calls tryAbortExpiredTransaction) runs in these
+  // isolations; READ_COMMITTED defers recovery to a background path that does not take this route.
+  static Stream<Arguments> snapshotOrSerializableIsolationAndCommitType() {
+    return Arrays.stream(Isolation.values())
+        .filter(isolation -> isolation != Isolation.READ_COMMITTED)
         .flatMap(
             isolation ->
                 Arrays.stream(CommitType.values())


### PR DESCRIPTION
## Description

Consensus Commit has historically assumed that a transaction's Coordinator state row, once written, is never removed — so on the recovery and read paths an absent state row was taken to mean "this transaction never committed." `finishTransaction` (#3567) and an upcoming cleanup now **delete** Coordinator state rows after a transaction is finished. With deletion, an absent state row is ambiguous: the writer may have committed (or aborted) and then had its row cleaned up.

Under the old assumptions this leads to several correctness problems once cleanup is in play:

- a read returns a **stale before-image** for a record that actually committed and was cleaned up;
- lazy recovery / `recoverRecord` writes a **spurious `ABORTED`** state for a transaction that actually committed;
- the group-commit lazy-recovery rollback hits an **`AssertionError`** when the parent Coordinator row was cleaned up;
- `getState` / `rollback` / `abort`-by-ID give overly conservative or misleading results.

This PR makes the read path, lazy recovery, and commit/abort conflict resolution correct (or honestly `UNKNOWN`) when a Coordinator state cleanup process can delete state rows, and documents the resulting `getState` / `rollback` contracts.

The changes are split into self-contained commits so the PR can be reviewed commit by commit (hashes are current as of the latest push and will change if the branch is rebased):

- 25e7eea Re-read the record to resolve a coordinator-state-absent read under cleanup deletion (read path + `abortIfExpired` re-read guard)
- 8245c16 Handle a cleaned-up parent row in group-commit lazy-recovery rollback
- b51d989 Resolve a coordinator-state-absent commit/abort conflict by calling path
- d7a11d8 Document getState and rollback/abort semantics for cleaned-up transactions
- 83c81c1 Add integration tests for reads racing coordinator-state cleanup

## Related issues and/or PRs

- #3567 (`finishTransaction`, which introduced Coordinator state deletion)
- #3621 (read before-image fix, merged)
- #3619 (abort-by-ID, merged).

## Changes made

- **Read path (`RETURN_LATEST_RESULT_AND_RECOVER`, get/scan/streaming-scanner):** before resolving an expired writer that has no Coordinator state, physically re-read the record and resolve from its real state — return the committed value, return empty, or re-resolve against a different writer — instead of blindly returning the before-image. After writing the lazy-recovery rollback, re-read once more to close the cleanup TOCTOU. Bounded by `MAX_RESOLUTION_ATTEMPTS`.
- **Lazy recovery / `recoverRecord` (`abortIfExpired`):** apply the same pre-abort re-read guard so the background and guaranteed-recovery paths never write a spurious `ABORTED` for a committed-and-cleaned-up writer.
- **Group-commit lazy-recovery rollback:** treat a cleaned-up parent Coordinator row as normal flow (fall through to the full-ID write) instead of throwing `AssertionError`.
- **Commit/abort conflict resolution:** resolve a now-absent Coordinator state by what the calling path can prove — `handleCommitConflict` rolls back and throws `CommitConflictException`; the self-abort path and all Two-phase Commit aborts resolve to `ABORTED`; the One-phase Commit abort-by-ID path stays an honest `UNKNOWN` (it can target a transaction that actually committed and whose row `finishTransaction` can remove).
- **Documentation:** `getState` returns `UNKNOWN` for a finished, cleaned-up transaction (indistinguishable from never-existed / read-error); `rollback`/`abort` document the finished-transaction limitation.
- **Tests:** unit tests for all of the above, plus integration tests covering reads racing Coordinator-state cleanup (five scenarios across isolation levels, read-only modes, and commit types), verified on PostgreSQL with and without coordinator group commit enabled.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The integration-test bases rename the `prepared_at` test locals to `preparedAt` for Java naming consistency; this touches a few pre-existing test variables in the touched files.

## Release notes

Fixed the Consensus Commit recovery and read paths to stay correct when Coordinator state records are removed by cleanup (for example, by `finishTransaction`), preventing stale reads, spurious aborts, and a crash during group-commit lazy recovery.
