### PR TITLE
Split CommitHandler into an orchestrator and specialized handlers

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/BeforePreparationHook.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/BeforePreparationHook.java
@@ -2,7 +2,12 @@ package com.scalar.db.transaction.consensuscommit;
 
 import java.util.concurrent.Future;
 
+/**
+ * A hook invoked by {@link CommitHandler#commit} before the prepare phase begins.
+ *
+ * <p>This hook is invoked only on the two-phase commit path (prepare, validate, commit-state). It
+ * is not invoked when the one-phase commit optimization path is taken.
+ */
 public interface BeforePreparationHook {
-  Future<Void> handle(
-      TransactionTableMetadataManager transactionTableMetadataManager, TransactionContext context);
+  Future<Void> handle(TransactionContext context);
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -2,16 +2,10 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.concurrent.LazyInit;
-import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Mutation;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.CoreError;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
@@ -19,34 +13,45 @@ import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
-import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
-import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Orchestrates the Consensus Commit protocol. Holds two specialized handlers and delegates to them:
+ *
+ * <ul>
+ *   <li>{@link CoordinatorCommitHandler} owns Coordinator-table state writes (COMMITTED / ABORTED).
+ *       The group-commit-enabled variant ({@link CoordinatorCommitHandlerWithGroupCommit}) routes
+ *       commitState through the group-commit emitter.
+ *   <li>{@link ParticipantCommitHandler} owns participant-side data-record writes (prepare,
+ *       validate, commit, rollback, one-phase commit).
+ * </ul>
+ *
+ * <p>The orchestrator owns the {@link #commit(TransactionContext)} flow (prepare → validate →
+ * commit-state → commit-records, plus the abort/rollback path on failure) and the {@link
+ * BeforePreparationHook} integration. {@link #forceAbortState(String)} is exposed on this class as
+ * a convenience pass-through to the Coordinator-side handler so the manager-level rollback callers
+ * (ConsensusCommit / TwoPhaseConsensusCommit / ConsensusCommitManager) can depend on the
+ * orchestrator alone.
+ *
+ * <p>Public methods like {@code commitState}, {@code abortState}, {@code prepareRecords}, {@code
+ * commitRecords}, {@code rollbackRecords}, {@code commitStateWithoutWriteSet}, and {@code
+ * abortStateWithoutWriteSet} are exposed on this class as thin pass-throughs to the specialized
+ * handlers so direct callers (notably {@link TwoPhaseConsensusCommit}) can drive individual commit
+ * phases without depending on the handlers directly.
+ */
 @ThreadSafe
 public class CommitHandler {
   private static final Logger logger = LoggerFactory.getLogger(CommitHandler.class);
-  private final DistributedStorage storage;
-  protected final Coordinator coordinator;
-  private final TransactionTableMetadataManager tableMetadataManager;
-  private final ParallelExecutor parallelExecutor;
-  private final MutationsGrouper mutationsGrouper;
-  final WriteSetEncoder writeSetEncoder;
+
+  private final ParticipantCommitHandler participantCommitHandler;
+  private final CoordinatorCommitHandler coordinatorCommitHandler;
   protected final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
-  private final boolean onePhaseCommitEnabled;
 
   @LazyInit @Nullable private BeforePreparationHook beforePreparationHook;
 
@@ -59,14 +64,31 @@ public class CommitHandler {
       MutationsGrouper mutationsGrouper,
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean onePhaseCommitEnabled) {
-    this.storage = checkNotNull(storage);
-    this.coordinator = checkNotNull(coordinator);
-    this.tableMetadataManager = checkNotNull(tableMetadataManager);
-    this.parallelExecutor = checkNotNull(parallelExecutor);
-    this.mutationsGrouper = checkNotNull(mutationsGrouper);
-    this.writeSetEncoder = new WriteSetEncoder(tableMetadataManager);
     this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
-    this.onePhaseCommitEnabled = onePhaseCommitEnabled;
+    this.participantCommitHandler =
+        new ParticipantCommitHandler(
+            storage,
+            tableMetadataManager,
+            parallelExecutor,
+            mutationsGrouper,
+            onePhaseCommitEnabled);
+    this.coordinatorCommitHandler =
+        new CoordinatorCommitHandler(
+            coordinator, new WriteSetEncoder(tableMetadataManager), participantCommitHandler);
+  }
+
+  // Constructor for subclasses (CommitHandlerWithGroupCommit) that need to inject a
+  // group-commit-aware CoordinatorCommitHandler. The two handlers are still constructed by the
+  // subclass to keep the dependency graph explicit. `onePhaseCommitEnabled` is baked into the
+  // pre-built ParticipantCommitHandler, so it is not threaded through here.
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  protected CommitHandler(
+      boolean coordinatorWriteOmissionOnReadOnlyEnabled,
+      ParticipantCommitHandler participantCommitHandler,
+      CoordinatorCommitHandler coordinatorCommitHandler) {
+    this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
+    this.participantCommitHandler = checkNotNull(participantCommitHandler);
+    this.coordinatorCommitHandler = checkNotNull(coordinatorCommitHandler);
   }
 
   /**
@@ -84,25 +106,6 @@ public class CommitHandler {
     }
   }
 
-  /**
-   * Aborts the coordinator state and rolls back records as needed after a pre-commit failure. When
-   * the transaction has no writes and deletes, there are no records to roll back. In that case the
-   * coordinator state is still aborted unless coordinator write omission on read-only is enabled:
-   * when it is, a write-less transaction (a read-only one, or a non-read-only one with an empty
-   * write set) writes no coordinator state row on the commit path either, so there is nothing to
-   * abort.
-   */
-  private void abortStateAndRollbackRecordsIfNeeded(
-      TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
-      throws UnknownTransactionStatusException {
-    if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
-      abortState(context);
-    }
-    if (hasWritesOrDeletesInSnapshot) {
-      rollbackRecords(context);
-    }
-  }
-
   private Optional<Future<Void>> invokeBeforePreparationHook(
       TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
       throws UnknownTransactionStatusException, CommitException {
@@ -111,7 +114,7 @@ public class CommitHandler {
     }
 
     try {
-      return Optional.of(beforePreparationHook.handle(tableMetadataManager, context));
+      return Optional.of(beforePreparationHook.handle(context));
     } catch (Exception e) {
       safelyCallOnFailureBeforeCommit(context);
 
@@ -154,9 +157,6 @@ public class CommitHandler {
     boolean hasWritesOrDeletesInSnapshot =
         !context.readOnly && context.snapshot.hasWritesOrDeletes();
 
-    Optional<Future<Void>> beforePreparationHookFuture =
-        invokeBeforePreparationHook(context, hasWritesOrDeletesInSnapshot);
-
     if (canOnePhaseCommit(context)) {
       try {
         onePhaseCommitRecords(context);
@@ -166,6 +166,10 @@ public class CommitHandler {
         throw e;
       }
     }
+
+    // The one-phase commit fast path does not invoke the before-preparation hook.
+    Optional<Future<Void>> beforePreparationHookFuture =
+        invokeBeforePreparationHook(context, hasWritesOrDeletesInSnapshot);
 
     if (hasWritesOrDeletesInSnapshot) {
       try {
@@ -211,438 +215,88 @@ public class CommitHandler {
     }
   }
 
-  @VisibleForTesting
-  boolean canOnePhaseCommit(TransactionContext context) throws CommitException {
-    if (!onePhaseCommitEnabled) {
-      return false;
+  /**
+   * Aborts the coordinator state and rolls back records as needed after a pre-commit failure. When
+   * the transaction has no writes and deletes, there are no records to roll back. In that case the
+   * coordinator state is still aborted unless coordinator write omission on read-only is enabled:
+   * when it is, a write-less transaction (a read-only one, or a non-read-only one with an empty
+   * write set) writes no coordinator state row on the commit path either, so there is nothing to
+   * abort.
+   */
+  private void abortStateAndRollbackRecordsIfNeeded(
+      TransactionContext context, boolean hasWritesOrDeletesInSnapshot)
+      throws UnknownTransactionStatusException {
+    if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
+      abortState(context);
     }
-
-    // If validation is required, we cannot one-phase commit the transaction
-    if (context.isValidationRequired()) {
-      return false;
-    }
-
-    // If the snapshot has no write and deletes, we do not one-phase commit the transaction
-    if (!context.snapshot.hasWritesOrDeletes()) {
-      return false;
-    }
-
-    Collection<Map.Entry<Snapshot.Key, Delete>> deleteSetEntries = context.snapshot.getDeleteSet();
-
-    // If a record corresponding to a delete in the delete set does not exist in the storage,　we
-    // cannot one-phase commit the transaction. This is because the storage does not support
-    // delete-if-not-exists semantics, so we cannot detect conflicts with other transactions.
-    for (Map.Entry<Snapshot.Key, Delete> entry : deleteSetEntries) {
-      Delete delete = entry.getValue();
-      Optional<TransactionResult> result =
-          context.snapshot.getFromReadSet(new Snapshot.Key(delete));
-
-      // For deletes, we always perform implicit pre-reads if the result does not exit in the read
-      // set. So the result should always exist in the read set.
-      assert result != null;
-
-      if (!result.isPresent()) {
-        return false;
-      }
-    }
-
-    try {
-      // If the mutations can be grouped altogether, the mutations can be done in a single mutate
-      // API call, so we can one-phase commit the transaction
-      return mutationsGrouper.canBeGroupedAltogether(
-          Stream.concat(
-                  context.snapshot.getWriteSet().stream().map(Map.Entry::getValue),
-                  deleteSetEntries.stream().map(Map.Entry::getValue))
-              .collect(Collectors.toList()));
-    } catch (ExecutionException e) {
-      throw new CommitException(
-          CoreError.CONSENSUS_COMMIT_COMMITTING_RECORDS_FAILED.buildMessage(e.getMessage()),
-          e,
-          context.transactionId);
+    if (hasWritesOrDeletesInSnapshot) {
+      rollbackRecords(context);
     }
   }
 
-  protected void handleCommitConflict(TransactionContext context, Exception cause)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    try {
-      Optional<State> s = coordinator.getState(context.transactionId);
-      if (s.isPresent()) {
-        TransactionState state = s.get().getState();
-        if (state.equals(TransactionState.ABORTED)) {
-          rollbackRecords(context);
-          throw new CommitConflictException(
-              CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
-                  cause.getMessage()),
-              cause,
-              context.transactionId);
-        }
-        // Otherwise the coordinator state is present and COMMITTED, which means this transaction
-        // has already committed. Only Two-phase Commit I/F reaches this branch: there the same
-        // transaction's commit can be driven more than once -- re-invoked for recovery, or
-        // committed by multiple participants -- so an earlier or concurrent commit of this
-        // transaction may have already written its COMMITTED state, and this commit then loses the
-        // putIfNotExists race and observes it here. With One-phase Commit I/F this is unreachable:
-        // this commit is the only writer of the COMMITTED state and it just lost the race, so the
-        // conflicting row was an ABORTED from a lazy recovery, handled above. The transaction is
-        // committed, so return normally and let the caller commit the records.
-        //
-        // TODO: revisit this if/when the Two-phase Commit I/F is removed -- it would
-        // then be unreachable (a COMMITTED state could never be observed after a conflict here).
-      } else {
-        // The coordinator state is absent: a row existed when our putIfNotExists lost the race, but
-        // it is gone now. In both interfaces this means the conflicting row was an ABORTED written
-        // by a lazy recovery (which also rolled the records back) and later removed by the
-        // Coordinator state cleanup process, so the transaction is definitively aborted. Roll the
-        // records back and report a conflict -- the same outcome as the present-ABORTED case above.
-        //
-        // A COMMITTED row can be ruled out here in both interfaces:
-        //   - One-phase Commit I/F: this commit is the only writer of this transaction's COMMITTED
-        //     state, and it just lost the race, so the conflicting row could only have been an
-        //     ABORTED from a lazy recovery -- a COMMITTED for this transaction never existed.
-        //   - Two-phase Commit I/F: other participants or re-driven commits of the same transaction
-        //     can also write COMMITTED, so the conflict could in principle have been against a
-        //     COMMITTED row. But the Two-phase Commit I/F does not assume finishTransaction,
-        //     and a COMMITTED coordinator row is only ever removed by finishTransaction (the
-        //     periodic cleanup removes only ABORTED rows). So a COMMITTED row never disappears
-        //     here: had the conflict been against one, it would still be present and handled by
-        //     the present-COMMITTED branch above. An absent row therefore means the conflict was
-        //     an ABORTED.
-        //
-        // Group commit reaches an absent state by a second, more common route, and the outcome is
-        // still correct. There the conflicting putIfNotExists is keyed on the parent ID (the group
-        // emitter writes the parent-ID COMMITTED row), so the row it conflicts with -- a lazy
-        // recovery's empty-tx_child_ids ABORTED parent row -- can still be present. getState then
-        // resolves by full ID: it finds the parent row, sees it does not list this child, and finds
-        // no full-ID row, so it returns empty. That empty does not mean a cleaned-up row; it means
-        // this child was never committed (a committed child would either be listed in the parent
-        // row or have its own full-ID COMMITTED row, and getState would return it). Rolling back
-        // and reporting a retryable conflict is the correct outcome for such an uncommitted child.
-        //
-        // TODO: revisit this if/when the Two-phase Commit I/F is removed.
-
-        rollbackRecords(context);
-        throw new CommitConflictException(
-            CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
-                cause.getMessage()),
-            cause,
-            context.transactionId);
-      }
-    } catch (CoordinatorException ex) {
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(ex.getMessage()),
-          ex,
-          context.transactionId);
-    }
-  }
-
-  @VisibleForTesting
-  void onePhaseCommitRecords(TransactionContext context)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    try {
-      OnePhaseCommitMutationComposer composer =
-          new OnePhaseCommitMutationComposer(context.transactionId, tableMetadataManager);
-      context.snapshot.to(composer);
-
-      // One-phase commit does not require grouping mutations and using the parallel executor since
-      // it is always executed in a single mutate API call.
-      storage.mutate(composer.get());
-    } catch (NoMutationException e) {
-      throw new CommitConflictException(
-          CoreError.CONSENSUS_COMMIT_PREPARING_RECORD_EXISTS.buildMessage(e.getMessage()),
-          e,
-          context.transactionId);
-    } catch (RetriableExecutionException e) {
-      throw new CommitConflictException(
-          CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_RECORDS.buildMessage(
-              e.getMessage()),
-          e,
-          context.transactionId);
-    } catch (ExecutionException e) {
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_ONE_PHASE_COMMITTING_RECORDS_FAILED.buildMessage(
-              e.getMessage()),
-          e,
-          context.transactionId);
-    }
-  }
+  // ---------- Pass-through methods that delegate to the specialized handlers. ----------
+  // Exposed on this class so direct callers (TwoPhaseConsensusCommit / ConsensusCommit /
+  // ConsensusCommitManager / RecoveryHandler / tests) can drive individual commit phases through
+  // the orchestrator's primary dependency.
+  //
+  // TODO: revisit this if/when the Two-phase Commit I/F is removed.
 
   public void prepareRecords(TransactionContext context) throws PreparationException {
-    try {
-      PrepareMutationComposer composer =
-          new PrepareMutationComposer(context.transactionId, tableMetadataManager);
-      context.snapshot.to(composer);
-      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
-
-      List<ParallelExecutorTask> tasks = new ArrayList<>(groupedMutations.size());
-      for (List<Mutation> mutations : groupedMutations) {
-        tasks.add(() -> storage.mutate(mutations));
-      }
-      parallelExecutor.prepareRecords(tasks, context.transactionId);
-    } catch (NoMutationException e) {
-      throw new PreparationConflictException(
-          CoreError.CONSENSUS_COMMIT_PREPARING_RECORD_EXISTS.buildMessage(e.getMessage()),
-          e,
-          context.transactionId);
-    } catch (RetriableExecutionException e) {
-      throw new PreparationConflictException(
-          CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_PREPARING_RECORDS.buildMessage(
-              e.getMessage()),
-          e,
-          context.transactionId);
-    } catch (ExecutionException e) {
-      throw new PreparationException(
-          CoreError.CONSENSUS_COMMIT_PREPARING_RECORDS_FAILED.buildMessage(e.getMessage()),
-          e,
-          context.transactionId);
-    }
+    participantCommitHandler.prepareRecords(context);
   }
 
   public void validateRecords(TransactionContext context) throws ValidationException {
-    if (!context.isValidationRequired()) {
-      return;
-    }
-
-    try {
-      // validation is executed when SERIALIZABLE is chosen.
-      context.snapshot.toSerializable(storage);
-    } catch (ExecutionException e) {
-      throw new ValidationException(
-          CoreError.CONSENSUS_COMMIT_VALIDATION_FAILED.buildMessage(e.getMessage()),
-          e,
-          context.transactionId);
-    }
-  }
-
-  /**
-   * Writes the COMMITTED state with the {@code tx_write_set} populated from the given context's
-   * snapshot.
-   *
-   * @param context the transaction context
-   * @throws CommitConflictException if another commit attempt has already written a conflicting
-   *     coordinator state
-   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
-   */
-  public void commitState(TransactionContext context)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    commitStateInternal(context, writeSetEncoder.encodeSingleGroupWriteSet(context, false));
-  }
-
-  /**
-   * Writes the COMMITTED state without persisting a {@code tx_write_set}. Intended for callers that
-   * don't want per-transaction write-set logging.
-   *
-   * @param context the transaction context
-   * @throws CommitConflictException if another commit attempt has already written a conflicting
-   *     coordinator state
-   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
-   */
-  public void commitStateWithoutWriteSet(TransactionContext context)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    commitStateInternal(context, null);
-  }
-
-  private void commitStateInternal(TransactionContext context, @Nullable WriteSet writeSet)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    String id = context.transactionId;
-    try {
-      Coordinator.State state =
-          new Coordinator.State(
-              id, writeSet, TransactionState.COMMITTED, System.currentTimeMillis());
-      coordinator.putState(state);
-      logger.debug(
-          "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
-    } catch (CoordinatorConflictException e) {
-      handleCommitConflict(context, e);
-    } catch (CoordinatorException e) {
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
-          e,
-          id);
-    }
+    participantCommitHandler.validateRecords(context);
   }
 
   public void commitRecords(TransactionContext context) {
-    try {
-      CommitMutationComposer composer =
-          new CommitMutationComposer(context.transactionId, tableMetadataManager);
-      context.snapshot.to(composer);
-      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
-
-      List<ParallelExecutorTask> tasks = new ArrayList<>(groupedMutations.size());
-      for (List<Mutation> mutations : groupedMutations) {
-        tasks.add(() -> storage.mutate(mutations));
-      }
-      parallelExecutor.commitRecords(tasks, context.transactionId);
-    } catch (Exception e) {
-      logger.info("Committing records failed. Transaction ID: {}", context.transactionId, e);
-      // ignore since records are recovered lazily
-    }
-  }
-
-  /**
-   * Writes the ABORTED state with the {@code tx_write_set} populated from the given context's
-   * snapshot.
-   *
-   * @param context the transaction context
-   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
-   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
-   *     TransactionState#ABORTED}) is already persisted
-   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
-   */
-  public TransactionState abortState(TransactionContext context)
-      throws UnknownTransactionStatusException {
-    return abortStateInternal(
-        context.transactionId, writeSetEncoder.encodeSingleGroupWriteSet(context, false));
-  }
-
-  /**
-   * Writes the ABORTED state without persisting a {@code tx_write_set} using a single {@code
-   * putState}. Intended for callers that don't want per-transaction write-set logging.
-   *
-   * <p>On a {@code putIfNotExists} conflict this resolves a now-absent coordinator state as {@link
-   * TransactionState#ABORTED} (see {@link #abortStateInternal}). That is only sound for callers
-   * that cannot be racing a real, deletable COMMITTED row: the self-abort path (which provably
-   * never committed) and all Two-phase Commit I/F aborts (the Two-phase Commit I/F does not assume
-   * {@code finishTransaction}, so a COMMITTED coordinator row is never removed). A One-phase Commit
-   * I/F abort-by-id, which can target a transaction that actually committed and whose COMMITTED row
-   * {@code finishTransaction} can remove, must NOT use this method — use {@link
-   * #abortStateForRollback} instead, which honestly reports {@code UNKNOWN} for an absent row.
-   *
-   * @param id the transaction ID
-   * @return the resulting transaction state — {@link TransactionState#ABORTED} (including when a
-   *     concurrent writer's row is absent on re-read), or, if a concurrent writer beat us and its
-   *     state is still present, whatever state ({@link TransactionState#COMMITTED} or {@link
-   *     TransactionState#ABORTED}) is already persisted
-   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
-   */
-  public TransactionState abortStateWithoutWriteSet(String id)
-      throws UnknownTransactionStatusException {
-    return abortStateInternal(id, null);
-  }
-
-  private TransactionState abortStateInternal(String id, @Nullable WriteSet writeSet)
-      throws UnknownTransactionStatusException {
-    try {
-      Coordinator.State state =
-          new Coordinator.State(id, writeSet, TransactionState.ABORTED, System.currentTimeMillis());
-      coordinator.putState(state);
-      return TransactionState.ABORTED;
-    } catch (CoordinatorConflictException e) {
-      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
-      // the self-abort path and all Two-phase Commit I/F aborts. Follows the persisted state when
-      // present; an absent row is determinable as ABORTED here:
-      //   - One-phase Commit I/F self-abort (abortState from a commit-path failure, before
-      //     commitState runs): the transaction provably never committed, so the conflicting row
-      //     could only have been a lazy-recovery ABORTED, later removed by the cleanup process.
-      //   - Two-phase Commit I/F (rollback and abort-by-id): other participants can write
-      //     COMMITTED, but the Two-phase Commit I/F does not assume finishTransaction, and a
-      //     COMMITTED coordinator row is only ever removed by finishTransaction (the periodic
-      //     cleanup removes only ABORTED rows). So a COMMITTED never disappears: had the conflict
-      //     been against one, it would still be present and returned above. An absent row therefore
-      //     means the conflict was an ABORTED.
-      //
-      // TODO: revisit this if/when the Two-phase Commit I/F is removed
-
-      return readCoordinatorStateAfterAbortConflict(id, e).orElse(TransactionState.ABORTED);
-    } catch (CoordinatorException e) {
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
-          e,
-          id);
-    }
-  }
-
-  /**
-   * Reads the persisted coordinator state after our ABORTED putIfNotExists lost the race. Returns
-   * the already-persisted COMMITTED/ABORTED state when present, or empty when the row is absent
-   * (already removed by the Coordinator state cleanup process). The two resolvers below interpret
-   * an absent row differently, because whether it is determinable depends on the calling path. A
-   * coordinator read failure is undeterminable regardless of path, so it surfaces as
-   * UnknownTransactionStatusException with the original conflict preserved as the cause.
-   */
-  private Optional<TransactionState> readCoordinatorStateAfterAbortConflict(
-      String id, CoordinatorConflictException e) throws UnknownTransactionStatusException {
-    try {
-      return coordinator.getState(id).map(Coordinator.State::getState);
-    } catch (CoordinatorException e1) {
-      e1.addSuppressed(e);
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
-          e1,
-          id);
-    }
+    participantCommitHandler.commitRecords(context);
   }
 
   public void rollbackRecords(TransactionContext context) {
-    logger.debug("Rollback from snapshot for {}", context.transactionId);
-    try {
-      RollbackMutationComposer composer =
-          new RollbackMutationComposer(context.transactionId, storage, tableMetadataManager);
-      context.snapshot.to(composer);
-      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
-
-      List<ParallelExecutorTask> tasks = new ArrayList<>(groupedMutations.size());
-      for (List<Mutation> mutations : groupedMutations) {
-        tasks.add(() -> storage.mutate(mutations));
-      }
-      parallelExecutor.rollbackRecords(tasks, context.transactionId);
-    } catch (Exception e) {
-      logger.info("Rolling back records failed. Transaction ID: {}", context.transactionId, e);
-      // ignore since records are recovered lazily
-    }
+    participantCommitHandler.rollbackRecords(context);
   }
 
   /**
-   * Writes the ABORTED state for a manager-level rollback/abort by transaction ID (the {@code
-   * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
-   * transaction ID is known.
-   *
-   * <p>This delegates to {@link Coordinator#forceAbort(String)}, which branches on the given ID:
-   * for a group commit full key it uses the same two-step protocol as lazy recovery, writing the
-   * parent-ID conflict marker before the full-ID ABORTED record so the abort wins against an
-   * in-flight normal group commit (which writes the COMMITTED state under the parent ID); for a
-   * non-group-commit ID it just writes the ABORTED record.
-   *
-   * @param id the transaction ID
-   * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
-   *     concurrent writer beat us, whatever state ({@link TransactionState#COMMITTED} or {@link
-   *     TransactionState#ABORTED}) is already persisted
-   * @throws UnknownTransactionStatusException if the final transaction status cannot be determined
+   * Checks whether the transaction is eligible for a one-phase commit. Subclasses may override to
+   * insert behavior (the group-commit variant cancels its slot reservation on the exception path).
    */
-  public TransactionState abortStateForRollback(String id)
-      throws UnknownTransactionStatusException {
-    try {
-      coordinator.forceAbort(id);
-      return TransactionState.ABORTED;
-    } catch (CoordinatorConflictException e) {
-      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
-      // the One-phase Commit I/F abort-by-id path (DistributedTransactionManager.rollback(String) /
-      // abort(String)). Follows the persisted state when present. Unlike the self-abort and
-      // Two-phase Commit I/F aborts, an absent row here is genuinely undeterminable: abort-by-id
-      // can target a transaction that actually committed, and in One-phase Commit I/F
-      // finishTransaction can remove that COMMITTED row, so an absent row may be a cleaned-up
-      // COMMITTED rather than a cleaned-up ABORTED. Report an honest
-      // UnknownTransactionStatusException preserving the original conflict, rather than fabricating
-      // a terminal state.
-      //
-      // TODO: revisit this if/when the Two-phase Commit I/F is removed
+  boolean canOnePhaseCommit(TransactionContext context) throws CommitException {
+    return participantCommitHandler.canOnePhaseCommit(context);
+  }
 
-      Optional<TransactionState> persisted = readCoordinatorStateAfterAbortConflict(id, e);
-      if (persisted.isPresent()) {
-        return persisted.get();
-      }
-      throw new UnknownTransactionStatusException(
-          CoreError
-              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
-              .buildMessage(e.getMessage()),
-          e,
-          id);
-    } catch (CoordinatorException e) {
-      throw new UnknownTransactionStatusException(
-          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
-          e,
-          id);
-    }
+  /**
+   * Performs the one-phase commit storage mutation. Called only when {@link
+   * #canOnePhaseCommit(TransactionContext)} returns {@code true}. Subclasses may override to insert
+   * behavior (the group-commit variant cancels its slot reservation before / after).
+   */
+  void onePhaseCommitRecords(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    participantCommitHandler.onePhaseCommitRecords(context);
+  }
+
+  public void commitState(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    coordinatorCommitHandler.commitState(context);
+  }
+
+  public void commitStateWithoutWriteSet(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    coordinatorCommitHandler.commitStateWithoutWriteSet(context);
+  }
+
+  public TransactionState abortState(TransactionContext context)
+      throws UnknownTransactionStatusException {
+    return coordinatorCommitHandler.abortState(context);
+  }
+
+  public TransactionState abortStateWithoutWriteSet(String id)
+      throws UnknownTransactionStatusException {
+    return coordinatorCommitHandler.abortStateWithoutWriteSet(id);
+  }
+
+  public TransactionState forceAbortState(String id) throws UnknownTransactionStatusException {
+    return coordinatorCommitHandler.forceAbortState(id);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 public class CommitHandler {
   private static final Logger logger = LoggerFactory.getLogger(CommitHandler.class);
 
-  private final ParticipantCommitHandler participantCommitHandler;
   private final CoordinatorCommitHandler coordinatorCommitHandler;
+  private final ParticipantCommitHandler participantCommitHandler;
   protected final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
 
   @LazyInit @Nullable private BeforePreparationHook beforePreparationHook;
@@ -65,6 +65,8 @@ public class CommitHandler {
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean onePhaseCommitEnabled) {
     this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
+    this.coordinatorCommitHandler =
+        new CoordinatorCommitHandler(coordinator, new WriteSetEncoder(tableMetadataManager));
     this.participantCommitHandler =
         new ParticipantCommitHandler(
             storage,
@@ -72,9 +74,6 @@ public class CommitHandler {
             parallelExecutor,
             mutationsGrouper,
             onePhaseCommitEnabled);
-    this.coordinatorCommitHandler =
-        new CoordinatorCommitHandler(
-            coordinator, new WriteSetEncoder(tableMetadataManager), participantCommitHandler);
   }
 
   // Constructor for subclasses (CommitHandlerWithGroupCommit) that need to inject a
@@ -84,11 +83,11 @@ public class CommitHandler {
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   protected CommitHandler(
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
-      ParticipantCommitHandler participantCommitHandler,
-      CoordinatorCommitHandler coordinatorCommitHandler) {
+      CoordinatorCommitHandler coordinatorCommitHandler,
+      ParticipantCommitHandler participantCommitHandler) {
     this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
-    this.participantCommitHandler = checkNotNull(participantCommitHandler);
     this.coordinatorCommitHandler = checkNotNull(coordinatorCommitHandler);
+    this.participantCommitHandler = checkNotNull(participantCommitHandler);
   }
 
   /**
@@ -208,7 +207,18 @@ public class CommitHandler {
         context, beforePreparationHookFuture.orElse(null), hasWritesOrDeletesInSnapshot);
 
     if (hasWritesOrDeletesInSnapshot || !coordinatorWriteOmissionOnReadOnlyEnabled) {
-      commitState(context);
+      try {
+        commitState(context);
+      } catch (CommitConflictException e) {
+        // The COMMITTED-state write lost a putState race that resolved to ABORTED (or absent): the
+        // transaction is aborted. The Coordinator-side handler only reports the conflict; the
+        // orchestrator owns the records, so roll back the prepared records here before surfacing
+        // it.
+        if (hasWritesOrDeletesInSnapshot) {
+          rollbackRecords(context);
+        }
+        throw e;
+      }
     }
     if (hasWritesOrDeletesInSnapshot) {
       commitRecords(context);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -2,30 +2,26 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
-import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
-import com.scalar.db.util.groupcommit.Emittable;
-import com.scalar.db.util.groupcommit.GroupCommitConflictException;
-import com.scalar.db.util.groupcommit.GroupCommitException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Group-commit-aware orchestrator variant. The protocol flow is the same as {@link CommitHandler};
+ * the responsibility added at this layer is releasing the group-commit slot reservation on the
+ * various failure / cleanup paths so an aborted transaction does not sit in the group buffer
+ * waiting for a sibling.
+ *
+ * <p>The actual group-commit emitter and slot-cancellation primitive live on {@link
+ * CoordinatorCommitHandlerWithGroupCommit}; this orchestrator merely wires in the right
+ * Coordinator-side handler and invokes the slot cancellation at the right points in the flow.
+ */
 @ThreadSafe
 public class CommitHandlerWithGroupCommit extends CommitHandler {
-  private static final Logger logger = LoggerFactory.getLogger(CommitHandlerWithGroupCommit.class);
-  private static final CoordinatorGroupCommitKeyManipulator KEY_MANIPULATOR =
-      new CoordinatorGroupCommitKeyManipulator();
-  private final CoordinatorGroupCommitter groupCommitter;
+  private final CoordinatorCommitHandlerWithGroupCommit coordinatorHandler;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CommitHandlerWithGroupCommit(
@@ -37,30 +33,75 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean onePhaseCommitEnabled,
       CoordinatorGroupCommitter groupCommitter) {
-    super(
-        storage,
-        coordinator,
+    this(
         tableMetadataManager,
-        parallelExecutor,
-        mutationsGrouper,
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        onePhaseCommitEnabled);
-    checkNotNull(groupCommitter);
-    // The methods of this emitter will be called via GroupCommitter.ready().
-    groupCommitter.setEmitter(new Emitter(coordinator, writeSetEncoder));
-    this.groupCommitter = groupCommitter;
+        new ParticipantCommitHandler(
+            storage,
+            tableMetadataManager,
+            parallelExecutor,
+            mutationsGrouper,
+            onePhaseCommitEnabled),
+        coordinator,
+        checkNotNull(groupCommitter));
+  }
+
+  // Second-stage delegating constructor so the ParticipantCommitHandler is available when we build
+  // the CoordinatorCommitHandlerWithGroupCommit.
+  private CommitHandlerWithGroupCommit(
+      TransactionTableMetadataManager tableMetadataManager,
+      boolean coordinatorWriteOmissionOnReadOnlyEnabled,
+      ParticipantCommitHandler participantCommitHandler,
+      Coordinator coordinator,
+      CoordinatorGroupCommitter groupCommitter) {
+    this(
+        coordinatorWriteOmissionOnReadOnlyEnabled,
+        participantCommitHandler,
+        new CoordinatorCommitHandlerWithGroupCommit(
+            coordinator,
+            new WriteSetEncoder(tableMetadataManager),
+            participantCommitHandler,
+            groupCommitter));
+  }
+
+  // Package-private so test code can inject Mockito spies of ParticipantCommitHandler /
+  // CoordinatorCommitHandlerWithGroupCommit via constructor injection rather than via reflection.
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  CommitHandlerWithGroupCommit(
+      boolean coordinatorWriteOmissionOnReadOnlyEnabled,
+      ParticipantCommitHandler participantCommitHandler,
+      CoordinatorCommitHandlerWithGroupCommit coordinatorHandler) {
+    super(coordinatorWriteOmissionOnReadOnlyEnabled, participantCommitHandler, coordinatorHandler);
+    this.coordinatorHandler = coordinatorHandler;
   }
 
   @Override
   public void commit(TransactionContext context)
       throws CommitException, UnknownTransactionStatusException {
+    cancelGroupCommitIfCoordinatorStateOmitted(context);
+    super.commit(context);
+  }
+
+  /**
+   * Releases the group-commit slot reservation when the orchestrator will not write a Coordinator
+   * state row through the normal 2-phase commit path. That happens when the transaction was begun
+   * as non-read-only (and therefore reserved a slot) but turned out to have no writes/deletes,
+   * combined with coordinator-write-omission being enabled — in which case {@link
+   * CommitHandler#commit} skips {@code commitState} entirely and the reserved slot would otherwise
+   * sit unused for the rest of the commit flow.
+   *
+   * <p>The other places that call {@link
+   * CoordinatorCommitHandlerWithGroupCommit#cancelGroupCommitIfNeeded} (one-phase commit,
+   * abort/conflict paths, before-commit failure cleanup) cannot share this predicate: at those
+   * sites the transaction has writes/deletes, so the predicate would block the cancellation that
+   * those paths actually need.
+   */
+  private void cancelGroupCommitIfCoordinatorStateOmitted(TransactionContext context) {
     if (!context.readOnly
         && !context.snapshot.hasWritesOrDeletes()
         && coordinatorWriteOmissionOnReadOnlyEnabled) {
-      cancelGroupCommitIfNeeded(context);
+      coordinatorHandler.cancelGroupCommitIfNeeded(context);
     }
-
-    super.commit(context);
   }
 
   @Override
@@ -68,7 +109,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
     try {
       return super.canOnePhaseCommit(context);
     } catch (CommitException e) {
-      cancelGroupCommitIfNeeded(context);
+      coordinatorHandler.cancelGroupCommitIfNeeded(context);
       throw e;
     }
   }
@@ -76,145 +117,12 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   @Override
   void onePhaseCommitRecords(TransactionContext context)
       throws CommitConflictException, UnknownTransactionStatusException {
-    cancelGroupCommitIfNeeded(context);
+    coordinatorHandler.cancelGroupCommitIfNeeded(context);
     super.onePhaseCommitRecords(context);
   }
 
   @Override
   protected void onFailureBeforeCommit(TransactionContext context) {
-    cancelGroupCommitIfNeeded(context);
-  }
-
-  private void commitStateViaGroupCommit(TransactionContext context)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    String id = context.transactionId;
-    try {
-      // Group commit the state by internally calling `groupCommitState()` via the emitter.
-      groupCommitter.ready(id, context);
-      logger.debug(
-          "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
-    } catch (GroupCommitConflictException e) {
-      cancelGroupCommitIfNeeded(context);
-      // Throw a proper exception from this method if needed.
-      handleCommitConflict(context, e);
-    } catch (GroupCommitException e) {
-      cancelGroupCommitIfNeeded(context);
-      Throwable cause = e.getCause();
-      if (cause instanceof CoordinatorConflictException) {
-        // Throw a proper exception from this method if needed.
-        handleCommitConflict(context, (CoordinatorConflictException) cause);
-      } else {
-        // Failed to access the coordinator state. The state is unknown.
-        throw new UnknownTransactionStatusException("Coordinator status is unknown", cause, id);
-      }
-    } catch (Exception e) {
-      // This is an unexpected exception, but clean up resources just in case.
-      cancelGroupCommitIfNeeded(context);
-      throw new AssertionError("Group commit unexpectedly failed. TransactionID: " + id, e);
-    }
-  }
-
-  private void cancelGroupCommitIfNeeded(TransactionContext context) {
-    // A transaction only holds a group commit slot when one was reserved at begin time (e.g., a
-    // read-only transaction does not reserve a slot when coordinator write omission is enabled).
-    // When no slot was reserved there is nothing to release.
-    if (!context.groupCommitSlotReserved) {
-      return;
-    }
-
-    // FIXME: When a slot was reserved (so the early return above did not fire), this can run more
-    // than once on a single failure path, because several cleanup callbacks each release the slot:
-    //   - onFailureBeforeCommit() runs on every failure path (via safelyCallOnFailureBeforeCommit);
-    //   - abortState() additionally runs from abortStateAndRollbackRecordsIfNeeded() when the
-    //     transaction has writes/deletes, or coordinator write omission on read-only is disabled;
-    //   - onePhaseCommitRecords() pre-cancels the slot before its body, so a one-phase-commit
-    //     failure followed by onFailureBeforeCommit() also cancels twice.
-    // It is currently safe only because groupCommitter.remove() is idempotent. The cleanup paths
-    // should be reworked so the slot is released exactly once instead of relying on that
-    // idempotency.
-    try {
-      groupCommitter.remove(context.transactionId);
-    } catch (Exception e) {
-      logger.warn(
-          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}",
-          context.transactionId,
-          e);
-    }
-  }
-
-  @Override
-  public void commitState(TransactionContext context)
-      throws CommitConflictException, UnknownTransactionStatusException {
-    commitStateViaGroupCommit(context);
-  }
-
-  @Override
-  public TransactionState abortState(TransactionContext context)
-      throws UnknownTransactionStatusException {
-    cancelGroupCommitIfNeeded(context);
-    return super.abortState(context);
-  }
-
-  @VisibleForTesting
-  static class Emitter implements Emittable<String, String, TransactionContext> {
-    private final Coordinator coordinator;
-    private final WriteSetEncoder writeSetEncoder;
-
-    public Emitter(Coordinator coordinator, WriteSetEncoder writeSetEncoder) {
-      this.coordinator = coordinator;
-      this.writeSetEncoder = writeSetEncoder;
-    }
-
-    @Override
-    public void emitNormalGroup(String parentId, List<TransactionContext> contexts)
-        throws CoordinatorException {
-      if (contexts.isEmpty()) {
-        // This means all buffered transactions were manually rolled back. Nothing to do.
-        return;
-      }
-
-      // These transactions are contained in a normal group that has multiple transactions.
-      // Therefore, the transaction states should be put together in Coordinator.State. The State
-      // carries the child IDs derived from each transaction's full ID; the parent ID is the row's
-      // partition key.
-      if (KEY_MANIPULATOR.isFullKey(parentId)) {
-        throw new AssertionError(
-            "emitNormalGroup is only for normal group commits that use a parent ID as the key");
-      }
-      List<String> childIds = new ArrayList<>(contexts.size());
-      for (TransactionContext context : contexts) {
-        childIds.add(KEY_MANIPULATOR.keysFromFullKey(context.transactionId).childKey);
-      }
-
-      coordinator.putState(
-          new State(
-              parentId,
-              childIds,
-              writeSetEncoder.encodeMultiGroupWriteSet(contexts, false),
-              TransactionState.COMMITTED,
-              System.currentTimeMillis()));
-
-      logger.debug(
-          "Transaction {} (parent ID) is committed successfully at {}",
-          parentId,
-          System.currentTimeMillis());
-    }
-
-    @Override
-    public void emitDelayedGroup(String fullId, TransactionContext context)
-        throws CoordinatorException {
-      // This transaction is contained in a delayed group that has only a single transaction.
-      // Therefore, the transaction state can be committed as if it's a normal commit (not a
-      // group commit).
-      coordinator.putState(
-          new State(
-              fullId,
-              writeSetEncoder.encodeSingleGroupWriteSet(context, false),
-              TransactionState.COMMITTED,
-              System.currentTimeMillis()));
-
-      logger.debug(
-          "Transaction {} is committed successfully at {}", fullId, System.currentTimeMillis());
-    }
+    coordinatorHandler.cancelGroupCommitIfNeeded(context);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -46,8 +46,8 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
         checkNotNull(groupCommitter));
   }
 
-  // Second-stage delegating constructor so the ParticipantCommitHandler is available when we build
-  // the CoordinatorCommitHandlerWithGroupCommit.
+  // Second-stage delegating constructor that builds the two specialized handlers before handing
+  // them to the package-private constructor.
   private CommitHandlerWithGroupCommit(
       TransactionTableMetadataManager tableMetadataManager,
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
@@ -56,22 +56,19 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       CoordinatorGroupCommitter groupCommitter) {
     this(
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        participantCommitHandler,
         new CoordinatorCommitHandlerWithGroupCommit(
-            coordinator,
-            new WriteSetEncoder(tableMetadataManager),
-            participantCommitHandler,
-            groupCommitter));
+            coordinator, new WriteSetEncoder(tableMetadataManager), groupCommitter),
+        participantCommitHandler);
   }
 
-  // Package-private so test code can inject Mockito spies of ParticipantCommitHandler /
-  // CoordinatorCommitHandlerWithGroupCommit via constructor injection rather than via reflection.
+  // Package-private so test code can inject Mockito spies of the two specialized handlers via
+  // constructor injection rather than via reflection.
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   CommitHandlerWithGroupCommit(
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
-      ParticipantCommitHandler participantCommitHandler,
-      CoordinatorCommitHandlerWithGroupCommit coordinatorHandler) {
-    super(coordinatorWriteOmissionOnReadOnlyEnabled, participantCommitHandler, coordinatorHandler);
+      CoordinatorCommitHandlerWithGroupCommit coordinatorHandler,
+      ParticipantCommitHandler participantCommitHandler) {
+    super(coordinatorWriteOmissionOnReadOnlyEnabled, coordinatorHandler, participantCommitHandler);
     this.coordinatorHandler = coordinatorHandler;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -585,7 +585,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   public TransactionState rollback(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
-      return commit.abortStateForRollback(txId);
+      return commit.forceAbortState(txId);
     } catch (UnknownTransactionStatusException ignored) {
       return TransactionState.UNKNOWN;
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li><b>parent ID</b> — the key for a <i>normal group</i>: one record under the parent ID lists
  *       the child IDs of all transactions committed together (written by {@code
- *       CommitHandlerWithGroupCommit.Emitter#emitNormalGroup} via {@link #putState}).
+ *       CoordinatorCommitHandlerWithGroupCommit.Emitter#emitNormalGroup} via {@link #putState}).
  *   <li><b>full ID</b> ({@code parent + child}) — the key for a transaction committed on its own: a
  *       <i>delayed</i> group commit, or a transaction whose lifecycle abort writes under its own
  *       full ID.
@@ -76,14 +76,16 @@ import org.slf4j.LoggerFactory;
  * must be careful not to write under a key that does not conflict with the commit:
  *
  * <ul>
- *   <li><b>normal group commit</b> — {@code CommitHandlerWithGroupCommit.Emitter#emitNormalGroup}
- *       writes {@code COMMITTED} under the parent ID via {@link #putState}.
- *   <li><b>delayed group commit</b> — {@code CommitHandlerWithGroupCommit.Emitter#emitDelayedGroup}
- *       writes {@code putState(fullId, COMMITTED)}.
- *   <li><b>lifecycle abort</b> ({@link CommitHandlerWithGroupCommit#abortState}) — writes {@code
- *       putState(fullId, ABORTED)}. Safe because the caller first removes the slot from the group
- *       committer (so a normal group commit can no longer list this child under the parent ID), and
- *       against a delayed commit it conflicts on the same full ID.
+ *   <li><b>normal group commit</b> — {@code
+ *       CoordinatorCommitHandlerWithGroupCommit.Emitter#emitNormalGroup} writes {@code COMMITTED}
+ *       under the parent ID via {@link #putState}.
+ *   <li><b>delayed group commit</b> — {@code
+ *       CoordinatorCommitHandlerWithGroupCommit.Emitter#emitDelayedGroup} writes {@code
+ *       putState(fullId, COMMITTED)}.
+ *   <li><b>lifecycle abort</b> ({@link CoordinatorCommitHandlerWithGroupCommit#abortState}) —
+ *       writes {@code putState(fullId, ABORTED)}. Safe because the caller first removes the slot
+ *       from the group committer (so a normal group commit can no longer list this child under the
+ *       parent ID), and against a delayed commit it conflicts on the same full ID.
  *   <li><b>lazy recovery / manager-level rollback-or-abort by ID</b> — {@link #forceAbort} runs the
  *       two-step protocol: write the parent-ID conflict marker (empty {@code tx_child_ids}) first,
  *       then the full-ID {@code ABORTED} record. Needed because the caller does <i>not</i> own the

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
@@ -18,15 +18,11 @@ import org.slf4j.LoggerFactory;
  * Handles the Coordinator-side (state-table) operations of the Consensus Commit protocol: writing
  * the COMMITTED / ABORTED records to the Coordinator state table and resolving putState conflicts.
  *
- * <p>This is one of the two specialized handlers that {@link CommitHandler} delegates to. The other
- * is {@link ParticipantCommitHandler}, which owns participant-side data-record operations.
- *
- * <p>Methods here only touch the Coordinator state table via {@link Coordinator}. They never write
- * to user data tables — except indirectly: when {@code commitState} loses a putState race and the
- * persisted state turns out to be ABORTED (or absent), this handler asks the orchestrator-provided
- * {@link ParticipantCommitHandler} to roll back the records that the transaction had prepared. That
- * cross-handler call keeps the "commit conflict → rollback records" invariant atomic from the
- * orchestrator's perspective.
+ * <p>Methods here only touch the Coordinator state table via {@link Coordinator}; they never touch
+ * user data tables. When {@code commitState} loses a putState race and the persisted state turns
+ * out to be ABORTED (or absent), this handler reports a {@link CommitConflictException} and leaves
+ * the rollback of the transaction's prepared records to the caller. This keeps the handler free of
+ * any participant-side dependency.
  */
 @ThreadSafe
 class CoordinatorCommitHandler {
@@ -34,16 +30,11 @@ class CoordinatorCommitHandler {
 
   private final Coordinator coordinator;
   private final WriteSetEncoder writeSetEncoder;
-  private final ParticipantCommitHandler participantCommitHandler;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  CoordinatorCommitHandler(
-      Coordinator coordinator,
-      WriteSetEncoder writeSetEncoder,
-      ParticipantCommitHandler participantCommitHandler) {
+  CoordinatorCommitHandler(Coordinator coordinator, WriteSetEncoder writeSetEncoder) {
     this.coordinator = checkNotNull(coordinator);
     this.writeSetEncoder = checkNotNull(writeSetEncoder);
-    this.participantCommitHandler = checkNotNull(participantCommitHandler);
   }
 
   /**
@@ -88,7 +79,6 @@ class CoordinatorCommitHandler {
       if (s.isPresent()) {
         TransactionState state = s.get().getState();
         if (state == TransactionState.ABORTED) {
-          participantCommitHandler.rollbackRecords(context);
           throw new CommitConflictException(
               CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
                   cause.getMessage()),
@@ -111,8 +101,9 @@ class CoordinatorCommitHandler {
         // The coordinator state is absent: a row existed when our putIfNotExists lost the race, but
         // it is gone now. In both interfaces this means the conflicting row was an ABORTED written
         // by a lazy recovery (which also rolled the records back) and later removed by the
-        // Coordinator state cleanup process, so the transaction is definitively aborted. Roll the
-        // records back and report a conflict -- the same outcome as the present-ABORTED case above.
+        // Coordinator state cleanup process, so the transaction is definitively aborted. Report a
+        // conflict (the orchestrator rolls the records back) -- the same outcome as the
+        // present-ABORTED case above.
         //
         // A COMMITTED row can be ruled out here in both interfaces:
         //   - One-phase Commit I/F: this commit is the only writer of this transaction's COMMITTED
@@ -139,7 +130,6 @@ class CoordinatorCommitHandler {
         //
         // TODO: revisit this if/when the Two-phase Commit I/F is removed.
 
-        participantCommitHandler.rollbackRecords(context);
         throw new CommitConflictException(
             CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
                 cause.getMessage()),

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
@@ -1,0 +1,263 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the Coordinator-side (state-table) operations of the Consensus Commit protocol: writing
+ * the COMMITTED / ABORTED records to the Coordinator state table and resolving putState conflicts.
+ *
+ * <p>This is one of the two specialized handlers that {@link CommitHandler} delegates to. The other
+ * is {@link ParticipantCommitHandler}, which owns participant-side data-record operations.
+ *
+ * <p>Methods here only touch the Coordinator state table via {@link Coordinator}. They never write
+ * to user data tables — except indirectly: when {@code commitState} loses a putState race and the
+ * persisted state turns out to be ABORTED (or absent), this handler asks the orchestrator-provided
+ * {@link ParticipantCommitHandler} to roll back the records that the transaction had prepared. That
+ * cross-handler call keeps the "commit conflict → rollback records" invariant atomic from the
+ * orchestrator's perspective.
+ */
+@ThreadSafe
+class CoordinatorCommitHandler {
+  private static final Logger logger = LoggerFactory.getLogger(CoordinatorCommitHandler.class);
+
+  private final Coordinator coordinator;
+  private final WriteSetEncoder writeSetEncoder;
+  private final ParticipantCommitHandler participantCommitHandler;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  CoordinatorCommitHandler(
+      Coordinator coordinator,
+      WriteSetEncoder writeSetEncoder,
+      ParticipantCommitHandler participantCommitHandler) {
+    this.coordinator = checkNotNull(coordinator);
+    this.writeSetEncoder = checkNotNull(writeSetEncoder);
+    this.participantCommitHandler = checkNotNull(participantCommitHandler);
+  }
+
+  /**
+   * Writes the COMMITTED state with the {@code tx_write_set} populated from the given context's
+   * snapshot.
+   */
+  void commitState(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    commitStateInternal(context, writeSetEncoder.encodeSingleGroupWriteSet(context, false));
+  }
+
+  /** Writes the COMMITTED state without persisting a {@code tx_write_set}. */
+  void commitStateWithoutWriteSet(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    commitStateInternal(context, null);
+  }
+
+  private void commitStateInternal(TransactionContext context, @Nullable WriteSet writeSet)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    String id = context.transactionId;
+    try {
+      Coordinator.State state =
+          new Coordinator.State(
+              id, writeSet, TransactionState.COMMITTED, System.currentTimeMillis());
+      coordinator.putState(state);
+      logger.debug(
+          "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
+    } catch (CoordinatorConflictException e) {
+      handleCommitConflict(context, e);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
+          e,
+          id);
+    }
+  }
+
+  void handleCommitConflict(TransactionContext context, Exception cause)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    try {
+      Optional<Coordinator.State> s = coordinator.getState(context.transactionId);
+      if (s.isPresent()) {
+        TransactionState state = s.get().getState();
+        if (state == TransactionState.ABORTED) {
+          participantCommitHandler.rollbackRecords(context);
+          throw new CommitConflictException(
+              CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
+                  cause.getMessage()),
+              cause,
+              context.transactionId);
+        }
+        // Otherwise the coordinator state is present and COMMITTED, which means this transaction
+        // has already committed. Only Two-phase Commit I/F reaches this branch: there the same
+        // transaction's commit can be driven more than once -- re-invoked for recovery, or
+        // committed by multiple participants -- so an earlier or concurrent commit of this
+        // transaction may have already written its COMMITTED state, and this commit then loses the
+        // putIfNotExists race and observes it here. With One-phase Commit I/F this is unreachable:
+        // this commit is the only writer of the COMMITTED state and it just lost the race, so the
+        // conflicting row was an ABORTED from a lazy recovery, handled above. The transaction is
+        // committed, so return normally and let the caller commit the records.
+        //
+        // TODO: revisit this if/when the Two-phase Commit I/F is removed -- it would then be
+        // unreachable (a COMMITTED state could never be observed after a conflict here).
+      } else {
+        // The coordinator state is absent: a row existed when our putIfNotExists lost the race, but
+        // it is gone now. In both interfaces this means the conflicting row was an ABORTED written
+        // by a lazy recovery (which also rolled the records back) and later removed by the
+        // Coordinator state cleanup process, so the transaction is definitively aborted. Roll the
+        // records back and report a conflict -- the same outcome as the present-ABORTED case above.
+        //
+        // A COMMITTED row can be ruled out here in both interfaces:
+        //   - One-phase Commit I/F: this commit is the only writer of this transaction's COMMITTED
+        //     state, and it just lost the race, so the conflicting row could only have been an
+        //     ABORTED from a lazy recovery -- a COMMITTED for this transaction never existed.
+        //   - Two-phase Commit I/F: other participants or re-driven commits of the same transaction
+        //     can also write COMMITTED, so the conflict could in principle have been against a
+        //     COMMITTED row. But the Two-phase Commit I/F does not assume finishTransaction,
+        //     and a COMMITTED coordinator row is only ever removed by finishTransaction (the
+        //     periodic cleanup removes only ABORTED rows). So a COMMITTED row never disappears
+        //     here: had the conflict been against one, it would still be present and handled by
+        //     the present-COMMITTED branch above. An absent row therefore means the conflict was
+        //     an ABORTED.
+        //
+        // Group commit reaches an absent state by a second, more common route, and the outcome is
+        // still correct. There the conflicting putIfNotExists is keyed on the parent ID (the group
+        // emitter writes the parent-ID COMMITTED row), so the row it conflicts with -- a lazy
+        // recovery's empty-tx_child_ids ABORTED parent row -- can still be present. getState then
+        // resolves by full ID: it finds the parent row, sees it does not list this child, and finds
+        // no full-ID row, so it returns empty. That empty does not mean a cleaned-up row; it means
+        // this child was never committed (a committed child would either be listed in the parent
+        // row or have its own full-ID COMMITTED row, and getState would return it). Rolling back
+        // and reporting a retryable conflict is the correct outcome for such an uncommitted child.
+        //
+        // TODO: revisit this if/when the Two-phase Commit I/F is removed.
+
+        participantCommitHandler.rollbackRecords(context);
+        throw new CommitConflictException(
+            CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
+                cause.getMessage()),
+            cause,
+            context.transactionId);
+      }
+    } catch (CoordinatorException ex) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(ex.getMessage()),
+          ex,
+          context.transactionId);
+    }
+  }
+
+  /**
+   * Writes the ABORTED state with the {@code tx_write_set} populated from the given context's
+   * snapshot.
+   */
+  TransactionState abortState(TransactionContext context) throws UnknownTransactionStatusException {
+    return abortStateInternal(
+        context.transactionId, writeSetEncoder.encodeSingleGroupWriteSet(context, false));
+  }
+
+  /** Writes the ABORTED state without persisting a {@code tx_write_set} via a single putState. */
+  TransactionState abortStateWithoutWriteSet(String id) throws UnknownTransactionStatusException {
+    return abortStateInternal(id, null);
+  }
+
+  private TransactionState abortStateInternal(String id, @Nullable WriteSet writeSet)
+      throws UnknownTransactionStatusException {
+    try {
+      Coordinator.State state =
+          new Coordinator.State(id, writeSet, TransactionState.ABORTED, System.currentTimeMillis());
+      coordinator.putState(state);
+      return TransactionState.ABORTED;
+    } catch (CoordinatorConflictException e) {
+      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
+      // the self-abort path and all Two-phase Commit I/F aborts. Follows the persisted state when
+      // present; an absent row is determinable as ABORTED here:
+      //   - One-phase Commit I/F self-abort (abortState from a commit-path failure, before
+      //     commitState runs): the transaction provably never committed, so the conflicting row
+      //     could only have been a lazy-recovery ABORTED, later removed by the cleanup process.
+      //   - Two-phase Commit I/F (rollback and abort-by-id): other participants can write
+      //     COMMITTED, but the Two-phase Commit I/F does not assume finishTransaction, and a
+      //     COMMITTED coordinator row is only ever removed by finishTransaction (the periodic
+      //     cleanup removes only ABORTED rows). So a COMMITTED never disappears: had the conflict
+      //     been against one, it would still be present and returned above. An absent row therefore
+      //     means the conflict was an ABORTED.
+      //
+      // TODO: revisit this if/when the Two-phase Commit I/F is removed
+
+      return readCoordinatorStateAfterAbortConflict(id, e).orElse(TransactionState.ABORTED);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
+          e,
+          id);
+    }
+  }
+
+  /**
+   * Writes the ABORTED state for a manager-level rollback/abort by transaction ID. Uses {@link
+   * Coordinator#forceAbort} so the 2-step protocol wins against an in-flight normal group commit
+   * when the id is a group-commit full key.
+   */
+  TransactionState forceAbortState(String id) throws UnknownTransactionStatusException {
+    try {
+      coordinator.forceAbort(id);
+      return TransactionState.ABORTED;
+    } catch (CoordinatorConflictException e) {
+      // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for
+      // the One-phase Commit I/F abort-by-id path (DistributedTransactionManager.rollback(String) /
+      // abort(String)). Follows the persisted state when present. Unlike the self-abort and
+      // Two-phase Commit I/F aborts, an absent row here is genuinely undeterminable: abort-by-id
+      // can target a transaction that actually committed, and in One-phase Commit I/F
+      // finishTransaction can remove that COMMITTED row, so an absent row may be a cleaned-up
+      // COMMITTED rather than a cleaned-up ABORTED. Report an honest
+      // UnknownTransactionStatusException preserving the original conflict, rather than fabricating
+      // a terminal state.
+      //
+      // TODO: revisit this if/when the Two-phase Commit I/F is removed
+
+      Optional<TransactionState> persisted = readCoordinatorStateAfterAbortConflict(id, e);
+      if (persisted.isPresent()) {
+        return persisted.get();
+      }
+      throw new UnknownTransactionStatusException(
+          CoreError
+              .CONSENSUS_COMMIT_ABORTING_STATE_FAILED_WITH_NO_MUTATION_EXCEPTION_BUT_COORDINATOR_STATUS_DOES_NOT_EXIST
+              .buildMessage(e.getMessage()),
+          e,
+          id);
+    } catch (CoordinatorException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(e.getMessage()),
+          e,
+          id);
+    }
+  }
+
+  /**
+   * Reads the persisted coordinator state after our ABORTED putIfNotExists lost the race. Returns
+   * the already-persisted COMMITTED/ABORTED state when present, or empty when the row is absent
+   * (already removed by the Coordinator state cleanup process). The two callers interpret an absent
+   * row differently, because whether it is determinable depends on the calling path. A coordinator
+   * read failure is undeterminable regardless of path, so it surfaces as
+   * UnknownTransactionStatusException with the original conflict preserved as the cause.
+   */
+  private Optional<TransactionState> readCoordinatorStateAfterAbortConflict(
+      String id, CoordinatorConflictException e) throws UnknownTransactionStatusException {
+    try {
+      return coordinator.getState(id).map(Coordinator.State::getState);
+    } catch (CoordinatorException e1) {
+      e1.addSuppressed(e);
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_CANNOT_GET_COORDINATOR_STATUS.buildMessage(e1.getMessage()),
+          e1,
+          id);
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
@@ -23,9 +23,6 @@ import org.slf4j.LoggerFactory;
  * Group-commit-aware variant of {@link CoordinatorCommitHandler}. Routes {@code commitState} into
  * the group-commit emitter so that multiple transactions' COMMITTED states can be batched into one
  * Coordinator-table row. Cancels the group commit slot reservation on the abort path.
- *
- * <p>Used by {@link CommitHandlerWithGroupCommit} (the orchestrator variant) in place of the base
- * {@link CoordinatorCommitHandler} when group commit is enabled.
  */
 @ThreadSafe
 class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
@@ -40,9 +37,8 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
   CoordinatorCommitHandlerWithGroupCommit(
       Coordinator coordinator,
       WriteSetEncoder writeSetEncoder,
-      ParticipantCommitHandler participantCommitHandler,
       CoordinatorGroupCommitter groupCommitter) {
-    super(coordinator, writeSetEncoder, participantCommitHandler);
+    super(coordinator, writeSetEncoder);
     checkNotNull(groupCommitter);
     // The methods of this emitter will be called via GroupCommitter.ready().
     groupCommitter.setEmitter(new Emitter(coordinator, writeSetEncoder));

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
@@ -1,0 +1,173 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.consensuscommit.Coordinator.State;
+import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.util.groupcommit.Emittable;
+import com.scalar.db.util.groupcommit.GroupCommitConflictException;
+import com.scalar.db.util.groupcommit.GroupCommitException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Group-commit-aware variant of {@link CoordinatorCommitHandler}. Routes {@code commitState} into
+ * the group-commit emitter so that multiple transactions' COMMITTED states can be batched into one
+ * Coordinator-table row. Cancels the group commit slot reservation on the abort path.
+ *
+ * <p>Used by {@link CommitHandlerWithGroupCommit} (the orchestrator variant) in place of the base
+ * {@link CoordinatorCommitHandler} when group commit is enabled.
+ */
+@ThreadSafe
+class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
+  private static final Logger logger =
+      LoggerFactory.getLogger(CoordinatorCommitHandlerWithGroupCommit.class);
+  private static final CoordinatorGroupCommitKeyManipulator KEY_MANIPULATOR =
+      new CoordinatorGroupCommitKeyManipulator();
+
+  private final CoordinatorGroupCommitter groupCommitter;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  CoordinatorCommitHandlerWithGroupCommit(
+      Coordinator coordinator,
+      WriteSetEncoder writeSetEncoder,
+      ParticipantCommitHandler participantCommitHandler,
+      CoordinatorGroupCommitter groupCommitter) {
+    super(coordinator, writeSetEncoder, participantCommitHandler);
+    checkNotNull(groupCommitter);
+    // The methods of this emitter will be called via GroupCommitter.ready().
+    groupCommitter.setEmitter(new Emitter(coordinator, writeSetEncoder));
+    this.groupCommitter = groupCommitter;
+  }
+
+  @Override
+  void commitState(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    String id = context.transactionId;
+    try {
+      // Group commit the state by internally calling `groupCommitState()` via the emitter.
+      groupCommitter.ready(id, context);
+      logger.debug(
+          "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
+    } catch (GroupCommitConflictException e) {
+      cancelGroupCommitIfNeeded(context);
+      handleCommitConflict(context, e);
+    } catch (GroupCommitException e) {
+      cancelGroupCommitIfNeeded(context);
+      Throwable cause = e.getCause();
+      if (cause instanceof CoordinatorConflictException) {
+        handleCommitConflict(context, (CoordinatorConflictException) cause);
+      } else {
+        // Failed to access the coordinator state. The state is unknown.
+        throw new UnknownTransactionStatusException(
+            CoreError.CONSENSUS_COMMIT_UNKNOWN_COORDINATOR_STATUS.buildMessage(
+                cause == null ? "" : cause.getMessage()),
+            cause,
+            id);
+      }
+    } catch (Exception e) {
+      // This is an unexpected exception, but clean up resources just in case.
+      cancelGroupCommitIfNeeded(context);
+      throw new AssertionError("Group commit unexpectedly failed. TransactionID: " + id, e);
+    }
+  }
+
+  @Override
+  TransactionState abortState(TransactionContext context) throws UnknownTransactionStatusException {
+    cancelGroupCommitIfNeeded(context);
+    return super.abortState(context);
+  }
+
+  /**
+   * Releases the group-commit slot reservation if one was made for this transaction. Called from
+   * the abort/cleanup paths so an aborted transaction doesn't sit in the group buffer waiting for a
+   * sibling.
+   */
+  void cancelGroupCommitIfNeeded(TransactionContext context) {
+    // A transaction only holds a group commit slot when one was reserved at begin time (e.g., a
+    // read-only transaction does not reserve a slot when coordinator write omission is enabled).
+    // When no slot was reserved there is nothing to release.
+    if (!context.groupCommitSlotReserved) {
+      return;
+    }
+
+    // FIXME: When a slot was reserved (so the early return above did not fire), this can run more
+    // than once on a single failure path, because several cleanup callbacks each release the slot:
+    //   - onFailureBeforeCommit() runs on every failure path (via safelyCallOnFailureBeforeCommit);
+    //   - abortState() additionally runs from abortStateAndRollbackRecordsIfNeeded() when the
+    //     transaction has writes/deletes, or coordinator write omission on read-only is disabled;
+    //   - onePhaseCommitRecords() pre-cancels the slot before its body, so a one-phase-commit
+    //     failure followed by onFailureBeforeCommit() also cancels twice.
+    // It is currently safe only because groupCommitter.remove() is idempotent. The cleanup paths
+    // should be reworked so the slot is released exactly once instead of relying on that
+    // idempotency.
+    try {
+      groupCommitter.remove(context.transactionId);
+    } catch (Exception e) {
+      logger.warn(
+          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}",
+          context.transactionId,
+          e);
+    }
+  }
+
+  @VisibleForTesting
+  static class Emitter implements Emittable<String, String, TransactionContext> {
+    private final Coordinator coordinator;
+    private final WriteSetEncoder writeSetEncoder;
+
+    Emitter(Coordinator coordinator, WriteSetEncoder writeSetEncoder) {
+      this.coordinator = coordinator;
+      this.writeSetEncoder = writeSetEncoder;
+    }
+
+    @Override
+    public void emitNormalGroup(String parentId, List<TransactionContext> contexts)
+        throws CoordinatorException {
+      if (contexts.isEmpty()) {
+        return;
+      }
+      if (KEY_MANIPULATOR.isFullKey(parentId)) {
+        throw new AssertionError(
+            "emitNormalGroup is only for normal group commits that use a parent ID as the key");
+      }
+      List<String> childIds = new ArrayList<>(contexts.size());
+      for (TransactionContext context : contexts) {
+        childIds.add(KEY_MANIPULATOR.keysFromFullKey(context.transactionId).childKey);
+      }
+      coordinator.putState(
+          new State(
+              parentId,
+              childIds,
+              writeSetEncoder.encodeMultiGroupWriteSet(contexts, false),
+              TransactionState.COMMITTED,
+              System.currentTimeMillis()));
+      logger.debug(
+          "Transaction {} (parent ID) is committed successfully at {}",
+          parentId,
+          System.currentTimeMillis());
+    }
+
+    @Override
+    public void emitDelayedGroup(String fullId, TransactionContext context)
+        throws CoordinatorException {
+      coordinator.putState(
+          new State(
+              fullId,
+              writeSetEncoder.encodeSingleGroupWriteSet(context, false),
+              TransactionState.COMMITTED,
+              System.currentTimeMillis()));
+      logger.debug(
+          "Transaction {} is committed successfully at {}", fullId, System.currentTimeMillis());
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandler.java
@@ -33,9 +33,6 @@ import org.slf4j.LoggerFactory;
  * preparing, validating, committing, and rolling back the records the transaction touches in user
  * data tables.
  *
- * <p>This is one of the two specialized handlers that {@link CommitHandler} delegates to. The other
- * is {@link CoordinatorCommitHandler}, which owns Coordinator-table state writes.
- *
  * <p>Methods here only touch user data tables via {@link DistributedStorage} and the {@link
  * MutationsGrouper} / {@link ParallelExecutor} stack. They never write to the Coordinator table.
  */

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandler.java
@@ -1,0 +1,235 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the participant-side (data-record) operations of the Consensus Commit protocol:
+ * preparing, validating, committing, and rolling back the records the transaction touches in user
+ * data tables.
+ *
+ * <p>This is one of the two specialized handlers that {@link CommitHandler} delegates to. The other
+ * is {@link CoordinatorCommitHandler}, which owns Coordinator-table state writes.
+ *
+ * <p>Methods here only touch user data tables via {@link DistributedStorage} and the {@link
+ * MutationsGrouper} / {@link ParallelExecutor} stack. They never write to the Coordinator table.
+ */
+@ThreadSafe
+class ParticipantCommitHandler {
+  private static final Logger logger = LoggerFactory.getLogger(ParticipantCommitHandler.class);
+
+  private final DistributedStorage storage;
+  private final TransactionTableMetadataManager tableMetadataManager;
+  private final ParallelExecutor parallelExecutor;
+  private final MutationsGrouper mutationsGrouper;
+  private final boolean onePhaseCommitEnabled;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  ParticipantCommitHandler(
+      DistributedStorage storage,
+      TransactionTableMetadataManager tableMetadataManager,
+      ParallelExecutor parallelExecutor,
+      MutationsGrouper mutationsGrouper,
+      boolean onePhaseCommitEnabled) {
+    this.storage = checkNotNull(storage);
+    this.tableMetadataManager = checkNotNull(tableMetadataManager);
+    this.parallelExecutor = checkNotNull(parallelExecutor);
+    this.mutationsGrouper = checkNotNull(mutationsGrouper);
+    this.onePhaseCommitEnabled = onePhaseCommitEnabled;
+  }
+
+  void prepareRecords(TransactionContext context) throws PreparationException {
+    try {
+      PrepareMutationComposer composer =
+          new PrepareMutationComposer(context.transactionId, tableMetadataManager);
+      context.snapshot.to(composer);
+      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
+
+      List<ParallelExecutorTask> tasks = toTasks(groupedMutations);
+      parallelExecutor.prepareRecords(tasks, context.transactionId);
+    } catch (NoMutationException e) {
+      throw new PreparationConflictException(
+          CoreError.CONSENSUS_COMMIT_PREPARING_RECORD_EXISTS.buildMessage(e.getMessage()),
+          e,
+          context.transactionId);
+    } catch (RetriableExecutionException e) {
+      throw new PreparationConflictException(
+          CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_PREPARING_RECORDS.buildMessage(
+              e.getMessage()),
+          e,
+          context.transactionId);
+    } catch (ExecutionException e) {
+      throw new PreparationException(
+          CoreError.CONSENSUS_COMMIT_PREPARING_RECORDS_FAILED.buildMessage(e.getMessage()),
+          e,
+          context.transactionId);
+    }
+  }
+
+  void validateRecords(TransactionContext context) throws ValidationException {
+    if (!context.isValidationRequired()) {
+      return;
+    }
+
+    try {
+      // validation is executed when SERIALIZABLE is chosen.
+      context.snapshot.toSerializable(storage);
+    } catch (ExecutionException e) {
+      throw new ValidationException(
+          CoreError.CONSENSUS_COMMIT_VALIDATION_FAILED.buildMessage(e.getMessage()),
+          e,
+          context.transactionId);
+    }
+  }
+
+  void commitRecords(TransactionContext context) {
+    try {
+      CommitMutationComposer composer =
+          new CommitMutationComposer(context.transactionId, tableMetadataManager);
+      context.snapshot.to(composer);
+      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
+
+      List<ParallelExecutorTask> tasks = toTasks(groupedMutations);
+      parallelExecutor.commitRecords(tasks, context.transactionId);
+    } catch (Exception e) {
+      logger.info("Committing records failed. Transaction ID: {}", context.transactionId, e);
+      // ignore since records are recovered lazily
+    }
+  }
+
+  void rollbackRecords(TransactionContext context) {
+    logger.debug("Rollback from snapshot for {}", context.transactionId);
+    try {
+      RollbackMutationComposer composer =
+          new RollbackMutationComposer(context.transactionId, storage, tableMetadataManager);
+      context.snapshot.to(composer);
+      List<List<Mutation>> groupedMutations = mutationsGrouper.groupMutations(composer.get());
+
+      List<ParallelExecutorTask> tasks = toTasks(groupedMutations);
+      parallelExecutor.rollbackRecords(tasks, context.transactionId);
+    } catch (Exception e) {
+      logger.info("Rolling back records failed. Transaction ID: {}", context.transactionId, e);
+      // ignore since records are recovered lazily
+    }
+  }
+
+  private List<ParallelExecutorTask> toTasks(List<List<Mutation>> groupedMutations) {
+    List<ParallelExecutorTask> tasks = new ArrayList<>(groupedMutations.size());
+    for (List<Mutation> mutations : groupedMutations) {
+      tasks.add(() -> storage.mutate(mutations));
+    }
+    return tasks;
+  }
+
+  /**
+   * Checks whether the transaction is eligible for a one-phase commit. The caller is the
+   * orchestrator: when this returns {@code true}, it follows up with {@link
+   * #onePhaseCommitRecords(TransactionContext)} to perform the actual commit; otherwise it falls
+   * back to the two-phase path.
+   */
+  boolean canOnePhaseCommit(TransactionContext context) throws CommitException {
+    if (!onePhaseCommitEnabled) {
+      return false;
+    }
+
+    // If validation is required, we cannot one-phase commit the transaction
+    if (context.isValidationRequired()) {
+      return false;
+    }
+
+    // If the snapshot has no writes or deletes, we do not one-phase commit the transaction
+    if (!context.snapshot.hasWritesOrDeletes()) {
+      return false;
+    }
+
+    Collection<Map.Entry<Snapshot.Key, Delete>> deleteSetEntries = context.snapshot.getDeleteSet();
+
+    // If a record corresponding to a delete in the delete set does not exist in storage, we
+    // cannot one-phase commit the transaction. This is because the storage does not support
+    // delete-if-not-exists semantics, so we cannot detect conflicts with other transactions.
+    for (Map.Entry<Snapshot.Key, Delete> entry : deleteSetEntries) {
+      Optional<TransactionResult> result = context.snapshot.getFromReadSet(entry.getKey());
+
+      // For deletes, we always perform implicit pre-reads if the result does not exist in the read
+      // set, so the result should normally exist in the read set. If it is absent (null) or empty,
+      // the transaction is not eligible for a one-phase commit.
+      if (result == null || !result.isPresent()) {
+        return false;
+      }
+    }
+
+    try {
+      // If the mutations can be grouped altogether, the mutations can be done in a single mutate
+      // API call, so we can one-phase commit the transaction
+      return mutationsGrouper.canBeGroupedAltogether(
+          Stream.concat(
+                  context.snapshot.getWriteSet().stream().map(Map.Entry::getValue),
+                  deleteSetEntries.stream().map(Map.Entry::getValue))
+              .collect(Collectors.toList()));
+    } catch (ExecutionException e) {
+      throw new CommitException(
+          CoreError.CONSENSUS_COMMIT_COMMITTING_RECORDS_FAILED.buildMessage(e.getMessage()),
+          e,
+          context.transactionId);
+    }
+  }
+
+  /**
+   * Performs the one-phase commit storage mutation. The caller is expected to have just checked
+   * eligibility via {@link #canOnePhaseCommit(TransactionContext)}.
+   */
+  void onePhaseCommitRecords(TransactionContext context)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    try {
+      OnePhaseCommitMutationComposer composer =
+          new OnePhaseCommitMutationComposer(context.transactionId, tableMetadataManager);
+      context.snapshot.to(composer);
+
+      // One-phase commit does not require grouping mutations and using the parallel executor since
+      // it is always executed in a single mutate API call.
+      storage.mutate(composer.get());
+    } catch (NoMutationException e) {
+      throw new CommitConflictException(
+          CoreError.CONSENSUS_COMMIT_PREPARING_RECORD_EXISTS.buildMessage(e.getMessage()),
+          e,
+          context.transactionId);
+    } catch (RetriableExecutionException e) {
+      throw new CommitConflictException(
+          CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_RECORDS.buildMessage(
+              e.getMessage()),
+          e,
+          context.transactionId);
+    } catch (ExecutionException e) {
+      throw new UnknownTransactionStatusException(
+          CoreError.CONSENSUS_COMMIT_ONE_PHASE_COMMITTING_RECORDS_FAILED.buildMessage(
+              e.getMessage()),
+          e,
+          context.transactionId);
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -234,8 +234,13 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
 
     try {
       commit.commitStateWithoutWriteSet(context);
-    } catch (CommitConflictException | UnknownTransactionStatusException e) {
-      // no need to rollback because the transaction has already been rolled back
+    } catch (CommitConflictException e) {
+      commit.rollbackRecords(context);
+      needRollback = false;
+      throw e;
+    } catch (UnknownTransactionStatusException e) {
+      // The coordinator state is unknown, so we must not roll back the records: the transaction may
+      // have committed.
       needRollback = false;
 
       throw e;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -1,78 +1,54 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.StorageInfo;
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.StorageInfoImpl;
-import com.scalar.db.common.StorageInfoProvider;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+/**
+ * Tests for {@link CommitHandler} as an orchestrator: each test pins which {@link
+ * ParticipantCommitHandler} and {@link CoordinatorCommitHandler} methods are called (and which are
+ * skipped) for each branch of {@code commit()}, plus a delegation test per pass-through method.
+ *
+ * <p>The participant and coordinator handlers are mocked (not spied); the participant / coordinator
+ * behavior tests live in {@link ParticipantCommitHandlerTest} and {@link
+ * CoordinatorCommitHandlerTest}. {@link Snapshot} is mocked too -- the orchestrator only reads
+ * {@code hasWritesOrDeletes()} from it for branch control.
+ */
 public class CommitHandlerTest {
-  private static final String ANY_NAMESPACE_NAME = "namespace";
-  private static final String ANY_TABLE_NAME = "table";
-  private static final String ANY_NAME_1 = "name1";
-  private static final String ANY_NAME_2 = "name2";
-  private static final String ANY_NAME_3 = "name3";
-  private static final String ANY_TEXT_1 = "text1";
-  private static final String ANY_TEXT_2 = "text2";
-  private static final String ANY_TEXT_3 = "text3";
-  private static final String ANY_TEXT_4 = "text4";
   private static final String ANY_ID = "id";
-  private static final int ANY_INT_1 = 100;
-  private static final int ANY_INT_2 = 200;
 
-  @Mock protected DistributedStorage storage;
-  @Mock protected Coordinator coordinator;
-  @Mock protected TransactionTableMetadataManager tableMetadataManager;
-  @Mock protected StorageInfoProvider storageInfoProvider;
-  @Mock protected ConsensusCommitConfig config;
+  @Mock protected ParticipantCommitHandler participantCommitHandler;
+  @Mock protected CoordinatorCommitHandler coordinatorCommitHandler;
   @Mock protected BeforePreparationHook beforePreparationHook;
   @Mock protected Future<Void> beforePreparationHookFuture;
 
-  private CommitHandler handler;
-  protected ParallelExecutor parallelExecutor;
-  protected MutationsGrouper mutationsGrouper;
+  protected CommitHandler handler;
 
   protected String anyId() {
     return ANY_ID;
@@ -91,170 +67,65 @@ public class CommitHandlerTest {
 
   protected CommitHandler createCommitHandler(boolean coordinatorWriteOmissionOnReadOnlyEnabled) {
     return new CommitHandler(
-        storage,
-        coordinator,
-        tableMetadataManager,
-        parallelExecutor,
-        new MutationsGrouper(storageInfoProvider),
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        false);
-  }
-
-  protected CommitHandler createCommitHandlerWithOnePhaseCommit() {
-    return new CommitHandler(
-        storage, coordinator, tableMetadataManager, parallelExecutor, mutationsGrouper, true, true);
+        participantCommitHandler,
+        coordinatorCommitHandler);
   }
 
   @BeforeEach
   void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-
-    parallelExecutor = new ParallelExecutor(config);
     handler = spy(createCommitHandler(true));
-    mutationsGrouper = spy(new MutationsGrouper(storageInfoProvider));
-
     extraInitialize();
-
-    // Arrange
-    when(storageInfoProvider.getStorageInfo(ANY_NAMESPACE_NAME))
-        .thenReturn(
-            new StorageInfoImpl(
-                "storage1", StorageInfo.MutationAtomicityUnit.PARTITION, Integer.MAX_VALUE, false));
   }
 
   @AfterEach
   void tearDown() {
     extraCleanup();
-
-    parallelExecutor.close();
   }
 
-  private Put preparePut1() {
-    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
-    return Put.newBuilder()
-        .namespace(ANY_NAMESPACE_NAME)
-        .table(ANY_TABLE_NAME)
-        .partitionKey(partitionKey)
-        .clusteringKey(clusteringKey)
-        .intValue(ANY_NAME_3, ANY_INT_1)
-        .build();
-  }
-
-  private Put preparePut2() {
-    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_3);
-    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_4);
-    return Put.newBuilder()
-        .namespace(ANY_NAMESPACE_NAME)
-        .table(ANY_TABLE_NAME)
-        .partitionKey(partitionKey)
-        .clusteringKey(clusteringKey)
-        .intValue(ANY_NAME_3, ANY_INT_2)
-        .build();
-  }
-
-  private Put preparePut3() {
-    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
-    return Put.newBuilder()
-        .namespace(ANY_NAMESPACE_NAME)
-        .table(ANY_TABLE_NAME)
-        .partitionKey(partitionKey)
-        .clusteringKey(clusteringKey)
-        .intValue(ANY_NAME_3, ANY_INT_2)
-        .build();
-  }
-
-  private Get prepareGet() {
-    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_3);
-    return Get.newBuilder()
-        .namespace(ANY_NAMESPACE_NAME)
-        .table(ANY_TABLE_NAME)
-        .partitionKey(partitionKey)
-        .clusteringKey(clusteringKey)
-        .build();
-  }
-
-  private Delete prepareDelete() {
-    return Delete.newBuilder()
-        .namespace(ANY_NAMESPACE_NAME)
-        .table(ANY_TABLE_NAME)
-        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-        .build();
-  }
-
-  protected Snapshot prepareSnapshotWithDifferentPartitionPut() throws CrudException {
-    Snapshot snapshot = prepareSnapshot();
-
-    // different partition
-    Put put1 = preparePut1();
-    Put put2 = preparePut2();
-    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
-    snapshot.putIntoWriteSet(new Snapshot.Key(put2), put2);
-
-    Get get = prepareGet();
-    snapshot.putIntoGetSet(get, Optional.empty());
-
+  // Builds a mock Snapshot that reports having writes/deletes. The orchestrator only reads
+  // hasWritesOrDeletes() from the snapshot; participant / coordinator handlers are mocked, so the
+  // snapshot's contents are otherwise irrelevant.
+  protected Snapshot snapshotWithWrites() {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.hasWritesOrDeletes()).thenReturn(true);
     return snapshot;
   }
 
-  protected Snapshot prepareSnapshotWithSamePartitionPut() throws CrudException {
-    Snapshot snapshot = prepareSnapshot();
-
-    // same partition
-    Put put1 = preparePut1();
-    Put put3 = preparePut3();
-    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
-    snapshot.putIntoWriteSet(new Snapshot.Key(put3), put3);
-
-    Get get = prepareGet();
-    snapshot.putIntoGetSet(get, Optional.empty());
-
+  // Builds a mock Snapshot that reports no writes/deletes.
+  protected Snapshot snapshotWithoutWrites() {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.hasWritesOrDeletes()).thenReturn(false);
     return snapshot;
-  }
-
-  protected Snapshot prepareSnapshotWithoutWrites() {
-    Snapshot snapshot = prepareSnapshot();
-
-    Get get = prepareGet();
-    snapshot.putIntoGetSet(get, Optional.empty());
-
-    return snapshot;
-  }
-
-  private Snapshot prepareSnapshot() {
-    return new Snapshot(anyId(), tableMetadataManager, new ParallelExecutor(config));
   }
 
   private void setBeforePreparationHookIfNeeded(boolean withBeforePreparationHook) {
     if (withBeforePreparationHook) {
-      doReturn(beforePreparationHookFuture).when(beforePreparationHook).handle(any(), any());
+      doReturn(beforePreparationHookFuture).when(beforePreparationHook).handle(any());
       handler.setBeforePreparationHook(beforePreparationHook);
     }
   }
 
-  // Test helper: encode the WriteSet that production would persist for a single-group transaction
-  // commit/abort whose snapshot is `snapshot`. The WriteSet output depends only on the snapshot
-  // content (not on the transaction id), so wrapping in a fresh TransactionContext is sufficient.
-  private com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet expectedSingleGroupWriteSet(
-      Snapshot snapshot) {
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-    return handler.writeSetEncoder.encodeSingleGroupWriteSet(context, false);
+  private void verifyBeforePreparationHook(
+      boolean withBeforePreparationHook, TransactionContext context) {
+    if (withBeforePreparationHook) {
+      verify(beforePreparationHook).handle(eq(context));
+    } else {
+      verify(beforePreparationHook, never()).handle(any());
+    }
   }
+
+  // =========================================================================
+  // commit() — happy path
+  // =========================================================================
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
-  public void commit_SnapshotWithDifferentPartitionPutsGiven_ShouldCommitRespectively(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
+  public void commit_WithWrites_ShouldDelegatePrepareValidateCommitStateCommitRecordsInOrder(
+      boolean withBeforePreparationHook) throws Exception {
     // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doNothingWhenCoordinatorPutState();
+    Snapshot snapshot = snapshotWithWrites();
     setBeforePreparationHookIfNeeded(withBeforePreparationHook);
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
@@ -263,47 +134,26 @@ public class CommitHandlerTest {
     handler.commit(context);
 
     // Assert
-    verify(storage, times(4)).mutate(anyList());
-    verify(snapshot, never()).toSerializable(storage);
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
+    InOrder inOrder = inOrder(participantCommitHandler, coordinatorCommitHandler);
+    inOrder.verify(participantCommitHandler).prepareRecords(context);
+    inOrder.verify(participantCommitHandler).validateRecords(context);
+    inOrder.verify(coordinatorCommitHandler).commitState(context);
+    inOrder.verify(participantCommitHandler).commitRecords(context);
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+    verify(coordinatorCommitHandler, never()).abortState(any());
     verifyBeforePreparationHook(withBeforePreparationHook, context);
     verify(handler, never()).onFailureBeforeCommit(any());
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void commit_SnapshotWithSamePartitionPutsGiven_ShouldCommitAtOnce(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
+  // =========================================================================
+  // commit() — read-only / no-writes branches
+  // =========================================================================
+
+  @Test
+  public void commit_InReadOnlyMode_ShouldOnlyDelegateValidateRecords() throws Exception {
+    // Read-only path: coordinator-write omission is enabled by default, so commitState is skipped.
     // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithSamePartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doNothingWhenCoordinatorPutState();
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    handler.commit(context);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(snapshot, never()).toSerializable(storage);
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void commit_InReadOnlyMode_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
+    Snapshot snapshot = snapshotWithoutWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
 
@@ -311,23 +161,20 @@ public class CommitHandlerTest {
     handler.commit(context);
 
     // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(snapshot, never()).toSerializable(storage);
-    verify(coordinator, never()).putState(any());
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
+    verify(participantCommitHandler).validateRecords(context);
+    verify(participantCommitHandler, never()).prepareRecords(any());
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(coordinatorCommitHandler, never()).abortState(any());
     verify(handler, never()).onFailureBeforeCommit(any());
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void
-      commit_NoWritesAndDeletesInSnapshot_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-          boolean withBeforePreparationHook)
-          throws CommitException, UnknownTransactionStatusException, ExecutionException,
-              CoordinatorException, ValidationConflictException {
+  @Test
+  public void commit_NoWritesNonReadOnly_OmissionEnabled_ShouldOnlyDelegateValidateRecords()
+      throws Exception {
+    // Non-read-only tx with empty write set + omission enabled: coordinator state row omitted.
     // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
+    Snapshot snapshot = snapshotWithoutWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
@@ -335,24 +182,20 @@ public class CommitHandlerTest {
     handler.commit(context);
 
     // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(snapshot, never()).toSerializable(storage);
-    verify(coordinator, never()).putState(any());
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler, never()).onFailureBeforeCommit(any());
+    verify(participantCommitHandler).validateRecords(context);
+    verify(participantCommitHandler, never()).prepareRecords(any());
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(coordinatorCommitHandler, never()).abortState(any());
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void
-      commit_NoWritesAndDeletesInSnapshot_CoordinatorWriteOmissionOnReadOnlyDisabled_ShouldNotPrepareRecordsAndCommitRecordsButShouldCommitState(
-          boolean withBeforePreparationHook)
-          throws CommitException, UnknownTransactionStatusException, ExecutionException,
-              CoordinatorException, ValidationConflictException {
+  @Test
+  public void commit_NoWritesNonReadOnly_OmissionDisabled_ShouldDelegateValidateAndCommitState()
+      throws Exception {
+    // Non-read-only tx with empty write set + omission disabled: commitState still runs.
     // Arrange
-    handler = spy(createCommitHandler(false));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
+    handler = spy(createCommitHandler(/* coordinatorWriteOmissionOnReadOnlyEnabled= */ false));
+    Snapshot snapshot = snapshotWithoutWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
@@ -360,1407 +203,322 @@ public class CommitHandlerTest {
     handler.commit(context);
 
     // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(snapshot, never()).toSerializable(storage);
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler, never()).onFailureBeforeCommit(any());
+    verify(participantCommitHandler).validateRecords(context);
+    verify(coordinatorCommitHandler).commitState(context);
+    verify(participantCommitHandler, never()).prepareRecords(any());
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(coordinatorCommitHandler, never()).abortState(any());
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void
-      commit_NoWritesAndDeletesInSnapshot_ValidationFailed_ShouldNotPrepareRecordsAndAbortStateAndRollbackRecords(
-          boolean withBeforePreparationHook)
-          throws ExecutionException, CoordinatorException, ValidationConflictException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
-    doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(snapshot).toSerializable(storage);
-    verify(coordinator, never()).putState(any());
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void
-      commit_NoWritesAndDeletesInSnapshot_ValidationFailed_CoordinatorWriteOmissionOnReadOnlyDisabled_ShouldNotPrepareRecordsAndRollbackRecordsButShouldAbortState(
-          boolean withBeforePreparationHook)
-          throws ExecutionException, CoordinatorException, ValidationConflictException {
-    // Arrange
-    handler = spy(createCommitHandler(false));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
-    doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(snapshot).toSerializable(storage);
-    verify(coordinator).putState(any());
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void commit_SnapshotIsolationWithReads_ShouldNotValidateRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doNothingWhenCoordinatorPutState();
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    handler.commit(context);
-
-    // Assert
-    verify(storage, times(4)).mutate(anyList());
-    // With SNAPSHOT isolation, validation should not be performed even if there are reads
-    verify(snapshot, never()).toSerializable(storage);
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void commit_SerializableIsolationWithReads_ShouldValidateRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doNothing().when(snapshot).toSerializable(storage);
-    doNothingWhenCoordinatorPutState();
-    setBeforePreparationHookIfNeeded(withBeforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    handler.commit(context);
-
-    // Assert
-    verify(storage, times(4)).mutate(anyList());
-    // With SERIALIZABLE isolation, validation should be performed when there are reads
-    verify(snapshot).toSerializable(storage);
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verifyBeforePreparationHook(withBeforePreparationHook, context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
+  // =========================================================================
+  // commit() — prepareRecords failure
+  // =========================================================================
 
   @Test
-  public void validateRecords_ValidationNotRequired_ShouldNotCallToSerializable()
-      throws ValidationException, ExecutionException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    // With SNAPSHOT isolation, validation is not required
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    handler.validateRecords(context);
-
-    // Assert
-    verify(snapshot, never()).toSerializable(storage);
-  }
-
-  @Test
-  public void validateRecords_ValidationRequired_ShouldCallToSerializable()
-      throws ValidationException, ExecutionException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(snapshot).toSerializable(storage);
-    // With SERIALIZABLE isolation, validation is required when there are reads
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    handler.validateRecords(context);
-
-    // Assert
-    verify(snapshot).toSerializable(storage);
-  }
-
-  @Test
-  public void commit_NoMutationExceptionThrownInPrepareRecords_ShouldThrowCCException()
-      throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(NoMutationException.class).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void commit_RetriableExecutionExceptionThrownInPrepareRecords_ShouldThrowCCException()
-      throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(RetriableExecutionException.class).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void commit_ExceptionThrownInPrepareRecords_ShouldAbortAndRollbackRecords()
-      throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenAbortedReturnedInGetState_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(),
-                    expectedSingleGroupWriteSet(snapshot),
-                    TransactionState.ABORTED,
-                    System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
-      throws CoordinatorException, UnknownTransactionStatusException {
-    // Arrange
-    doNothing().when(coordinator).forceAbort(anyId());
-
-    // Act
-    TransactionState result = handler.abortStateForRollback(anyId());
-
-    // Assert
-    // The abort delegates to Coordinator#forceAbort rather than a plain
-    // putState. That method branches on the ID: it writes the parent-ID conflict marker before the
-    // full-ID record for a group commit full key (so the abort wins against an in-flight group
-    // commit), and falls back to a single putState for a non-group-commit ID. Which branch runs
-    // here depends on anyId(): a non-group-commit ID in this base class, a group commit full key in
-    // the group commit subclass that overrides anyId().
-    assertThat(result).isEqualTo(TransactionState.ABORTED);
-    verify(coordinator).forceAbort(anyId());
-    verify(coordinator, never()).putState(any());
-  }
-
-  @Test
-  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
-      throws CoordinatorException, UnknownTransactionStatusException {
-    // Arrange
-    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-
-    // Act
-    TransactionState result = handler.abortStateForRollback(anyId());
-
-    // Assert
-    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
-    assertThat(result).isEqualTo(TransactionState.COMMITTED);
-    verify(coordinator).getState(anyId());
-  }
-
-  @Test
-  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
-      throws CoordinatorException {
-    // The conflicting state row is absent on re-read, which is reachable once the Coordinator state
-    // cleanup process removes a finished row. The outcome cannot be recovered, so an honest
-    // UnknownTransactionStatusException is thrown, preserving the original conflict as the cause.
-
-    // Arrange
-    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
-    doReturn(Optional.empty()).when(coordinator).getState(anyId());
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
-        .isInstanceOf(UnknownTransactionStatusException.class)
-        .hasCauseInstanceOf(CoordinatorConflictException.class);
-    verify(coordinator).getState(anyId());
-  }
-
-  @Test
-  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
-      throws CoordinatorException {
-    // Arrange
-    doThrow(CoordinatorException.class).when(coordinator).forceAbort(anyId());
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-  }
-
-  @Test
-  public void
-      abortStateWithoutWriteSet_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
-          throws CoordinatorException, UnknownTransactionStatusException {
-    // Arrange
-    doThrow(CoordinatorConflictException.class).when(coordinator).putState(any());
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-
-    // Act
-    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
-
-    // Assert
-    // A concurrent writer committed first, so the persisted COMMITTED state is followed.
-    assertThat(result).isEqualTo(TransactionState.COMMITTED);
-    verify(coordinator).getState(anyId());
-  }
-
-  @Test
-  public void abortStateWithoutWriteSet_WhenConflictAndNoStatePersisted_ShouldReturnAborted()
-      throws CoordinatorException, UnknownTransactionStatusException {
-    // Unlike abortStateForRollback (the One-phase Commit I/F abort-by-id path), this method is used
-    // by the self-abort path and all Two-phase Commit I/F aborts, which cannot be racing a real,
-    // deletable COMMITTED row. A conflicting-then-absent coordinator state is therefore
-    // determinable as ABORTED (the conflict was a lazy-recovery ABORTED later removed by the
-    // Coordinator state cleanup process), not an honest UNKNOWN.
-
-    // Arrange
-    doThrow(CoordinatorConflictException.class).when(coordinator).putState(any());
-    doReturn(Optional.empty()).when(coordinator).getState(anyId());
-
-    // Act
-    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
-
-    // Assert
-    assertThat(result).isEqualTo(TransactionState.ABORTED);
-    verify(coordinator).getState(anyId());
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitException()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    doReturn(Optional.empty()).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-
-    // The self-abort path provably never committed, so a conflicting-then-absent coordinator state
-    // resolves to ABORTED rather than UNKNOWN. The commit then surfaces the original preparation
-    // failure (a CommitException) instead of masking it with an UnknownTransactionStatusException.
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(CommitException.class)
-        .isNotInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndCoordinatorExceptionThrownInCoordinatorAbort_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    doThrow(CoordinatorException.class)
-        .when(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void commit_ValidationConflictExceptionThrownInValidation_ShouldAbortAndRollbackRecords()
-      throws ExecutionException, CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void commit_ExceptionThrownInValidation_ShouldAbortAndRollbackRecords()
-      throws ExecutionException, CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInValidationAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenAbortedReturnedInGetState_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException, ValidationConflictException,
-              CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    WriteSet writeSet = expectedSingleGroupWriteSet(snapshot);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(), writeSet, TransactionState.ABORTED, System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInValidationAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitException()
-          throws ExecutionException, CoordinatorException, ValidationConflictException,
-              CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    WriteSet writeSet = expectedSingleGroupWriteSet(snapshot);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    doReturn(Optional.empty()).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-
-    // The self-abort path provably never committed, so a conflicting-then-absent coordinator state
-    // resolves to ABORTED rather than UNKNOWN. The commit then surfaces the original validation
-    // failure (a CommitException) instead of masking it with an UnknownTransactionStatusException.
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(CommitException.class)
-        .isNotInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInValidationAndCoordinatorConflictExceptionThrownInCoordinatorAbortThenExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException, ValidationConflictException,
-              CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    WriteSet writeSet = expectedSingleGroupWriteSet(snapshot);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
-    verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInValidationAndCoordinatorExceptionThrownInCoordinatorAbort_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException, ValidationConflictException,
-              CrudException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
-    WriteSet writeSet = expectedSingleGroupWriteSet(snapshot);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
-    doThrow(CoordinatorException.class)
-        .when(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-
-    // An exception is thrown before group commit even when it's enabled. So, the normal
-    // `putState(ABORT)` must be called.
-    verify(coordinator)
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenCommittedReturnedInGetState_ShouldBeIgnored()
-          throws ExecutionException, CoordinatorException, CommitException,
-              UnknownTransactionStatusException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorConflictException.class, snapshot);
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(),
-                    expectedSingleGroupWriteSet(snapshot),
-                    TransactionState.COMMITTED,
-                    System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    handler.commit(context);
-
-    // Assert
-    verify(storage, times(4)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenAbortedReturnedInGetState_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorConflictException.class, snapshot);
-    doReturn(
-            Optional.of(
-                new Coordinator.State(
-                    anyId(),
-                    expectedSingleGroupWriteSet(snapshot),
-                    TransactionState.ABORTED,
-                    System.currentTimeMillis())))
-        .when(coordinator)
-        .getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenNothingReturnedInGetState_ShouldRollbackRecordsAndThrowCommitConflict()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Writing the COMMITTED state conflicts, and the conflicting row is absent on re-read. The only
-    // concurrent writer of this transaction's state is a lazy recovery, which only ever writes
-    // ABORTED, so the conflicting row was an ABORTED state that the Coordinator state cleanup
-    // process then removed. The transaction is therefore aborted, so the records are rolled back
-    // and a conflict is reported -- the same outcome as when the ABORTED state is still present.
-
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorConflictException.class, snapshot);
-    doReturn(Optional.empty()).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCauseInstanceOf(CoordinatorConflictException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(coordinator).getState(anyId());
-    verify(handler).rollbackRecords(context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_CoordinatorConflictExceptionThrownInCoordinatorCommitAndThenExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorConflictException.class, snapshot);
-    doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(coordinator).getState(anyId());
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void commit_ExceptionThrownInCoordinatorCommit_ShouldThrowUnknown()
-      throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorException.class, snapshot);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(handler, never()).rollbackRecords(context);
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_BeforePreparationHookGiven_ShouldWaitBeforePreparationHookFinishesBeforeCommitState()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrowExceptionWhenCoordinatorPutState(
-        TransactionState.COMMITTED, CoordinatorException.class, snapshot);
-    // Lambda can't be spied...
-    BeforePreparationHook delayedBeforePreparationHook =
-        spy(
-            new BeforePreparationHook() {
-              @Override
-              public Future<Void> handle(
-                  TransactionTableMetadataManager tableMetadataManager,
-                  TransactionContext context) {
-                Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(2));
-                return beforePreparationHookFuture;
-              }
-            });
-    handler.setBeforePreparationHook(delayedBeforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    Instant start = Instant.now();
-    assertThatThrownBy(() -> handler.commit(context))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-    Instant end = Instant.now();
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(handler, never()).rollbackRecords(context);
-    verify(delayedBeforePreparationHook).handle(tableMetadataManager, context);
-    // This means `commit()` waited until the callback was completed before throwing
-    // an exception from `commitState()`.
-    assertThat(Duration.between(start, end)).isGreaterThanOrEqualTo(Duration.ofSeconds(2));
-    verify(handler, never()).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void commit_FailingBeforePreparationHookGiven_ShouldThrowCommitException()
-      throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doThrow(new RuntimeException("Something is wrong"))
-        .when(beforePreparationHook)
-        .handle(any(), any());
-    handler.setBeforePreparationHook(beforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void commit_FailingBeforePreparationHookFutureGiven_ShouldThrowCommitException()
-      throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
-          InterruptedException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
-    setBeforePreparationHookIfNeeded(true);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(coordinator, never())
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
-    verify(handler).rollbackRecords(context);
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException,
-              UnknownTransactionStatusException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong"))
-        .when(beforePreparationHook)
-        .handle(any(), any());
-    handler.setBeforePreparationHook(beforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    // With coordinator write omission enabled, a read-only transaction must not write any
-    // coordinator row even when the before-preparation hook fails.
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
-              InterruptedException, UnknownTransactionStatusException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
-    setBeforePreparationHookIfNeeded(true);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException {
-    // Arrange
-    handler = spy(createCommitHandler(false));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong"))
-        .when(beforePreparationHook)
-        .handle(any(), any());
-    handler.setBeforePreparationHook(beforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    // With coordinator write omission disabled, the ABORTED state is written even for a read-only
-    // transaction, but record rollback is still skipped since there are no writes.
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
-          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
-              InterruptedException, UnknownTransactionStatusException {
-    // Arrange
-    handler = spy(createCommitHandler(false));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
-    setBeforePreparationHookIfNeeded(true);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    // With coordinator write omission disabled, the ABORTED state is written even for a read-only
-    // transaction, but record rollback is still skipped since there are no writes.
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookGiven_InNonReadOnlyModeWithoutWritesAndWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws ExecutionException, CoordinatorException, UnknownTransactionStatusException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong"))
-        .when(beforePreparationHook)
-        .handle(any(), any());
-    handler.setBeforePreparationHook(beforePreparationHook);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    // A non-read-only transaction without writes and deletes writes no coordinator row when
-    // coordinator write omission is enabled, so the before-preparation hook failure must not abort
-    // the state. There are also no records to roll back.
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(any());
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookFutureGiven_InNonReadOnlyModeWithoutWritesAndWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws CoordinatorException, java.util.concurrent.ExecutionException,
-              InterruptedException, UnknownTransactionStatusException {
-    // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
-    setBeforePreparationHookIfNeeded(true);
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    // Same as above for the before-preparation hook future failure path.
-    verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(context);
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() throws Exception {
-    // Arrange
-    Snapshot snapshot = prepareSnapshot();
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    assertThat(actual).isFalse();
-    verify(mutationsGrouper, never()).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenSerializableIsolationWithReads_ShouldReturnFalse()
+  public void commit_PrepareThrowsConflict_ShouldDelegateAbortAndRollbackAndThrowConflict()
       throws Exception {
     // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new PreparationConflictException("conflict", anyId()))
+        .when(participantCommitHandler)
+        .prepareRecords(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    TransactionResult result = mock(TransactionResult.class);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.of(result));
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
 
-    // Add a read that is not in the write set or delete set to trigger validation
-    Get get = prepareGet();
-    snapshot.putIntoGetSet(get, Optional.empty());
+    InOrder inOrder = inOrder(participantCommitHandler, coordinatorCommitHandler);
+    inOrder.verify(participantCommitHandler).prepareRecords(context);
+    inOrder.verify(coordinatorCommitHandler).abortState(context);
+    inOrder.verify(participantCommitHandler).rollbackRecords(context);
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
 
+  @Test
+  public void commit_PrepareThrowsGenericPreparationException_ShouldDelegateAbortAndRollback()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new PreparationException("prep failed", anyId()))
+        .when(participantCommitHandler)
+        .prepareRecords(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context))
+        .isInstanceOf(CommitException.class)
+        .isNotInstanceOf(CommitConflictException.class);
+
+    verify(participantCommitHandler).prepareRecords(context);
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  // =========================================================================
+  // commit() — validateRecords failure
+  // =========================================================================
+
+  @Test
+  public void commit_ValidateThrowsConflict_WithWrites_ShouldDelegateAbortAndRollback()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new ValidationConflictException("conflict", anyId()))
+        .when(participantCommitHandler)
+        .validateRecords(any());
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
 
-    // Assert
-    // With SERIALIZABLE isolation and reads that require validation, one-phase commit is not
-    // allowed
-    assertThat(actual).isFalse();
-    verify(mutationsGrouper, never()).canBeGroupedAltogether(anyList());
+    verify(participantCommitHandler).validateRecords(context);
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
   }
 
   @Test
-  public void canOnePhaseCommit_WhenSnapshotIsolationWithReads_ShouldReturnTrue() throws Exception {
-    // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
-
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    TransactionResult result = mock(TransactionResult.class);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.of(result));
-
-    // Add a read that is not in the write set or delete set
-    Get get = prepareGet();
-    snapshot.putIntoGetSet(get, Optional.empty());
-
-    doReturn(true).when(mutationsGrouper).canBeGroupedAltogether(anyList());
-
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    // With SNAPSHOT isolation, validation is not required, so one-phase commit is allowed
-    assertThat(actual).isTrue();
-    verify(mutationsGrouper).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse() throws Exception {
-    // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshotWithoutWrites();
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    assertThat(actual).isFalse();
-    verify(mutationsGrouper, never()).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse()
+  public void commit_ValidateThrowsGenericException_WithWrites_ShouldDelegateAbortAndRollback()
       throws Exception {
     // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
-
-    // Setup a delete with no corresponding record in read set
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.empty());
-
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new ValidationException("validate failed", anyId()))
+        .when(participantCommitHandler)
+        .validateRecords(any());
     TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    assertThat(actual).isFalse();
-    verify(mutationsGrouper, never()).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue() throws Exception {
-    // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
-
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    TransactionResult result = mock(TransactionResult.class);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.of(result));
-
-    doReturn(true).when(mutationsGrouper).canBeGroupedAltogether(anyList());
-
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    assertThat(actual).isTrue();
-    verify(mutationsGrouper).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse() throws Exception {
-    // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
-
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    TransactionResult result = mock(TransactionResult.class);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.of(result));
-
-    doReturn(false).when(mutationsGrouper).canBeGroupedAltogether(anyList());
-
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act
-    boolean actual = handler.canOnePhaseCommit(context);
-
-    // Assert
-    assertThat(actual).isFalse();
-    verify(mutationsGrouper).canBeGroupedAltogether(anyList());
-  }
-
-  @Test
-  public void
-      canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException()
-          throws ExecutionException {
-    // Arrange
-    CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
-    Snapshot snapshot = prepareSnapshot();
-
-    Delete delete = prepareDelete();
-    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
-    TransactionResult result = mock(TransactionResult.class);
-    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.of(result));
-
-    doThrow(ExecutionException.class).when(mutationsGrouper).canBeGroupedAltogether(anyList());
-
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.canOnePhaseCommit(context))
+    assertThatThrownBy(() -> handler.commit(context))
         .isInstanceOf(CommitException.class)
-        .hasCauseInstanceOf(ExecutionException.class);
+        .isNotInstanceOf(CommitConflictException.class);
+
+    verify(participantCommitHandler).validateRecords(context);
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
   }
 
   @Test
-  public void onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations()
-      throws CommitConflictException, UnknownTransactionStatusException, ExecutionException,
-          CrudException {
+  public void commit_ValidateThrows_NoWrites_OmissionEnabled_ShouldNotDelegateAbortNorRollback()
+      throws Exception {
+    // abortStateAndRollbackRecordsIfNeeded skips both: !hasWrites + omission.
     // Arrange
-    Snapshot snapshot = spy(prepareSnapshotWithSamePartitionPut());
-    doNothing().when(storage).mutate(anyList());
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new ValidationConflictException("conflict", anyId()))
+        .when(participantCommitHandler)
+        .validateRecords(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
+
+    verify(coordinatorCommitHandler, never()).abortState(any());
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
+  public void commit_ValidateThrows_NoWrites_OmissionDisabled_ShouldDelegateAbortStateOnly()
+      throws Exception {
+    // abortStateAndRollbackRecordsIfNeeded: !hasWrites + !omission → abortState yes, rollback no.
+    // Arrange
+    handler = spy(createCommitHandler(/* coordinatorWriteOmissionOnReadOnlyEnabled= */ false));
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new ValidationConflictException("conflict", anyId()))
+        .when(participantCommitHandler)
+        .validateRecords(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
+
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+  }
+
+  // =========================================================================
+  // commit() — commitState failure
+  // =========================================================================
+
+  @Test
+  public void commit_CommitStateThrowsUnknown_ShouldNotDelegateRollback() throws Exception {
+    // The orchestrator does not roll back when commitState throws -- conflict handling lives
+    // inside CoordinatorCommitHandler (which may itself roll back via the cross-handler call).
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new UnknownTransactionStatusException("unknown", anyId()))
+        .when(coordinatorCommitHandler)
+        .commitState(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+
+    verify(participantCommitHandler).prepareRecords(context);
+    verify(participantCommitHandler).validateRecords(context);
+    verify(coordinatorCommitHandler).commitState(context);
+    verify(participantCommitHandler, never()).commitRecords(any());
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+    verify(handler, never()).onFailureBeforeCommit(any());
+  }
+
+  // =========================================================================
+  // commit() — beforePreparationHook
+  // =========================================================================
+
+  @Test
+  public void commit_BeforePreparationHookFails_WithWrites_ShouldDelegateAbortAndRollback()
+      throws Exception {
+    // Hook throws synchronously → orchestrator runs the abort+rollback cleanup for write txs.
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(participantCommitHandler, never()).prepareRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
+  public void commit_BeforePreparationHookFutureFails_WithWrites_ShouldDelegateAbortAndRollback()
+      throws Exception {
+    // Hook returns a future that fails → orchestrator runs the abort+rollback cleanup after
+    // prepare/validate already succeeded.
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHookFuture).get();
+    setBeforePreparationHookIfNeeded(true);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(participantCommitHandler).prepareRecords(context);
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
+  public void
+      commit_BeforePreparationHookFails_ReadOnly_OmissionEnabled_ShouldNotDelegateAbortNorRollback()
+          throws Exception {
+    // Read-only + omission enabled: no coordinator row written even when the hook fails.
+    // Arrange
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(coordinatorCommitHandler, never()).abortState(any());
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+    verify(handler).onFailureBeforeCommit(context);
+  }
+
+  @Test
+  public void
+      commit_BeforePreparationHookFails_ReadOnly_OmissionDisabled_ShouldDelegateAbortStateOnly()
+          throws Exception {
+    // Read-only + omission disabled: ABORTED state still written even though there are no writes.
+    // Arrange
+    handler = spy(createCommitHandler(/* coordinatorWriteOmissionOnReadOnlyEnabled= */ false));
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(coordinatorCommitHandler).abortState(context);
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+  }
+
+  @Test
+  public void
+      commit_BeforePreparationHookFails_NonReadOnlyNoWrites_OmissionEnabled_ShouldNotDelegateAbortNorRollback()
+          throws Exception {
+    // Non-read-only tx without writes/deletes + omission enabled: no coordinator row written.
+    // Arrange
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(coordinatorCommitHandler, never()).abortState(any());
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+  }
+
+  @Test
+  public void commit_BeforePreparationHookGiven_ShouldWaitFutureBeforeCommitState()
+      throws Exception {
+    // The orchestrator must wait on the hook future before invoking commitState.
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doReturn(beforePreparationHookFuture).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
-    handler.onePhaseCommitRecords(context);
+    handler.commit(context);
 
-    // Assert
-    verify(storage).mutate(anyList());
-    verify(snapshot).to(any(OnePhaseCommitMutationComposer.class));
+    // Assert: the orchestrator must wait on the hook future (Future#get) before committing the
+    // state.
+    InOrder inOrder =
+        inOrder(beforePreparationHook, beforePreparationHookFuture, coordinatorCommitHandler);
+    inOrder.verify(beforePreparationHook).handle(context);
+    inOrder.verify(beforePreparationHookFuture).get();
+    inOrder.verify(coordinatorCommitHandler).commitState(context);
   }
 
-  @Test
-  public void
-      onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException()
-          throws ExecutionException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-    doThrow(NoMutationException.class).when(storage).mutate(anyList());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCauseInstanceOf(NoMutationException.class);
-  }
+  // =========================================================================
+  // commit() — one-phase commit
+  // =========================================================================
 
   @Test
-  public void
-      onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException()
-          throws ExecutionException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-    doThrow(RetriableExecutionException.class).when(storage).mutate(anyList());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCauseInstanceOf(RetriableExecutionException.class);
-  }
-
-  @Test
-  public void
-      onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException()
-          throws ExecutionException, CrudException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-    doThrow(ExecutionException.class).when(storage).mutate(anyList());
-    TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
-        .isInstanceOf(UnknownTransactionStatusException.class)
-        .hasCauseInstanceOf(ExecutionException.class);
-  }
-
-  @Test
-  public void commit_OnePhaseCommitted_ShouldNotThrowAnyException()
-      throws CommitException, UnknownTransactionStatusException, CrudException {
-    // Arrange
-    CommitHandler handler = spy(createCommitHandlerWithOnePhaseCommit());
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-
+  public void commit_OnePhaseCommitted_ShouldShortCircuitAndNotRunTwoPhaseFlow()
+      throws CommitException, UnknownTransactionStatusException, CrudException,
+          PreparationException {
+    // Arrange — stub canOnePhaseCommit on the spied handler so we exercise the short-circuit.
+    Snapshot snapshot = snapshotWithWrites();
     doReturn(true).when(handler).canOnePhaseCommit(any(TransactionContext.class));
-    doNothing().when(handler).onePhaseCommitRecords(any(TransactionContext.class));
-
+    // Set a hook to confirm the one-phase fast path does not invoke it. (In production the hook and
+    // the one-phase optimization are mutually exclusive by configuration, but pin the behavior.)
+    doReturn(beforePreparationHookFuture).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
     TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
@@ -1768,23 +526,22 @@ public class CommitHandlerTest {
     // Assert
     verify(handler).canOnePhaseCommit(context);
     verify(handler).onePhaseCommitRecords(context);
+    verify(participantCommitHandler, never()).prepareRecords(any());
+    verify(coordinatorCommitHandler, never()).commitState(any());
+    verify(beforePreparationHook, never()).handle(any());
   }
 
   @Test
-  public void
-      commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException()
-          throws CommitException, UnknownTransactionStatusException, CrudException {
+  public void commit_OnePhaseCommitted_ThrowsUnknown_ShouldDelegateOnFailureBeforeCommit()
+      throws CommitException, UnknownTransactionStatusException, CrudException {
     // Arrange
-    CommitHandler handler = spy(createCommitHandlerWithOnePhaseCommit());
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-
+    Snapshot snapshot = snapshotWithWrites();
     doReturn(true).when(handler).canOnePhaseCommit(any(TransactionContext.class));
     doThrow(UnknownTransactionStatusException.class)
         .when(handler)
         .onePhaseCommitRecords(any(TransactionContext.class));
-
     TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.commit(context))
@@ -1793,48 +550,120 @@ public class CommitHandlerTest {
     verify(handler).onFailureBeforeCommit(context);
   }
 
-  protected void doThrowExceptionWhenCoordinatorPutState(
-      TransactionState targetState, Class<? extends Exception> exceptionClass, Snapshot snapshot)
-      throws CoordinatorException {
-    doThrow(exceptionClass)
-        .when(coordinator)
-        .putState(
-            argThat(stateMatcher(anyId(), expectedSingleGroupWriteSet(snapshot), targetState)));
+  // =========================================================================
+  // Pass-through delegation tests
+  // =========================================================================
+
+  @Test
+  public void prepareRecords_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.prepareRecords(context);
+
+    verify(participantCommitHandler).prepareRecords(context);
   }
 
-  protected void doNothingWhenCoordinatorPutState() throws CoordinatorException {
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+  @Test
+  public void validateRecords_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.validateRecords(context);
+
+    verify(participantCommitHandler).validateRecords(context);
   }
 
-  protected void verifyCoordinatorPutState(
-      TransactionState expectedTransactionState, Snapshot snapshot) throws CoordinatorException {
-    verify(coordinator)
-        .putState(
-            argThat(
-                stateMatcher(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), expectedTransactionState)));
+  @Test
+  public void commitRecords_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.commitRecords(context);
+
+    verify(participantCommitHandler).commitRecords(context);
   }
 
-  /**
-   * Mockito matcher that compares Coordinator.State by id, writeSet, and state -- ignoring
-   * createdAt. Useful when the production code stamps a real-time timestamp the test cannot
-   * reproduce exactly.
-   */
-  private static org.mockito.ArgumentMatcher<Coordinator.State> stateMatcher(
-      String id, WriteSet writeSet, TransactionState state) {
-    return actual ->
-        actual != null
-            && java.util.Objects.equals(actual.getId(), id)
-            && actual.getWriteSet().equals(java.util.Optional.ofNullable(writeSet))
-            && actual.getState() == state;
+  @Test
+  public void rollbackRecords_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.rollbackRecords(context);
+
+    verify(participantCommitHandler).rollbackRecords(context);
   }
 
-  private void verifyBeforePreparationHook(
-      boolean withBeforePreparationHook, TransactionContext context) {
-    if (withBeforePreparationHook) {
-      verify(beforePreparationHook).handle(eq(tableMetadataManager), eq(context));
-    } else {
-      verify(beforePreparationHook, never()).handle(any(), any());
-    }
+  @Test
+  public void canOnePhaseCommit_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.canOnePhaseCommit(context);
+
+    verify(participantCommitHandler).canOnePhaseCommit(context);
+  }
+
+  @Test
+  public void onePhaseCommitRecords_ShouldDelegateToParticipantHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.onePhaseCommitRecords(context);
+
+    verify(participantCommitHandler).onePhaseCommitRecords(context);
+  }
+
+  @Test
+  public void commitState_ShouldDelegateToCoordinatorHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.commitState(context);
+
+    verify(coordinatorCommitHandler).commitState(context);
+  }
+
+  @Test
+  public void commitStateWithoutWriteSet_ShouldDelegateToCoordinatorHandler() throws Exception {
+    Snapshot snapshot = snapshotWithoutWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.commitStateWithoutWriteSet(context);
+
+    verify(coordinatorCommitHandler).commitStateWithoutWriteSet(context);
+  }
+
+  @Test
+  public void abortState_ShouldDelegateToCoordinatorHandler() throws Exception {
+    Snapshot snapshot = snapshotWithWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    handler.abortState(context);
+
+    verify(coordinatorCommitHandler).abortState(context);
+  }
+
+  @Test
+  public void abortStateWithoutWriteSet_ShouldDelegateToCoordinatorHandler() throws Exception {
+    handler.abortStateWithoutWriteSet(anyId());
+
+    verify(coordinatorCommitHandler).abortStateWithoutWriteSet(anyId());
+  }
+
+  @Test
+  public void forceAbortState_ShouldDelegateToCoordinatorHandler() throws Exception {
+    handler.forceAbortState(anyId());
+
+    verify(coordinatorCommitHandler).forceAbortState(anyId());
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -68,8 +68,8 @@ public class CommitHandlerTest {
   protected CommitHandler createCommitHandler(boolean coordinatorWriteOmissionOnReadOnlyEnabled) {
     return new CommitHandler(
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        participantCommitHandler,
-        coordinatorCommitHandler);
+        coordinatorCommitHandler,
+        participantCommitHandler);
   }
 
   @BeforeEach
@@ -304,6 +304,29 @@ public class CommitHandlerTest {
     verify(participantCommitHandler).validateRecords(context);
     verify(coordinatorCommitHandler).abortState(context);
     verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  public void commit_CommitStateThrowsConflict_WithWrites_ShouldRollbackRecordsAndThrowConflict()
+      throws Exception {
+    // The Coordinator-side handler only reports the commit-state putState conflict; the
+    // orchestrator
+    // owns the records, so it rolls them back here before surfacing the conflict.
+
+    // Arrange
+    Snapshot snapshot = snapshotWithWrites();
+    doThrow(new CommitConflictException("conflict", anyId()))
+        .when(coordinatorCommitHandler)
+        .commitState(any());
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitConflictException.class);
+
+    verify(coordinatorCommitHandler).commitState(context);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(participantCommitHandler, never()).commitRecords(any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -1,834 +1,236 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.exception.transaction.ValidationConflictException;
-import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
-import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
-import com.scalar.db.util.groupcommit.GroupCommitConfig;
-import com.scalar.db.util.groupcommit.GroupCommitConflictException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.mockito.InOrder;
 
+/**
+ * Tests for {@link CommitHandlerWithGroupCommit}. Inherits the orchestration tests from {@link
+ * CommitHandlerTest} (which pin which participant / coordinator handler methods are called for each
+ * branch of {@code commit()}). The tests added here layer the group-commit-specific assertions on
+ * top -- specifically, when the orchestrator delegates {@code cancelGroupCommitIfNeeded} to the
+ * group-commit coordinator handler.
+ *
+ * <p>Both {@code participantCommitHandler} and the group-commit coordinator handler are mocks; the
+ * underlying group committer is never instantiated.
+ */
 class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
-  private final CoordinatorGroupCommitKeyManipulator keyManipulator =
-      new CoordinatorGroupCommitKeyManipulator();
-  private String parentKey;
-  private String childKey;
-  private CoordinatorGroupCommitter groupCommitter;
-  @Captor private ArgumentCaptor<List<String>> groupCommitFullIdsArgumentCaptor;
-
-  @Override
-  protected void extraInitialize() {
-    childKey = UUID.randomUUID().toString();
-    String fullKey = groupCommitter.reserve(childKey);
-    parentKey = keyManipulator.keysFromFullKey(fullKey).parentKey;
-  }
-
-  @Override
-  protected String anyId() {
-    return keyManipulator.fullKey(parentKey, childKey);
-  }
+  // Subclass-typed mock that doubles as the parent's coordinatorCommitHandler. Verifying
+  // cancelGroupCommitIfNeeded requires the subclass type.
+  private CoordinatorCommitHandlerWithGroupCommit groupCommitCoordinatorHandler;
 
   @Override
   protected TransactionContext createTransactionContext(
       String id, Snapshot snapshot, Isolation isolation, boolean readOnly, boolean oneOperation) {
-    // In the group commit tests a slot is reserved for the transaction (extraInitialize() and the
-    // per-test reserve() calls), so mark the context as holding a reserved slot. Tests that
-    // intentionally model an unreserved transaction build the context with the raw constructor.
+    // In the group commit tests a slot is reserved for the transaction (the orchestrator's
+    // group-commit-specific paths inspect this flag), so mark the context accordingly.
     return new TransactionContext(
         id, snapshot, isolation, readOnly, oneOperation, /* groupCommitSlotReserved= */ true);
   }
 
   @Override
-  protected void extraCleanup() {
-    groupCommitter.close();
-  }
-
-  private void createGroupCommitterIfNotExists() {
-    if (groupCommitter == null) {
-      groupCommitter =
-          spy(new CoordinatorGroupCommitter(new GroupCommitConfig(4, 100, 500, 60000, 10)));
-    }
-  }
-
-  @Override
   protected CommitHandler createCommitHandler(boolean coordinatorWriteOmissionOnReadOnlyEnabled) {
-    createGroupCommitterIfNotExists();
+    groupCommitCoordinatorHandler = mock(CoordinatorCommitHandlerWithGroupCommit.class);
+    coordinatorCommitHandler = groupCommitCoordinatorHandler;
     return new CommitHandlerWithGroupCommit(
-        storage,
-        coordinator,
-        tableMetadataManager,
-        parallelExecutor,
-        new MutationsGrouper(storageInfoProvider),
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        false,
-        groupCommitter);
+        participantCommitHandler,
+        groupCommitCoordinatorHandler);
   }
 
-  @Override
-  protected CommitHandler createCommitHandlerWithOnePhaseCommit() {
-    createGroupCommitterIfNotExists();
-    return new CommitHandlerWithGroupCommit(
-        storage,
-        coordinator,
-        tableMetadataManager,
-        parallelExecutor,
-        mutationsGrouper,
-        true,
-        true,
-        groupCommitter);
-  }
-
-  private String anyGroupCommitParentId() {
-    return parentKey;
-  }
-
-  @Override
-  protected void doThrowExceptionWhenCoordinatorPutState(
-      TransactionState targetState, Class<? extends Exception> exceptionClass, Snapshot snapshot)
-      throws CoordinatorException {
-
-    doThrow(exceptionClass)
-        .when(coordinator)
-        .putState(argThat(groupCommitStateMatcher(anyGroupCommitParentId(), targetState)));
-  }
-
-  @Override
-  protected void doNothingWhenCoordinatorPutState() throws CoordinatorException {
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-  }
-
-  @Override
-  protected void verifyCoordinatorPutState(
-      TransactionState expectedTransactionState, Snapshot snapshot) throws CoordinatorException {
-
-    org.mockito.ArgumentCaptor<Coordinator.State> captor =
-        org.mockito.ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinator).putState(captor.capture());
-    Coordinator.State captured = captor.getValue();
-    assertThat(captured.getId()).isEqualTo(anyGroupCommitParentId());
-    assertThat(captured.getState()).isEqualTo(expectedTransactionState);
-    List<String> childIds = captured.getChildIds();
-    assertThat(childIds.size()).isEqualTo(1);
-    // The State's child IDs are the *child* portion of each full transaction id; verify the
-    // captured value matches the child of anyId().
-    assertThat(childIds.get(0))
-        .isEqualTo(
-            new CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator()
-                .keysFromFullKey(anyId())
-                .childKey);
-  }
-
-  /**
-   * Matcher for the group-commit parent-row State emitted by Emitter#emitNormalGroup: the id equals
-   * the parent key, childIds are non-empty (one entry per tx), and the txState matches.
-   */
-  private static org.mockito.ArgumentMatcher<Coordinator.State> groupCommitStateMatcher(
-      String parentId, TransactionState state) {
-    return actual ->
-        actual != null
-            && parentId.equals(actual.getId())
-            && !actual.getChildIds().isEmpty()
-            && actual.getState() == state;
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void commit_SnapshotWithDifferentPartitionPutsGiven_ShouldCommitRespectively(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    super.commit_SnapshotWithDifferentPartitionPutsGiven_ShouldCommitRespectively(
-        withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void commit_SnapshotWithSamePartitionPutsGiven_ShouldCommitAtOnce(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    super.commit_SnapshotWithSamePartitionPutsGiven_ShouldCommitAtOnce(withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void commit_InReadOnlyMode_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    // Arrange
-    groupCommitter.remove(anyId());
-    clearInvocations(groupCommitter);
-
-    super.commit_InReadOnlyMode_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-        withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void
-      commit_NoWritesAndDeletesInSnapshot_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-          boolean withBeforePreparationHook)
-          throws CommitException, UnknownTransactionStatusException, ExecutionException,
-              CoordinatorException, ValidationConflictException {
-
-    super.commit_NoWritesAndDeletesInSnapshot_ShouldNotPrepareRecordsAndCommitStateAndCommitRecords(
-        withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void
-      commit_NoWritesAndDeletesInSnapshot_CoordinatorWriteOmissionOnReadOnlyDisabled_ShouldNotPrepareRecordsAndCommitRecordsButShouldCommitState(
-          boolean withBeforePreparationHook)
-          throws CommitException, UnknownTransactionStatusException, ExecutionException,
-              CoordinatorException, ValidationConflictException {
-    super
-        .commit_NoWritesAndDeletesInSnapshot_CoordinatorWriteOmissionOnReadOnlyDisabled_ShouldNotPrepareRecordsAndCommitRecordsButShouldCommitState(
-            withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
+  // =========================================================================
+  // Group-commit-specific assertions
+  //
+  // Inherited tests cover which participant / coordinator handler methods are called for each
+  // branch of commit(); the tests below add slot-cancel assertions specific to the override.
+  // =========================================================================
 
   @Test
-  public void commit_InReadOnlyModeWithWriteOmissionDisabled_ShouldCommitStateViaGroupCommit()
-      throws CommitException, UnknownTransactionStatusException, CoordinatorException,
-          ExecutionException {
+  public void commit_WithWrites_ShouldNotEarlyCancelGroupCommit() throws Exception {
+    // For a normal (writes) commit the slot is consumed by commitState via groupCommitter.ready,
+    // so the orchestrator's early-cancel optimization does NOT fire.
     // Arrange
-    // With coordinator write omission disabled, a read-only transaction writes a coordinator state
-    // row. ConsensusCommitManager.begin() reserves a group commit slot for it (so its transaction
-    // ID is a group commit full key), and the state must be committed through the group commit path
-    // like any other state-writing transaction.
-    CommitHandler handler = spy(createCommitHandler(false));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doNothingWhenCoordinatorPutState();
+    Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
-        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
     // Act
     handler.commit(context);
 
     // Assert
-    verify(storage, never()).mutate(anyList());
-    // The COMMITTED state is written via the group commit path (putStateForGroupCommit).
-    verifyCoordinatorPutState(TransactionState.COMMITTED, snapshot);
-    verify(groupCommitter, never()).remove(anyId());
+    verify(groupCommitCoordinatorHandler, never()).cancelGroupCommitIfNeeded(context);
   }
 
   @Test
-  @Override
-  public void
-      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException,
-              UnknownTransactionStatusException {
-    super
-        .commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords();
-
-    // Assert
-    // abortState is skipped (omission enabled), but the reserved group commit slot is still
-    // released once via onFailureBeforeCommit, so it does not leak.
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords()
-          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
-              InterruptedException, UnknownTransactionStatusException {
-    super
-        .commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionEnabled_ShouldNotAbortStateNorRollbackRecords();
-
-    // Assert
-    // abortState is skipped (omission enabled), but the reserved group commit slot is still
-    // released once via onFailureBeforeCommit, so it does not leak.
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  public void
-      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionEnabledAndBareTransactionId_ShouldNotWriteCoordinatorRowNorTouchGroupCommitter()
-          throws ExecutionException, CoordinatorException, UnknownTransactionStatusException {
+  public void commit_NonReadOnlyNoWritesOmissionEnabled_ShouldEarlyCancelGroupCommit()
+      throws Exception {
+    // The reserved slot is NOT consumed by the commit (commitState is skipped because of write
+    // omission), so cancelGroupCommitIfCoordinatorStateOmitted delegates the cancel eagerly.
     // Arrange
-    // With coordinator write omission enabled, ConsensusCommitManager.begin() does not reserve a
-    // group commit slot for a read-only transaction, so the context's groupCommitSlotReserved stays
-    // false. This reproduces that production case (the inherited tests use
-    // createTransactionContext()
-    // which marks the slot as reserved instead). When the before-preparation hook fails, commit()
-    // must still fail with CommitException, write no coordinator row, and leave the group committer
-    // untouched: cancelGroupCommitIfNeeded skips remove() because no slot was reserved.
-    // Release the slot reserved by extraInitialize(); it is unrelated to this test's bare
-    // transaction ID, and leaving it outstanding would make groupCommitter.close() block on it
-    // during teardown. clearInvocations() then lets the remove() assertion count only the act
-    // phase.
-    groupCommitter.remove(anyId());
-    clearInvocations(groupCommitter);
-    String bareId = UUID.randomUUID().toString();
-    CommitHandler handler = spy(createCommitHandler(true));
-    Snapshot snapshot = spy(prepareSnapshotWithoutWrites());
-    doThrow(new RuntimeException("Something is wrong"))
-        .when(beforePreparationHook)
-        .handle(any(), any());
-    handler.setBeforePreparationHook(beforePreparationHook);
-    // This context deliberately did not reserve a group commit slot (groupCommitSlotReserved stays
-    // false), so it is built with the raw constructor rather than the createTransactionContext()
-    // helper that marks the slot as reserved.
-    TransactionContext context =
-        new TransactionContext(
-            bareId,
-            snapshot,
-            Isolation.SNAPSHOT,
-            true,
-            false,
-            /* groupCommitSlotReserved= */ false);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(storage, never()).mutate(anyList());
-    verify(coordinator, never()).putState(any());
-    verify(handler, never()).abortState(any());
-    verify(handler, never()).rollbackRecords(any());
-    verify(handler).onFailureBeforeCommit(any());
-    // The bare ID never reserved a slot, so cancelGroupCommitIfNeeded skips remove() entirely.
-    verify(groupCommitter, never()).remove(anyString());
-  }
-
-  @Test
-  public void
-      handleCommitConflict_GroupCommitConflictExceptionGivenAndNoStatePersisted_ShouldRollbackRecordsAndThrowCommitConflict()
-          throws Exception {
-    // The group-commit conflict route (commitStateViaGroupCommit catches
-    // GroupCommitConflictException and calls handleCommitConflict) must, when the coordinator state
-    // is absent on re-read, resolve to a definitive conflict -- roll the records back and throw
-    // CommitConflictException -- the same outcome as the normal-commit conflict route. getState for
-    // a group-commit child checks both the parent and full-ID rows, so an absent state genuinely
-    // means the transaction never committed.
-
-    // Arrange
-    // This test resolves the conflict by calling handleCommitConflict directly and never emits or
-    // removes the group, so release the slot reserved by extraInitialize() up front. Leaving it
-    // outstanding would make groupCommitter.close() block on it during teardown.
-    groupCommitter.remove(anyId());
-    clearInvocations(groupCommitter);
-
-    CommitHandler handler = spy(createCommitHandler(true));
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    Snapshot snapshot = snapshotWithoutWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-    doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
-    when(coordinator.getState(anyId())).thenReturn(Optional.empty());
-    GroupCommitConflictException cause = new GroupCommitConflictException("conflict");
+
+    // Act
+    handler.commit(context);
+
+    // Assert
+    verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
+  }
+
+  @Test
+  public void commit_NonReadOnlyNoWritesOmissionDisabled_ShouldNotEarlyCancelGroupCommit()
+      throws Exception {
+    // With omission disabled, commitState still runs and needs the slot, so the early-cancel must
+    // not fire.
+    // Arrange
+    handler = spy(createCommitHandler(/* coordinatorWriteOmissionOnReadOnlyEnabled= */ false));
+    Snapshot snapshot = snapshotWithoutWrites();
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    handler.commit(context);
+
+    // Assert
+    verify(groupCommitCoordinatorHandler, never()).cancelGroupCommitIfNeeded(context);
+  }
+
+  @Test
+  public void commit_OnFailure_ShouldDelegateCancelGroupCommitViaOnFailureBeforeCommit()
+      throws Exception {
+    // The orchestrator's onFailureBeforeCommit override delegates to
+    // coordinatorHandler.cancelGroupCommitIfNeeded.
+    // Arrange
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    TransactionContext context =
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, true, false);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCause(cause);
-    verify(handler).rollbackRecords(context);
-    verify(coordinator).getState(anyId());
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
+
+    verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
   }
 
   @Test
-  @Override
   public void
-      commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
-          throws ExecutionException, CoordinatorException, CrudException {
-    super
-        .commit_FailingBeforePreparationHookGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords();
-
-    // Assert
-    // The reserved group commit slot is released twice — once via onFailureBeforeCommit and once
-    // via abortState (omission disabled) — both routing through cancelGroupCommitIfNeeded.
-    verify(groupCommitter, times(2)).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords()
-          throws ExecutionException, CoordinatorException, java.util.concurrent.ExecutionException,
-              InterruptedException, UnknownTransactionStatusException {
-    super
-        .commit_FailingBeforePreparationHookFutureGiven_InReadOnlyModeWithWriteOmissionDisabled_ShouldAbortStateButNotRollbackRecords();
-
-    // Assert
-    // The reserved group commit slot is released twice — once via onFailureBeforeCommit and once
-    // via abortState (omission disabled) — both routing through cancelGroupCommitIfNeeded.
-    verify(groupCommitter, times(2)).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void commit_SnapshotIsolationWithReads_ShouldNotValidateRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    super.commit_SnapshotIsolationWithReads_ShouldNotValidateRecords(withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  @Override
-  public void commit_SerializableIsolationWithReads_ShouldValidateRecords(
-      boolean withBeforePreparationHook)
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException, ValidationConflictException, CrudException {
-    super.commit_SerializableIsolationWithReads_ShouldValidateRecords(withBeforePreparationHook);
-
-    // Assert
-    verify(groupCommitter, never()).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void validateRecords_ValidationNotRequired_ShouldNotCallToSerializable()
-      throws ValidationException, ExecutionException, CrudException {
-    super.validateRecords_ValidationNotRequired_ShouldNotCallToSerializable();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void validateRecords_ValidationRequired_ShouldCallToSerializable()
-      throws ValidationException, ExecutionException, CrudException {
-    super.validateRecords_ValidationRequired_ShouldCallToSerializable();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations()
-      throws CommitConflictException, UnknownTransactionStatusException, ExecutionException,
-          CrudException {
-    super.onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations();
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException()
-          throws ExecutionException, CrudException {
-    super.onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException();
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException()
-          throws ExecutionException, CrudException {
-    super
-        .onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException();
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException()
-          throws ExecutionException, CrudException {
-    super
-        .onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException();
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() throws Exception {
-    super.canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse() throws Exception {
-    super.canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse()
-      throws Exception {
-    super.canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue() throws Exception {
-    super.canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse() throws Exception {
-    super.canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenSerializableIsolationWithReads_ShouldReturnFalse()
-      throws Exception {
-    super.canOnePhaseCommit_WhenSerializableIsolationWithReads_ShouldReturnFalse();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void canOnePhaseCommit_WhenSnapshotIsolationWithReads_ShouldReturnTrue() throws Exception {
-    super.canOnePhaseCommit_WhenSnapshotIsolationWithReads_ShouldReturnTrue();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException()
-          throws ExecutionException {
-    super
-        .canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException();
-
-    // Assert
-    verify(groupCommitter).remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void commit_OnePhaseCommitted_ShouldNotThrowAnyException()
-      throws CommitException, UnknownTransactionStatusException, CrudException {
-    super.commit_OnePhaseCommitted_ShouldNotThrowAnyException();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void
-      commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException()
-          throws CommitException, UnknownTransactionStatusException, CrudException {
-    super
-        .commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
-      throws CoordinatorException, UnknownTransactionStatusException {
-    super.abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted();
-
-    // abortStateForRollback(id) only writes the coordinator rollback marker; it never goes through
-    // the group commit path, so the slot reserved by extraInitialize() is not released. Release it
-    // here so the @AfterEach groupCommitter.close() does not block on the slot-abort timeout.
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
-      throws CoordinatorException, UnknownTransactionStatusException {
-    super.abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
-      throws CoordinatorException {
-    super.abortStateForRollback_WhenConflictAndNoStatePersisted_ShouldThrowUnknown();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  @Override
-  public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
-      throws CoordinatorException {
-    super.abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown();
-    groupCommitter.remove(anyId());
-  }
-
-  @Test
-  void emitter_emitNormalGroup_WithMultipleWritingChildren_ShouldAggregatePerChild()
-      throws Exception {
-    // The slot reserved by extraInitialize is unused here — these emitter tests bypass the group
-    // committer and drive the Emitter directly — so release it now to keep the @AfterEach
-    // groupCommitter.close() from waiting out the slot-abort timeout.
-    groupCommitter.remove(anyId());
-
+      commit_FailingBeforePreparationHookGiven_BareTransactionId_ShouldNotTouchGroupCommitter()
+          throws Exception {
+    // With coordinator write omission enabled, ConsensusCommitManager.begin() does not reserve a
+    // group commit slot for a read-only transaction, so the context's groupCommitSlotReserved
+    // stays false. When the before-preparation hook fails, commit() must still fail with
+    // CommitException, and cancelGroupCommitIfNeeded internally skips remove() because no slot
+    // was reserved.
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-    String fullTxId1 = keyManipulator.fullKey(parentId, "child-1");
-    String fullTxId2 = keyManipulator.fullKey(parentId, "child-2");
-
-    TransactionContext context1 =
-        createTransactionContext(
-            fullTxId1,
-            prepareSnapshotWithDifferentPartitionPut(),
+    Snapshot snapshot = snapshotWithoutWrites();
+    doThrow(new RuntimeException("Something is wrong")).when(beforePreparationHook).handle(any());
+    handler.setBeforePreparationHook(beforePreparationHook);
+    // Override createTransactionContext's default reserved=true with reserved=false here.
+    TransactionContext context =
+        new TransactionContext(
+            anyId(),
+            snapshot,
             Isolation.SNAPSHOT,
-            false,
-            false);
-    TransactionContext context2 =
-        createTransactionContext(
-            fullTxId2, prepareSnapshotWithSamePartitionPut(), Isolation.SNAPSHOT, false, false);
+            /* readOnly= */ true,
+            /* oneOperation= */ false,
+            /* groupCommitSlotReserved= */ false);
 
-    // Act
-    emitter.emitNormalGroup(parentId, Arrays.asList(context1, context2));
+    // Act Assert
+    assertThatThrownBy(() -> handler.commit(context)).isInstanceOf(CommitException.class);
 
-    // Assert — capture the State and inspect its WriteSet content.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinatorMock).putState(stateCaptor.capture());
-
-    Coordinator.State capturedState = stateCaptor.getValue();
-    assertThat(capturedState.getId()).isEqualTo(parentId);
-    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(capturedState.getWriteSet()).isPresent();
-    WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).hasSize(2);
-    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("child-1");
-    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
-    assertThat(captured.getEntryGroups(1).getChildId()).isEqualTo("child-2");
-    assertThat(captured.getEntryGroups(1).getEntriesList()).isNotEmpty();
+    // The orchestrator still calls cancelGroupCommitIfNeeded; the coordinator handler internally
+    // no-ops when slot is not reserved. The contract we pin here is "called once", with the
+    // internal no-op behavior covered in CoordinatorCommitHandlerWithGroupCommitTest.
+    verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
   }
 
-  @Test
-  void emitter_emitNormalGroup_WithReadOnlyChildMixed_ShouldOmitReadOnlyEntryGroups()
-      throws Exception {
-    groupCommitter.remove(anyId());
-
-    // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-    String fullTxIdWriting = keyManipulator.fullKey(parentId, "writing");
-    String fullTxIdReadOnly = keyManipulator.fullKey(parentId, "read-only");
-
-    TransactionContext writingContext =
-        createTransactionContext(
-            fullTxIdWriting,
-            prepareSnapshotWithDifferentPartitionPut(),
-            Isolation.SNAPSHOT,
-            false,
-            false);
-    TransactionContext readOnlyContext =
-        createTransactionContext(
-            fullTxIdReadOnly, prepareSnapshotWithoutWrites(), Isolation.SNAPSHOT, false, false);
-
-    // Act
-    emitter.emitNormalGroup(parentId, Arrays.asList(writingContext, readOnlyContext));
-
-    // Assert — only the writing child appears in entry_groups.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinatorMock).putState(stateCaptor.capture());
-    Coordinator.State capturedState = stateCaptor.getValue();
-    assertThat(capturedState.getId()).isEqualTo(parentId);
-    assertThat(capturedState.getWriteSet()).isPresent();
-
-    WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getEntryGroupsList()).hasSize(1);
-    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("writing");
-  }
+  // =========================================================================
+  // Override-specific behaviour for canOnePhaseCommit / onePhaseCommitRecords
+  // =========================================================================
 
   @Test
-  void emitter_emitNormalGroup_WithAllReadOnlyChildren_ShouldStillSetSchemaVersion()
-      throws Exception {
-    groupCommitter.remove(anyId());
-
+  public void onePhaseCommitRecords_ShouldCancelSlotBeforeDelegating() throws Exception {
+    // The group-commit override releases the reserved slot before delegating to
+    // super.onePhaseCommitRecords, so the storage mutation runs outside the group buffer.
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
-        createTransactionContext(
-            fullTxId, prepareSnapshotWithoutWrites(), Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+    doNothing().when(participantCommitHandler).onePhaseCommitRecords(context);
 
     // Act
-    emitter.emitNormalGroup(parentId, Collections.singletonList(context));
+    handler.onePhaseCommitRecords(context);
 
-    // Assert — WriteSet is still non-null with schema_version set, but has no EntryGroups.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinatorMock).putState(stateCaptor.capture());
-    Coordinator.State capturedState = stateCaptor.getValue();
-    assertThat(capturedState.getId()).isEqualTo(parentId);
-    assertThat(capturedState.getWriteSet()).isPresent();
-
-    WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).isEmpty();
+    // Assert
+    InOrder inOrder = inOrder(groupCommitCoordinatorHandler, participantCommitHandler);
+    inOrder.verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
+    inOrder.verify(participantCommitHandler).onePhaseCommitRecords(context);
   }
 
   @Test
-  void emitter_emitNormalGroup_WithEmptyContexts_ShouldNotCallPutState() throws Exception {
-    groupCommitter.remove(anyId());
-
+  public void onePhaseCommitRecords_ShouldCancelSlotEvenWhenDelegateThrows() throws Exception {
+    // The slot is released before delegating, so the storage mutation throwing afterwards still
+    // leaves the slot released (cancel-before-delegate is unconditional).
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-
-    // Act — all buffered transactions were manually rolled back, so emitNormalGroup is invoked
-    // with an empty context list.
-    emitter.emitNormalGroup(parentId, Collections.emptyList());
-
-    // Assert — putState must not be called; otherwise a spurious COMMITTED parent row would be
-    // written.
-    verify(coordinatorMock, never()).putState(any(Coordinator.State.class));
-  }
-
-  @Test
-  void emitter_emitDelayedGroup_WithWritingContext_ShouldPersistStateWithWriteSet()
-      throws Exception {
-    groupCommitter.remove(anyId());
-
-    // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
-        createTransactionContext(
-            fullTxId, prepareSnapshotWithDifferentPartitionPut(), Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+    UnknownTransactionStatusException cause =
+        new UnknownTransactionStatusException("storage failure", anyId());
+    doThrow(cause).when(participantCommitHandler).onePhaseCommitRecords(context);
 
-    // Act
-    emitter.emitDelayedGroup(fullTxId, context);
+    // Act Assert
+    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context)).isSameAs(cause);
 
-    // Assert — putState is called with a State carrying the encoded WriteSet.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinatorMock).putState(stateCaptor.capture());
-
-    Coordinator.State capturedState = stateCaptor.getValue();
-    assertThat(capturedState.getId()).isEqualTo(fullTxId);
-    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(capturedState.getWriteSet()).isPresent();
-
-    WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).hasSize(1);
-    // Delayed group commit emits a single EntryGroup with child_id unset, distinguishing it from
-    // a normal group commit row where each EntryGroup carries the child id.
-    assertThat(captured.getEntryGroups(0).hasChildId()).isFalse();
-    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
+    verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
   }
 
   @Test
-  void emitter_emitDelayedGroup_WithReadOnlyContext_ShouldPersistStateWithEmptyWriteSet()
-      throws Exception {
-    groupCommitter.remove(anyId());
-
+  public void canOnePhaseCommit_WhenSuperThrows_ShouldCancelSlotAndRethrow() throws Exception {
+    // The group-commit override of canOnePhaseCommit cancels the slot on any CommitException from
+    // super (e.g., MutationsGrouper throws ExecutionException → wrapped as CommitException) so the
+    // slot does not stay reserved when one-phase commit will not be attempted.
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
-    CommitHandlerWithGroupCommit.Emitter emitter =
-        new CommitHandlerWithGroupCommit.Emitter(
-            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
-
-    String parentId = keyManipulator.generateParentKey();
-    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
-        createTransactionContext(
-            fullTxId, prepareSnapshotWithoutWrites(), Isolation.SNAPSHOT, false, false);
+        createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+    CommitException cause = new CommitException("grouper failure", anyId());
+    doThrow(cause).when(participantCommitHandler).canOnePhaseCommit(context);
 
-    // Act
-    emitter.emitDelayedGroup(fullTxId, context);
+    // Act Assert
+    assertThatThrownBy(() -> handler.canOnePhaseCommit(context)).isSameAs(cause);
 
-    // Assert — WriteSet is still non-null with schema_version set, but has no EntryGroups.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
-    verify(coordinatorMock).putState(stateCaptor.capture());
+    verify(groupCommitCoordinatorHandler).cancelGroupCommitIfNeeded(context);
+  }
 
-    Coordinator.State capturedState = stateCaptor.getValue();
-    assertThat(capturedState.getId()).isEqualTo(fullTxId);
-    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(capturedState.getWriteSet()).isPresent();
+  // We replace the snapshot mock builders to also wire up the participant's hasWritesOrDeletes
+  // view, since the orchestrator hits the snapshot through context only (already covered by the
+  // parent mock helpers).
+  @Override
+  protected Snapshot snapshotWithWrites() {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.hasWritesOrDeletes()).thenReturn(true);
+    return snapshot;
+  }
 
-    WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).isEmpty();
+  @Override
+  protected Snapshot snapshotWithoutWrites() {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.hasWritesOrDeletes()).thenReturn(false);
+    return snapshot;
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -46,8 +46,8 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     coordinatorCommitHandler = groupCommitCoordinatorHandler;
     return new CommitHandlerWithGroupCommit(
         coordinatorWriteOmissionOnReadOnlyEnabled,
-        participantCommitHandler,
-        groupCommitCoordinatorHandler);
+        groupCommitCoordinatorHandler,
+        participantCommitHandler);
   }
 
   // =========================================================================

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -698,7 +698,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
+    when(commit.forceAbortState(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -712,7 +712,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
+    when(commit.forceAbortState(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -725,8 +725,7 @@ public class ConsensusCommitManagerTest {
   public void rollback_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortStateForRollback(ANY_TX_ID))
-        .thenThrow(UnknownTransactionStatusException.class);
+    when(commit.forceAbortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.rollback(ANY_TX_ID);
@@ -739,7 +738,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerReturnsAborted_ShouldReturnTheState() throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.ABORTED;
-    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
+    when(commit.forceAbortState(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -753,7 +752,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(commit.abortStateForRollback(ANY_TX_ID)).thenReturn(expected);
+    when(commit.forceAbortState(ANY_TX_ID)).thenReturn(expected);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);
@@ -766,8 +765,7 @@ public class ConsensusCommitManagerTest {
   public void abort_CommitHandlerThrowsUnknownTransactionStatusException_ShouldReturnUnknown()
       throws TransactionException {
     // Arrange
-    when(commit.abortStateForRollback(ANY_TX_ID))
-        .thenThrow(UnknownTransactionStatusException.class);
+    when(commit.forceAbortState(ANY_TX_ID)).thenThrow(UnknownTransactionStatusException.class);
 
     // Act
     TransactionState actual = manager.abort(ANY_TX_ID);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
@@ -1,0 +1,505 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.Put;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Direct unit tests for {@link CoordinatorCommitHandler}. */
+class CoordinatorCommitHandlerTest {
+  private static final String ANY_NAMESPACE_NAME = "namespace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_ID = "id";
+  private static final int ANY_INT_1 = 100;
+
+  @Mock private Coordinator coordinator;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+  @Mock private ParticipantCommitHandler participantCommitHandler;
+  @Mock private ConsensusCommitConfig config;
+
+  private ParallelExecutor parallelExecutor;
+  private CoordinatorCommitHandler handler;
+
+  private String anyId() {
+    return ANY_ID;
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    parallelExecutor = new ParallelExecutor(config);
+    handler = createHandler();
+  }
+
+  @AfterEach
+  void tearDown() {
+    parallelExecutor.close();
+  }
+
+  private CoordinatorCommitHandler createHandler() {
+    return new CoordinatorCommitHandler(
+        coordinator, new WriteSetEncoder(tableMetadataManager), participantCommitHandler);
+  }
+
+  private Put preparePut1() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .build();
+  }
+
+  private Snapshot prepareSnapshotWithWrite() throws CrudException {
+    Snapshot snapshot = new Snapshot(anyId(), tableMetadataManager, new ParallelExecutor(config));
+    Put put1 = preparePut1();
+    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
+    return snapshot;
+  }
+
+  private TransactionContext createTransactionContext(Snapshot snapshot) {
+    return new TransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
+  }
+
+  // Helper: encode the WriteSet that would be persisted for the given snapshot/context.
+  private WriteSet expectedSingleGroupWriteSet(Snapshot snapshot) {
+    TransactionContext context = createTransactionContext(snapshot);
+    return new WriteSetEncoder(tableMetadataManager).encodeSingleGroupWriteSet(context, false);
+  }
+
+  // Mockito matcher that compares Coordinator.State by id + writeSet + state (ignores createdAt).
+  private static ArgumentMatcher<Coordinator.State> stateMatcher(
+      String id, WriteSet writeSet, TransactionState state) {
+    return actual ->
+        actual != null
+            && Objects.equals(actual.getId(), id)
+            && actual.getWriteSet().equals(Optional.ofNullable(writeSet))
+            && actual.getState() == state;
+  }
+
+  // ---------- commitState ----------
+
+  @Test
+  void commitState_WhenSuccessful_ShouldPutCommittedState()
+      throws CommitConflictException, UnknownTransactionStatusException, CoordinatorException,
+          CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    handler.commitState(context);
+
+    // Assert
+    verify(coordinator)
+        .putState(
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
+  }
+
+  @Test
+  void
+      commitState_WhenCoordinatorConflictAndAbortedReturnedInGetState_ShouldRollbackRecordsAndThrowConflict()
+          throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.ABORTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(CommitConflictException.class);
+
+    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  void commitState_WhenCoordinatorConflictAndCommittedReturnedInGetState_ShouldReturnNormally()
+      throws Exception {
+    // Two-phase Commit can drive the same commit twice (multiple participants / recovery), so the
+    // COMMITTED case is reachable and treated as success.
+
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act (must not throw)
+    handler.commitState(context);
+
+    // Assert
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+  }
+
+  @Test
+  void
+      commitState_WhenCoordinatorConflictAndNoStatePersisted_ShouldRollbackRecordsAndThrowConflict()
+          throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(CommitConflictException.class);
+
+    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  void commitState_WhenCoordinatorExceptionThrown_ShouldThrowUnknown() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorException.class).when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  // ---------- commitStateWithoutWriteSet ----------
+
+  @Test
+  void commitStateWithoutWriteSet_WhenSuccessful_ShouldPutCommittedStateWithoutWriteSet()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    handler.commitStateWithoutWriteSet(context);
+
+    // Assert — writeSet absent (null in matcher).
+    verify(coordinator).putState(argThat(stateMatcher(anyId(), null, TransactionState.COMMITTED)));
+  }
+
+  // ---------- abortState ----------
+
+  @Test
+  void abortState_WhenSuccessful_ShouldPutAbortedStateAndReturnAborted() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    TransactionState result = handler.abortState(context);
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator)
+        .putState(
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
+  }
+
+  @Test
+  void abortState_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(any(Coordinator.State.class));
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortState(context);
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+  }
+
+  @Test
+  void abortState_WhenConflictAndNoStatePersisted_ShouldReturnAborted() throws Exception {
+    // Unlike forceAbortState (the One-phase Commit I/F abort-by-id path), abortState is used by the
+    // self-abort path and all Two-phase Commit I/F aborts, which cannot be racing a real, deletable
+    // COMMITTED row. A conflicting-then-absent coordinator state is therefore determinable as
+    // ABORTED (the conflict was a lazy-recovery ABORTED later removed by the Coordinator state
+    // cleanup process), not an honest UNKNOWN.
+
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(any(Coordinator.State.class));
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortState(context);
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  void abortState_WhenCoordinatorExceptionThrown_ShouldThrowUnknown() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorException.class).when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.abortState(context))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  // ---------- abortStateWithoutWriteSet ----------
+
+  @Test
+  void abortStateWithoutWriteSet_WhenSuccessful_ShouldPutAbortedStateWithoutWriteSet()
+      throws Exception {
+    // Arrange
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).putState(argThat(stateMatcher(anyId(), null, TransactionState.ABORTED)));
+  }
+
+  @Test
+  void abortStateWithoutWriteSet_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws Exception {
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(any(Coordinator.State.class));
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  void abortStateWithoutWriteSet_WhenConflictAndNoStatePersisted_ShouldReturnAborted()
+      throws Exception {
+    // Like abortState, this path cannot be racing a deletable COMMITTED row, so a
+    // conflicting-then-absent coordinator state resolves to ABORTED, not UNKNOWN.
+
+    // Arrange
+    doThrow(CoordinatorConflictException.class)
+        .when(coordinator)
+        .putState(any(Coordinator.State.class));
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act
+    TransactionState result = handler.abortStateWithoutWriteSet(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  // ---------- forceAbortState ----------
+
+  @Test
+  void forceAbortState_ShouldForceAbortAndReturnAborted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doNothing().when(coordinator).forceAbort(anyId());
+
+    // Act
+    TransactionState result = handler.forceAbortState(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(coordinator).forceAbort(anyId());
+    verify(coordinator, never()).putState(any());
+  }
+
+  @Test
+  void forceAbortState_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
+      throws CoordinatorException, UnknownTransactionStatusException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act
+    TransactionState result = handler.forceAbortState(anyId());
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.COMMITTED);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  void forceAbortState_WhenConflictAndNoStatePersisted_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.forceAbortState(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class)
+        .hasCauseInstanceOf(CoordinatorConflictException.class);
+    verify(coordinator).getState(anyId());
+  }
+
+  @Test
+  void forceAbortState_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
+      throws CoordinatorException {
+    // Arrange
+    doThrow(CoordinatorException.class).when(coordinator).forceAbort(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.forceAbortState(anyId()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  // ---------- handleCommitConflict ----------
+
+  @Test
+  void handleCommitConflict_WhenAbortedStatePersisted_ShouldRollbackRecordsAndThrowConflict()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.ABORTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+    Exception cause = new RuntimeException("conflict");
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCause(cause);
+    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  void handleCommitConflict_WhenCommittedStatePersisted_ShouldReturnNormally() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
+        .when(coordinator)
+        .getState(anyId());
+
+    // Act (must not throw)
+    handler.handleCommitConflict(context, new RuntimeException("conflict"));
+
+    // Assert
+    verify(participantCommitHandler, never()).rollbackRecords(any());
+  }
+
+  @Test
+  void handleCommitConflict_WhenNoStatePersisted_ShouldRollbackRecordsAndThrowConflict()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doReturn(Optional.empty()).when(coordinator).getState(anyId());
+    Exception cause = new RuntimeException("conflict");
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCause(cause);
+    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  void handleCommitConflict_WhenGetStateThrowsCoordinatorException_ShouldThrowUnknown()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite();
+    TransactionContext context = createTransactionContext(snapshot);
+    doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.handleCommitConflict(context, new RuntimeException()))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
@@ -40,7 +40,6 @@ class CoordinatorCommitHandlerTest {
 
   @Mock private Coordinator coordinator;
   @Mock private TransactionTableMetadataManager tableMetadataManager;
-  @Mock private ParticipantCommitHandler participantCommitHandler;
   @Mock private ConsensusCommitConfig config;
 
   private ParallelExecutor parallelExecutor;
@@ -63,8 +62,7 @@ class CoordinatorCommitHandlerTest {
   }
 
   private CoordinatorCommitHandler createHandler() {
-    return new CoordinatorCommitHandler(
-        coordinator, new WriteSetEncoder(tableMetadataManager), participantCommitHandler);
+    return new CoordinatorCommitHandler(coordinator, new WriteSetEncoder(tableMetadataManager));
   }
 
   private Put preparePut1() {
@@ -127,9 +125,11 @@ class CoordinatorCommitHandlerTest {
   }
 
   @Test
-  void
-      commitState_WhenCoordinatorConflictAndAbortedReturnedInGetState_ShouldRollbackRecordsAndThrowConflict()
-          throws Exception {
+  void commitState_WhenCoordinatorConflictAndAbortedReturnedInGetState_ShouldThrowConflict()
+      throws Exception {
+    // Record rollback is the orchestrator's responsibility (see CommitHandlerTest); here we only
+    // assert that the conflict is surfaced.
+
     // Arrange
     Snapshot snapshot = prepareSnapshotWithWrite();
     TransactionContext context = createTransactionContext(snapshot);
@@ -149,8 +149,6 @@ class CoordinatorCommitHandlerTest {
     // Act Assert
     assertThatThrownBy(() -> handler.commitState(context))
         .isInstanceOf(CommitConflictException.class);
-
-    verify(participantCommitHandler).rollbackRecords(context);
   }
 
   @Test
@@ -175,17 +173,16 @@ class CoordinatorCommitHandlerTest {
         .when(coordinator)
         .getState(anyId());
 
-    // Act (must not throw)
+    // Act Assert (must not throw — the transaction is already committed)
     handler.commitState(context);
-
-    // Assert
-    verify(participantCommitHandler, never()).rollbackRecords(any());
   }
 
   @Test
-  void
-      commitState_WhenCoordinatorConflictAndNoStatePersisted_ShouldRollbackRecordsAndThrowConflict()
-          throws Exception {
+  void commitState_WhenCoordinatorConflictAndNoStatePersisted_ShouldThrowConflict()
+      throws Exception {
+    // Record rollback is the orchestrator's responsibility (see CommitHandlerTest); here we only
+    // assert that the conflict is surfaced.
+
     // Arrange
     Snapshot snapshot = prepareSnapshotWithWrite();
     TransactionContext context = createTransactionContext(snapshot);
@@ -200,8 +197,6 @@ class CoordinatorCommitHandlerTest {
     // Act Assert
     assertThatThrownBy(() -> handler.commitState(context))
         .isInstanceOf(CommitConflictException.class);
-
-    verify(participantCommitHandler).rollbackRecords(context);
   }
 
   @Test
@@ -435,8 +430,10 @@ class CoordinatorCommitHandlerTest {
   // ---------- handleCommitConflict ----------
 
   @Test
-  void handleCommitConflict_WhenAbortedStatePersisted_ShouldRollbackRecordsAndThrowConflict()
-      throws Exception {
+  void handleCommitConflict_WhenAbortedStatePersisted_ShouldThrowConflict() throws Exception {
+    // Record rollback is the orchestrator's responsibility (see CommitHandlerTest); here we only
+    // assert that the conflict is surfaced.
+
     // Arrange
     Snapshot snapshot = prepareSnapshotWithWrite();
     TransactionContext context = createTransactionContext(snapshot);
@@ -452,7 +449,6 @@ class CoordinatorCommitHandlerTest {
     assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
         .isInstanceOf(CommitConflictException.class)
         .hasCause(cause);
-    verify(participantCommitHandler).rollbackRecords(context);
   }
 
   @Test
@@ -467,16 +463,15 @@ class CoordinatorCommitHandlerTest {
         .when(coordinator)
         .getState(anyId());
 
-    // Act (must not throw)
+    // Act Assert (must not throw)
     handler.handleCommitConflict(context, new RuntimeException("conflict"));
-
-    // Assert
-    verify(participantCommitHandler, never()).rollbackRecords(any());
   }
 
   @Test
-  void handleCommitConflict_WhenNoStatePersisted_ShouldRollbackRecordsAndThrowConflict()
-      throws Exception {
+  void handleCommitConflict_WhenNoStatePersisted_ShouldThrowConflict() throws Exception {
+    // Record rollback is the orchestrator's responsibility (see CommitHandlerTest); here we only
+    // assert that the conflict is surfaced.
+
     // Arrange
     Snapshot snapshot = prepareSnapshotWithWrite();
     TransactionContext context = createTransactionContext(snapshot);
@@ -487,7 +482,6 @@ class CoordinatorCommitHandlerTest {
     assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
         .isInstanceOf(CommitConflictException.class)
         .hasCause(cause);
-    verify(participantCommitHandler).rollbackRecords(context);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
@@ -1,0 +1,409 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Put;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.io.Key;
+import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import com.scalar.db.util.groupcommit.GroupCommitConfig;
+import com.scalar.db.util.groupcommit.GroupCommitConflictException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Direct unit tests for {@link CoordinatorCommitHandlerWithGroupCommit} and its inner {@link
+ * CoordinatorCommitHandlerWithGroupCommit.Emitter}. Tests for inherited (unchanged) methods like
+ * {@code forceAbortState} and {@code handleCommitConflict} live in {@link
+ * CoordinatorCommitHandlerTest}.
+ */
+class CoordinatorCommitHandlerWithGroupCommitTest {
+  private static final String ANY_NAMESPACE_NAME = "namespace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final int ANY_INT_1 = 100;
+
+  @Mock private Coordinator coordinator;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+  @Mock private ParticipantCommitHandler participantCommitHandler;
+  @Mock private ConsensusCommitConfig config;
+
+  private final CoordinatorGroupCommitKeyManipulator keyManipulator =
+      new CoordinatorGroupCommitKeyManipulator();
+  private String fullId;
+  private CoordinatorGroupCommitter groupCommitter;
+  private CoordinatorCommitHandlerWithGroupCommit handler;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    groupCommitter =
+        spy(new CoordinatorGroupCommitter(new GroupCommitConfig(4, 100, 500, 60000, 10)));
+    // The handler's constructor wires the Emitter into the groupCommitter via setEmitter(); the
+    // emitter must be in place before reserve() is called so that the slot can be emitted later.
+    handler =
+        new CoordinatorCommitHandlerWithGroupCommit(
+            coordinator,
+            new WriteSetEncoder(tableMetadataManager),
+            participantCommitHandler,
+            groupCommitter);
+    fullId = groupCommitter.reserve(UUID.randomUUID().toString());
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Release any outstanding reserved slot so groupCommitter.close() does not block on the
+    // slot-abort timeout. Tests that drive Emitter directly never bind the slot to a result.
+    try {
+      groupCommitter.remove(fullId);
+    } catch (Exception ignored) {
+      // Slot already removed by the test; safe.
+    }
+    groupCommitter.close();
+  }
+
+  private Put preparePut() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .build();
+  }
+
+  private Snapshot prepareSnapshotWithWrite(String id) throws CrudException {
+    Snapshot snapshot = new Snapshot(id, tableMetadataManager, new ParallelExecutor(config));
+    Put put = preparePut();
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    return snapshot;
+  }
+
+  private Snapshot prepareEmptySnapshot(String id) {
+    return new Snapshot(id, tableMetadataManager, new ParallelExecutor(config));
+  }
+
+  private TransactionContext createContext(String id, Snapshot snapshot, boolean slotReserved) {
+    return new TransactionContext(id, snapshot, Isolation.SNAPSHOT, false, false, slotReserved);
+  }
+
+  // ---------- commitState (group-commit path) ----------
+
+  @Test
+  void commitState_WhenSuccessful_ShouldRouteThroughGroupCommitter() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    handler.commitState(context);
+
+    // Assert — the group-committer.ready() is the dispatch boundary into the emitter.
+    verify(groupCommitter).ready(eq(fullId), eq(context));
+  }
+
+  @Test
+  void commitState_WhenGroupCommitConflict_ShouldCancelSlotAndHandleConflict() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    GroupCommitConflictException cause = new GroupCommitConflictException("conflict");
+    doThrow(cause).when(groupCommitter).ready(eq(fullId), eq(context));
+    when(coordinator.getState(anyString())).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(CommitConflictException.class);
+
+    // Slot is released on the conflict path; rollback is dispatched through participant handler.
+    verify(groupCommitter).remove(fullId);
+    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  // ---------- abortState (cancelGroupCommitIfNeeded) ----------
+
+  @Test
+  void abortState_WhenSlotReserved_ShouldCancelGroupCommitAndDelegate() throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    TransactionState result = handler.abortState(context);
+
+    // Assert
+    assertThat(result).isEqualTo(TransactionState.ABORTED);
+    verify(groupCommitter).remove(fullId);
+    verify(coordinator).putState(any(Coordinator.State.class));
+  }
+
+  @Test
+  void abortState_WhenSlotNotReserved_ShouldNotTouchGroupCommitter() throws Exception {
+    // Arrange — release the slot reserved by setUp() so the bare-id context starts clean and
+    // groupCommitter.close() does not block on it during teardown.
+    groupCommitter.remove(fullId);
+    clearInvocations(groupCommitter);
+
+    String bareId = UUID.randomUUID().toString();
+    Snapshot snapshot = prepareSnapshotWithWrite(bareId);
+    TransactionContext context = createContext(bareId, snapshot, /* slotReserved= */ false);
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+
+    // Act
+    handler.abortState(context);
+
+    // Assert
+    verify(groupCommitter, never()).remove(anyString());
+  }
+
+  // ---------- handleCommitConflict (group-commit specific) ----------
+
+  @Test
+  void
+      handleCommitConflict_GroupCommitConflictExceptionGivenAndNoStatePersisted_ShouldRollbackRecordsAndThrowCommitConflict()
+          throws Exception {
+    // The group-commit conflict route (commitState catches GroupCommitConflictException and calls
+    // handleCommitConflict) must, when the coordinator state is absent on re-read, resolve to a
+    // definitive conflict -- roll the records back and throw CommitConflictException -- the same
+    // outcome as the normal-commit conflict route. getState for a group-commit child checks both
+    // the parent and full-ID rows, so an absent state genuinely means the transaction never
+    // committed.
+
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    when(coordinator.getState(fullId)).thenReturn(Optional.empty());
+    GroupCommitConflictException cause = new GroupCommitConflictException("conflict");
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCause(cause);
+    verify(participantCommitHandler).rollbackRecords(context);
+    verify(coordinator).getState(fullId);
+  }
+
+  // ---------- Emitter ----------
+
+  @Test
+  void emitter_emitNormalGroup_WithMultipleWritingChildren_ShouldAggregatePerChild()
+      throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+    String fullTxId1 = keyManipulator.fullKey(parentId, "child-1");
+    String fullTxId2 = keyManipulator.fullKey(parentId, "child-2");
+
+    TransactionContext context1 =
+        createContext(fullTxId1, prepareSnapshotWithWrite(fullTxId1), /* slotReserved= */ true);
+    TransactionContext context2 =
+        createContext(fullTxId2, prepareSnapshotWithWrite(fullTxId2), /* slotReserved= */ true);
+
+    // Act
+    emitter.emitNormalGroup(parentId, Arrays.asList(context1, context2));
+
+    // Assert
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(capturedState.getChildIds()).containsExactly("child-1", "child-2");
+    assertThat(capturedState.getWriteSet()).isPresent();
+    WriteSet captured = capturedState.getWriteSet().get();
+    assertThat(captured.getSchemaVersion()).isEqualTo(1);
+    assertThat(captured.getEntryGroupsList()).hasSize(2);
+    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("child-1");
+    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
+    assertThat(captured.getEntryGroups(1).getChildId()).isEqualTo("child-2");
+    assertThat(captured.getEntryGroups(1).getEntriesList()).isNotEmpty();
+  }
+
+  @Test
+  void emitter_emitNormalGroup_WithReadOnlyChildMixed_ShouldOmitReadOnlyEntryGroups()
+      throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+    String fullTxIdWriting = keyManipulator.fullKey(parentId, "writing");
+    String fullTxIdReadOnly = keyManipulator.fullKey(parentId, "read-only");
+
+    TransactionContext writingContext =
+        createContext(
+            fullTxIdWriting, prepareSnapshotWithWrite(fullTxIdWriting), /* slotReserved= */ true);
+    TransactionContext readOnlyContext =
+        createContext(
+            fullTxIdReadOnly, prepareEmptySnapshot(fullTxIdReadOnly), /* slotReserved= */ true);
+
+    // Act
+    emitter.emitNormalGroup(parentId, Arrays.asList(writingContext, readOnlyContext));
+
+    // Assert
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getWriteSet()).isPresent();
+
+    WriteSet captured = capturedState.getWriteSet().get();
+    assertThat(captured.getEntryGroupsList()).hasSize(1);
+    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("writing");
+  }
+
+  @Test
+  void emitter_emitNormalGroup_WithAllReadOnlyChildren_ShouldStillSetSchemaVersion()
+      throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    TransactionContext context =
+        createContext(fullTxId, prepareEmptySnapshot(fullTxId), /* slotReserved= */ true);
+
+    // Act
+    emitter.emitNormalGroup(parentId, Collections.singletonList(context));
+
+    // Assert
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getWriteSet()).isPresent();
+
+    WriteSet captured = capturedState.getWriteSet().get();
+    assertThat(captured.getSchemaVersion()).isEqualTo(1);
+    assertThat(captured.getEntryGroupsList()).isEmpty();
+  }
+
+  @Test
+  void emitter_emitNormalGroup_WithEmptyContexts_ShouldNotCallPutState() throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+
+    // Act — all buffered transactions were manually rolled back, so emitNormalGroup is invoked
+    // with an empty context list.
+    emitter.emitNormalGroup(parentId, Collections.emptyList());
+
+    // Assert — putState must not be called; otherwise a spurious COMMITTED parent row would be
+    // written.
+    verify(coordinatorMock, never()).putState(any(Coordinator.State.class));
+  }
+
+  @Test
+  void emitter_emitDelayedGroup_WithWritingContext_ShouldPersistStateWithWriteSet()
+      throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    TransactionContext context =
+        createContext(fullTxId, prepareSnapshotWithWrite(fullTxId), /* slotReserved= */ true);
+
+    // Act
+    emitter.emitDelayedGroup(fullTxId, context);
+
+    // Assert
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(fullTxId);
+    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(capturedState.getWriteSet()).isPresent();
+
+    WriteSet captured = capturedState.getWriteSet().get();
+    assertThat(captured.getSchemaVersion()).isEqualTo(1);
+    assertThat(captured.getEntryGroupsList()).hasSize(1);
+    // Delayed group commit emits a single EntryGroup with child_id unset, distinguishing it from
+    // a normal group commit row where each EntryGroup carries the child id.
+    assertThat(captured.getEntryGroups(0).hasChildId()).isFalse();
+    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
+  }
+
+  @Test
+  void emitter_emitDelayedGroup_WithReadOnlyContext_ShouldPersistStateWithEmptyWriteSet()
+      throws Exception {
+    // Arrange
+    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
+        new CoordinatorCommitHandlerWithGroupCommit.Emitter(
+            coordinatorMock, new WriteSetEncoder(tableMetadataManager));
+
+    String parentId = keyManipulator.generateParentKey();
+    String fullTxId = keyManipulator.fullKey(parentId, "child");
+    TransactionContext context =
+        createContext(fullTxId, prepareEmptySnapshot(fullTxId), /* slotReserved= */ true);
+
+    // Act
+    emitter.emitDelayedGroup(fullTxId, context);
+
+    // Assert
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(fullTxId);
+    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(capturedState.getWriteSet()).isPresent();
+
+    WriteSet captured = capturedState.getWriteSet().get();
+    assertThat(captured.getSchemaVersion()).isEqualTo(1);
+    assertThat(captured.getEntryGroupsList()).isEmpty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
@@ -18,11 +18,13 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.GroupCommitConfig;
 import com.scalar.db.util.groupcommit.GroupCommitConflictException;
+import com.scalar.db.util.groupcommit.GroupCommitException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -52,7 +54,6 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
   @Mock private Coordinator coordinator;
   @Mock private TransactionTableMetadataManager tableMetadataManager;
-  @Mock private ParticipantCommitHandler participantCommitHandler;
   @Mock private ConsensusCommitConfig config;
 
   private final CoordinatorGroupCommitKeyManipulator keyManipulator =
@@ -70,10 +71,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     // emitter must be in place before reserve() is called so that the slot can be emitted later.
     handler =
         new CoordinatorCommitHandlerWithGroupCommit(
-            coordinator,
-            new WriteSetEncoder(tableMetadataManager),
-            participantCommitHandler,
-            groupCommitter);
+            coordinator, new WriteSetEncoder(tableMetadataManager), groupCommitter);
     fullId = groupCommitter.reserve(UUID.randomUUID().toString());
   }
 
@@ -143,9 +141,59 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     assertThatThrownBy(() -> handler.commitState(context))
         .isInstanceOf(CommitConflictException.class);
 
-    // Slot is released on the conflict path; rollback is dispatched through participant handler.
+    // Slot is released on the conflict path. Record rollback is the orchestrator's responsibility
+    // (see CommitHandlerTest), not this Coordinator-side handler's.
     verify(groupCommitter).remove(fullId);
-    verify(participantCommitHandler).rollbackRecords(context);
+  }
+
+  @Test
+  void
+      commitState_WhenGroupCommitExceptionWithCoordinatorConflictCause_ShouldCancelSlotAndHandleConflict()
+          throws Exception {
+    // A plain GroupCommitException (not GroupCommitConflictException) whose cause is a
+    // CoordinatorConflictException is routed to handleCommitConflict. With the coordinator state
+    // absent on re-read, that resolves to a definitive conflict (CommitConflictException).
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    CoordinatorConflictException cause = new CoordinatorConflictException("coordinator conflict");
+    GroupCommitException groupCommitException =
+        new GroupCommitException("group commit failed", cause);
+    doThrow(groupCommitException).when(groupCommitter).ready(eq(fullId), eq(context));
+    when(coordinator.getState(anyString())).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCause(cause);
+
+    // The slot is released before the conflict is handled.
+    verify(groupCommitter).remove(fullId);
+  }
+
+  @Test
+  void commitState_WhenGroupCommitExceptionWithNonConflictCause_ShouldCancelSlotAndThrowUnknown()
+      throws Exception {
+    // A plain GroupCommitException whose cause is not a CoordinatorConflictException means the
+    // group committer failed to access the coordinator state, so the transaction status is unknown.
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithWrite(fullId);
+    TransactionContext context = createContext(fullId, snapshot, /* slotReserved= */ true);
+    RuntimeException cause = new RuntimeException("storage unavailable");
+    GroupCommitException groupCommitException =
+        new GroupCommitException("group commit failed", cause);
+    doThrow(groupCommitException).when(groupCommitter).ready(eq(fullId), eq(context));
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.commitState(context))
+        .isInstanceOf(UnknownTransactionStatusException.class)
+        .hasMessageContaining("The coordinator status is unknown")
+        .hasCause(cause);
+
+    // The slot is released even on the unknown-status path.
+    verify(groupCommitter).remove(fullId);
+    // The state is unknown, so the coordinator state is never re-read to resolve a conflict.
+    verify(coordinator, never()).getState(anyString());
   }
 
   // ---------- abortState (cancelGroupCommitIfNeeded) ----------
@@ -189,14 +237,14 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
   @Test
   void
-      handleCommitConflict_GroupCommitConflictExceptionGivenAndNoStatePersisted_ShouldRollbackRecordsAndThrowCommitConflict()
+      handleCommitConflict_GroupCommitConflictExceptionGivenAndNoStatePersisted_ShouldThrowCommitConflict()
           throws Exception {
     // The group-commit conflict route (commitState catches GroupCommitConflictException and calls
     // handleCommitConflict) must, when the coordinator state is absent on re-read, resolve to a
-    // definitive conflict -- roll the records back and throw CommitConflictException -- the same
-    // outcome as the normal-commit conflict route. getState for a group-commit child checks both
-    // the parent and full-ID rows, so an absent state genuinely means the transaction never
-    // committed.
+    // definitive conflict -- throw CommitConflictException -- the same outcome as the normal-commit
+    // conflict route. getState for a group-commit child checks both the parent and full-ID rows, so
+    // an absent state genuinely means the transaction never committed. Record rollback itself is
+    // the orchestrator's responsibility (see CommitHandlerTest).
 
     // Arrange
     Snapshot snapshot = prepareSnapshotWithWrite(fullId);
@@ -208,7 +256,6 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     assertThatThrownBy(() -> handler.handleCommitConflict(context, cause))
         .isInstanceOf(CommitConflictException.class)
         .hasCause(cause);
-    verify(participantCommitHandler).rollbackRecords(context);
     verify(coordinator).getState(fullId);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ParticipantCommitHandlerTest.java
@@ -1,0 +1,465 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.StorageInfo;
+import com.scalar.db.common.StorageInfoImpl;
+import com.scalar.db.common.StorageInfoProvider;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationConflictException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.io.Key;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Direct unit tests for {@link ParticipantCommitHandler}. */
+class ParticipantCommitHandlerTest {
+  private static final String ANY_NAMESPACE_NAME = "namespace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
+  private static final String ANY_ID = "id";
+  private static final int ANY_INT_1 = 100;
+  private static final int ANY_INT_2 = 200;
+
+  @Mock private DistributedStorage storage;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+  @Mock private StorageInfoProvider storageInfoProvider;
+  @Mock private ConsensusCommitConfig config;
+
+  private ParallelExecutor parallelExecutor;
+  private MutationsGrouper mutationsGrouper;
+  private ParticipantCommitHandler handler;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    parallelExecutor = new ParallelExecutor(config);
+    mutationsGrouper = spy(new MutationsGrouper(storageInfoProvider));
+    handler = newHandler(/* onePhaseCommitEnabled= */ false);
+
+    when(storageInfoProvider.getStorageInfo(ANY_NAMESPACE_NAME))
+        .thenReturn(
+            new StorageInfoImpl(
+                "storage1", StorageInfo.MutationAtomicityUnit.PARTITION, Integer.MAX_VALUE, false));
+  }
+
+  // Builds a ParticipantCommitHandler with the given one-phase-commit configuration. Tests that
+  // exercise tryOnePhaseCommitRecords use the enabled variant; the rest use the default.
+  private ParticipantCommitHandler newHandler(boolean onePhaseCommitEnabled) {
+    return new ParticipantCommitHandler(
+        storage, tableMetadataManager, parallelExecutor, mutationsGrouper, onePhaseCommitEnabled);
+  }
+
+  @AfterEach
+  void tearDown() {
+    parallelExecutor.close();
+  }
+
+  private Put preparePut1() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .intValue(ANY_NAME_3, ANY_INT_1)
+        .build();
+  }
+
+  private Put preparePut2() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_3))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_4))
+        .intValue(ANY_NAME_3, ANY_INT_2)
+        .build();
+  }
+
+  private Get prepareGet() {
+    return Get.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_3))
+        .build();
+  }
+
+  private Snapshot prepareSnapshot() {
+    return new Snapshot(ANY_ID, tableMetadataManager, new ParallelExecutor(config));
+  }
+
+  private Snapshot prepareSnapshotWithDifferentPartitionPut() throws CrudException {
+    Snapshot snapshot = prepareSnapshot();
+    Put put1 = preparePut1();
+    Put put2 = preparePut2();
+    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
+    snapshot.putIntoWriteSet(new Snapshot.Key(put2), put2);
+    snapshot.putIntoGetSet(prepareGet(), Optional.empty());
+    return snapshot;
+  }
+
+  private Snapshot prepareSnapshotWithoutWrites() {
+    Snapshot snapshot = prepareSnapshot();
+    snapshot.putIntoGetSet(prepareGet(), Optional.empty());
+    return snapshot;
+  }
+
+  private TransactionContext createTransactionContext(Snapshot snapshot, Isolation isolation) {
+    return new TransactionContext(ANY_ID, snapshot, isolation, false, false);
+  }
+
+  // ---------- prepareRecords ----------
+
+  @Test
+  void prepareRecords_WhenSuccessful_ShouldMutateStorage()
+      throws ExecutionException, PreparationException, CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doNothing().when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act
+    handler.prepareRecords(context);
+
+    // Assert
+    verify(storage, times(2)).mutate(anyList());
+  }
+
+  @Test
+  void prepareRecords_WhenNoMutationExceptionThrown_ShouldThrowPreparationConflictException()
+      throws ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(NoMutationException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.prepareRecords(context))
+        .isInstanceOf(PreparationConflictException.class)
+        .hasCauseInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  void
+      prepareRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowPreparationConflictException()
+          throws ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(RetriableExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.prepareRecords(context))
+        .isInstanceOf(PreparationConflictException.class)
+        .hasCauseInstanceOf(RetriableExecutionException.class);
+  }
+
+  @Test
+  void prepareRecords_WhenExecutionExceptionThrown_ShouldThrowPreparationException()
+      throws ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(ExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.prepareRecords(context))
+        .isInstanceOf(PreparationException.class)
+        .hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  // ---------- validateRecords ----------
+
+  @Test
+  void validateRecords_ValidationNotRequired_ShouldNotCallToSerializable()
+      throws ValidationException, ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
+    // With SNAPSHOT isolation, validation is not required
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act
+    handler.validateRecords(context);
+
+    // Assert
+    verify(snapshot, never()).toSerializable(storage);
+  }
+
+  @Test
+  void validateRecords_ValidationRequired_ShouldCallToSerializable()
+      throws ValidationException, ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
+    doNothing().when(snapshot).toSerializable(storage);
+    // With SERIALIZABLE isolation, validation is required when there are reads
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SERIALIZABLE);
+
+    // Act
+    handler.validateRecords(context);
+
+    // Assert
+    verify(snapshot).toSerializable(storage);
+  }
+
+  @Test
+  void validateRecords_WhenExecutionExceptionThrown_ShouldThrowValidationException()
+      throws ExecutionException, CrudException, ValidationConflictException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SERIALIZABLE);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.validateRecords(context))
+        .isInstanceOf(ValidationException.class)
+        .hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  // ---------- commitRecords ----------
+
+  @Test
+  void commitRecords_WhenSuccessful_ShouldMutateStorage() throws ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doNothing().when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act
+    handler.commitRecords(context);
+
+    // Assert
+    verify(storage, times(2)).mutate(anyList());
+  }
+
+  @Test
+  void commitRecords_WhenStorageThrows_ShouldNotPropagateException()
+      throws ExecutionException, CrudException {
+    // Lazy recovery picks up failed commits, so commitRecords ignores storage failures.
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(ExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act (must not throw)
+    handler.commitRecords(context);
+  }
+
+  // ---------- rollbackRecords ----------
+
+  @Test
+  void rollbackRecords_WhenSuccessful_ShouldDriveSnapshotThroughComposer()
+      throws ExecutionException, CrudException {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
+    doNothing().when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act
+    handler.rollbackRecords(context);
+
+    // Assert
+    verify(snapshot).to(any(RollbackMutationComposer.class));
+  }
+
+  @Test
+  void rollbackRecords_WhenStorageThrows_ShouldNotPropagateException()
+      throws ExecutionException, CrudException {
+    // Lazy recovery picks up failed rollbacks, so rollbackRecords ignores storage failures.
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(ExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act (must not throw)
+    handler.rollbackRecords(context);
+  }
+
+  // ---------- canOnePhaseCommit ----------
+
+  @Test
+  void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() throws Exception {
+    // Arrange — default handler has onePhaseCommitEnabled = false.
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThat(handler.canOnePhaseCommit(context)).isFalse();
+    verify(mutationsGrouper, never()).canBeGroupedAltogether(anyList());
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenSerializableIsolationWithReads_ShouldReturnFalse() throws Exception {
+    // SERIALIZABLE + reads requires validation, which one-phase commit cannot satisfy.
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SERIALIZABLE);
+
+    // Act Assert
+    assertThat(enabled.canOnePhaseCommit(context)).isFalse();
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse() throws Exception {
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshotWithoutWrites();
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThat(enabled.canOnePhaseCommit(context)).isFalse();
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse() throws Exception {
+    // A delete with no corresponding record in the read set means we cannot detect conflicts
+    // through delete-if-exists semantics.
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshot();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .build();
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(delete), Optional.empty());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThat(enabled.canOnePhaseCommit(context)).isFalse();
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse() throws Exception {
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doReturn(false).when(mutationsGrouper).canBeGroupedAltogether(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThat(enabled.canOnePhaseCommit(context)).isFalse();
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenEligible_ShouldReturnTrue() throws Exception {
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doReturn(true).when(mutationsGrouper).canBeGroupedAltogether(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThat(enabled.canOnePhaseCommit(context)).isTrue();
+  }
+
+  @Test
+  void canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException()
+      throws Exception {
+    // Arrange
+    ParticipantCommitHandler enabled = newHandler(/* onePhaseCommitEnabled= */ true);
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(ExecutionException.class).when(mutationsGrouper).canBeGroupedAltogether(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> enabled.canOnePhaseCommit(context))
+        .isInstanceOf(CommitException.class)
+        .hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  // ---------- onePhaseCommitRecords ----------
+
+  @Test
+  void onePhaseCommitRecords_WhenSuccessful_ShouldMutateStorage() throws Exception {
+    // Arrange
+    Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
+    doNothing().when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act
+    handler.onePhaseCommitRecords(context);
+
+    // Assert
+    verify(storage).mutate(anyList());
+    verify(snapshot).to(any(OnePhaseCommitMutationComposer.class));
+  }
+
+  @Test
+  void onePhaseCommitRecords_WhenNoMutationException_ShouldThrowCommitConflictException()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(NoMutationException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  void onePhaseCommitRecords_WhenRetriableExecutionException_ShouldThrowCommitConflictException()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(RetriableExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(RetriableExecutionException.class);
+  }
+
+  @Test
+  void onePhaseCommitRecords_WhenExecutionException_ShouldThrowUnknownTransactionStatusException()
+      throws Exception {
+    // Arrange
+    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+    doThrow(ExecutionException.class).when(storage).mutate(anyList());
+    TransactionContext context = createTransactionContext(snapshot, Isolation.SNAPSHOT);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.onePhaseCommitRecords(context))
+        .isInstanceOf(UnknownTransactionStatusException.class)
+        .hasCauseInstanceOf(ExecutionException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -906,8 +906,9 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void rollback_CalledAfterCommitFails_ShouldNeverAbortStateAndRollbackRecords()
-      throws TransactionException {
+  public void
+      rollback_CalledAfterCommitConflict_ShouldRollbackRecordsOnceDuringCommitAndNotAgainOnRollback()
+          throws TransactionException {
     // Arrange
     transaction.prepare();
     doThrow(CommitConflictException.class).when(commit).commitStateWithoutWriteSet(context);
@@ -917,9 +918,11 @@ public class TwoPhaseConsensusCommitTest {
     transaction.rollback();
 
     // Assert
+    // commit() rolls the prepared records back eagerly on the conflict, so rollback() is a no-op:
+    // it must not abort the state or roll the records back a second time.
     verify(context).closeScanners();
+    verify(commit).rollbackRecords(context);
     verify(commit, never()).abortStateWithoutWriteSet(ANY_TX_ID);
-    verify(commit, never()).rollbackRecords(context);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR splits the monolithic `CommitHandler` into an orchestrator plus specialized handlers so that participant-side record operations and Coordinator-side state writes are cleanly separated. It also removes the `TransactionTableMetadataManager` argument from `BeforePreparationHook.handle`, since the metadata manager is a long-lived singleton that is better injected once via the constructor. This is a preparatory refactoring with no behavioral change for callers.

## Related issues and/or PRs

N/A

## Changes made

- **Split `CommitHandler`.**
  - `ParticipantCommitHandler`: participant-side data-record operations (`prepareRecords`, `validateRecords`, `commitRecords`, `rollbackRecords`, `onePhaseCommitRecords`).
  - `CoordinatorCommitHandler`: Coordinator-table state writes (`commitState`, `commitStateWithoutWriteSet`, `abortState`, `abortStateWithoutWriteSet`, `abortStateForRollback`) plus the commit-conflict resolution helper.
  - `CoordinatorCommitHandlerWithGroupCommit`: extends the Coordinator-side handler with the group-commit emitter / slot-cancellation behavior.
  - `CommitHandler` becomes the orchestrator owning `commit(context)`, `canOnePhaseCommit`, `invokeBeforePreparationHook`, and the prepare -> validate -> commitState -> commitRecords sequencing. Existing public methods remain as thin pass-throughs so direct callers continue to work unchanged.
- **Drop the `TransactionTableMetadataManager` argument from `BeforePreparationHook.handle`;** implementations now hold it via constructor injection.
- Reorganize and add unit tests for the new handlers (`ParticipantCommitHandlerTest`, `CoordinatorCommitHandlerTest`, `CoordinatorCommitHandlerWithGroupCommitTest`).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Pure refactoring; existing callers (`TwoPhaseConsensusCommit` / `ConsensusCommit` / `ConsensusCommitManager` / `RecoveryHandler`) are unaffected thanks to the pass-through methods. A paired change in `LogWriterBeforePreparationHook` is in a separate repository.

## Release notes

N/A
