### PR TITLE
Add an emit result type to the group commit framework

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
@@ -117,7 +117,7 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
   }
 
   @VisibleForTesting
-  static class Emitter implements Emittable<String, String, TransactionContext> {
+  static class Emitter implements Emittable<String, String, TransactionContext, Void> {
     private final Coordinator coordinator;
     private final WriteSetEncoder writeSetEncoder;
 
@@ -127,10 +127,10 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
     }
 
     @Override
-    public void emitNormalGroup(String parentId, List<TransactionContext> contexts)
+    public Void emitNormalGroup(String parentId, List<TransactionContext> contexts)
         throws CoordinatorException {
       if (contexts.isEmpty()) {
-        return;
+        return null;
       }
       if (KEY_MANIPULATOR.isFullKey(parentId)) {
         throw new AssertionError(
@@ -151,10 +151,11 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
           "Transaction {} (parent ID) is committed successfully at {}",
           parentId,
           System.currentTimeMillis());
+      return null;
     }
 
     @Override
-    public void emitDelayedGroup(String fullId, TransactionContext context)
+    public Void emitDelayedGroup(String fullId, TransactionContext context)
         throws CoordinatorException {
       coordinator.putState(
           new State(
@@ -164,6 +165,7 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
               System.currentTimeMillis()));
       logger.debug(
           "Transaction {} is committed successfully at {}", fullId, System.currentTimeMillis());
+      return null;
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
@@ -6,7 +6,7 @@ import com.scalar.db.util.groupcommit.GroupCommitter;
 import java.util.Optional;
 
 public class CoordinatorGroupCommitter
-    extends GroupCommitter<String, String, String, String, String, TransactionContext> {
+    extends GroupCommitter<String, String, String, String, String, TransactionContext, Void> {
   CoordinatorGroupCommitter(GroupCommitConfig config) {
     super("coordinator", config, new CoordinatorGroupCommitKeyManipulator());
   }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/DelayedGroup.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/DelayedGroup.java
@@ -7,14 +7,14 @@ import javax.annotation.concurrent.ThreadSafe;
 
 // A group for a delayed slot. This group contains only a single slot.
 @ThreadSafe
-class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
-    extends Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
+class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+    extends Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> {
   private final FULL_KEY fullKey;
 
   DelayedGroup(
       GroupCommitConfig config,
       FULL_KEY fullKey,
-      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
+      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter,
       GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     super(emitter, keyManipulator, 1, config.oldGroupAbortTimeoutMillis());
@@ -35,7 +35,7 @@ class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   // slot. But just in case.
   protected synchronized void delegateEmitTaskToWaiter() {
     assert slots.size() == 1;
-    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
+    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
         slots.values()) {
       // Pass `emitter` to ask the receiver's thread to emit the value
       slot.delegateTaskToWaiter(
@@ -50,7 +50,7 @@ class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   @Nullable
   @Override
   protected synchronized FULL_KEY reserveNewSlot(
-      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot) {
+      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot) {
     slot.changeParentGroupToDelayedGroup(this);
     FULL_KEY fullKey = super.reserveNewSlot(slot);
     if (fullKey == null) {
@@ -64,7 +64,7 @@ class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof DelayedGroup)) return false;
-    DelayedGroup<?, ?, ?, ?, ?, ?> that = (DelayedGroup<?, ?, ?, ?, ?, ?>) o;
+    DelayedGroup<?, ?, ?, ?, ?, ?, ?> that = (DelayedGroup<?, ?, ?, ?, ?, ?, ?>) o;
     return Objects.equal(fullKey, that.fullKey);
   }
 

--- a/core/src/main/java/com/scalar/db/util/groupcommit/DelayedSlotMoveWorker.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/DelayedSlotMoveWorker.java
@@ -8,20 +8,21 @@ import javax.annotation.concurrent.ThreadSafe;
 // A worker manages NormalGroup instances to move delayed slots to a new DelayedGroup.
 // Ready NormalGroup is passed to GroupCleanupWorker.
 @ThreadSafe
-class DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+class DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
     extends BackgroundWorker<
-        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>> {
-  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>> {
+  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupManager;
   private final GroupCleanupWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupCleanupWorker;
 
   DelayedSlotMoveWorker(
       String label,
       long queueCheckIntervalInMillis,
-      GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> groupManager,
-      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          groupManager,
+      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           groupCleanupWorker) {
     super(
         label + "-group-commit-delayed-slot-move",
@@ -34,7 +35,7 @@ class DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   }
 
   @Override
-  BlockingQueue<NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+  BlockingQueue<NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       createQueue() {
     // Use a priority queue to prioritize groups based on their timeout values, processing groups
     // with smaller timeout values first.
@@ -44,7 +45,8 @@ class DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
 
   @Override
   boolean processItem(
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup) {
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup) {
     if (normalGroup.isReady()) {
       groupCleanupWorker.add(normalGroup);
       // Already ready. Should remove the item.

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Emittable.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Emittable.java
@@ -1,16 +1,22 @@
 package com.scalar.db.util.groupcommit;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * An emittable interface to emit multiple values at once.
  *
- * @param <FULL_KEY> A full-key type that Emitter can interpret.
  * @param <PARENT_KEY> A parent-key type that Emitter can interpret.
+ * @param <FULL_KEY> A full-key type that Emitter can interpret.
  * @param <V> A value type to be set to a slot.
+ * @param <R> A result type returned by an emit. The same result is handed back to every slot that
+ *     belongs to the emitted group, so a client can obtain it from {@link
+ *     GroupCommitter#ready(Object, Object)}. The result may be null.
  */
-public interface Emittable<PARENT_KEY, FULL_KEY, V> {
-  void emitNormalGroup(PARENT_KEY parentKey, List<V> values) throws Exception;
+public interface Emittable<PARENT_KEY, FULL_KEY, V, R> {
+  @Nullable
+  R emitNormalGroup(PARENT_KEY parentKey, List<V> values) throws Exception;
 
-  void emitDelayedGroup(FULL_KEY fullKey, V value) throws Exception;
+  @Nullable
+  R emitDelayedGroup(FULL_KEY fullKey, V value) throws Exception;
 }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Group.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Group.java
@@ -10,17 +10,17 @@ import org.slf4j.LoggerFactory;
 
 // An abstract class that has logics and implementations to manage slots and trigger to emit it.
 @ThreadSafe
-abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
+abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> {
   private static final Logger logger = LoggerFactory.getLogger(Group.class);
 
-  protected final Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter;
+  protected final Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter;
   protected final GroupCommitKeyManipulator<
           PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
   private final int capacity;
   private final AtomicReference<Integer> size = new AtomicReference<>();
   protected final Map<
-          CHILD_KEY, Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+          CHILD_KEY, Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       slots;
   // Whether to reject a new value slot.
   protected final AtomicReference<Status> status = new AtomicReference<>(Status.OPEN);
@@ -61,7 +61,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   }
 
   Group(
-      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
+      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter,
       GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator,
       int capacity,
@@ -82,7 +82,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   // If it returns null, the Group is already size-fixed and a retry is needed.
   @Nullable
   protected synchronized FULL_KEY reserveNewSlot(
-      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot) {
+      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot) {
     if (isSizeFixed()) {
       return null;
     }
@@ -94,8 +94,8 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   }
 
   private void reserveSlot(
-      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot) {
-    Slot<?, ?, ?, ?, ?, ?> oldSlot = slots.put(slot.key(), slot);
+      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot) {
+    Slot<?, ?, ?, ?, ?, ?, ?> oldSlot = slots.put(slot.key(), slot);
     if (oldSlot != null) {
       throw new AssertionError(
           String.format("An old slot exist unexpectedly. Slot: %s, Old slot: %s", slot, oldSlot));
@@ -106,7 +106,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   // This sync is for moving timed-out value slot from a normal buf to a new delayed buf.
   // Returns null if the state of the group is changed (e.g., the slot is moved to another group).
   @Nullable
-  private synchronized Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private synchronized Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       putValueToSlot(CHILD_KEY childKey, V value) {
     if (isReady()) {
       logger.debug(
@@ -116,7 +116,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
       return null;
     }
 
-    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot =
+    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot =
         slots.get(childKey);
     if (slot == null) {
       return null;
@@ -125,20 +125,34 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
     return slot;
   }
 
-  boolean putValueToSlotAndWait(CHILD_KEY childKey, V value) throws GroupCommitException {
-    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot;
+  // Puts the value to the slot and waits until the group is emitted. Returns the emit result
+  // wrapped in an EmitResult on success, or null when a retry is needed (the slot was moved to
+  // another group). The result is wrapped so that a successful emit carrying a null result can be
+  // distinguished from the retry signal.
+  @Nullable
+  EmitResult<R> putValueToSlotAndWait(CHILD_KEY childKey, V value) throws GroupCommitException {
+    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot;
     synchronized (this) {
       slot = putValueToSlot(childKey, value);
       if (slot == null) {
         // Needs a retry since the state of the group is changed.
-        return false;
+        return null;
       }
       updateStatus();
 
       delegateEmitTaskToWaiterIfReady();
     }
-    slot.waitUntilEmit();
-    return true;
+    return new EmitResult<>(slot.waitUntilEmit());
+  }
+
+  // Wraps the (possibly null) emit result so the caller can distinguish a successful emit (non-null
+  // holder, possibly carrying a null result) from a "retry needed" signal (null holder).
+  static final class EmitResult<R> {
+    @Nullable final R value;
+
+    EmitResult(@Nullable R value) {
+      this.value = value;
+    }
   }
 
   private synchronized void updateSlotsSize() {
@@ -185,7 +199,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
 
     if (newStatus == Status.SIZE_FIXED) {
       int readySlotCount = 0;
-      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
+      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
           slots.values()) {
         if (slot.isReady()) {
           readySlotCount++;
@@ -198,7 +212,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
 
     if (newStatus == Status.READY) {
       int doneSlotCount = 0;
-      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
+      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
           slots.values()) {
         if (slot.isDone()) {
           doneSlotCount++;
@@ -212,7 +226,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   }
 
   synchronized boolean removeSlot(CHILD_KEY childKey) {
-    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot =
+    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot =
         slots.get(childKey);
     if (slot == null) {
       // Probably, the slot is already removed by the client or moved from NormalGroup to
@@ -231,7 +245,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
       return false;
     }
 
-    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> removed =
+    Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> removed =
         slots.remove(childKey);
     assert removed != null;
 
@@ -245,7 +259,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   }
 
   synchronized void abort() {
-    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
+    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
         slots.values()) {
       // Tell the clients that the slots are aborted.
       slot.markAsFailed(

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCleanupWorker.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCleanupWorker.java
@@ -8,17 +8,17 @@ import org.slf4j.LoggerFactory;
 
 // A worker manages Group instances to removes completed ones.
 @ThreadSafe
-class GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+class GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
     extends BackgroundWorker<
-        Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>> {
+        Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>> {
   private static final Logger logger = LoggerFactory.getLogger(GroupCleanupWorker.class);
-  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupManager;
 
   GroupCleanupWorker(
       String label,
       long queueCheckIntervalInMillis,
-      GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           groupManager) {
     super(
         label + "-group-commit-group-cleanup",
@@ -29,7 +29,7 @@ class GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_
   }
 
   @Override
-  BlockingQueue<Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+  BlockingQueue<Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       createQueue() {
     // Use a normal queue because:
     // - The timeout of the queued groups is large since it's for "just in case"
@@ -41,7 +41,7 @@ class GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_
 
   @Override
   boolean processItem(
-      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> group) {
+      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> group) {
     if (group.oldGroupAbortTimeoutAtMillis() < System.currentTimeMillis()) {
       groupManager.removeGroupFromMap(group);
       group.abort();

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
@@ -25,21 +25,23 @@ import org.slf4j.LoggerFactory;
  * @param <EMIT_PARENT_KEY> A parent-key type that Emitter can interpret.
  * @param <EMIT_FULL_KEY> A full-key type that Emitter can interpret.
  * @param <V> A value type to be set to a slot.
+ * @param <R> A result type returned by an emit and handed back to every slot in the emitted group;
+ *     it is the return type of {@link #ready(Object, Object)}.
  */
 @ThreadSafe
-public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
     implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(GroupCommitter.class);
 
   // Background workers
   private final GroupSizeFixWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupSizeFixWorker;
   private final DelayedSlotMoveWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       delayedSlotMoveWorker;
   private final GroupCleanupWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupCleanupWorker;
 
   // Monitor
@@ -50,7 +52,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
           PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
 
-  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupManager;
 
   private final AtomicBoolean closing = new AtomicBoolean();
@@ -98,7 +100,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
    *
    * @param emitter An emitter.
    */
-  public void setEmitter(Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter) {
+  public void setEmitter(Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter) {
     groupManager.setEmitter(emitter);
   }
 
@@ -135,16 +137,20 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
    *     GroupCommitter#reserve}.
    * @param value A value to be set to the slot. It will be committed with other values contained in
    *     slots of the same group.
+   * @return the emit result produced when the group containing this slot is emitted. May be null:
+   *     an emit can legitimately produce a null result, so null does not indicate a failure.
    * @throws GroupCommitException when group commit fails
    */
-  public void ready(FULL_KEY fullKey, V value) throws GroupCommitException {
+  @Nullable
+  public R ready(FULL_KEY fullKey, V value) throws GroupCommitException {
     Keys<PARENT_KEY, CHILD_KEY, FULL_KEY> keys = keyManipulator.keysFromFullKey(fullKey);
     boolean failed = false;
     while (true) {
-      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> group =
+      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> group =
           groupManager.getGroup(keys);
-      if (group.putValueToSlotAndWait(keys.childKey, value)) {
-        return;
+      Group.EmitResult<R> result = group.putValueToSlotAndWait(keys.childKey, value);
+      if (result != null) {
+        return result.value;
       }
       // Failing to put a value to the slot can happen only when the slot is moved from the original
       // NormalGroup to a new DelayedGroup. So, only a single retry must be enough.
@@ -207,7 +213,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   }
 
   @VisibleForTesting
-  GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       createGroupManager(
           GroupCommitConfig config,
           GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
@@ -216,45 +222,50 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   }
 
   @VisibleForTesting
-  GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       createGroupCleanupWorker(
           String label,
           GroupCommitConfig config,
-          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               groupManager) {
-    GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> worker =
-        new GroupCleanupWorker<>(label, config.timeoutCheckIntervalMillis(), groupManager);
+    GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+        worker = new GroupCleanupWorker<>(label, config.timeoutCheckIntervalMillis(), groupManager);
     groupManager.setGroupCleanupWorker(worker);
     return worker;
   }
 
   @VisibleForTesting
-  DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       createDelayedSlotMoveWorker(
           String label,
           GroupCommitConfig config,
-          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               groupManager,
-          GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               groupCleanupWorker) {
     return new DelayedSlotMoveWorker<>(
         label, config.timeoutCheckIntervalMillis(), groupManager, groupCleanupWorker);
   }
 
   @VisibleForTesting
-  GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       createGroupSizeFixWorker(
           String label,
           GroupCommitConfig config,
-          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               groupManager,
-          DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          DelayedSlotMoveWorker<
+                  PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               delayedSlotMoveWorker,
-          GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
               groupCleanupWorker) {
-    GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> worker =
-        new GroupSizeFixWorker<>(
-            label, config.timeoutCheckIntervalMillis(), delayedSlotMoveWorker, groupCleanupWorker);
+    GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+        worker =
+            new GroupSizeFixWorker<>(
+                label,
+                config.timeoutCheckIntervalMillis(),
+                delayedSlotMoveWorker,
+                groupCleanupWorker);
     groupManager.setGroupSizeFixWorker(worker);
     return worker;
   }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
@@ -15,24 +15,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
+class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> {
   private static final Logger logger = LoggerFactory.getLogger(GroupManager.class);
 
   // Groups
   @Nullable
-  private NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       currentGroup;
   // Note: Using ConcurrentHashMap results in less performance.
   @VisibleForTesting
   protected final Map<
           PARENT_KEY,
-          NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+          NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       normalGroupMap = new HashMap<>();
 
   @VisibleForTesting
   protected final Map<
           FULL_KEY,
-          DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+          DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       delayedGroupMap = new HashMap<>();
 
   // Only this class uses this type of lock since the class can be heavy hotspot and StampedLock has
@@ -41,18 +41,18 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
 
   // Background workers
   @LazyInit
-  private GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupSizeFixWorker;
 
   @LazyInit
-  private GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+  private GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupCleanupWorker;
 
   // Custom operations injected by the client
   private final GroupCommitKeyManipulator<
           PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
-  @LazyInit private Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter;
+  @LazyInit private Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter;
 
   private final GroupCommitConfig config;
 
@@ -65,13 +65,13 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   }
 
   void setGroupSizeFixWorker(
-      GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           groupSizeFixWorker) {
     this.groupSizeFixWorker = groupSizeFixWorker;
   }
 
   void setGroupCleanupWorker(
-      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           groupCleanupWorker) {
     this.groupCleanupWorker = groupCleanupWorker;
   }
@@ -96,7 +96,7 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   }
 
   // Gets the corresponding group associated with the given key.
-  Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> getGroup(
+  Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> getGroup(
       Keys<PARENT_KEY, CHILD_KEY, FULL_KEY> keys) throws GroupCommitException {
     long stamp = lock.writeLock();
     try {
@@ -104,14 +104,14 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
       // with the parent key in `normalGroupMap` would return the NormalGroup even if the target
       // slot is already moved from the NormalGroup to the DelayedGroup. So, checking
       // `delayedGroupMap` first is necessary.
-      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           delayedGroup = delayedGroupMap.get(keys.fullKey);
       if (delayedGroup != null) {
         return delayedGroup;
       }
 
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup =
-          normalGroupMap.get(keys.parentKey);
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup = normalGroupMap.get(keys.parentKey);
       if (normalGroup != null) {
         return normalGroup;
       }
@@ -125,20 +125,21 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
 
   // Remove the specified group from group map.
   boolean removeGroupFromMap(
-      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> group) {
+      Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> group) {
     long stamp = lock.writeLock();
     try {
       if (group instanceof NormalGroup) {
-        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
             normalGroup =
-                (NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>)
+                (NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>)
                     group;
         return normalGroupMap.remove(normalGroup.parentKey()) != null;
       } else {
         assert group instanceof DelayedGroup;
-        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
             delayedGroup =
-                (DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>)
+                (DelayedGroup<
+                        PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>)
                     group;
         return delayedGroupMap.remove(delayedGroup.fullKey()) != null;
       }
@@ -153,14 +154,14 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
     try {
       boolean removed = false;
 
-      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           delayedGroup = delayedGroupMap.get(keys.fullKey);
       if (delayedGroup != null) {
         removed = delayedGroup.removeSlot(keys.childKey);
       }
 
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup =
-          normalGroupMap.get(keys.parentKey);
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup = normalGroupMap.get(keys.parentKey);
       if (normalGroup != null) {
         removed = normalGroup.removeSlot(keys.childKey) || removed;
       }
@@ -177,26 +178,27 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
   //
   // Returns true if any delayed slot is moved, false otherwise.
   boolean moveDelayedSlotToDelayedGroup(
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup) {
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup) {
     long stamp = lock.writeLock();
     try {
       // TODO: NormalGroup.removeNotReadySlots() calls updateStatus() potentially resulting in
       //       delegateEmitTaskToWaiter(). Maybe it should be called outside the lock.
 
       // Remove delayed tasks from the NormalGroup so that it can be ready.
-      List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>> notReadySlots =
-          normalGroup.removeNotReadySlots();
+      List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
+          notReadySlots = normalGroup.removeNotReadySlots();
       if (notReadySlots == null) {
         normalGroup.updateDelayedSlotMoveTimeoutAt();
         logger.debug(
             "This group isn't needed to remove slots. Updated the timeout. Group: {}", normalGroup);
         return false;
       }
-      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> notReadySlot :
-          notReadySlots) {
+      for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          notReadySlot : notReadySlots) {
         // Create a new DelayedGroup
         FULL_KEY fullKey = notReadySlot.fullKey();
-        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
             delayedGroup = new DelayedGroup<>(config, fullKey, emitter, keyManipulator);
 
         // Set the slot stored in the NormalGroup into the new DelayedGroup.
@@ -204,7 +206,7 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
         checkNotNull(delayedGroup.reserveNewSlot(notReadySlot));
 
         // Register the new DelayedGroup to the map and cleanup queue.
-        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> old =
+        DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> old =
             delayedGroupMap.put(fullKey, delayedGroup);
         if (old != null) {
           throw new AssertionError(
@@ -224,7 +226,7 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
     return true;
   }
 
-  void setEmitter(Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter) {
+  void setEmitter(Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter) {
     this.emitter = emitter;
   }
 

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupSizeFixWorker.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupSizeFixWorker.java
@@ -8,22 +8,22 @@ import javax.annotation.concurrent.ThreadSafe;
 // DelayedSlotMoveWorker.
 // Ready NormalGroup is passed to GroupCleanupWorker.
 @ThreadSafe
-class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
     extends BackgroundWorker<
-        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>> {
+        NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>> {
   private final DelayedSlotMoveWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       delayedSlotMoveWorker;
   private final GroupCleanupWorker<
-          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
       groupCleanupWorker;
 
   GroupSizeFixWorker(
       String label,
       long queueCheckIntervalInMillis,
-      DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      DelayedSlotMoveWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           delayedSlotMoveWorker,
-      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           groupCleanupWorker) {
     super(
         label + "-group-commit-normal-group-size-fix",
@@ -34,7 +34,8 @@ class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_
   }
 
   private void enqueueItemToNextQueue(
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup) {
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup) {
     if (normalGroup.isReady()) {
       groupCleanupWorker.add(normalGroup);
     } else {
@@ -43,7 +44,7 @@ class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_
   }
 
   @Override
-  BlockingQueue<NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+  BlockingQueue<NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       createQueue() {
     // Use a normal queue because:
     // - Queued groups are removed once processed, without being re-enqueued
@@ -54,7 +55,8 @@ class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_
 
   @Override
   boolean processItem(
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> normalGroup) {
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          normalGroup) {
     // Size-fix the group if needed.
     if (normalGroup.isSizeFixed()) {
       enqueueItemToNextQueue(normalGroup);

--- a/core/src/main/java/com/scalar/db/util/groupcommit/NormalGroup.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/NormalGroup.java
@@ -2,7 +2,7 @@ package com.scalar.db.util.groupcommit;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.scalar.db.util.ThrowableRunnable;
+import com.scalar.db.util.ThrowableSupplier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -15,8 +15,8 @@ import org.slf4j.LoggerFactory;
 
 // A group for multiple slots that will be group-committed at once.
 @ThreadSafe
-class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
-    extends Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
+class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+    extends Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> {
   private static final Logger logger = LoggerFactory.getLogger(NormalGroup.class);
 
   private final PARENT_KEY parentKey;
@@ -26,7 +26,7 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
 
   NormalGroup(
       GroupCommitConfig config,
-      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
+      Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> emitter,
       GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     super(emitter, keyManipulator, config.slotCapacity(), config.oldGroupAbortTimeoutMillis());
@@ -53,7 +53,7 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
   }
 
   @Nullable
-  synchronized List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+  synchronized List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       removeNotReadySlots() {
     if (!isSizeFixed()) {
       logger.info(
@@ -63,11 +63,12 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
 
     // Lazy instantiation might be better, but it's likely there is a not-ready value slot since
     // it's already timed-out.
-    List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>> removed =
+    List<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>> removed =
         new ArrayList<>();
-    for (Entry<CHILD_KEY, Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+    for (Entry<
+            CHILD_KEY, Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
         entry : slots.entrySet()) {
-      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot =
+      Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot =
           entry.getValue();
       if (!slot.isReady()) {
         removed.add(slot);
@@ -82,7 +83,8 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
       return null;
     }
 
-    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot : removed) {
+    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
+        removed) {
       removeSlot(slot.key());
       logger.debug(
           "Removed a value slot from group to move it to delayed group. Group: {}, Slot: {}",
@@ -94,12 +96,13 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
 
   @Override
   public synchronized void delegateEmitTaskToWaiter() {
-    final AtomicReference<Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+    final AtomicReference<
+            Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
         emitterSlot = new AtomicReference<>();
 
     boolean isFirst = true;
     List<V> values = new ArrayList<>(slots.size());
-    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
+    for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> slot :
         slots.values()) {
       // Use the first slot as an emitter.
       if (isFirst) {
@@ -111,33 +114,40 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
 
     // This task is passed to only the first slot, so the slot will be resumed.
     // Other slots will be blocked until `markAsXxxx()` is called.
-    ThrowableRunnable<Exception> taskForEmitterSlot =
+    ThrowableSupplier<R, Exception> taskForEmitterSlot =
         () -> {
           try {
             if (isDone()) {
-              logger.info("This group is already done, but trying to emit. Group: {}", this);
-              return;
+              // Unreachable: the emit task runs on the emitter slot's thread, that slot is always
+              // ready (so it is never removed from the group) and is not marked done until after
+              // this task returns. Hence the group cannot be DONE while this task runs. Fail loudly
+              // if that invariant is ever broken so we never fabricate an emit result.
+              throw new AssertionError(
+                  String.format("The group is unexpectedly already done. Group: %s", this));
             }
-            emitter.emitNormalGroup(keyManipulator.emitParentKeyFromParentKey(parentKey), values);
+            R result =
+                emitter.emitNormalGroup(
+                    keyManipulator.emitParentKeyFromParentKey(parentKey), values);
 
             synchronized (this) {
-              // Wake up the other waiting threads.
-              // Pass null since the value is already emitted by the thread of `firstSlot`.
-              for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
-                  slots.values()) {
+              // Wake up the other waiting threads, handing each the emit result. The value is
+              // already emitted by the thread of `firstSlot`, so they do not run the task again.
+              for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+                  slot : slots.values()) {
                 if (slot != emitterSlot.get()) {
-                  slot.markAsSuccess();
+                  slot.markAsSuccess(result);
                 }
               }
             }
+            return result;
           } catch (Exception e) {
             GroupCommitException exception =
                 new GroupCommitException(String.format("Group commit failed. Group: %s", this), e);
 
             // Let other threads know the exception.
             synchronized (this) {
-              for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> slot :
-                  slots.values()) {
+              for (Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+                  slot : slots.values()) {
                 if (slot != emitterSlot.get()) {
                   slot.markAsFailed(exception);
                 }
@@ -168,7 +178,7 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof NormalGroup)) return false;
-    NormalGroup<?, ?, ?, ?, ?, ?> that = (NormalGroup<?, ?, ?, ?, ?, ?>) o;
+    NormalGroup<?, ?, ?, ?, ?, ?, ?> that = (NormalGroup<?, ?, ?, ?, ?, ?, ?>) o;
     return Objects.equal(parentKey, that.parentKey);
   }
 

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Slot.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Slot.java
@@ -1,7 +1,7 @@
 package com.scalar.db.util.groupcommit;
 
 import com.google.common.base.MoreObjects;
-import com.scalar.db.util.ThrowableRunnable;
+import com.scalar.db.util.ThrowableSupplier;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -12,15 +12,18 @@ import javax.annotation.concurrent.ThreadSafe;
 
 // A container of value which is stored in a group.
 @ThreadSafe
-class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
+class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R> {
   private final AtomicReference<
-          Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>>
+          Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>>
       parentGroup = new AtomicReference<>();
   private final CHILD_KEY key;
-  // If a result value is null, the value is already emitted.
-  // Otherwise, the result lambda must be emitted by the receiver's thread.
-  private final CompletableFuture<ThrowableRunnable<Exception>> completableFuture =
+  // If the completed task is null, the group was already emitted by another slot's thread, and the
+  // emit result is handed to this slot via `emitResult`. Otherwise, the task must be emitted by the
+  // receiver's thread, which obtains the result as the task's return value.
+  private final CompletableFuture<ThrowableSupplier<R, Exception>> completableFuture =
       new CompletableFuture<>();
+  // The emit result handed to this slot when the group is emitted by another slot's thread.
+  private final AtomicReference<R> emitResult = new AtomicReference<>();
   // This value can be changed from null -> non-null, not vice versa.
   private final AtomicReference<V> value = new AtomicReference<>();
   // The status of Slot becomes done once the client obtains the result not when a value is set.
@@ -32,14 +35,15 @@ class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
 
   Slot(
       CHILD_KEY key,
-      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> parentGroup) {
+      NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
+          parentGroup) {
     this.key = key;
     this.parentGroup.set(parentGroup);
   }
 
   // This is called only once when being moved from NormalGroup to DelayedGroup.
   void changeParentGroupToDelayedGroup(
-      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
+      DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V, R>
           parentGroup) {
     this.parentGroup.set(parentGroup);
   }
@@ -52,14 +56,17 @@ class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
     this.value.set(Objects.requireNonNull(value));
   }
 
-  void waitUntilEmit() throws GroupCommitException {
+  @Nullable
+  R waitUntilEmit() throws GroupCommitException {
     try {
-      // If a result value is null, the value is already emitted.
-      // Otherwise, the result lambda must be emitted by the waiter's thread.
-      ThrowableRunnable<Exception> taskToEmit = completableFuture.get();
+      // If the task is null, the group was already emitted by another slot's thread and the result
+      // was handed to this slot via `emitResult`. Otherwise, this slot's thread must run the emit
+      // task and obtains the result as its return value.
+      ThrowableSupplier<R, Exception> taskToEmit = completableFuture.get();
       if (taskToEmit != null) {
-        taskToEmit.run();
+        return taskToEmit.get();
       }
+      return emitResult.get();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new GroupCommitException(
@@ -102,8 +109,12 @@ class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
     return value.get();
   }
 
-  // Marks this slot as a success.
-  void markAsSuccess() {
+  // Marks this slot as a success, handing it the emit result obtained by the emitter slot's thread.
+  void markAsSuccess(R result) {
+    // The order matters: emitResult must be set before completing the future. The waiter reads
+    // emitResult.get() only after completableFuture.get() returns, and that completion is the
+    // happens-before publication point that makes the result visible. Do not reorder these.
+    emitResult.set(result);
     completableFuture.complete(null);
   }
 
@@ -113,8 +124,8 @@ class Slot<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V> {
   }
 
   // Delegates the emit task to the client. The client receiving this task needs to handle the emit
-  // task.
-  void delegateTaskToWaiter(ThrowableRunnable<Exception> task) {
+  // task and obtains the emit result as its return value.
+  void delegateTaskToWaiter(ThrowableSupplier<R, Exception> task) {
     completableFuture.complete(task);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitterTest.java
@@ -31,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CoordinatorGroupCommitterTest {
   private final CoordinatorGroupCommitKeyManipulator keyManipulator =
       new CoordinatorGroupCommitKeyManipulator();
-  @Mock private Emittable<String, String, TransactionContext> emitter;
+  @Mock private Emittable<String, String, TransactionContext, Void> emitter;
   @Captor private ArgumentCaptor<List<TransactionContext>> contextsArgumentCaptor;
   @Captor private ArgumentCaptor<TransactionContext> contextArgumentCaptor;
 

--- a/core/src/test/java/com/scalar/db/util/groupcommit/DelayedGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/DelayedGroupTest.java
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DelayedGroupTest {
-  @Mock private Emittable<String, String, Integer> emitter;
+  @Mock private Emittable<String, String, Integer, Void> emitter;
   private TestableGroupCommitKeyManipulator keyManipulator;
 
   @BeforeEach
@@ -39,7 +39,7 @@ class DelayedGroupTest {
   void fullKey_GivenFullKeyViaConstructor_ShouldReturnProperly() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
 
     // Act
@@ -51,11 +51,11 @@ class DelayedGroupTest {
   void reserveNewSlot_GivenArbitrarySlot_ShouldStoreIt() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot =
+    Slot<String, String, String, String, String, Integer, Void> slot =
         spy(new Slot<>("child-key", oldGroup));
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
 
     assertThat(group.size()).isNull();
@@ -75,10 +75,11 @@ class DelayedGroupTest {
   void reserveNewSlot_GivenAlreadyReservedSlot_ShouldThrowException() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot = new Slot<>("child-key", oldGroup);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    Slot<String, String, String, String, String, Integer, Void> slot =
+        new Slot<>("child-key", oldGroup);
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
     group.reserveNewSlot(slot);
 
@@ -88,20 +89,22 @@ class DelayedGroupTest {
     assertThat(group.isReady()).isFalse();
   }
 
-  private Emittable<String, String, Integer> createEmitter(ThrowableRunnable<Exception> task) {
-    return new Emittable<String, String, Integer>() {
+  private Emittable<String, String, Integer, Void> createEmitter(
+      ThrowableRunnable<Exception> task) {
+    return new Emittable<String, String, Integer, Void>() {
       @Override
-      public void emitNormalGroup(String parentKey, List<Integer> values) {
+      public Void emitNormalGroup(String parentKey, List<Integer> values) {
         throw new AssertionError();
       }
 
       @Override
-      public void emitDelayedGroup(String fullKey, Integer value) {
+      public Void emitDelayedGroup(String fullKey, Integer value) {
         try {
           task.run();
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
+        return null;
       }
     };
   }
@@ -113,17 +116,18 @@ class DelayedGroupTest {
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     AtomicBoolean emitted = new AtomicBoolean();
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> waitableEmitter =
+    Emittable<String, String, Integer, Void> waitableEmitter =
         createEmitter(
             () -> {
               wait.await();
               emitted.set(true);
             });
 
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, waitableEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot = new Slot<>("child-key", oldGroup);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    Slot<String, String, String, String, String, Integer, Void> slot =
+        new Slot<>("child-key", oldGroup);
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", waitableEmitter, keyManipulator);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
@@ -165,16 +169,17 @@ class DelayedGroupTest {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> failingEmitter =
+    Emittable<String, String, Integer, Void> failingEmitter =
         createEmitter(
             () -> {
               wait.await();
               throw new RuntimeException("Something is wrong");
             });
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, failingEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot = new Slot<>("child-key", oldGroup);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    Slot<String, String, String, String, String, Integer, Void> slot =
+        new Slot<>("child-key", oldGroup);
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", failingEmitter, keyManipulator);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
@@ -213,10 +218,11 @@ class DelayedGroupTest {
   void removeSlot_GivenNoReadySlot_ShouldRemoveSlotAndGetDone() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot = new Slot<>("child-key", oldGroup);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    Slot<String, String, String, String, String, Integer, Void> slot =
+        new Slot<>("child-key", oldGroup);
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
 
     group.reserveNewSlot(slot);
@@ -239,16 +245,17 @@ class DelayedGroupTest {
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     AtomicBoolean emitted = new AtomicBoolean();
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> waitableEmitter =
+    Emittable<String, String, Integer, Void> waitableEmitter =
         createEmitter(
             () -> {
               wait.await();
               emitted.set(true);
             });
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, waitableEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot = new Slot<>("child-key", oldGroup);
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    Slot<String, String, String, String, String, Integer, Void> slot =
+        new Slot<>("child-key", oldGroup);
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", waitableEmitter, keyManipulator);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
@@ -290,7 +297,7 @@ class DelayedGroupTest {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     long minOfCurrentTimeMillis = System.currentTimeMillis();
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
     long maxOfCurrentTimeMillis = System.currentTimeMillis();
 
@@ -305,11 +312,11 @@ class DelayedGroupTest {
   void abort_ShouldAbortSlot() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> oldGroup =
+    NormalGroup<String, String, String, String, String, Integer, Void> oldGroup =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot =
+    Slot<String, String, String, String, String, Integer, Void> slot =
         spy(new Slot<>("child-key", oldGroup));
-    DelayedGroup<String, String, String, String, String, Integer> group =
+    DelayedGroup<String, String, String, String, String, Integer, Void> group =
         new DelayedGroup<>(config, "0000:full-key", emitter, keyManipulator);
     group.reserveNewSlot(slot);
 

--- a/core/src/test/java/com/scalar/db/util/groupcommit/DelayedSlotMoveWorkerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/DelayedSlotMoveWorkerTest.java
@@ -25,15 +25,17 @@ class DelayedSlotMoveWorkerTest {
   private static final int LONG_WAIT_MILLIS = 500;
 
   @Mock
-  private GroupCleanupWorker<String, String, String, String, String, Integer> groupCleanupWorker;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+      groupCleanupWorker;
 
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup1;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup2;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup3;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup4;
-  @Mock private GroupManager<String, String, String, String, String, Integer> groupManager;
-  private DelayedSlotMoveWorker<String, String, String, String, String, Integer> worker;
-  private DelayedSlotMoveWorker<String, String, String, String, String, Integer> workerWithWait;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup1;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup2;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup3;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup4;
+  @Mock private GroupManager<String, String, String, String, String, Integer, Void> groupManager;
+  private DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void> worker;
+  private DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void>
+      workerWithWait;
 
   @BeforeEach
   void setUp() {
@@ -50,7 +52,7 @@ class DelayedSlotMoveWorkerTest {
   }
 
   private void doReturnOldGroupAbortTimeoutAtMillis(
-      NormalGroup<String, String, String, String, String, Integer> normalGroup) {
+      NormalGroup<String, String, String, String, String, Integer, Void> normalGroup) {
     long oldGroupAbortMillis = System.currentTimeMillis() + 60 * 1000;
     doReturn(oldGroupAbortMillis).when(normalGroup).oldGroupAbortTimeoutAtMillis();
   }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCleanupWorkerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCleanupWorkerTest.java
@@ -21,13 +21,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class GroupCleanupWorkerTest {
   private static final int LONG_WAIT_MILLIS = 500;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup1;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup2;
-  @Mock private DelayedGroup<String, String, String, String, String, Integer> delayedGroup1;
-  @Mock private DelayedGroup<String, String, String, String, String, Integer> delayedGroup2;
-  @Mock private GroupManager<String, String, String, String, String, Integer> groupManager;
-  private GroupCleanupWorker<String, String, String, String, String, Integer> worker;
-  private GroupCleanupWorker<String, String, String, String, String, Integer> workerWithWait;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup1;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup2;
+  @Mock private DelayedGroup<String, String, String, String, String, Integer, Void> delayedGroup1;
+  @Mock private DelayedGroup<String, String, String, String, String, Integer, Void> delayedGroup2;
+  @Mock private GroupManager<String, String, String, String, String, Integer, Void> groupManager;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void> worker;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void> workerWithWait;
 
   @BeforeEach
   void setUp() {
@@ -42,7 +42,7 @@ class GroupCleanupWorkerTest {
   }
 
   private void doReturnOldGroupAbortTimeoutAtMillis(
-      Group<String, String, String, String, String, Integer> group) {
+      Group<String, String, String, String, String, Integer, Void> group) {
     long oldGroupAbortMillis = System.currentTimeMillis() + 60 * 1000;
     doReturn(oldGroupAbortMillis).when(group).oldGroupAbortTimeoutAtMillis();
   }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
@@ -152,8 +152,8 @@ class GroupCommitterConcurrentTest {
     }
 
     // Returns a lambda that will be executed once the group is ready to group-commit.
-    private Emittable<String, String, Value> createEmitter() {
-      return new Emittable<String, String, Value>() {
+    private Emittable<String, String, Value, Void> createEmitter() {
+      return new Emittable<String, String, Value, Void>() {
         private void emit(String ignored, List<Value> values) {
           if (maxEmitDurationInMillis > 0) {
             int waitInMillis = rand.nextInt(maxEmitDurationInMillis);
@@ -177,19 +177,21 @@ class GroupCommitterConcurrentTest {
         }
 
         @Override
-        public void emitNormalGroup(String parentKey, List<Value> values) throws Exception {
+        public Void emitNormalGroup(String parentKey, List<Value> values) throws Exception {
           emit(parentKey, values);
+          return null;
         }
 
         @Override
-        public void emitDelayedGroup(String fullKey, Value value) throws Exception {
+        public Void emitDelayedGroup(String fullKey, Value value) throws Exception {
           emit(fullKey, Collections.singletonList(value));
+          return null;
         }
       };
     }
 
     private Callable<Void> groupCommitterCaller(
-        GroupCommitter<String, String, String, String, String, Value> groupCommitter,
+        GroupCommitter<String, String, String, String, String, Value, Void> groupCommitter,
         String childKey,
         Value value) {
       return () -> {
@@ -231,7 +233,7 @@ class GroupCommitterConcurrentTest {
 
     private void exec(GroupCommitConfig groupCommitConfig)
         throws ExecutionException, InterruptedException, TimeoutException {
-      try (GroupCommitter<String, String, String, String, String, Value> groupCommitter =
+      try (GroupCommitter<String, String, String, String, String, Value, Void> groupCommitter =
           new GroupCommitter<>("test", groupCommitConfig, new MyKeyManipulator())) {
         groupCommitter.setEmitter(createEmitter());
 
@@ -308,7 +310,7 @@ class GroupCommitterConcurrentTest {
     }
 
     private void checkGarbage(
-        GroupCommitter<String, String, String, String, String, Value> groupCommitter) {
+        GroupCommitter<String, String, String, String, String, Value, Void> groupCommitter) {
       boolean noGarbage = false;
       GroupCommitMetrics groupCommitMetrics = null;
       for (int i = 0; i < 60; i++) {

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
@@ -32,18 +32,20 @@ class GroupCommitterTest {
   private static final int OLD_GROUP_ABORT_TIMEOUT_MILLIS = 10000;
   private static final int TIMEOUT_CHECK_INTERVAL_MILLIS = 10;
 
-  @Mock private Emittable<String, String, Integer> emitter;
-  @Mock private GroupManager<String, String, String, String, String, Integer> groupManager;
+  @Mock private Emittable<String, String, Integer, Void> emitter;
+  @Mock private GroupManager<String, String, String, String, String, Integer, Void> groupManager;
 
   @Mock
-  private GroupSizeFixWorker<String, String, String, String, String, Integer> groupSizeFixWorker;
+  private GroupSizeFixWorker<String, String, String, String, String, Integer, Void>
+      groupSizeFixWorker;
 
   @Mock
-  private DelayedSlotMoveWorker<String, String, String, String, String, Integer>
+  private DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void>
       delayedSlotMoveWorker;
 
   @Mock
-  private GroupCleanupWorker<String, String, String, String, String, Integer> groupCleanupWorker;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+      groupCleanupWorker;
 
   @Mock private GroupCommitMonitor groupCommitMonitor;
   @Mock private GroupCommitMetrics groupCommitMetrics;
@@ -57,7 +59,7 @@ class GroupCommitterTest {
 
   // Use only a single instance at most in a test case.
   private class TestableGroupCommitter
-      extends GroupCommitter<String, String, String, String, String, Integer> {
+      extends GroupCommitter<String, String, String, String, String, Integer, Void> {
 
     TestableGroupCommitter(
         GroupCommitConfig config,
@@ -66,7 +68,7 @@ class GroupCommitterTest {
     }
 
     @Override
-    GroupManager<String, String, String, String, String, Integer> createGroupManager(
+    GroupManager<String, String, String, String, String, Integer, Void> createGroupManager(
         GroupCommitConfig config,
         GroupCommitKeyManipulator<String, String, String, String, String> keyManipulator) {
       testableGroupCommitterGroupManagerCreated.set(true);
@@ -74,34 +76,37 @@ class GroupCommitterTest {
     }
 
     @Override
-    GroupSizeFixWorker<String, String, String, String, String, Integer> createGroupSizeFixWorker(
-        String label,
-        GroupCommitConfig config,
-        GroupManager<String, String, String, String, String, Integer> groupManager,
-        DelayedSlotMoveWorker<String, String, String, String, String, Integer>
-            delayedSlotMoveWorker,
-        GroupCleanupWorker<String, String, String, String, String, Integer> groupCleanupWorker) {
+    GroupSizeFixWorker<String, String, String, String, String, Integer, Void>
+        createGroupSizeFixWorker(
+            String label,
+            GroupCommitConfig config,
+            GroupManager<String, String, String, String, String, Integer, Void> groupManager,
+            DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void>
+                delayedSlotMoveWorker,
+            GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+                groupCleanupWorker) {
       testableGroupCommitterGroupSizeFixWorkerCreated.set(true);
       return groupSizeFixWorker;
     }
 
     @Override
-    DelayedSlotMoveWorker<String, String, String, String, String, Integer>
+    DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void>
         createDelayedSlotMoveWorker(
             String label,
             GroupCommitConfig config,
-            GroupManager<String, String, String, String, String, Integer> groupManager,
-            GroupCleanupWorker<String, String, String, String, String, Integer>
+            GroupManager<String, String, String, String, String, Integer, Void> groupManager,
+            GroupCleanupWorker<String, String, String, String, String, Integer, Void>
                 groupCleanupWorker) {
       testableGroupCommitterDelayedSlotMoveWorkerCreated.set(true);
       return delayedSlotMoveWorker;
     }
 
     @Override
-    GroupCleanupWorker<String, String, String, String, String, Integer> createGroupCleanupWorker(
-        String label,
-        GroupCommitConfig config,
-        GroupManager<String, String, String, String, String, Integer> groupManager) {
+    GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+        createGroupCleanupWorker(
+            String label,
+            GroupCommitConfig config,
+            GroupManager<String, String, String, String, String, Integer, Void> groupManager) {
       testableGroupCommitterGroupCleanupWorkerCreated.set(true);
       return groupCleanupWorker;
     }
@@ -127,8 +132,9 @@ class GroupCommitterTest {
     testableGroupCommitterGroupCommitMonitorCreated.set(false);
   }
 
-  private GroupCommitter<String, String, String, String, String, Integer> createGroupCommitter(
-      int slotCapacity, int groupSizeFixTimeoutMillis, int delayedSlotMoveTimeoutMillis) {
+  private GroupCommitter<String, String, String, String, String, Integer, Void>
+      createGroupCommitter(
+          int slotCapacity, int groupSizeFixTimeoutMillis, int delayedSlotMoveTimeoutMillis) {
     return new GroupCommitter<>(
         "test",
         new GroupCommitConfig(
@@ -177,7 +183,7 @@ class GroupCommitterTest {
   @Test
   void reserve_GivenArbitraryChildKey_ShouldReturnFullKeyProperly() throws Exception {
     // Arrange
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(emitter);
 
@@ -203,7 +209,7 @@ class GroupCommitterTest {
   @Test
   void reserve_WhenAlreadyClosed_ShouldThrowException() {
     // Arrange
-    GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400);
     groupCommitter.setEmitter(emitter);
     groupCommitter.close();
@@ -217,7 +223,7 @@ class GroupCommitterTest {
   void ready_WhenTwoSlotsAreReadyInNormalGroup_WithSuccessfulEmitTask_ShouldEmitThem()
       throws Exception {
     // Arrange
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(emitter);
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -256,21 +262,21 @@ class GroupCommitterTest {
   @Test
   void ready_WhenTwoSlotsAreReadyInNormalGroup_WithFailingEmitTask_ShouldFail() throws Exception {
     // Arrange
-    Emittable<String, String, Integer> failingEmitter =
+    Emittable<String, String, Integer, Void> failingEmitter =
         spy(
-            new Emittable<String, String, Integer>() {
+            new Emittable<String, String, Integer, Void>() {
               @Override
-              public void emitNormalGroup(String parentKey, List<Integer> values) {
+              public Void emitNormalGroup(String parentKey, List<Integer> values) {
                 throw new RuntimeException("Something is wrong");
               }
 
               @Override
-              public void emitDelayedGroup(String fullKey, Integer value) throws Exception {
+              public Void emitDelayedGroup(String fullKey, Integer value) throws Exception {
                 throw new RuntimeException("Something is wrong");
               }
             });
 
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(failingEmitter);
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -313,7 +319,7 @@ class GroupCommitterTest {
     // Arrange
 
     // `delayedSlotMoveTimeoutMillis` is enough long to wait `ready()`.
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 2000)) {
       groupCommitter.setEmitter(emitter);
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -354,7 +360,7 @@ class GroupCommitterTest {
   void ready_WhenSlotIsReadyInDelayedGroup_WithSuccessfulEmitTask_ShouldEmitThem()
       throws Exception {
     // Arrange
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(emitter);
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -398,21 +404,21 @@ class GroupCommitterTest {
   @Test
   void ready_WhenSlotIsReadyInDelayedGroup_WithFailingEmitTask_ShouldFail() throws Exception {
     // Arrange
-    Emittable<String, String, Integer> failingEmitter =
+    Emittable<String, String, Integer, Void> failingEmitter =
         spy(
-            new Emittable<String, String, Integer>() {
+            new Emittable<String, String, Integer, Void>() {
               @Override
-              public void emitNormalGroup(String parentKey, List<Integer> values) {
+              public Void emitNormalGroup(String parentKey, List<Integer> values) {
                 throw new RuntimeException("Something is wrong");
               }
 
               @Override
-              public void emitDelayedGroup(String fullKey, Integer value) throws Exception {
+              public Void emitDelayedGroup(String fullKey, Integer value) throws Exception {
                 throw new RuntimeException("Something is wrong");
               }
             });
 
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(failingEmitter);
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -459,7 +465,7 @@ class GroupCommitterTest {
   void remove_GivenKeyForOpenGroup_ShouldRemoveIt() throws Exception {
     // Arrange
     // `slotCapacity` is 3 to prevent the group from being size-fixed.
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(3, 100, 400)) {
       groupCommitter.setEmitter(emitter);
 
@@ -488,7 +494,7 @@ class GroupCommitterTest {
   @Test
   void remove_GivenKeyForSizeFixedGroup_ShouldRemoveIt() throws Exception {
     // Arrange
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(emitter);
 
@@ -518,21 +524,22 @@ class GroupCommitterTest {
   void remove_GivenKeyForReadyGroup_ShouldFail() throws Exception {
     // Arrange
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    Emittable<String, String, Integer> testableEmitter =
+    Emittable<String, String, Integer, Void> testableEmitter =
         spy(
-            new Emittable<String, String, Integer>() {
+            new Emittable<String, String, Integer, Void>() {
               @Override
-              public void emitNormalGroup(String parentKey, List<Integer> values) throws Exception {
+              public Void emitNormalGroup(String parentKey, List<Integer> values) throws Exception {
                 countDownLatch.await();
+                return null;
               }
 
               @Override
-              public void emitDelayedGroup(String fullKey, Integer value) {
+              public Void emitDelayedGroup(String fullKey, Integer value) {
                 throw new AssertionError();
               }
             });
 
-    try (GroupCommitter<String, String, String, String, String, Integer> groupCommitter =
+    try (GroupCommitter<String, String, String, String, String, Integer, Void> groupCommitter =
         createGroupCommitter(2, 100, 400)) {
       groupCommitter.setEmitter(testableEmitter);
       ExecutorService executorService = Executors.newCachedThreadPool();

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
@@ -21,13 +21,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class GroupManagerTest {
   private static final int TIMEOUT_CHECK_INTERVAL_MILLIS = 10;
   private TestableGroupCommitKeyManipulator keyManipulator;
-  @Mock private Emittable<String, String, Integer> emittable;
+  @Mock private Emittable<String, String, Integer, Void> emittable;
 
   @Mock
-  private GroupSizeFixWorker<String, String, String, String, String, Integer> groupSizeFixWorker;
+  private GroupSizeFixWorker<String, String, String, String, String, Integer, Void>
+      groupSizeFixWorker;
 
   @Mock
-  private GroupCleanupWorker<String, String, String, String, String, Integer> groupCleanupWorker;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+      groupCleanupWorker;
 
   @BeforeEach
   void setUp() {
@@ -41,7 +43,7 @@ class GroupManagerTest {
   void reserveNewSlot_WhenCurrentGroupDoesNotExist_ShouldCreateNewGroupAndReserveSlotInIt() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -65,7 +67,7 @@ class GroupManagerTest {
   void reserveNewSlot_WhenAvailableSlotsExistInCurrentGroup_ShouldReserveSlotInCurrentGroup() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -93,7 +95,7 @@ class GroupManagerTest {
   void reserveNewSlot_WhenCurrentGroupIsSizeFixed_ShouldCreateNewGroupAndReserveSlotInIt() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -127,7 +129,7 @@ class GroupManagerTest {
   void getGroup_GivenKeyForNormalGroup_ShouldReturnProperly() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -149,21 +151,21 @@ class GroupManagerTest {
     // - NormalGroup("0001", OPEN, slots:[Slot("child-key-3")])
 
     // Act
-    Group<String, String, String, String, String, Integer> groupForKeys1 =
+    Group<String, String, String, String, String, Integer, Void> groupForKeys1 =
         groupManager.getGroup(keys1);
-    Group<String, String, String, String, String, Integer> groupForKeys2 =
+    Group<String, String, String, String, String, Integer, Void> groupForKeys2 =
         groupManager.getGroup(keys2);
-    Group<String, String, String, String, String, Integer> groupForKeys3 =
+    Group<String, String, String, String, String, Integer, Void> groupForKeys3 =
         groupManager.getGroup(keys3);
 
     // Assert
     assertThat(groupForKeys1).isInstanceOf(NormalGroup.class);
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupForKeys1;
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>) groupForKeys1;
 
     assertThat(groupForKeys3).isInstanceOf(NormalGroup.class);
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey3 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupForKeys3;
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey3 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>) groupForKeys3;
 
     // The first 2 NormalGroups are the same since the capacity is 2.
     assertThat(normalGroupForKey1).isEqualTo(groupForKeys2);
@@ -182,7 +184,7 @@ class GroupManagerTest {
       throws ExecutionException, InterruptedException {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -201,12 +203,14 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", SIZE-FIXED, slots:[Slot("child-key-1"), Slot("child-key-2")])
 
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
 
     // Put a value to the slot to mark it as ready.
     Future<Boolean> future =
-        executorService.submit(() -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42));
+        executorService.submit(
+            () -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42) != null);
     executorService.shutdown();
     // Wait until the thread waits on the slot.
     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
@@ -227,8 +231,8 @@ class GroupManagerTest {
     assertThat(normalGroupForKey1.slots.size()).isEqualTo(1);
     assertThat(normalGroupForKey1.isDone()).isTrue();
 
-    DelayedGroup<String, String, String, String, String, Integer> delayedGroupForKey2 =
-        (DelayedGroup<String, String, String, String, String, Integer>)
+    DelayedGroup<String, String, String, String, String, Integer, Void> delayedGroupForKey2 =
+        (DelayedGroup<String, String, String, String, String, Integer, Void>)
             groupManager.getGroup(keys2);
     assertThat(delayedGroupForKey2.isSizeFixed()).isTrue();
     assertThat(delayedGroupForKey2.isReady()).isFalse();
@@ -238,7 +242,7 @@ class GroupManagerTest {
   void removeGroupFromMap_GivenKeyForNormalGroup_ShouldRemoveThemProperly() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -271,7 +275,7 @@ class GroupManagerTest {
       throws ExecutionException, InterruptedException {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -290,12 +294,14 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", SIZE-FIXED, slots:[Slot("child-key-1"), Slot("child-key-2")])
 
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
 
     // Put a value to the slot to mark the slot as ready.
     Future<Boolean> future =
-        executorService.submit(() -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42));
+        executorService.submit(
+            () -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42) != null);
     executorService.shutdown();
     // Wait until the thread waits on the slot.
     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
@@ -307,7 +313,7 @@ class GroupManagerTest {
     // - NormalGroup("0000", READY, slots:[Slot(READY, "child-key-1")])
     // - DelayedGroup("0000:child-key-2", SIZE-FIXED, slots:[Slot("child-key-2")])
 
-    Group<String, String, String, String, String, Integer> groupForKey2 =
+    Group<String, String, String, String, String, Integer, Void> groupForKey2 =
         groupManager.getGroup(keys2);
     assertThat(groupForKey2).isInstanceOf(DelayedGroup.class);
     assertThat(groupForKey2.isSizeFixed()).isTrue();
@@ -333,7 +339,7 @@ class GroupManagerTest {
   void removeSlotFromGroup_GivenKeyForSlotInNormalGroup_ShouldRemoveSlotFromThemProperly() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -354,9 +360,9 @@ class GroupManagerTest {
     // - NormalGroup("0000", SIZE-FIXED, slots:[Slot("child-key-1"), Slot("child-key-2")])
     // - NormalGroup("0001", OPEN, slots:[Slot("child-key-3")])
 
-    Group<String, String, String, String, String, Integer> groupForKeys1 =
+    Group<String, String, String, String, String, Integer, Void> groupForKeys1 =
         groupManager.getGroup(keys1);
-    Group<String, String, String, String, String, Integer> groupForKeys3 =
+    Group<String, String, String, String, String, Integer, Void> groupForKeys3 =
         groupManager.getGroup(keys3);
 
     // Act
@@ -383,7 +389,7 @@ class GroupManagerTest {
       throws ExecutionException, InterruptedException {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -399,10 +405,12 @@ class GroupManagerTest {
     // Add slot-2.
     Keys<String, String, String> keys2 =
         keyManipulator.keysFromFullKey(groupManager.reserveNewSlot("child-key-2"));
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
     Future<Boolean> future =
-        executorService.submit(() -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42));
+        executorService.submit(
+            () -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42) != null);
     executorService.shutdown();
     // Wait until the thread waits on the slot.
     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
@@ -416,7 +424,7 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", READY, slots:[Slot(READY, "child-key-1")])
     // - DelayedGroup("0000:child-key-2", SIZE-FIXED, slots:[Slot("child-key-2")])
-    Group<String, String, String, String, String, Integer> groupForKey2 =
+    Group<String, String, String, String, String, Integer, Void> groupForKey2 =
         groupManager.getGroup(keys2);
     assertThat(groupForKey2).isInstanceOf(DelayedGroup.class);
     assertThat(groupForKey2.isSizeFixed()).isTrue();
@@ -442,7 +450,7 @@ class GroupManagerTest {
   void moveDelayedSlotToDelayedGroup_GivenKeyForOpenGroup_ShouldKeepThem() {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -456,8 +464,9 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", OPEN, slots:[Slot("child-key-1")])
 
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
 
     // Act
     boolean moved = groupManager.moveDelayedSlotToDelayedGroup(normalGroupForKey1);
@@ -473,7 +482,7 @@ class GroupManagerTest {
       throws ExecutionException, InterruptedException {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(3, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -491,10 +500,12 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", OPEN, slots:[Slot("child-key-1"), Slot("child-key-2")])
 
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
     Future<Boolean> future =
-        executorService.submit(() -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42));
+        executorService.submit(
+            () -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42) != null);
     executorService.shutdown();
     // Wait until the thread waits on the slot.
     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
@@ -529,7 +540,7 @@ class GroupManagerTest {
   void
       moveDelayedSlotToDelayedGroup_GivenKeyForSizeFixedGroupWithAllNotReadySlots_ShouldKeepThem() {
     // Arrange
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -545,8 +556,9 @@ class GroupManagerTest {
     // These groups are supposed to exist at this moment.
     // - NormalGroup("0000", SIZE-FIXED, slots:[Slot("child-key-1"), Slot("child-key-2")])
 
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
 
     // Act
     boolean moved = groupManager.moveDelayedSlotToDelayedGroup(normalGroupForKey1);
@@ -563,7 +575,7 @@ class GroupManagerTest {
           throws InterruptedException, ExecutionException {
     // Arrange
 
-    GroupManager<String, String, String, String, String, Integer> groupManager =
+    GroupManager<String, String, String, String, String, Integer, Void> groupManager =
         new GroupManager<>(
             new GroupCommitConfig(2, 100, 400, 60000, TIMEOUT_CHECK_INTERVAL_MILLIS),
             keyManipulator);
@@ -579,10 +591,12 @@ class GroupManagerTest {
     // Add slot-2.
     Keys<String, String, String> keys2 =
         keyManipulator.keysFromFullKey(groupManager.reserveNewSlot("child-key-2"));
-    NormalGroup<String, String, String, String, String, Integer> normalGroupForKey1 =
-        (NormalGroup<String, String, String, String, String, Integer>) groupManager.getGroup(keys1);
+    NormalGroup<String, String, String, String, String, Integer, Void> normalGroupForKey1 =
+        (NormalGroup<String, String, String, String, String, Integer, Void>)
+            groupManager.getGroup(keys1);
     Future<Boolean> future =
-        executorService.submit(() -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42));
+        executorService.submit(
+            () -> normalGroupForKey1.putValueToSlotAndWait("child-key-1", 42) != null);
     executorService.shutdown();
     // Wait until the thread waits on the slot.
     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
@@ -602,8 +616,8 @@ class GroupManagerTest {
     assertThat(normalGroupForKey1.slots.size()).isEqualTo(1);
     assertThat(normalGroupForKey1.isDone()).isTrue();
 
-    DelayedGroup<String, String, String, String, String, Integer> delayedGroupForKey2 =
-        (DelayedGroup<String, String, String, String, String, Integer>)
+    DelayedGroup<String, String, String, String, String, Integer, Void> delayedGroupForKey2 =
+        (DelayedGroup<String, String, String, String, String, Integer, Void>)
             groupManager.getGroup(keys2);
     assertThat(delayedGroupForKey2.isSizeFixed()).isTrue();
     assertThat(delayedGroupForKey2.isReady()).isFalse();

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupSizeFixWorkerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupSizeFixWorkerTest.java
@@ -23,18 +23,19 @@ class GroupSizeFixWorkerTest {
   private static final int LONG_WAIT_MILLIS = 500;
 
   @Mock
-  private DelayedSlotMoveWorker<String, String, String, String, String, Integer>
+  private DelayedSlotMoveWorker<String, String, String, String, String, Integer, Void>
       delayedSlotMoveWorker;
 
   @Mock
-  private GroupCleanupWorker<String, String, String, String, String, Integer> groupCleanupWorker;
+  private GroupCleanupWorker<String, String, String, String, String, Integer, Void>
+      groupCleanupWorker;
 
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup1;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup2;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup3;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> normalGroup4;
-  private GroupSizeFixWorker<String, String, String, String, String, Integer> worker;
-  private GroupSizeFixWorker<String, String, String, String, String, Integer> workerWithWait;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup1;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup2;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup3;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> normalGroup4;
+  private GroupSizeFixWorker<String, String, String, String, String, Integer, Void> worker;
+  private GroupSizeFixWorker<String, String, String, String, String, Integer, Void> workerWithWait;
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
@@ -24,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class NormalGroupTest {
-  @Mock private Emittable<String, String, Integer> emitter;
+  @Mock private Emittable<String, String, Integer, Void> emitter;
   private TestableGroupCommitKeyManipulator keyManipulator;
 
   @BeforeEach
@@ -38,7 +38,7 @@ class NormalGroupTest {
   void parentKey_WithKeyManipulator_ShouldReturnProperly() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
 
     // Act
@@ -50,7 +50,7 @@ class NormalGroupTest {
   void fullKey_WithKeyManipulator_ShouldReturnProperly() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
 
     // Act
@@ -62,10 +62,12 @@ class NormalGroupTest {
   void reserveNewSlot_GivenArbitrarySlot_ShouldStoreIt() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
 
     assertThat(group.size()).isNull();
     assertThat(group.isSizeFixed()).isFalse();
@@ -82,19 +84,20 @@ class NormalGroupTest {
     assertThat(group.isReady()).isFalse();
   }
 
-  Emittable<String, String, Integer> createEmitter(ThrowableRunnable<Exception> task) {
-    return new Emittable<String, String, Integer>() {
+  Emittable<String, String, Integer, Void> createEmitter(ThrowableRunnable<Exception> task) {
+    return new Emittable<String, String, Integer, Void>() {
       @Override
-      public void emitNormalGroup(String s, List<Integer> values) {
+      public Void emitNormalGroup(String s, List<Integer> values) {
         try {
           task.run();
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
+        return null;
       }
 
       @Override
-      public void emitDelayedGroup(String s, Integer value) {
+      public Void emitDelayedGroup(String s, Integer value) {
         throw new AssertionError();
       }
     };
@@ -107,15 +110,16 @@ class NormalGroupTest {
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     AtomicBoolean emitted = new AtomicBoolean();
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> waitableEmitter =
+    Emittable<String, String, Integer, Void> waitableEmitter =
         createEmitter(
             () -> {
               wait.await();
               emitted.set(true);
             });
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, waitableEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     group.reserveNewSlot(slot1);
@@ -158,16 +162,18 @@ class NormalGroupTest {
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     AtomicBoolean emitted = new AtomicBoolean();
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> waitableEmitter =
+    Emittable<String, String, Integer, Void> waitableEmitter =
         createEmitter(
             () -> {
               wait.await();
               emitted.set(true);
             });
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, waitableEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     group.reserveNewSlot(slot1);
@@ -216,17 +222,20 @@ class NormalGroupTest {
     GroupCommitConfig config = new GroupCommitConfig(2 + 1, 100, 1000, 60000, 20);
     AtomicBoolean emitted = new AtomicBoolean();
     CountDownLatch wait = new CountDownLatch(1);
-    Emittable<String, String, Integer> waitableEmitter =
+    Emittable<String, String, Integer, Void> waitableEmitter =
         createEmitter(
             () -> {
               wait.await();
               emitted.set(true);
             });
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, waitableEmitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
-    Slot<String, String, String, String, String, Integer> slot3 = new Slot<>("child-key-3", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot3 =
+        new Slot<>("child-key-3", group);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     group.reserveNewSlot(slot1);
@@ -258,7 +267,7 @@ class NormalGroupTest {
     // Assert
 
     // Remove the not-ready slot (slot3).
-    List<Slot<String, String, String, String, String, Integer>> notReadySlots =
+    List<Slot<String, String, String, String, String, Integer, Void>> notReadySlots =
         group.removeNotReadySlots();
     assertThat(notReadySlots).isNotNull().size().isEqualTo(1);
     assertThat(notReadySlots.get(0).isReady()).isFalse();
@@ -283,10 +292,12 @@ class NormalGroupTest {
   void removeNotReadySlots_WhenAllSlotsAreNotReady_ShouldRetainSlots() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
 
     group.reserveNewSlot(slot1);
     group.reserveNewSlot(slot2);
@@ -302,10 +313,12 @@ class NormalGroupTest {
   void removeSlot_GivenNotReadySlot_ShouldRemoveSlotAndGetDone() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
 
     group.reserveNewSlot(slot1);
     group.reserveNewSlot(slot2);
@@ -327,10 +340,12 @@ class NormalGroupTest {
   void removeSlot_GivenReadySlot_ShouldDoNothing() throws ExecutionException, InterruptedException {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 = new Slot<>("child-key-1", group);
-    Slot<String, String, String, String, String, Integer> slot2 = new Slot<>("child-key-2", group);
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
+        new Slot<>("child-key-1", group);
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
+        new Slot<>("child-key-2", group);
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     group.reserveNewSlot(slot1);
@@ -370,11 +385,11 @@ class NormalGroupTest {
   void abort_ShouldAbortSlot() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
-    Slot<String, String, String, String, String, Integer> slot1 =
+    Slot<String, String, String, String, String, Integer, Void> slot1 =
         spy(new Slot<>("child-key-1", group));
-    Slot<String, String, String, String, String, Integer> slot2 =
+    Slot<String, String, String, String, String, Integer, Void> slot2 =
         spy(new Slot<>("child-key-2", group));
     group.reserveNewSlot(slot1);
     group.reserveNewSlot(slot2);
@@ -392,7 +407,7 @@ class NormalGroupTest {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     long minOfCurrentTimeMillis = System.currentTimeMillis();
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
     long maxOfCurrentTimeMillis = System.currentTimeMillis();
 
@@ -408,7 +423,7 @@ class NormalGroupTest {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     long minOfCurrentTimeMillis = System.currentTimeMillis();
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
     long maxOfCurrentTimeMillis = System.currentTimeMillis();
 
@@ -424,7 +439,7 @@ class NormalGroupTest {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
     long minOfCurrentTimeMillis = System.currentTimeMillis();
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
     long maxOfCurrentTimeMillis = System.currentTimeMillis();
 
@@ -439,7 +454,7 @@ class NormalGroupTest {
   void updateDelayedSlotMoveTimeoutAtMillis_GivenArbitraryTimeoutValue_ShouldUpdateProperly() {
     // Arrange
     GroupCommitConfig config = new GroupCommitConfig(2, 100, 1000, 60000, 20);
-    NormalGroup<String, String, String, String, String, Integer> group =
+    NormalGroup<String, String, String, String, String, Integer, Void> group =
         new NormalGroup<>(config, emitter, keyManipulator);
 
     // Act

--- a/core/src/test/java/com/scalar/db/util/groupcommit/SlotTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/SlotTest.java
@@ -21,9 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SlotTest {
-  private Slot<String, String, String, String, String, Integer> slot;
-  @Mock private NormalGroup<String, String, String, String, String, Integer> parentGroup;
-  @Mock private DelayedGroup<String, String, String, String, String, Integer> newParentGroup;
+  private Slot<String, String, String, String, String, Integer, Void> slot;
+  @Mock private NormalGroup<String, String, String, String, String, Integer, Void> parentGroup;
+  @Mock private DelayedGroup<String, String, String, String, String, Integer, Void> newParentGroup;
 
   @BeforeEach
   void setUp() {
@@ -33,7 +33,7 @@ class SlotTest {
   @Test
   void key_WithArbitraryValue_ShouldReturnProperly() {
     // Arrange
-    Slot<String, String, String, String, String, Integer> slot =
+    Slot<String, String, String, String, String, Integer, Void> slot =
         new Slot<>("child-key", parentGroup);
 
     // Act
@@ -122,7 +122,7 @@ class SlotTest {
       assertThat(exception.get()).isNull();
       assertThat(slot.isDone()).isFalse();
     } finally {
-      slot.markAsSuccess();
+      slot.markAsSuccess(null);
     }
   }
 
@@ -146,7 +146,7 @@ class SlotTest {
             });
     executorService.shutdown();
 
-    slot.markAsSuccess();
+    slot.markAsSuccess(null);
 
     // Assert
     future.get();
@@ -206,7 +206,11 @@ class SlotTest {
             });
     executorService.shutdown();
 
-    slot.delegateTaskToWaiter(() -> result.set(42));
+    slot.delegateTaskToWaiter(
+        () -> {
+          result.set(42);
+          return null;
+        });
 
     // Assert
     future.get();


### PR DESCRIPTION
## Description

The group commit framework (`com.scalar.db.util.groupcommit`) emits a group of slots through an `Emittable`, but the emit produced no value: `Emittable#emitNormalGroup` / `emitDelayedGroup` returned `void` and `GroupCommitter#ready` returned `void`. As a result, a value computed at emit time (for example, the timestamp written when the Coordinator state row is persisted) could not be handed back to the transactions that were grouped into that emit.

This PR generalizes the framework with a trailing emit-result type parameter `R` so that an emit can return a result, and that single result is handed back to every slot in the emitted group via `GroupCommitter#ready`. This is a behavior-preserving change on its own: the only current caller (the Coordinator-side group committer) adopts `R = Void` and ignores the result, so nothing changes functionally yet. It is the prerequisite for a follow-up change that uses the emit-time commit timestamp so that, under group commit, the COMMITTED Coordinator row and the committed data records share a single `committedAt`.

## Related issues and/or PRs

- Prerequisite for #3654 (Unify commit-phase timestamps), which will be retargeted on top of this branch and will use the new emit result to thread `committedAt` through the group-commit path.

## Changes made

- Added a trailing type parameter `R` (the emit result) to the group commit framework:
  - `Emittable<PARENT_KEY, FULL_KEY, V, R>`: `emitNormalGroup` / `emitDelayedGroup` now return `R`.
  - `GroupCommitter#ready(...)` now returns `R`.
  - `Slot`: the emit task is now a `ThrowableSupplier<R, Exception>`; `waitUntilEmit()` returns `R`; added an `emitResult` holder; `markAsSuccess(R)` hands the result to non-emitter slots.
  - `NormalGroup`: the emitter slot computes the single emit result and distributes the same value to every other slot in the group; `DelayedGroup` returns its single emit's result.
  - `Group#putValueToSlotAndWait` returns an `EmitResult<R>` wrapper (null = retry needed) so a successful emit carrying a `null` result is distinguishable from the retry signal.
  - Threaded `R` through `GroupManager` and the background workers (`GroupSizeFixWorker`, `DelayedSlotMoveWorker`, `GroupCleanupWorker`).
- Wired the Coordinator layer with `R = Void` (no behavioral change): `CoordinatorGroupCommitter extends GroupCommitter<..., TransactionContext, Void>` and the `Emitter` implements `Emittable<..., Void>` (returns `null`).
- Updated the affected unit tests to the new signatures.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The change deliberately rides the framework's existing emitter/waiter mechanism (one slot runs the emit, the others wait and are woken): the emitter slot obtains the result as the task's return value, and the other slots receive the same result through `markAsSuccess(R)`. As such, all transactions grouped into one emit observe the same result from `ready()`.

Because the only current consumer uses `R = Void`, the result is unused for now; it becomes meaningful in #3654.

## Release notes

N/A
