### PR TITLE
Implement the TwoPhaseCommit Coordinator and Participant for Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
@@ -46,4 +46,26 @@ public interface DistributedTransactionProvider {
    */
   @Nullable
   TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(DatabaseConfig config);
+
+  /**
+   * Creates an instance of {@link TwoPhaseCommit.Coordinator} for the new multi-participant
+   * two-phase commit interface.
+   *
+   * @param config a database config
+   * @return an instance of {@link TwoPhaseCommit.Coordinator}
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config);
+
+  /**
+   * Creates an instance of {@link TwoPhaseCommit.Participant} for the new multi-participant
+   * two-phase commit interface.
+   *
+   * @param config a database config
+   * @return an instance of {@link TwoPhaseCommit.Participant}
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config);
 }

--- a/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
@@ -5,57 +5,19 @@ import com.scalar.db.api.CrudOperable;
 import com.scalar.db.api.Result;
 import com.scalar.db.exception.transaction.TransactionException;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.NotThreadSafe;
 
 public abstract class AbstractCrudOperableScanner<E extends TransactionException>
     implements CrudOperable.Scanner<E> {
 
-  @LazyInit private ScannerIterator scannerIterator;
+  @LazyInit private ScannerIterator<E> scannerIterator;
 
   @Override
   @Nonnull
   public Iterator<Result> iterator() {
     if (scannerIterator == null) {
-      scannerIterator = new ScannerIterator(this);
+      scannerIterator = new ScannerIterator<>(this);
     }
     return scannerIterator;
-  }
-
-  @NotThreadSafe
-  public class ScannerIterator implements Iterator<Result> {
-
-    private final CrudOperable.Scanner<E> scanner;
-    private Result next;
-
-    public ScannerIterator(CrudOperable.Scanner<E> scanner) {
-      this.scanner = Objects.requireNonNull(scanner);
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (next != null) {
-        return true;
-      }
-
-      try {
-        return (next = scanner.one().orElse(null)) != null;
-      } catch (TransactionException e) {
-        throw new RuntimeException(e.getMessage(), e);
-      }
-    }
-
-    @Override
-    public Result next() {
-      if (!hasNext()) {
-        throw new NoSuchElementException();
-      }
-
-      Result ret = next;
-      next = null;
-      return ret;
-    }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -237,13 +237,6 @@ public enum CoreError implements ScalarDbError {
       "",
       ""),
   TRANSACTION_ALREADY_EXISTS(Category.USER_ERROR, "0047", "The transaction already exists", "", ""),
-  TRANSACTION_NOT_FOUND(
-      Category.USER_ERROR,
-      "0048",
-      "A transaction associated with the specified transaction ID is not found. "
-          + "The transaction might have expired",
-      "",
-      ""),
   SYSTEM_NAMESPACE_SPECIFIED(
       Category.USER_ERROR, "0049", "%s is the system namespace name", "", ""),
   NAMESPACE_ALREADY_EXISTS(
@@ -1101,6 +1094,25 @@ public enum CoreError implements ScalarDbError {
       "Recovering a record is not supported in single CRUD operation transactions",
       "",
       ""),
+  CONSENSUS_COMMIT_PARTICIPANT_ID_IS_REQUIRED(
+      Category.USER_ERROR,
+      "0293",
+      "A participant ID is required for the new TwoPhaseCommit.Participant. "
+          + "Set the property: scalar.db.consensus_commit.participant_id",
+      "",
+      ""),
+  JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0294",
+      "Two-phase commit is not supported in JDBC transactions",
+      "",
+      ""),
+  SINGLE_CRUD_OPERATION_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0295",
+      "Two-phase commit is not supported in single CRUD operation transactions",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -1250,6 +1262,13 @@ public enum CoreError implements ScalarDbError {
       Category.CONCURRENCY_ERROR,
       "0030",
       "Resolving an uncommitted record exceeded the retry limit during recovery. Transaction ID: %s",
+      "",
+      ""),
+  TRANSACTION_NOT_FOUND(
+      Category.CONCURRENCY_ERROR,
+      "0031",
+      "A transaction associated with the specified transaction ID is not found. "
+          + "The transaction might have expired",
       "",
       ""),
 

--- a/core/src/main/java/com/scalar/db/common/ScannerIterator.java
+++ b/core/src/main/java/com/scalar/db/common/ScannerIterator.java
@@ -1,0 +1,56 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Result;
+import com.scalar.db.exception.transaction.TransactionException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * An {@link Iterator} over a {@link CrudOperable.Scanner} that drives the scanner's {@code one()}
+ * for every element.
+ *
+ * <p>Scanner decorators return this from {@code iterator()} so that iteration flows through the
+ * (decorated) {@code one()} — inheriting whatever that {@code one()} does (e.g. locking, a liveness
+ * re-check, or an idle-timer refresh) — rather than the underlying scanner's own iterator, which
+ * would bypass the decorator. It is single-consumer and not thread-safe; any synchronization it
+ * appears to provide actually lives in the {@code one()} it drives, not here.
+ *
+ * @param <E> the checked exception the scanner's read methods throw
+ */
+@NotThreadSafe
+public class ScannerIterator<E extends TransactionException> implements Iterator<Result> {
+
+  private final CrudOperable.Scanner<E> scanner;
+  private Result next;
+
+  public ScannerIterator(CrudOperable.Scanner<E> scanner) {
+    this.scanner = Objects.requireNonNull(scanner);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (next != null) {
+      return true;
+    }
+
+    try {
+      return (next = scanner.one().orElse(null)) != null;
+    } catch (TransactionException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public Result next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    Result ret = next;
+    next = null;
+    return ret;
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/SynchronizedScanner.java
+++ b/core/src/main/java/com/scalar/db/common/SynchronizedScanner.java
@@ -55,8 +55,9 @@ public class SynchronizedScanner implements Scanner {
   @Nonnull
   @Override
   public Iterator<Result> iterator() {
-    synchronized (lock) {
-      return delegate.iterator();
-    }
+    // Drive iteration through this decorator's one() (which synchronizes on the lock) rather than
+    // returning delegate.iterator(): the delegate's iterator is bound to the raw scanner, so its
+    // hasNext()/next() would call the underlying one() without the lock, defeating this decorator.
+    return new ScannerIterator<>(this);
   }
 }

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransaction.java
@@ -1,0 +1,191 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Adapts a {@link TwoPhaseCommit.Coordinator} + a single in-process {@link
+ * TwoPhaseCommit.Participant} to the single-phase {@link com.scalar.db.api.DistributedTransaction}
+ * API.
+ *
+ * <p>CRUD is delegated to the participant (keyed by this transaction's canonical ID); {@link
+ * #commit()} drives the full two-phase commit through the coordinator (which generates the
+ * prepared/committed timestamps internally); {@link #rollback()} drives the coordinator's rollback.
+ * The two-phase nature is fully internalized — callers see a single-phase transaction, so existing
+ * {@code DistributedTransaction} decorators and tests work unchanged.
+ *
+ * <p>See {@link TwoPhaseCommitBackedDistributedTransactionManager} for how the coordinator and
+ * participant are wired and the transaction is begun or joined.
+ */
+public class TwoPhaseCommitBackedDistributedTransaction extends AbstractDistributedTransaction {
+
+  private final TwoPhaseCommit.Coordinator coordinator;
+  @Nullable private final TwoPhaseCommit.Participant participant;
+  private final String transactionId;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public TwoPhaseCommitBackedDistributedTransaction(
+      TwoPhaseCommit.Coordinator coordinator,
+      @Nullable TwoPhaseCommit.Participant participant,
+      String transactionId) {
+    this.coordinator = coordinator;
+    this.participant = participant;
+    this.transactionId = transactionId;
+  }
+
+  @Override
+  public String getId() {
+    return transactionId;
+  }
+
+  private TwoPhaseCommit.Participant participant() {
+    if (participant == null) {
+      throw new UnsupportedOperationException(getParticipantNotConfiguredMessage());
+    }
+    return participant;
+  }
+
+  /**
+   * Builds the message for the {@link UnsupportedOperationException} thrown when an operation
+   * requires a participant but none is configured. This is a template method: subclasses can
+   * override it to customize the message.
+   *
+   * @return the exception message
+   */
+  protected String getParticipantNotConfiguredMessage() {
+    return "CRUD operations are not supported by this two-phase-commit-backed transaction because no"
+        + " participant is configured";
+  }
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException {
+    return crud(() -> participant().get(transactionId, copyAndSetTargetToIfNot(get)));
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException {
+    return crud(() -> participant().scan(transactionId, copyAndSetTargetToIfNot(scan)));
+  }
+
+  @Override
+  public TransactionCrudOperable.Scanner getScanner(Scan scan) throws CrudException {
+    return crud(() -> participant().getScanner(transactionId, copyAndSetTargetToIfNot(scan)));
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0 */
+  @Deprecated
+  @Override
+  public void put(Put put) throws CrudException {
+    crud(() -> participant().put(transactionId, copyAndSetTargetToIfNot(put)));
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0 */
+  @Deprecated
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    crud(() -> participant().mutate(transactionId, copyAndSetTargetToIfNot(puts)));
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    crud(() -> participant().insert(transactionId, copyAndSetTargetToIfNot(insert)));
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    crud(() -> participant().upsert(transactionId, copyAndSetTargetToIfNot(upsert)));
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    crud(() -> participant().update(transactionId, copyAndSetTargetToIfNot(update)));
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    crud(() -> participant().delete(transactionId, copyAndSetTargetToIfNot(delete)));
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    crud(() -> participant().mutate(transactionId, copyAndSetTargetToIfNot(deletes)));
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    crud(() -> participant().mutate(transactionId, copyAndSetTargetToIfNot(mutations)));
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(List<? extends Operation> operations)
+      throws CrudException {
+    return crud(() -> participant().batch(transactionId, copyAndSetTargetToIfNot(operations)));
+  }
+
+  @FunctionalInterface
+  private interface CrudSupplier<T> {
+    T get() throws CrudException, TransactionNotFoundException;
+  }
+
+  @FunctionalInterface
+  private interface CrudRunnable {
+    void run() throws CrudException, TransactionNotFoundException;
+  }
+
+  private <T> T crud(CrudSupplier<T> supplier) throws CrudException {
+    try {
+      return supplier.get();
+    } catch (TransactionNotFoundException e) {
+      throw new CrudConflictException(e.getMessage(), e, transactionId);
+    }
+  }
+
+  private void crud(CrudRunnable runnable) throws CrudException {
+    crud(
+        () -> {
+          runnable.run();
+          return null;
+        });
+  }
+
+  @Override
+  public void commit() throws CommitException, UnknownTransactionStatusException {
+    // Drive the full 2PC; the coordinator generates the prepared/committed timestamps internally.
+    // The coordinator already reports prepare/validate failures as CommitConflictException /
+    // CommitException, so those propagate as-is; only an unknown transaction needs translating.
+    try {
+      coordinator.commit(transactionId);
+    } catch (TransactionNotFoundException e) {
+      // The coordinator no longer knows this transaction (e.g., it expired). Surface it as a
+      // retriable commit conflict so the caller can restart the transaction from the beginning.
+      throw new CommitConflictException(e.getMessage(), e, transactionId);
+    }
+  }
+
+  @Override
+  public void rollback() throws RollbackException {
+    coordinator.rollback(transactionId);
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransactionManager.java
@@ -1,0 +1,445 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Isolation;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Selection;
+import com.scalar.db.api.SerializableStrategy;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TransactionManagerCrudOperable;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.io.Key;
+import com.scalar.db.util.ThrowableFunction;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+/**
+ * Adapts a {@link TwoPhaseCommit.Coordinator} + a single in-process {@link
+ * TwoPhaseCommit.Participant} to the {@link com.scalar.db.api.DistributedTransactionManager} API.
+ *
+ * <p>Each {@code begin} allocates a transaction via the coordinator, registers the in-process
+ * participant, and returns a {@link TwoPhaseCommitBackedDistributedTransaction}. The full two-phase
+ * commit protocol is internalized behind the single-phase {@code commit()} — so this manager can
+ * front the new Coordinator/Participant pair for (a) single-cluster clients and (b) running the
+ * existing {@code DistributedTransaction} integration-test corpus against the new code path.
+ *
+ * <p>Implementation-agnostic: it depends only on the public {@link TwoPhaseCommit} and {@link
+ * com.scalar.db.api.DistributedTransactionManager} interfaces. The concrete coordinator and
+ * participant (e.g., the consensuscommit-backed ones) are injected by the wiring layer.
+ *
+ * <p>Limitations: the {@link TwoPhaseCommit.Coordinator} interface exposes no by-ID operation on
+ * the Coordinator state table, so {@link #getState(String)}, {@link #rollback(String)} (and {@code
+ * abort(String)}, which delegates to it), {@link #finishTransaction(String)}, {@code
+ * recoverRecord}, and {@code resume} are unsupported and throw {@link
+ * UnsupportedOperationException}. The deprecated {@code start(...)} overloads ignore the
+ * per-transaction isolation / serializable strategy they carry; per-transaction isolation is
+ * instead honored via the {@code cc-transaction-isolation} attribute passed to {@code begin}.
+ */
+public class TwoPhaseCommitBackedDistributedTransactionManager
+    extends AbstractDistributedTransactionManager {
+
+  private final TwoPhaseCommit.Coordinator coordinator;
+  @Nullable private final TwoPhaseCommit.Participant participant;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public TwoPhaseCommitBackedDistributedTransactionManager(
+      DatabaseConfig config,
+      TwoPhaseCommit.Coordinator coordinator,
+      @Nullable TwoPhaseCommit.Participant participant) {
+    super(config);
+    this.coordinator = coordinator;
+    this.participant = participant;
+  }
+
+  @Override
+  public DistributedTransaction begin(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return beginInternal(txId, false, attributes);
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId, Map<String, String> attributes)
+      throws TransactionException {
+    return beginInternal(txId, true, attributes);
+  }
+
+  private DistributedTransaction beginInternal(
+      String txId, boolean readOnly, Map<String, String> attributes) throws TransactionException {
+    String canonicalId = coordinator.begin(txId, readOnly, attributes, participant);
+    DistributedTransaction transaction = createTransaction(coordinator, participant, canonicalId);
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
+    return transaction;
+  }
+
+  @Override
+  public DistributedTransaction join(String txId) throws TransactionException {
+    checkParticipantConfigured();
+    coordinator.registerParticipant(txId, participant);
+    DistributedTransaction transaction = createTransaction(coordinator, participant, txId);
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
+    return transaction;
+  }
+
+  /**
+   * Creates the {@link DistributedTransaction} instance returned by {@link #begin}, {@link
+   * #beginReadOnly}, and {@link #join}. This is a template method: subclasses can override it to
+   * customize the transaction instance (for example, to wrap it in a decorator).
+   *
+   * @param coordinator the coordinator driving the transaction
+   * @param participant the in-process participant, or {@code null} if none is configured
+   * @param canonicalId the canonical transaction ID
+   * @return the transaction instance
+   */
+  protected DistributedTransaction createTransaction(
+      TwoPhaseCommit.Coordinator coordinator,
+      @Nullable TwoPhaseCommit.Participant participant,
+      String canonicalId) {
+    return new TwoPhaseCommitBackedDistributedTransaction(coordinator, participant, canonicalId);
+  }
+
+  // The deprecated start(...) overloads carry per-transaction isolation / serializable strategy,
+  // which this path does not honor (isolation comes from configuration). Delegate to begin.
+
+  @Override
+  public DistributedTransaction start(Isolation isolation) throws TransactionException {
+    return begin();
+  }
+
+  @Override
+  public DistributedTransaction start(String txId, Isolation isolation)
+      throws TransactionException {
+    return begin(txId);
+  }
+
+  @Override
+  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
+      throws TransactionException {
+    return begin();
+  }
+
+  @Override
+  public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
+    return begin();
+  }
+
+  @Override
+  public DistributedTransaction start(String txId, SerializableStrategy strategy)
+      throws TransactionException {
+    return begin(txId);
+  }
+
+  @Override
+  public DistributedTransaction start(
+      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
+    return begin(txId);
+  }
+
+  // ---- TransactionManagerCrudOperable: one-shot CRUD (begin -> op -> commit) ----
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException, UnknownTransactionStatusException {
+    return executeTransaction(t -> t.get(copyAndSetTargetToIfNot(get)), true, get.getAttributes());
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException, UnknownTransactionStatusException {
+    return executeTransaction(
+        t -> t.scan(copyAndSetTargetToIfNot(scan)), true, scan.getAttributes());
+  }
+
+  @Override
+  public TransactionManagerCrudOperable.Scanner getScanner(Scan scan) throws CrudException {
+    checkParticipantConfigured();
+    DistributedTransaction transaction = beginOneOperation(true, scan.getAttributes());
+    TransactionCrudOperable.Scanner scanner;
+    try {
+      scanner = transaction.getScanner(copyAndSetTargetToIfNot(scan));
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    }
+    return new AbstractTransactionManagerCrudOperableScanner() {
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (CrudException e) {
+          closeScannerAndRollback(e);
+          throw e;
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (CrudException e) {
+          closeScannerAndRollback(e);
+          throw e;
+        }
+      }
+
+      @Override
+      public void close() throws CrudException, UnknownTransactionStatusException {
+        if (!closed.compareAndSet(false, true)) {
+          return;
+        }
+        try {
+          scanner.close();
+        } catch (CrudException e) {
+          rollbackTransaction(transaction);
+          throw e;
+        }
+        try {
+          transaction.commit();
+        } catch (CommitConflictException e) {
+          rollbackTransaction(transaction);
+          throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (UnknownTransactionStatusException e) {
+          throw e;
+        } catch (TransactionException e) {
+          rollbackTransaction(transaction);
+          throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        }
+      }
+
+      private void closeScannerAndRollback(CrudException cause) {
+        closed.set(true);
+        try {
+          scanner.close();
+        } catch (CrudException ex) {
+          cause.addSuppressed(ex);
+        }
+        rollbackTransaction(transaction);
+      }
+    };
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0 */
+  @Deprecated
+  @Override
+  public void put(Put put) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.put(copyAndSetTargetToIfNot(put));
+          return null;
+        },
+        false,
+        put.getAttributes());
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0 */
+  @Deprecated
+  @Override
+  public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.put(copyAndSetTargetToIfNot(puts));
+          return null;
+        },
+        false,
+        puts.isEmpty() ? Collections.emptyMap() : puts.get(0).getAttributes());
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.insert(copyAndSetTargetToIfNot(insert));
+          return null;
+        },
+        false,
+        insert.getAttributes());
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.upsert(copyAndSetTargetToIfNot(upsert));
+          return null;
+        },
+        false,
+        upsert.getAttributes());
+  }
+
+  @Override
+  public void update(Update update) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.update(copyAndSetTargetToIfNot(update));
+          return null;
+        },
+        false,
+        update.getAttributes());
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.delete(copyAndSetTargetToIfNot(delete));
+          return null;
+        },
+        false,
+        delete.getAttributes());
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.delete(copyAndSetTargetToIfNot(deletes));
+          return null;
+        },
+        false,
+        deletes.isEmpty() ? Collections.emptyMap() : deletes.get(0).getAttributes());
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations)
+      throws CrudException, UnknownTransactionStatusException {
+    executeTransaction(
+        t -> {
+          t.mutate(copyAndSetTargetToIfNot(mutations));
+          return null;
+        },
+        false,
+        mutations.isEmpty() ? Collections.emptyMap() : mutations.get(0).getAttributes());
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(List<? extends Operation> operations)
+      throws CrudException, UnknownTransactionStatusException {
+    boolean readOnly = operations.stream().allMatch(o -> o instanceof Selection);
+    return executeTransaction(
+        t -> t.batch(copyAndSetTargetToIfNot(operations)),
+        readOnly,
+        operations.isEmpty() ? Collections.emptyMap() : operations.get(0).getAttributes());
+  }
+
+  private <R> R executeTransaction(
+      ThrowableFunction<DistributedTransaction, R, TransactionException> operation,
+      boolean readOnly,
+      Map<String, String> attributes)
+      throws CrudException, UnknownTransactionStatusException {
+    checkParticipantConfigured();
+    DistributedTransaction transaction = beginOneOperation(readOnly, attributes);
+    try {
+      R result = operation.apply(transaction);
+      transaction.commit();
+      return result;
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    } catch (CommitConflictException e) {
+      rollbackTransaction(transaction);
+      throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    } catch (UnknownTransactionStatusException e) {
+      throw e;
+    } catch (TransactionException e) {
+      rollbackTransaction(transaction);
+      throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    }
+  }
+
+  private void checkParticipantConfigured() {
+    if (participant == null) {
+      throw new UnsupportedOperationException(getParticipantNotConfiguredMessage());
+    }
+  }
+
+  /**
+   * Builds the message for the {@link UnsupportedOperationException} thrown when an operation
+   * requires a participant but none is configured. This is a template method: subclasses can
+   * override it to customize the message.
+   *
+   * @return the exception message
+   */
+  protected String getParticipantNotConfiguredMessage() {
+    return "This operation is not supported by this two-phase-commit-backed transaction manager"
+        + " because no participant is configured";
+  }
+
+  private DistributedTransaction beginOneOperation(boolean readOnly, Map<String, String> attributes)
+      throws CrudException {
+    try {
+      return readOnly ? beginReadOnly(attributes) : begin(attributes);
+    } catch (TransactionNotFoundException e) {
+      // A transient begin failure surfaces as a retriable CRUD conflict.
+      throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    } catch (TransactionException e) {
+      throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    }
+  }
+
+  private void rollbackTransaction(DistributedTransaction transaction) {
+    try {
+      transaction.rollback();
+    } catch (RollbackException ignored) {
+      // Best-effort rollback; the original error is the one that matters.
+    }
+  }
+
+  @Override
+  public TransactionState getState(String txId) {
+    throw new UnsupportedOperationException(
+        "getState is not supported by the two-phase-commit-backed transaction manager");
+  }
+
+  @Override
+  public boolean finishTransaction(String txId) {
+    throw new UnsupportedOperationException(
+        "finishTransaction is not supported by the two-phase-commit-backed transaction manager");
+  }
+
+  @Override
+  public boolean recoverRecord(
+      String namespace, String table, Key partitionKey, @Nullable Key clusteringKey) {
+    throw new UnsupportedOperationException(
+        "recoverRecord is not supported by the two-phase-commit-backed transaction manager");
+  }
+
+  @Override
+  public TransactionState rollback(String txId) {
+    throw new UnsupportedOperationException(
+        "rollback/abort by transaction ID is not supported by the two-phase-commit-backed"
+            + " transaction manager");
+  }
+
+  @Override
+  public void close() {
+    coordinator.close();
+    if (participant != null) {
+      participant.close();
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/service/ProviderManager.java
+++ b/core/src/main/java/com/scalar/db/service/ProviderManager.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.DistributedStorageProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
@@ -122,6 +123,32 @@ final class ProviderManager {
       DatabaseConfig config) {
     return getDistributedTransactionProvider(config.getTransactionManager())
         .createTwoPhaseCommitTransactionManager(config);
+  }
+
+  /**
+   * Returns an instance of {@link TwoPhaseCommit.Coordinator}.
+   *
+   * @param config a database config
+   * @return an instance of {@link TwoPhaseCommit.Coordinator}
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public static TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    return getDistributedTransactionProvider(config.getTransactionManager())
+        .createTwoPhaseCommitCoordinator(config);
+  }
+
+  /**
+   * Returns an instance of {@link TwoPhaseCommit.Participant}.
+   *
+   * @param config a database config
+   * @return an instance of {@link TwoPhaseCommit.Participant}
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public static TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+    return getDistributedTransactionProvider(config.getTransactionManager())
+        .createTwoPhaseCommitParticipant(config);
   }
 
   private static DistributedTransactionProvider getDistributedTransactionProvider(String name) {

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -2,6 +2,7 @@ package com.scalar.db.service;
 
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import java.io.File;
@@ -57,6 +58,30 @@ public class TransactionFactory {
   @Nullable
   public TwoPhaseCommitTransactionManager getTwoPhaseCommitTransactionManager() {
     return ProviderManager.createTwoPhaseCommitTransactionManager(config);
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommit.Coordinator} instance for the new multi-participant two-phase
+   * commit interface.
+   *
+   * @return a {@link TwoPhaseCommit.Coordinator} instance
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public TwoPhaseCommit.Coordinator getTwoPhaseCommitCoordinator() {
+    return ProviderManager.createTwoPhaseCommitCoordinator(config);
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommit.Participant} instance for the new multi-participant two-phase
+   * commit interface.
+   *
+   * @return a {@link TwoPhaseCommit.Participant} instance
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public TwoPhaseCommit.Participant getTwoPhaseCommitParticipant() {
+    return ProviderManager.createTwoPhaseCommitParticipant(config);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -23,6 +23,7 @@ public class ConsensusCommitConfig {
   public static final String PREFIX = DatabaseConfig.PREFIX + "consensus_commit.";
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
   public static final String COORDINATOR_NAMESPACE = PREFIX + "coordinator.namespace";
+  public static final String PARTICIPANT_ID = PREFIX + "participant_id";
 
   public static final String PARALLEL_EXECUTOR_COUNT = PREFIX + "parallel_executor_count";
   public static final String PARALLEL_PREPARATION_ENABLED = PREFIX + "parallel_preparation.enabled";
@@ -68,6 +69,7 @@ public class ConsensusCommitConfig {
 
   private final Isolation isolation;
   @Nullable private final String coordinatorNamespace;
+  @Nullable private final String participantId;
 
   private final int parallelExecutorCount;
   private final boolean parallelPreparationEnabled;
@@ -129,6 +131,7 @@ public class ConsensusCommitConfig {
     }
 
     coordinatorNamespace = getString(properties, COORDINATOR_NAMESPACE, null);
+    participantId = getString(properties, PARTICIPANT_ID, null);
 
     parallelExecutorCount =
         getInt(properties, PARALLEL_EXECUTOR_COUNT, DEFAULT_PARALLEL_EXECUTOR_COUNT);
@@ -194,6 +197,19 @@ public class ConsensusCommitConfig {
 
   public Optional<String> getCoordinatorNamespace() {
     return Optional.ofNullable(coordinatorNamespace);
+  }
+
+  /**
+   * Returns the stable logical identifier of this participant in the new TwoPhaseCommit API path.
+   *
+   * <p>Required for the multi-participant Participant implementation (constructor will throw if
+   * absent). Optional for the existing single-participant ConsensusCommit path, which never reads
+   * this property even when it is set.
+   *
+   * @return an {@code Optional} containing the configured participant ID, or empty if unset
+   */
+  public Optional<String> getParticipantId() {
+    return Optional.ofNullable(participantId);
   }
 
   public int getParallelExecutorCount() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -1,0 +1,387 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.TwoPhaseCommit.Participant;
+import com.scalar.db.api.TwoPhaseCommit.WriteSetEntry;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationConflictException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Consensus-commit-backed {@link TwoPhaseCommit.Coordinator} implementation.
+ *
+ * <p>Drives the two-phase commit protocol across the participants registered for a transaction
+ * (prepare -&gt; validate -&gt; write COMMITTED state -&gt; commit records, with the abort/rollback
+ * path on failure) and holds the per-transaction state in an in-memory map keyed by canonical
+ * transaction ID. Each entry records the registered participants and the read-only flag and
+ * attributes passed at {@code begin}. The map is cleaned up after every {@code commit} or {@code
+ * rollback}.
+ *
+ * <p>TODO: support group commit on the new Coordinator (tracked separately from this change). This
+ * is a planned extension, not a design limitation: the {@code WriteSet} persistence proto's {@code
+ * child_id} (group-commit dimension) and {@code participant_id} (two-phase-commit dimension) are
+ * orthogonal and already compose, and {@link CoordinatorStateAccessor#getState(String)} already
+ * resolves full (parent + child) transaction IDs. The remaining work is reserving a group-commit
+ * slot in {@code begin} (so the transaction ID becomes a full key) and routing the COMMITTED-state
+ * write through the group-commit variant of the Coordinator-side handler.
+ */
+@ThreadSafe
+public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
+  private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitCoordinator.class);
+
+  private final DistributedStorage storage;
+  private final CoordinatorCommitHandler coordinatorCommitHandler;
+  private final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
+
+  private final ConcurrentMap<String, CoordinatorContext> contexts = new ConcurrentHashMap<>();
+
+  public ConsensusCommitCoordinator(DatabaseConfig databaseConfig) {
+    ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
+    throwIfGroupCommitIsEnabled(config);
+    StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());
+    this.storage = storageFactory.getStorage();
+    this.coordinatorCommitHandler =
+        new CoordinatorCommitHandler(new CoordinatorStateAccessor(storage, config));
+    this.coordinatorWriteOmissionOnReadOnlyEnabled =
+        config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
+  }
+
+  @VisibleForTesting
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  ConsensusCommitCoordinator(
+      CoordinatorCommitHandler coordinatorCommitHandler, ConsensusCommitConfig config) {
+    throwIfGroupCommitIsEnabled(config);
+    this.storage = null;
+    this.coordinatorCommitHandler = checkNotNull(coordinatorCommitHandler);
+    this.coordinatorWriteOmissionOnReadOnlyEnabled =
+        config.isCoordinatorWriteOmissionOnReadOnlyEnabled();
+  }
+
+  // TODO: Remove this guard once group commit is supported on the new Coordinator (see the class
+  // Javadoc). It is a temporary not-yet-implemented gate, not a permanent restriction.
+  private static void throwIfGroupCommitIsEnabled(ConsensusCommitConfig config) {
+    if (CoordinatorGroupCommitter.isEnabled(config)) {
+      throw new IllegalArgumentException(
+          "Group commit is not yet supported on the new Coordinator implementation");
+    }
+  }
+
+  @Override
+  public String begin(
+      @Nullable String transactionId,
+      boolean readOnly,
+      Map<String, String> attributes,
+      @Nullable Participant participant)
+      throws TransactionException {
+    // Use the caller-supplied ID when present; otherwise generate one. Group commit is not yet
+    // supported on this path, so no parent-prefix logic is needed.
+    String canonical = transactionId != null ? transactionId : UUID.randomUUID().toString();
+    CoordinatorContext existing =
+        contexts.putIfAbsent(canonical, new CoordinatorContext(canonical, readOnly, attributes));
+    if (existing != null) {
+      throw new TransactionException(
+          CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), canonical);
+    }
+    if (participant != null) {
+      // Register the optional participant exactly as registerParticipant would. If join fails, drop
+      // the just-created context so a failed begin leaves no orphaned state.
+      try {
+        registerParticipant(canonical, participant);
+      } catch (TransactionException e) {
+        releaseResources(canonical);
+        throw e;
+      }
+    }
+    return canonical;
+  }
+
+  @Override
+  public void registerParticipant(String transactionId, Participant participant)
+      throws TransactionException {
+    CoordinatorContext context = getContext(transactionId);
+    synchronized (context) {
+      context.checkActive();
+      // Registration is idempotent per participant ID: if a participant with the same getId() is
+      // already registered, this is a no-op (the participant is not joined again). commit() keys
+      // each participant's write set by getId(), so registering the same ID twice would otherwise
+      // merge into one EntryGroup and misattribute the persisted records.
+      for (Participant registered : context.participants) {
+        if (registered.getId().equals(participant.getId())) {
+          return;
+        }
+      }
+      // Invoke Participant.join first; only on success do we add the participant to the list so
+      // subsequent commit/rollback drives only successfully-joined participants.
+      participant.join(transactionId, context.readOnly, context.attributes);
+      context.participants.add(participant);
+    }
+  }
+
+  @Override
+  public void commit(String transactionId)
+      throws CommitException, UnknownTransactionStatusException, TransactionNotFoundException {
+    CoordinatorContext context = getContext(transactionId);
+    synchronized (context) {
+      context.checkActive();
+      try {
+        List<Participant> participants = context.participants;
+
+        // Key each participant's write set by its stable ID so the persisted commit-state proto is
+        // stamped with the owning participant.
+        Map<String, List<WriteSetEntry>> writeSetsByParticipant = new LinkedHashMap<>();
+
+        // A write-less transaction (every participant returns an empty write set) writes no
+        // COMMITTED Coordinator state row when coordinator-write omission on read-only is enabled.
+        // Only the Coordinator state writes (commitState/abortState) are gated on this; the
+        // record-level steps (prepareRecords / commitRecords / rollbackRecords) are still driven on
+        // every participant so their local contexts are released.
+        boolean hasWrites = false;
+
+        long preparedAt = System.currentTimeMillis();
+        try {
+          for (Participant participant : participants) {
+            List<WriteSetEntry> entries =
+                participant.prepareRecords(transactionId, preparedAt).getWriteSet();
+            if (!entries.isEmpty()) {
+              hasWrites = true;
+            }
+            writeSetsByParticipant
+                .computeIfAbsent(participant.getId(), k -> new ArrayList<>())
+                .addAll(entries);
+          }
+          for (Participant participant : participants) {
+            participant.validateRecords(transactionId);
+          }
+        } catch (PreparationException | ValidationException e) {
+          // Prepare or validate failed. Abort the transaction and roll back the PREPARED records on
+          // every participant. The prepare/validate phases are internal to commit(), so the failure
+          // is reported as a commit-level exception: a conflict as CommitConflictException so the
+          // caller's retry logic still sees it as retriable, anything else as CommitException.
+          abortAndRollbackRecords(transactionId, participants, hasWrites);
+          if (e instanceof PreparationConflictException
+              || e instanceof ValidationConflictException) {
+            throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+          }
+          throw new CommitException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (TransactionNotFoundException e) {
+          // A participant no longer knows this transaction (its local context is gone, e.g. it
+          // expired). The transaction cannot commit: abort it and roll back the records already
+          // PREPARED on the other participants, then surface the TransactionNotFoundException as-is
+          // (the facade maps it to a retriable conflict).
+          abortAndRollbackRecords(transactionId, participants, hasWrites);
+          throw e;
+        }
+        long committedAt;
+        if (hasWrites || !coordinatorWriteOmissionOnReadOnlyEnabled) {
+          try {
+            committedAt = commitState(transactionId, writeSetsByParticipant);
+          } catch (CommitConflictException e) {
+            // The COMMITTED-state write lost a putState race that resolved to ABORTED: the
+            // transaction is aborted. Roll back the PREPARED records on every participant before
+            // surfacing it.
+            for (Participant participant : participants) {
+              bestEffortRollbackRecords(participant, transactionId);
+            }
+            throw e;
+          }
+        } else {
+          // Write-less transaction with the Coordinator write omitted: committedAt is an unused
+          // placeholder for the (no-op) commitRecords calls below.
+          committedAt = preparedAt;
+        }
+        for (Participant participant : participants) {
+          bestEffortCommitRecords(participant, transactionId, committedAt);
+        }
+      } finally {
+        context.markReleased();
+        releaseResources(transactionId);
+      }
+    }
+  }
+
+  @Override
+  public void rollback(String transactionId) {
+    CoordinatorContext context = contexts.get(transactionId);
+    if (context == null) {
+      // Unknown or already-finished transaction: nothing to roll back. Lenient no-op (unlike
+      // commit, which treats an unknown transaction as a caller error).
+      return;
+    }
+    synchronized (context) {
+      if (context.isReleased()) {
+        // Already terminated by a concurrent commit/rollback; nothing to roll back.
+        return;
+      }
+      try {
+        // This is an application rollback. Records are only ever PREPARED inside commit() (which
+        // handles its own abort and releases the context), so nothing is PREPARED here: no storage
+        // rollback and no ABORTED state write happen (an absent Coordinator state row is treated as
+        // ABORTED by lazy recovery). rollbackRecords is driven on each participant only to release
+        // its resources — close scanners and discard its in-memory snapshot/context.
+        for (Participant participant : context.participants) {
+          bestEffortRollbackRecords(participant, transactionId);
+        }
+      } finally {
+        context.markReleased();
+        releaseResources(transactionId);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    storage.close();
+  }
+
+  // Aborts the transaction and rolls back the PREPARED records on every participant. The ABORTED
+  // Coordinator state write is skipped for a write-less transaction when coordinator-write omission
+  // on read-only is enabled, since an absent Coordinator state row is treated as ABORTED by lazy
+  // recovery.
+  private void abortAndRollbackRecords(
+      String transactionId, List<Participant> participants, boolean hasWrites)
+      throws UnknownTransactionStatusException {
+    if (hasWrites || !coordinatorWriteOmissionOnReadOnlyEnabled) {
+      abortState(transactionId);
+    }
+    for (Participant participant : participants) {
+      bestEffortRollbackRecords(participant, transactionId);
+    }
+  }
+
+  private void bestEffortCommitRecords(Participant participant, String txId, long committedAt) {
+    try {
+      participant.commitRecords(txId, committedAt);
+    } catch (Exception e) {
+      // Best-effort step: the records are left PREPARED and lazy recovery commits them on a
+      // subsequent read of the record (no background sweep). Logged at WARN since the records hold
+      // locks until then.
+      logger.warn(
+          "commitRecords failed; the records are left PREPARED and will be committed by lazy "
+              + "recovery on a subsequent read. Transaction ID: {}",
+          txId,
+          e);
+    }
+  }
+
+  private void bestEffortRollbackRecords(Participant participant, String txId) {
+    try {
+      participant.rollbackRecords(txId);
+    } catch (Exception e) {
+      // Best-effort step: the records are left PREPARED and lazy recovery rolls them back on a
+      // subsequent read of the record (no background sweep). Logged at WARN since the records hold
+      // locks until then.
+      logger.warn(
+          "rollbackRecords failed; the records are left PREPARED and will be rolled back by lazy "
+              + "recovery on a subsequent read. Transaction ID: {}",
+          txId,
+          e);
+    }
+  }
+
+  // Resolves the in-memory context for a known transaction, or throws if none is registered (never
+  // begun on this Coordinator, or already finished by a prior commit/rollback).
+  private CoordinatorContext getContext(String transactionId) throws TransactionNotFoundException {
+    CoordinatorContext context = contexts.get(transactionId);
+    if (context == null) {
+      throw new TransactionNotFoundException(
+          CoreError.TRANSACTION_NOT_FOUND.buildMessage(), transactionId);
+    }
+    return context;
+  }
+
+  // Encodes the per-participant write sets and writes the COMMITTED state row via the
+  // Coordinator-side handler, which generates the committedAt and returns it so the records are
+  // committed with the same timestamp.
+  private long commitState(
+      String transactionId, Map<String, List<WriteSetEntry>> writeSetsByParticipant)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    WriteSet writeSet = WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant, false);
+    return coordinatorCommitHandler.commitState(transactionId, writeSet);
+  }
+
+  // Writes the ABORTED state row via the Coordinator-side handler. ABORTED rows carry no write set.
+  private void abortState(String transactionId) throws UnknownTransactionStatusException {
+    coordinatorCommitHandler.abortState(transactionId, null);
+  }
+
+  private void releaseResources(String transactionId) {
+    contexts.remove(transactionId);
+  }
+
+  /**
+   * Per-transaction state owned by the Coordinator, plus a lifecycle status.
+   *
+   * <p>The status rejects operations on a terminated transaction. The entry is removed from {@link
+   * #contexts} at {@code commit} / {@code rollback} (no terminal retention); {@link
+   * Status#RELEASED} only lets a concurrent in-flight operation that obtained its reference before
+   * the removal observe the termination under the lock. All {@code status} reads and transitions
+   * must be performed while synchronized on the instance.
+   */
+  private static final class CoordinatorContext {
+
+    private enum Status {
+      ACTIVE,
+      RELEASED
+    }
+
+    final String transactionId;
+    final boolean readOnly;
+    final Map<String, String> attributes;
+    final List<Participant> participants = new ArrayList<>();
+    private Status status = Status.ACTIVE;
+
+    CoordinatorContext(String transactionId, boolean readOnly, Map<String, String> attributes) {
+      this.transactionId = transactionId;
+      this.readOnly = readOnly;
+      // Defensive copy of attributes since the map is held for the lifetime of the transaction.
+      this.attributes =
+          attributes.isEmpty()
+              ? Collections.emptyMap()
+              : Collections.unmodifiableMap(new HashMap<>(attributes));
+    }
+
+    /** Throws if the transaction has already been terminated (committed or rolled back). */
+    void checkActive() throws TransactionNotFoundException {
+      if (status == Status.RELEASED) {
+        throw new TransactionNotFoundException(
+            CoreError.TRANSACTION_NOT_FOUND.buildMessage(), transactionId);
+      }
+    }
+
+    boolean isReleased() {
+      return status == Status.RELEASED;
+    }
+
+    void markReleased() {
+      status = Status.RELEASED;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -160,9 +160,10 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
 
         // A write-less transaction (every participant returns an empty write set) writes no
         // COMMITTED Coordinator state row when coordinator-write omission on read-only is enabled.
-        // Only the Coordinator state writes (commitState/abortState) are gated on this; the
-        // record-level steps (prepareRecords / commitRecords / rollbackRecords) are still driven on
-        // every participant so their local contexts are released.
+        // Only the commit-success path is gated on this; the abort path always writes ABORTED (see
+        // abortAndRollbackRecords). The record-level steps (prepareRecords / commitRecords /
+        // rollbackRecords) are still driven on every participant so their local contexts are
+        // released.
         boolean hasWrites = false;
 
         long preparedAt = System.currentTimeMillis();
@@ -185,7 +186,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // every participant. The prepare/validate phases are internal to commit(), so the failure
           // is reported as a commit-level exception: a conflict as CommitConflictException so the
           // caller's retry logic still sees it as retriable, anything else as CommitException.
-          abortAndRollbackRecords(transactionId, participants, hasWrites);
+          abortAndRollbackRecords(transactionId, participants);
           if (e instanceof PreparationConflictException
               || e instanceof ValidationConflictException) {
             throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
@@ -196,7 +197,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // expired). The transaction cannot commit: abort it and roll back the records already
           // PREPARED on the other participants, then surface the TransactionNotFoundException as-is
           // (the facade maps it to a retriable conflict).
-          abortAndRollbackRecords(transactionId, participants, hasWrites);
+          abortAndRollbackRecords(transactionId, participants);
           throw e;
         }
         long committedAt;
@@ -262,15 +263,20 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   }
 
   // Aborts the transaction and rolls back the PREPARED records on every participant. The ABORTED
-  // Coordinator state write is skipped for a write-less transaction when coordinator-write omission
-  // on read-only is enabled, since an absent Coordinator state row is treated as ABORTED by lazy
-  // recovery.
-  private void abortAndRollbackRecords(
-      String transactionId, List<Participant> participants, boolean hasWrites)
+  // Coordinator state row is always written here, unconditionally: a prepare/validate failure can
+  // leave records PREPARED that hasWrites has not observed (a participant that threw part-way
+  // through prepareRecords never returned its write set, and the first writer to throw leaves
+  // hasWrites false), so the write-less/read-only omission cannot be applied safely on the abort
+  // path. Writing ABORTED lets lazy recovery abort those records on the next read instead of
+  // leaving them locked until the transaction lifetime expires. This is more conservative than
+  // CommitHandler, which gates its abort on hasWritesOrDeletesInSnapshot -- a flag it derives
+  // accurately up-front from the snapshot; the Coordinator only learns each participant's write set
+  // incrementally during prepare, so it cannot compute that flag cheaply and always writes ABORTED
+  // here. (The omission still applies on the commit-success path, where hasWrites accurately
+  // reflects every participant's returned write set.)
+  private void abortAndRollbackRecords(String transactionId, List<Participant> participants)
       throws UnknownTransactionStatusException {
-    if (hasWrites || !coordinatorWriteOmissionOnReadOnlyEnabled) {
-      abortState(transactionId);
-    }
+    abortState(transactionId);
     for (Participant participant : participants) {
       bestEffortRollbackRecords(participant, transactionId);
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -1,0 +1,786 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.common.BatchResultImpl;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.common.ScannerIterator;
+import com.scalar.db.common.StorageInfoProvider;
+import com.scalar.db.common.VirtualTableInfoManager;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Consensus-commit-backed {@link TwoPhaseCommit.Participant} implementation.
+ *
+ * <p>Maintains a per-transaction {@link TransactionContext} keyed by the canonical transaction ID
+ * supplied by the Coordinator. The context is created by {@link #join} and removed after {@link
+ * #commitRecords} or {@link #rollbackRecords} returns.
+ *
+ * <p>This implementation requires a stable {@code participantId} (see {@link
+ * ConsensusCommitConfig#PARTICIPANT_ID}) so that {@link TwoPhaseCommit.WriteSetEntry} instances
+ * carry the participant attribution needed by active recovery. The constructor throws if the
+ * property is unset.
+ *
+ * <p>State writes on the Coordinator table are <strong>not</strong> performed by this class — those
+ * are the {@link TwoPhaseCommit.Coordinator}'s responsibility under the new model. This class only
+ * touches participant-owned records via {@link CrudHandler} and {@link ParticipantCommitHandler}'s
+ * record-level primitives ({@code prepareRecords}, {@code validateRecords}, {@code commitRecords},
+ * {@code rollbackRecords}).
+ */
+@ThreadSafe
+public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
+  private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitParticipant.class);
+
+  private final ConsensusCommitConfig config;
+  private final String participantId;
+  private final DistributedStorage storage;
+  private final DistributedStorageAdmin admin;
+  private final TransactionTableMetadataManager tableMetadataManager;
+  private final ParallelExecutor parallelExecutor;
+  private final RecoveryExecutor recoveryExecutor;
+  private final CrudHandler crud;
+  private final ParticipantCommitHandler commit;
+  private final ConsensusCommitOperationChecker operationChecker;
+
+  private final ConcurrentMap<String, ParticipantContext> contexts = new ConcurrentHashMap<>();
+
+  public ConsensusCommitParticipant(DatabaseConfig databaseConfig) {
+    this.config = new ConsensusCommitConfig(databaseConfig);
+    this.participantId = resolveParticipantId(config);
+    StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());
+    this.storage = storageFactory.getStorage();
+    this.admin = storageFactory.getStorageAdmin();
+    this.tableMetadataManager =
+        new TransactionTableMetadataManager(
+            admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
+    CoordinatorStateAccessor coordinator = new CoordinatorStateAccessor(storage, config);
+    this.parallelExecutor = new ParallelExecutor(config);
+    RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
+    this.recoveryExecutor =
+        new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
+    this.crud =
+        new CrudHandler(
+            storage,
+            recoveryExecutor,
+            tableMetadataManager,
+            config.isIncludeMetadataEnabled(),
+            config.isIndexEventuallyConsistentReadEnabled(),
+            parallelExecutor);
+    StorageInfoProvider storageInfoProvider = new StorageInfoProvider(admin);
+    this.commit =
+        new ParticipantCommitHandler(
+            storage,
+            tableMetadataManager,
+            parallelExecutor,
+            new MutationsGrouper(storageInfoProvider),
+            config.isOnePhaseCommitEnabled());
+    VirtualTableInfoManager virtualTableInfoManager =
+        new VirtualTableInfoManager(admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
+    this.operationChecker =
+        new ConsensusCommitOperationChecker(
+            tableMetadataManager,
+            virtualTableInfoManager,
+            storageInfoProvider,
+            config.isIncludeMetadataEnabled());
+  }
+
+  @VisibleForTesting
+  ConsensusCommitParticipant(
+      ConsensusCommitConfig config,
+      TransactionTableMetadataManager tableMetadataManager,
+      ParallelExecutor parallelExecutor,
+      RecoveryExecutor recoveryExecutor,
+      CrudHandler crud,
+      ParticipantCommitHandler commit,
+      ConsensusCommitOperationChecker operationChecker) {
+    this.config = checkNotNull(config);
+    this.participantId = resolveParticipantId(config);
+    this.storage = null;
+    this.admin = null;
+    this.tableMetadataManager = checkNotNull(tableMetadataManager);
+    this.parallelExecutor = checkNotNull(parallelExecutor);
+    this.recoveryExecutor = checkNotNull(recoveryExecutor);
+    this.crud = checkNotNull(crud);
+    this.commit = checkNotNull(commit);
+    this.operationChecker = checkNotNull(operationChecker);
+  }
+
+  private static String resolveParticipantId(ConsensusCommitConfig config) {
+    return config
+        .getParticipantId()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    CoreError.CONSENSUS_COMMIT_PARTICIPANT_ID_IS_REQUIRED.buildMessage()));
+  }
+
+  @Override
+  public String getId() {
+    return participantId;
+  }
+
+  @Override
+  public void join(String transactionId, boolean readOnly, Map<String, String> attributes)
+      throws TransactionException {
+    Snapshot snapshot = new Snapshot(transactionId, tableMetadataManager, parallelExecutor);
+    // The isolation level can be overridden per transaction via the transaction-isolation
+    // attribute; otherwise it falls back to the participant's configured default.
+    Isolation isolation =
+        ConsensusCommitOperationAttributes.getTransactionIsolation(attributes)
+            .orElse(config.getIsolation());
+    TransactionContext context =
+        new TransactionContext(transactionId, snapshot, isolation, readOnly, false);
+    ParticipantContext existing =
+        contexts.putIfAbsent(transactionId, new ParticipantContext(context));
+    if (existing != null) {
+      throw new TransactionException(
+          CoreError.TRANSACTION_ALREADY_EXISTS.buildMessage(), transactionId);
+    }
+  }
+
+  @Override
+  public Optional<Result> get(String transactionId, Get get)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      try {
+        operationChecker.check(get, context);
+      } catch (ExecutionException e) {
+        throw new CrudException(e.getMessage(), e, transactionId);
+      }
+      return crud.get(get, context);
+    }
+  }
+
+  @Override
+  public List<Result> scan(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      try {
+        operationChecker.check(scan, context);
+      } catch (ExecutionException e) {
+        throw new CrudException(e.getMessage(), e, transactionId);
+      }
+      return crud.scan(scan, context);
+    }
+  }
+
+  @Override
+  public TransactionCrudOperable.Scanner getScanner(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      try {
+        operationChecker.check(scan, context);
+      } catch (ExecutionException e) {
+        throw new CrudException(e.getMessage(), e, transactionId);
+      }
+      return new SynchronizedParticipantScanner(pc, crud.getScanner(scan, context));
+    }
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0 */
+  @Deprecated
+  @Override
+  public void put(String transactionId, Put put)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      checkWritable(transactionId, context);
+      checkMutation(transactionId, put);
+      crud.put(put, context);
+    }
+  }
+
+  @Override
+  public void insert(String transactionId, Insert insert)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      checkWritable(transactionId, context);
+      Put put = ConsensusCommitUtils.createPutForInsert(insert);
+      checkMutation(transactionId, put);
+      crud.put(put, context);
+    }
+  }
+
+  @Override
+  public void upsert(String transactionId, Upsert upsert)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      checkWritable(transactionId, context);
+      Put put = ConsensusCommitUtils.createPutForUpsert(upsert);
+      checkMutation(transactionId, put);
+      crud.put(put, context);
+    }
+  }
+
+  @Override
+  public void update(String transactionId, Update update)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      checkWritable(transactionId, context);
+      ScalarDbUtils.checkUpdate(update);
+      Put put = ConsensusCommitUtils.createPutForUpdate(update);
+      checkMutation(transactionId, put);
+      try {
+        crud.put(put, context);
+      } catch (UnsatisfiedConditionException e) {
+        if (update.getCondition().isPresent()) {
+          throw new UnsatisfiedConditionException(
+              ConsensusCommitUtils.convertUnsatisfiedConditionExceptionMessageForUpdate(
+                  e, update.getCondition().get()),
+              transactionId);
+        }
+        // If the condition is not specified, the record does not exist; do nothing.
+      }
+    }
+  }
+
+  @Override
+  public void delete(String transactionId, Delete delete)
+      throws CrudException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      checkWritable(transactionId, context);
+      checkMutation(transactionId, delete);
+      crud.delete(delete, context);
+    }
+  }
+
+  @Override
+  public void mutate(String transactionId, List<? extends Mutation> mutations)
+      throws CrudException, TransactionNotFoundException {
+    if (mutations.isEmpty()) {
+      throw new IllegalArgumentException(CoreError.EMPTY_MUTATIONS_SPECIFIED.buildMessage());
+    }
+    for (Mutation mutation : mutations) {
+      if (mutation instanceof Put) {
+        put(transactionId, (Put) mutation);
+      } else if (mutation instanceof Insert) {
+        insert(transactionId, (Insert) mutation);
+      } else if (mutation instanceof Upsert) {
+        upsert(transactionId, (Upsert) mutation);
+      } else if (mutation instanceof Update) {
+        update(transactionId, (Update) mutation);
+      } else if (mutation instanceof Delete) {
+        delete(transactionId, (Delete) mutation);
+      } else {
+        throw new AssertionError("Unknown mutation: " + mutation);
+      }
+    }
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(
+      String transactionId, List<? extends Operation> operations)
+      throws CrudException, TransactionNotFoundException {
+    if (operations.isEmpty()) {
+      throw new IllegalArgumentException(CoreError.EMPTY_OPERATIONS_SPECIFIED.buildMessage());
+    }
+    List<CrudOperable.BatchResult> results = new ArrayList<>(operations.size());
+    for (Operation operation : operations) {
+      if (operation instanceof Get) {
+        Optional<Result> result = get(transactionId, (Get) operation);
+        results.add(new BatchResultImpl(result));
+      } else if (operation instanceof Scan) {
+        List<Result> scanned = scan(transactionId, (Scan) operation);
+        results.add(new BatchResultImpl(scanned));
+      } else if (operation instanceof Insert) {
+        insert(transactionId, (Insert) operation);
+        results.add(BatchResultImpl.INSERT_BATCH_RESULT);
+      } else if (operation instanceof Upsert) {
+        upsert(transactionId, (Upsert) operation);
+        results.add(BatchResultImpl.UPSERT_BATCH_RESULT);
+      } else if (operation instanceof Update) {
+        update(transactionId, (Update) operation);
+        results.add(BatchResultImpl.UPDATE_BATCH_RESULT);
+      } else if (operation instanceof Delete) {
+        delete(transactionId, (Delete) operation);
+        results.add(BatchResultImpl.DELETE_BATCH_RESULT);
+      } else if (operation instanceof Put) {
+        put(transactionId, (Put) operation);
+        results.add(BatchResultImpl.PUT_BATCH_RESULT);
+      } else {
+        throw new AssertionError("Unknown operation: " + operation);
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public TwoPhaseCommit.PreparationResult prepareRecords(String transactionId, long preparedAt)
+      throws PreparationException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkActive();
+      TransactionContext context = pc.context();
+      if (!context.areAllScannersClosed()) {
+        throw new IllegalStateException(
+            CoreError.CONSENSUS_COMMIT_SCANNER_NOT_CLOSED.buildMessage());
+      }
+      try {
+        crud.readIfImplicitPreReadEnabled(context);
+      } catch (CrudConflictException e) {
+        throw new PreparationConflictException(
+            CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHILE_IMPLICIT_PRE_READ.buildMessage(
+                e.getMessage()),
+            e,
+            transactionId);
+      } catch (CrudException e) {
+        throw new PreparationException(
+            CoreError.CONSENSUS_COMMIT_EXECUTING_IMPLICIT_PRE_READ_FAILED.buildMessage(
+                e.getMessage()),
+            e,
+            transactionId);
+      }
+      try {
+        crud.waitForRecoveryCompletionIfNecessary(context);
+      } catch (CrudConflictException e) {
+        throw new PreparationConflictException(e.getMessage(), e, transactionId);
+      } catch (CrudException e) {
+        throw new PreparationException(e.getMessage(), e, transactionId);
+      }
+      try {
+        commit.prepareRecords(context, preparedAt);
+      } finally {
+        // Mark PREPARED even if prepareRecords throws partway: a partial prepare leaves PREPARED
+        // records in storage that rollbackRecords must undo (it gates the storage rollback on this
+        // status). Mirrors TwoPhaseConsensusCommit.prepare, which sets needRollback in a finally.
+        pc.toPrepared();
+      }
+      return new PreparationResultImpl(buildWriteSetEntries(context));
+    }
+  }
+
+  @Override
+  public void validateRecords(String transactionId)
+      throws ValidationException, TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkPrepared();
+      commit.validateRecords(pc.context());
+      pc.toValidated();
+    }
+  }
+
+  @Override
+  public void commitRecords(String transactionId, long committedAt)
+      throws TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkPreparedOrValidated();
+      try {
+        commit.commitRecords(pc.context(), committedAt);
+      } finally {
+        // The Coordinator has durably decided COMMITTED; release the context even on failure (lazy
+        // recovery commits the records via the COMMITTED Coordinator state).
+        pc.toReleased();
+        contexts.remove(transactionId, pc);
+      }
+    }
+  }
+
+  @Override
+  public void rollbackRecords(String transactionId) throws TransactionNotFoundException {
+    ParticipantContext pc = getParticipantContext(transactionId);
+    synchronized (pc) {
+      pc.checkAlive();
+      TransactionContext context = pc.context();
+      try {
+        try {
+          context.closeScanners();
+        } catch (CrudException e) {
+          logger.warn("Failed to close the scanner. Transaction ID: {}", transactionId, e);
+        }
+        if (pc.isPrepared()) {
+          // Only a prepared transaction has PREPARED records in storage to roll back. An unprepared
+          // transaction has only an in-memory snapshot, discarded by removing the context below.
+          commit.rollbackRecords(context);
+        }
+      } finally {
+        pc.toReleased();
+        contexts.remove(transactionId, pc);
+      }
+    }
+  }
+
+  // Resolves the participant context for a known transaction, or throws if none is registered
+  // (never joined, already terminated and removed, or expired). Callers must synchronize on the
+  // returned context before reading/transitioning its status or touching its TransactionContext.
+  private ParticipantContext getParticipantContext(String transactionId)
+      throws TransactionNotFoundException {
+    ParticipantContext context = contexts.get(transactionId);
+    if (context == null) {
+      throw new TransactionNotFoundException(
+          CoreError.TRANSACTION_NOT_FOUND.buildMessage(), transactionId);
+    }
+    return context;
+  }
+
+  // Rejects a mutation on a read-only transaction. Read-only is carried on the context from join,
+  // so the Participant is the authoritative enforcement point (CRUD lands here).
+  private void checkWritable(String transactionId, TransactionContext context) {
+    if (context.readOnly) {
+      throw new IllegalStateException(
+          CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(transactionId));
+    }
+  }
+
+  private void checkMutation(String transactionId, Mutation mutation) throws CrudException {
+    try {
+      operationChecker.check(mutation);
+    } catch (ExecutionException e) {
+      throw new CrudException(e.getMessage(), e, transactionId);
+    }
+  }
+
+  private List<TwoPhaseCommit.WriteSetEntry> buildWriteSetEntries(TransactionContext context) {
+    Snapshot snapshot = context.snapshot;
+    List<TwoPhaseCommit.WriteSetEntry> entries = new ArrayList<>();
+    if (!snapshot.hasWritesOrDeletes()) {
+      return entries;
+    }
+    for (Map.Entry<Snapshot.Key, Put> e : snapshot.getWriteSet()) {
+      Put put = e.getValue();
+      TableMetadata metadata = getTableMetadataForMutation(put);
+      List<Column<?>> filteredColumns = new ArrayList<>();
+      for (Column<?> column : put.getColumns().values()) {
+        if (!ConsensusCommitUtils.isTransactionMetaColumn(column.getName(), metadata)) {
+          filteredColumns.add(column);
+        }
+      }
+      entries.add(
+          new WriteSetEntryImpl(
+              TwoPhaseCommit.WriteSetEntry.Type.WRITE,
+              put.forNamespace().get(),
+              put.forTable().get(),
+              put.getPartitionKey(),
+              put.getClusteringKey(),
+              Collections.unmodifiableList(filteredColumns)));
+    }
+    for (Map.Entry<Snapshot.Key, Delete> e : snapshot.getDeleteSet()) {
+      Delete delete = e.getValue();
+      entries.add(
+          new WriteSetEntryImpl(
+              TwoPhaseCommit.WriteSetEntry.Type.DELETE,
+              delete.forNamespace().get(),
+              delete.forTable().get(),
+              delete.getPartitionKey(),
+              delete.getClusteringKey(),
+              Collections.emptyList()));
+    }
+    return entries;
+  }
+
+  private TableMetadata getTableMetadataForMutation(Mutation mutation) {
+    try {
+      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, mutation)
+          .getTableMetadata();
+    } catch (ExecutionException e) {
+      throw new AssertionError(
+          "Failed to retrieve transaction table metadata while building write set entries."
+              + " Operation: "
+              + mutation,
+          e);
+    }
+  }
+
+  @Override
+  public void close() {
+    storage.close();
+    admin.close();
+    parallelExecutor.close();
+    recoveryExecutor.close();
+  }
+
+  private static final class PreparationResultImpl implements TwoPhaseCommit.PreparationResult {
+    private final List<TwoPhaseCommit.WriteSetEntry> writeSet;
+
+    PreparationResultImpl(List<TwoPhaseCommit.WriteSetEntry> writeSet) {
+      this.writeSet = writeSet;
+    }
+
+    @Override
+    public List<TwoPhaseCommit.WriteSetEntry> getWriteSet() {
+      return writeSet;
+    }
+  }
+
+  private static final class WriteSetEntryImpl implements TwoPhaseCommit.WriteSetEntry {
+    private final Type type;
+    private final String namespaceName;
+    private final String tableName;
+    private final Key partitionKey;
+    private final Optional<Key> clusteringKey;
+    private final List<Column<?>> columns;
+
+    WriteSetEntryImpl(
+        Type type,
+        String namespaceName,
+        String tableName,
+        Key partitionKey,
+        Optional<Key> clusteringKey,
+        List<Column<?>> columns) {
+      this.type = type;
+      this.namespaceName = namespaceName;
+      this.tableName = tableName;
+      this.partitionKey = partitionKey;
+      this.clusteringKey = clusteringKey;
+      this.columns = columns;
+    }
+
+    @Override
+    public Type getType() {
+      return type;
+    }
+
+    @Override
+    public String getNamespaceName() {
+      return namespaceName;
+    }
+
+    @Override
+    public String getTableName() {
+      return tableName;
+    }
+
+    @Override
+    public Key getPartitionKey() {
+      return partitionKey;
+    }
+
+    @Override
+    public Optional<Key> getClusteringKey() {
+      return clusteringKey;
+    }
+
+    @Override
+    public List<Column<?>> getColumns() {
+      return columns;
+    }
+  }
+
+  /**
+   * A {@link TransactionCrudOperable.Scanner} that serializes its operations on the per-transaction
+   * {@link ParticipantContext} — the same monitor every participant method holds, including the
+   * context release that closes the scanners ({@code commitRecords} / {@code rollbackRecords}).
+   * This keeps scanner iteration and context release mutually exclusive, so the not-thread-safe
+   * underlying scanner is never touched by two threads at once.
+   *
+   * <p>Each {@code one()} / {@code all()} re-checks, under the lock, that the context has not been
+   * released; an iteration that loses the race to a release surfaces a retriable {@link
+   * CrudConflictException} (the {@link TransactionNotFoundException} the released context would
+   * raise cannot be thrown from the scanner API) instead of reading through a released, closed
+   * scanner. {@code iterator()} returns an iterator that drives {@code one()} for every element, so
+   * {@code hasNext()} / {@code next()} inherit the same lock and liveness re-check.
+   */
+  private static final class SynchronizedParticipantScanner
+      implements TransactionCrudOperable.Scanner {
+
+    private final ParticipantContext pc;
+    private final TransactionCrudOperable.Scanner delegate;
+
+    SynchronizedParticipantScanner(
+        ParticipantContext pc, TransactionCrudOperable.Scanner delegate) {
+      this.pc = pc;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<Result> one() throws CrudException {
+      synchronized (pc) {
+        checkNotReleased();
+        return delegate.one();
+      }
+    }
+
+    @Override
+    public List<Result> all() throws CrudException {
+      synchronized (pc) {
+        checkNotReleased();
+        return delegate.all();
+      }
+    }
+
+    @Override
+    public void close() throws CrudException {
+      synchronized (pc) {
+        delegate.close();
+      }
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<Result> iterator() {
+      // Drive iteration through this wrapper's one() (synchronized on pc, with the liveness
+      // re-check) rather than returning delegate.iterator(): the delegate's iterator is bound to
+      // the raw scanner, so its hasNext()/next() would touch the underlying scanner without the
+      // lock.
+      return new ScannerIterator<>(this);
+    }
+
+    // Translates a context released by a concurrent terminal step (a commitRecords /
+    // rollbackRecords on another thread) into a retriable conflict, so the caller retries the whole
+    // transaction rather than iterating a released, closed scanner. Must be called while
+    // synchronized on pc.
+    private void checkNotReleased() throws CrudConflictException {
+      try {
+        pc.checkAlive();
+      } catch (TransactionNotFoundException e) {
+        throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+      }
+    }
+  }
+
+  /**
+   * Per-transaction state: the shared {@link TransactionContext} plus a two-phase-commit lifecycle
+   * status. The status enforces the order the Coordinator drives the protocol in (and rejects
+   * application operations that arrive out of phase) by throwing {@link IllegalStateException}. It
+   * is kept here rather than on {@link TransactionContext} because that class is shared with the
+   * single-phase paths ({@code ConsensusCommit} / {@code ConsensusCommitManager}), which have no
+   * such lifecycle.
+   *
+   * <p>The entry is removed from {@link #contexts} at {@code commitRecords} / {@code
+   * rollbackRecords} (no terminal retention). {@link Status#RELEASED} is not for retention: it only
+   * lets a concurrent in-flight operation that obtained its reference before the removal observe
+   * the termination (under the lock) and fail with {@link TransactionNotFoundException} instead of
+   * acting on a finished transaction.
+   *
+   * <p>Not internally synchronized: every status read/transition below must be performed while
+   * synchronized on the instance (the participant holds {@code synchronized(context)} across check,
+   * work, and transition so they are atomic and concurrent same-transaction operations are
+   * serialized).
+   */
+  private static final class ParticipantContext {
+
+    private enum Status {
+      ACTIVE,
+      PREPARED,
+      VALIDATED,
+      RELEASED
+    }
+
+    private final TransactionContext context;
+    private Status status = Status.ACTIVE;
+
+    ParticipantContext(TransactionContext context) {
+      this.context = context;
+    }
+
+    TransactionContext context() {
+      return context;
+    }
+
+    /** Throws if the transaction has already been terminated (committed or rolled back). */
+    void checkAlive() throws TransactionNotFoundException {
+      if (status == Status.RELEASED) {
+        throw new TransactionNotFoundException(
+            CoreError.TRANSACTION_NOT_FOUND.buildMessage(), context.transactionId);
+      }
+    }
+
+    /** Requires {@code ACTIVE} (CRUD operations and {@code prepareRecords}). */
+    void checkActive() throws TransactionNotFoundException {
+      checkAlive();
+      if (status != Status.ACTIVE) {
+        throw new IllegalStateException(CoreError.TRANSACTION_NOT_ACTIVE.buildMessage(status));
+      }
+    }
+
+    /** Requires {@code PREPARED} ({@code validateRecords}). */
+    void checkPrepared() throws TransactionNotFoundException {
+      checkAlive();
+      if (status != Status.PREPARED) {
+        throw new IllegalStateException(CoreError.TRANSACTION_NOT_PREPARED.buildMessage(status));
+      }
+    }
+
+    /** Requires {@code PREPARED} or {@code VALIDATED} ({@code commitRecords}). */
+    void checkPreparedOrValidated() throws TransactionNotFoundException {
+      checkAlive();
+      if (status != Status.PREPARED && status != Status.VALIDATED) {
+        throw new IllegalStateException(
+            CoreError.TRANSACTION_NOT_PREPARED_OR_VALIDATED.buildMessage(status));
+      }
+    }
+
+    /** Whether records have been PREPARED in storage (so a rollback must undo them). */
+    boolean isPrepared() {
+      return status == Status.PREPARED || status == Status.VALIDATED;
+    }
+
+    void toPrepared() {
+      status = Status.PREPARED;
+    }
+
+    void toValidated() {
+      status = Status.VALIDATED;
+    }
+
+    void toReleased() {
+      status = Status.RELEASED;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 
@@ -28,5 +29,15 @@ public class ConsensusCommitProvider extends AbstractDistributedTransactionProvi
   public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     return new TwoPhaseConsensusCommitManager(config);
+  }
+
+  @Override
+  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    return new ConsensusCommitCoordinator(config);
+  }
+
+  @Override
+  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+    return new ConsensusCommitParticipant(config);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoder.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoder.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
@@ -289,6 +290,68 @@ final class WriteSetEncoder {
       }
       builder.setTimestamptzValue(valueBuilder);
     }
+  }
+
+  /**
+   * Encodes a {@link WriteSet} from the per-participant write sets aggregated across a
+   * multi-participant transaction.
+   *
+   * <p>One {@link EntryGroup} is emitted per participant (in the map's iteration order), and every
+   * {@link Entry} it produces is stamped with the owning participant's id. Participants with no
+   * writes are skipped. {@code child_id} is not used in this path (it is reserved for the existing
+   * group-commit grouping).
+   *
+   * <p>When {@code includeColumns} is true, each {@code WRITE} entry's non-key columns are encoded
+   * too; when false, only primary keys are persisted (the default commit-state convention). The
+   * supplied {@link TwoPhaseCommit.WriteSetEntry}s already exclude ConsensusCommit-internal
+   * columns, so no meta-column filtering is needed here.
+   *
+   * @param writeSetsByParticipant the write set produced by each participant, keyed by participant
+   *     ID
+   * @param includeColumns whether to include non-key column values for {@code WRITE} entries
+   * @return the encoded {@link WriteSet}
+   */
+  static WriteSet encodeFromWriteSetEntries(
+      Map<String, List<TwoPhaseCommit.WriteSetEntry>> writeSetsByParticipant,
+      boolean includeColumns) {
+    WriteSet.Builder builder = WriteSet.newBuilder().setSchemaVersion(SCHEMA_VERSION);
+    for (Map.Entry<String, List<TwoPhaseCommit.WriteSetEntry>> e :
+        writeSetsByParticipant.entrySet()) {
+      String participantId = checkNotNull(e.getKey());
+      List<TwoPhaseCommit.WriteSetEntry> entries = e.getValue();
+      if (entries.isEmpty()) {
+        continue;
+      }
+      EntryGroup.Builder groupBuilder = EntryGroup.newBuilder();
+      for (TwoPhaseCommit.WriteSetEntry entry : entries) {
+        groupBuilder.addEntries(encodeWriteSetEntry(entry, participantId, includeColumns));
+      }
+      builder.addEntryGroups(groupBuilder.build());
+    }
+    return builder.build();
+  }
+
+  private static Entry encodeWriteSetEntry(
+      TwoPhaseCommit.WriteSetEntry entry, String participantId, boolean includeColumns) {
+    Entry.Builder builder =
+        Entry.newBuilder()
+            .setEntryType(
+                entry.getType() == TwoPhaseCommit.WriteSetEntry.Type.WRITE
+                    ? Entry.EntryType.ENTRY_TYPE_WRITE
+                    : Entry.EntryType.ENTRY_TYPE_DELETE)
+            .setNamespaceName(entry.getNamespaceName())
+            .setTableName(entry.getTableName())
+            .setPartitionKey(encodeKey(entry.getPartitionKey()))
+            .setParticipantId(participantId);
+    entry.getClusteringKey().ifPresent(ck -> builder.setClusteringKey(encodeKey(ck)));
+    if (includeColumns && entry.getType() == TwoPhaseCommit.WriteSetEntry.Type.WRITE) {
+      // The entry's columns are already free of ConsensusCommit-internal columns (filtered when the
+      // participant built the write set), so encode them as-is.
+      for (Column<?> column : entry.getColumns()) {
+        builder.addColumns(encodeColumn(column));
+      }
+    }
+    return builder.build();
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -3,7 +3,9 @@ package com.scalar.db.transaction.jdbc;
 import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import javax.annotation.Nullable;
@@ -31,5 +33,17 @@ public class JdbcTransactionProvider extends AbstractDistributedTransactionProvi
   public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     return null;
+  }
+
+  @Override
+  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    throw new UnsupportedOperationException(
+        CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+    throw new UnsupportedOperationException(
+        CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionProvider.java
@@ -3,7 +3,9 @@ package com.scalar.db.transaction.singlecrudoperation;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import javax.annotation.Nullable;
 
@@ -29,5 +31,17 @@ public class SingleCrudOperationTransactionProvider implements DistributedTransa
   public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     return null;
+  }
+
+  @Override
+  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
   }
 }

--- a/core/src/main/proto/consensus_commit.proto
+++ b/core/src/main/proto/consensus_commit.proto
@@ -217,24 +217,33 @@ message Entry {
     ENTRY_TYPE_DELETE = 2;
   }
 
+  // The stable logical identifier of the participant that produced this entry.
+  //
+  // Unset for entries produced by the existing single-participant `ConsensusCommit` path (the
+  // existing writer never stamps a `participant_id`).
+  //
+  // For entries produced by the multi-participant TwoPhaseCommit path, this field is always set
+  // and is unique within the Coordinator deployment.
+  optional string participant_id = 1;
+
   // The entry type (write or delete) of this record.
-  EntryType entry_type = 1;
+  EntryType entry_type = 2;
 
   // The namespace name of the user table the record belongs to.
-  string namespace_name = 2;
+  string namespace_name = 3;
 
   // The table name of the user table the record belongs to.
-  string table_name = 3;
+  string table_name = 4;
 
   // The partition key of the record. Always present.
-  Key partition_key = 4;
+  Key partition_key = 5;
 
   // The clustering key of the record. Absent when the user table has no clustering key.
-  optional Key clustering_key = 5;
+  optional Key clustering_key = 6;
 
   // The non-key columns of the record. Only populated when `entry_type` is
   // `ENTRY_TYPE_WRITE`, and even then it is not always populated — the writer may persist just
   // the primary keys (e.g., the active-recovery use case) and leave this field empty.
   // `ENTRY_TYPE_DELETE` entries always leave this field empty.
-  repeated Column columns = 6;
+  repeated Column columns = 7;
 }

--- a/core/src/test/java/com/scalar/db/common/SynchronizedScannerTest.java
+++ b/core/src/test/java/com/scalar/db/common/SynchronizedScannerTest.java
@@ -1,0 +1,36 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import java.util.Iterator;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SynchronizedScannerTest {
+
+  @Test
+  void iterator_ShouldDriveDelegateOneAndNotDelegateIterator() throws Exception {
+    // Arrange — the delegate yields one result then exhausts.
+    Scanner delegate = mock(Scanner.class);
+    Result result = mock(Result.class);
+    when(delegate.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    SynchronizedScanner scanner = new SynchronizedScanner(new Object(), delegate);
+
+    // Act — iterate.
+    Iterator<Result> iterator = scanner.iterator();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isSameAs(result);
+    assertThat(iterator.hasNext()).isFalse();
+
+    // Assert — iteration is routed through the synchronized one() (so it inherits the lock), and
+    // the
+    // delegate's own (unsynchronized) iterator is never used.
+    verify(delegate, never()).iterator();
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedDistributedTransactionManagerTest.java
@@ -1,0 +1,385 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.io.Key;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class TwoPhaseCommitBackedDistributedTransactionManagerTest {
+
+  private static final String NS = "ns";
+  private static final String TBL = "tbl";
+  private static final String CANONICAL_ID = "canonical-1";
+
+  @Mock private DatabaseConfig config;
+  @Mock private TwoPhaseCommit.Coordinator coordinator;
+  @Mock private TwoPhaseCommit.Participant participant;
+
+  private TwoPhaseCommitBackedDistributedTransactionManager manager;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(config.getDefaultNamespaceName()).thenReturn(Optional.empty());
+    when(coordinator.begin(any(), anyBoolean(), anyMap(), any())).thenReturn(CANONICAL_ID);
+    manager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, participant);
+  }
+
+  @Test
+  void begin_ShouldBeginViaCoordinatorWithParticipantAndReturnCanonicalId() throws Exception {
+    // Act
+    DistributedTransaction transaction = manager.begin();
+
+    // Assert — the configured participant is passed to begin so the Coordinator registers it (the
+    // Coordinator owns registration and its cleanup-on-failure).
+    verify(coordinator).begin(any(), eq(false), anyMap(), eq(participant));
+    assertThat(transaction.getId()).isEqualTo(CANONICAL_ID);
+  }
+
+  @Test
+  void beginReadOnly_ShouldBeginReadOnlyViaCoordinatorWithParticipant() throws Exception {
+    manager.beginReadOnly();
+    verify(coordinator).begin(any(), eq(true), anyMap(), eq(participant));
+  }
+
+  @Test
+  void transactionCrud_ShouldDelegateToParticipantWithCanonicalId() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 10)
+            .build();
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    when(participant.get(eq(CANONICAL_ID), any(Get.class))).thenReturn(Optional.empty());
+
+    // Act
+    transaction.put(put);
+    transaction.get(get);
+
+    // Assert — CRUD is routed to the participant keyed by the canonical transaction ID.
+    verify(participant).put(eq(CANONICAL_ID), any(Put.class));
+    verify(participant).get(eq(CANONICAL_ID), any(Get.class));
+  }
+
+  @Test
+  void transactionCrud_WhenParticipantThrowsTransactionNotFound_ShouldThrowCrudConflict()
+      throws Exception {
+    // Arrange — the transaction body's CRUD (not begin) hits a participant that no longer knows the
+    // transaction, e.g. it expired mid-transaction.
+    DistributedTransaction transaction = manager.begin();
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    doThrow(new TransactionNotFoundException("expired", CANONICAL_ID))
+        .when(participant)
+        .get(eq(CANONICAL_ID), any(Get.class));
+
+    // Act Assert — surfaced as a retriable CrudConflictException so the caller restarts the
+    // transaction, not as a non-retriable CrudException.
+    assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  void batch_WhenAllSelections_ShouldBeginReadOnly() throws Exception {
+    // Arrange
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    when(participant.batch(eq(CANONICAL_ID), any())).thenReturn(java.util.Collections.emptyList());
+
+    // Act
+    manager.batch(java.util.Collections.singletonList(get));
+
+    // Assert — an all-Selection batch begins the transaction read-only, mirroring
+    // ConsensusCommitManager.
+    verify(coordinator).begin(any(), eq(true), anyMap(), eq(participant));
+  }
+
+  @Test
+  void batch_WhenContainsMutation_ShouldBeginWritable() throws Exception {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 10)
+            .build();
+    when(participant.batch(eq(CANONICAL_ID), any())).thenReturn(java.util.Collections.emptyList());
+
+    // Act
+    manager.batch(java.util.Collections.singletonList(put));
+
+    // Assert — a write-bearing batch begins a writable transaction.
+    verify(coordinator).begin(any(), eq(false), anyMap(), eq(participant));
+  }
+
+  @Test
+  void commit_ShouldDriveCoordinatorCommit() throws Exception {
+    DistributedTransaction transaction = manager.begin();
+    transaction.commit();
+    verify(coordinator).commit(CANONICAL_ID);
+  }
+
+  @Test
+  void commit_WhenCoordinatorThrowsCommitConflict_ShouldPropagate() throws Exception {
+    DistributedTransaction transaction = manager.begin();
+    // The coordinator already collapses prepare/validate failures into a commit-level exception, so
+    // the facade just propagates a CommitConflictException unchanged.
+    doThrow(new CommitConflictException("conflict", CANONICAL_ID))
+        .when(coordinator)
+        .commit(anyString());
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  void commit_WhenCoordinatorThrowsTransactionNotFound_ShouldThrowCommitConflict()
+      throws Exception {
+    DistributedTransaction transaction = manager.begin();
+    doThrow(new TransactionNotFoundException("not found", CANONICAL_ID))
+        .when(coordinator)
+        .commit(anyString());
+
+    // A coordinator that no longer knows the transaction (e.g., it expired) surfaces as a retriable
+    // commit conflict rather than an unrecoverable error.
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  void oneOperationCrud_WhenBeginThrowsTransactionNotFound_ShouldThrowCrudConflict()
+      throws Exception {
+    // Arrange — a transient begin failure on the one-operation CRUD path.
+    doThrow(new TransactionNotFoundException("transient begin failure", null))
+        .when(coordinator)
+        .begin(any(), anyBoolean(), anyMap(), any());
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    // Act Assert — surfaced as a retriable CRUD conflict, not a non-retriable CrudException.
+    assertThatThrownBy(() -> manager.get(get)).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  void getScanner_WhenBeginThrowsTransactionNotFound_ShouldThrowCrudConflict() throws Exception {
+    // Arrange — a transient begin failure on the one-operation scan path.
+    doThrow(new TransactionNotFoundException("transient begin failure", null))
+        .when(coordinator)
+        .begin(any(), anyBoolean(), anyMap(), any());
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    // Act Assert — surfaced as a retriable CRUD conflict.
+    assertThatThrownBy(() -> manager.getScanner(scan)).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  void rollback_ShouldDriveCoordinatorRollback() throws Exception {
+    DistributedTransaction transaction = manager.begin();
+    transaction.rollback();
+    verify(coordinator).rollback(CANONICAL_ID);
+  }
+
+  @Test
+  void rollbackByTransactionId_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.rollback("tx-1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void abortByTransactionId_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.abort("tx-1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void getState_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.getState("tx-1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void finishTransaction_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.finishTransaction("tx-1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void recoverRecord_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.recoverRecord(NS, TBL, Key.ofInt("pk", 1), null))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void resume_ShouldThrowUnsupportedOperationException() {
+    assertThatThrownBy(() -> manager.resume("tx-1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- join: register the participant into a transaction begun elsewhere; CRUD-only ----
+
+  @Test
+  void join_ShouldRegisterParticipantAndReturnJoinedTransaction() throws Exception {
+    // Act
+    DistributedTransaction transaction = manager.join(CANONICAL_ID);
+
+    // Assert — the participant is registered into the existing transaction.
+    verify(coordinator).registerParticipant(CANONICAL_ID, participant);
+    assertThat(transaction.getId()).isEqualTo(CANONICAL_ID);
+  }
+
+  @Test
+  void join_WhenCoordinatorThrowsTransactionNotFound_ShouldPropagate() throws Exception {
+    doThrow(new TransactionNotFoundException("not found", CANONICAL_ID))
+        .when(coordinator)
+        .registerParticipant(CANONICAL_ID, participant);
+
+    assertThatThrownBy(() -> manager.join(CANONICAL_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void join_WhenRegisterParticipantFails_ShouldPropagateTransactionException() throws Exception {
+    // A non-not-found registration failure propagates as-is, no longer masked as not-found (join
+    // now allows TransactionException).
+    doThrow(new TransactionException("join failed", CANONICAL_ID))
+        .when(coordinator)
+        .registerParticipant(CANONICAL_ID, participant);
+
+    assertThatThrownBy(() -> manager.join(CANONICAL_ID))
+        .isInstanceOf(TransactionException.class)
+        .isNotInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void joinedTransactionCrud_ShouldDelegateToParticipant() throws Exception {
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    when(participant.get(eq(CANONICAL_ID), any(Get.class))).thenReturn(Optional.empty());
+
+    DistributedTransaction transaction = manager.join(CANONICAL_ID);
+    transaction.get(get);
+
+    // A joined transaction participates in CRUD, keyed by the joined transaction ID.
+    verify(participant).get(eq(CANONICAL_ID), any(Get.class));
+  }
+
+  @Test
+  void joinedTransactionCommitAndRollback_ShouldDelegateToCoordinator() throws Exception {
+    // A joined transaction behaves the same as a begun one: commit/rollback drive the coordinator.
+    manager.join(CANONICAL_ID).commit();
+    verify(coordinator).commit(CANONICAL_ID);
+
+    manager.join(CANONICAL_ID).rollback();
+    verify(coordinator).rollback(CANONICAL_ID);
+  }
+
+  @Test
+  void join_WhenNoParticipant_ShouldThrowUnsupportedOperationException() {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+
+    assertThatThrownBy(() -> coordinatorOnlyManager.join(CANONICAL_ID))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- Coordinator-only manager (no participant): CRUD unsupported, lifecycle still works ----
+
+  @Test
+  void begin_WhenNoParticipant_ShouldBeginWithNullParticipant() throws Exception {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+
+    DistributedTransaction transaction = coordinatorOnlyManager.begin();
+
+    // begin works, and a null participant is passed through (nothing to register).
+    assertThat(transaction.getId()).isEqualTo(CANONICAL_ID);
+    verify(coordinator).begin(any(), anyBoolean(), anyMap(), isNull());
+  }
+
+  @Test
+  void oneOperationCrud_WhenNoParticipant_ShouldThrowUnsupportedOperationException() {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    assertThatThrownBy(() -> coordinatorOnlyManager.get(get))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void getScanner_WhenNoParticipant_ShouldThrowUnsupportedOperationException() {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    assertThatThrownBy(() -> coordinatorOnlyManager.getScanner(scan))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void transactionCrud_WhenNoParticipant_ShouldThrowUnsupportedOperationException()
+      throws Exception {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+    DistributedTransaction transaction = coordinatorOnlyManager.begin();
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    assertThatThrownBy(() -> transaction.get(get))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void transactionCommitAndRollback_WhenNoParticipant_ShouldStillWork() throws Exception {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+
+    // commit and rollback are Coordinator-only, so they work without a participant.
+    coordinatorOnlyManager.begin().commit();
+    verify(coordinator).commit(CANONICAL_ID);
+
+    coordinatorOnlyManager.begin().rollback();
+    verify(coordinator).rollback(CANONICAL_ID);
+  }
+
+  @Test
+  void close_ShouldCloseCoordinatorAndParticipant() {
+    manager.close();
+
+    verify(coordinator).close();
+    verify(participant).close();
+  }
+
+  @Test
+  void close_WhenNoParticipant_ShouldCloseCoordinatorOnlyWithoutThrowing() {
+    TwoPhaseCommitBackedDistributedTransactionManager coordinatorOnlyManager =
+        new TwoPhaseCommitBackedDistributedTransactionManager(config, coordinator, null);
+
+    // close must not dereference the null participant.
+    coordinatorOnlyManager.close();
+
+    verify(coordinator).close();
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/error/CoreErrorTest.java
+++ b/core/src/test/java/com/scalar/db/common/error/CoreErrorTest.java
@@ -28,6 +28,16 @@ public class CoreErrorTest {
   }
 
   @Test
+  public void buildCode_ForTransactionNotFound_ShouldBeConcurrencyErrorCode() {
+    // TRANSACTION_NOT_FOUND is intentionally categorized as a CONCURRENCY_ERROR (an expired or
+    // unknown transaction is retriable), not a USER_ERROR. Pin the category and the resulting code
+    // so the intentional recategorization is not silently reverted.
+    Assertions.assertThat(CoreError.TRANSACTION_NOT_FOUND.getCategory())
+        .isEqualTo(Category.CONCURRENCY_ERROR);
+    Assertions.assertThat(CoreError.TRANSACTION_NOT_FOUND.buildCode()).isEqualTo("DB-CORE-20031");
+  }
+
+  @Test
   public void buildMessage_ShouldBuildCorrectMessage() {
     // Arrange
     CoreError error = CoreError.OPERATION_CHECK_ERROR_INDEX_ONLY_SINGLE_COLUMN_INDEX_SUPPORTED;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -20,6 +20,7 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getCoordinatorNamespace()).isNotPresent();
+    assertThat(config.getParticipantId()).isNotPresent();
     assertThat(config.getParallelExecutorCount()).isEqualTo(128);
     assertThat(config.isParallelPreparationEnabled()).isTrue();
     assertThat(config.isParallelValidationEnabled()).isTrue();
@@ -83,6 +84,20 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getCoordinatorNamespace()).isPresent();
     assertThat(config.getCoordinatorNamespace().get()).isEqualTo("changed_coordinator");
+  }
+
+  @Test
+  public void constructor_PropertiesWithParticipantIdGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ConsensusCommitConfig.PARTICIPANT_ID, "participant-1");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getParticipantId()).isPresent();
+    assertThat(config.getParticipantId().get()).isEqualTo("participant-1");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -255,9 +255,9 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void commit_NoWrites_WithWriteOmission_WhenValidateFails_ShouldSkipAbortStateButRollback()
+  void commit_NoWrites_WithWriteOmission_WhenValidateFails_ShouldStillWriteAbortedAndRollback()
       throws Exception {
-    // Arrange — omission enabled, no writes, but validation fails.
+    // Arrange — omission enabled, no writes observed, but validation fails.
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
@@ -266,14 +266,14 @@ class ConsensusCommitCoordinatorTest {
         .when(participant)
         .validateRecords("tx-1");
 
-    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException, no
-    // ABORTED
-    // state row is written (an absent row is treated as ABORTED), but the participant records are
-    // still rolled back.
+    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException. The abort
+    // path always writes ABORTED even though no writes were observed: a prepare/validate failure
+    // can leave records PREPARED that hasWrites did not capture, so the write-omission is not
+    // applied here (it only applies on the commit-success path). Records are also rolled back.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class)
         .hasCauseInstanceOf(ValidationConflictException.class);
-    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
     verify(participant).rollbackRecords("tx-1");
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -1,0 +1,705 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.TwoPhaseCommit.Participant;
+import com.scalar.db.api.TwoPhaseCommit.PreparationResult;
+import com.scalar.db.api.TwoPhaseCommit.WriteSetEntry;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationConflictException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.io.Key;
+import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
+import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ConsensusCommitCoordinatorTest {
+  private static final long ANY_COMMITTED_AT = 200L;
+
+  @Mock private CoordinatorCommitHandler coordinatorCommitHandler;
+  @Mock private ConsensusCommitConfig config;
+
+  private ConsensusCommitCoordinator consensusCommitCoordinator;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(false);
+    // The handler generates the committedAt and returns it (in production it stamps the COMMITTED
+    // row with it); the orchestrator drives commitRecords with that returned value.
+    when(coordinatorCommitHandler.commitState(anyString(), any())).thenReturn(ANY_COMMITTED_AT);
+    consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
+  }
+
+  @Test
+  void constructor_GroupCommitEnabled_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> new ConsensusCommitCoordinator(coordinatorCommitHandler, config))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void begin_NoTransactionIdGiven_ShouldGenerateAndReturnId() throws Exception {
+    // Act
+    String id = consensusCommitCoordinator.begin(null, false, Collections.emptyMap(), null);
+
+    // Assert
+    assertThat(id).isNotNull().isNotEmpty();
+  }
+
+  @Test
+  void begin_TransactionIdGiven_ShouldReturnSameId() throws Exception {
+    // Act
+    String id = consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+
+    // Assert
+    assertThat(id).isEqualTo("tx-1");
+  }
+
+  @Test
+  void begin_SameTransactionIdTwice_ShouldThrowTransactionException() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null))
+        .isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  void registerParticipant_UnknownTransaction_ShouldThrowTransactionNotFoundException() {
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                consensusCommitCoordinator.registerParticipant("unknown", mock(Participant.class)))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void registerParticipant_ShouldInvokeJoinAndTrackParticipant() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap(), null);
+    Participant participant = mock(Participant.class);
+    when(participant.getId()).thenReturn("participant-1");
+    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(emptyPreparation());
+
+    // Act
+    consensusCommitCoordinator.registerParticipant("tx-1", participant);
+
+    // Assert — join is invoked with the begin-time readOnly flag and attributes ...
+    verify(participant).join("tx-1", true, Collections.emptyMap());
+    // ... and the participant is tracked, so a subsequent commit drives its record-level steps.
+    consensusCommitCoordinator.commit("tx-1");
+    verify(participant).prepareRecords(eq("tx-1"), anyLong());
+    verify(participant).validateRecords("tx-1");
+    verify(participant).commitRecords(eq("tx-1"), anyLong());
+  }
+
+  @Test
+  void registerParticipant_WhenJoinThrows_ShouldNotTrackParticipant() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant = mock(Participant.class);
+    doThrow(new TransactionException("join failed", "tx-1"))
+        .when(participant)
+        .join("tx-1", false, Collections.emptyMap());
+
+    // Act
+    assertThatThrownBy(() -> consensusCommitCoordinator.registerParticipant("tx-1", participant))
+        .isInstanceOf(TransactionException.class);
+
+    // Assert — a failed join leaves the participant untracked, so rollback never touches it.
+    consensusCommitCoordinator.rollback("tx-1");
+    verify(participant, never()).rollbackRecords(anyString());
+  }
+
+  @Test
+  void begin_WithParticipant_ShouldRegisterParticipant() throws Exception {
+    // Arrange
+    Participant participant = mock(Participant.class);
+    when(participant.getId()).thenReturn("participant-1");
+    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(emptyPreparation());
+
+    // Act — passing a participant to begin registers it exactly as registerParticipant would.
+    consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap(), participant);
+
+    // Assert — join is invoked with the begin-time readOnly flag and attributes ...
+    verify(participant).join("tx-1", true, Collections.emptyMap());
+    // ... and the participant is tracked, so a subsequent commit drives its record-level steps.
+    consensusCommitCoordinator.commit("tx-1");
+    verify(participant).prepareRecords(eq("tx-1"), anyLong());
+  }
+
+  @Test
+  void begin_WithParticipant_WhenJoinThrows_ShouldReleaseContextAndPropagate() throws Exception {
+    // Arrange
+    Participant participant = mock(Participant.class);
+    doThrow(new TransactionException("join failed", "tx-1"))
+        .when(participant)
+        .join("tx-1", false, Collections.emptyMap());
+
+    // Act Assert — the join failure propagates ...
+    assertThatThrownBy(
+            () ->
+                consensusCommitCoordinator.begin(
+                    "tx-1", false, Collections.emptyMap(), participant))
+        .isInstanceOf(TransactionException.class);
+
+    // ... and the context created by begin is released, so the same id can be begun again.
+    assertThat(consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null))
+        .isEqualTo("tx-1");
+  }
+
+  @Test
+  void commit_ShouldDelegateCommitStateToCoordinatorHandler() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — the COMMITTED state write is delegated to the Coordinator-side handler with the
+    // transaction id and the encoded write set (the handler generates the committedAt).
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
+  }
+
+  @Test
+  void commit_WhenCommitStateConflicts_ShouldThrowCommitConflictException() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    doThrow(new CommitConflictException("conflict", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+
+    // Act Assert
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  void commit_WhenCommitStateConflicts_ShouldRollBackPreparedRecordsOnEachParticipant()
+      throws Exception {
+    // Arrange — prepare/validate succeed on both participants, but the COMMITTED-state write loses
+    // a
+    // putState race that resolves to ABORTED (CommitConflictException).
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new CommitConflictException("conflict", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+
+    // Act Assert — the conflict propagates ...
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class);
+
+    // ... and the PREPARED records are rolled back on every participant before it surfaces ...
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+    // ... while commitRecords is never reached.
+    verify(p1, never()).commitRecords(anyString(), anyLong());
+    verify(p2, never()).commitRecords(anyString(), anyLong());
+  }
+
+  @Test
+  void commit_NoWrites_WithWriteOmission_ShouldSkipCommitStateButStillDriveRecords()
+      throws Exception {
+    // Arrange — coordinator-write omission on read-only is enabled (the production default), and
+    // the
+    // participant has no writes (prepareRecords returns an empty write set).
+    when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
+    consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant = registeredParticipant("tx-1");
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — with no writes, the COMMITTED Coordinator state row is not written ...
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+    // ... but the record-level steps are still driven so the participant context is released.
+    verify(participant).prepareRecords(eq("tx-1"), anyLong());
+    verify(participant).validateRecords("tx-1");
+    verify(participant).commitRecords(eq("tx-1"), anyLong());
+  }
+
+  @Test
+  void commit_NoWrites_WithWriteOmission_WhenValidateFails_ShouldSkipAbortStateButRollback()
+      throws Exception {
+    // Arrange — omission enabled, no writes, but validation fails.
+    when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
+    consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant = registeredParticipant("tx-1");
+    doThrow(new ValidationConflictException("validation conflict", "tx-1"))
+        .when(participant)
+        .validateRecords("tx-1");
+
+    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException, no
+    // ABORTED
+    // state row is written (an absent row is treated as ABORTED), but the participant records are
+    // still rolled back.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(ValidationConflictException.class);
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+    verify(participant).rollbackRecords("tx-1");
+  }
+
+  @Test
+  void commit_UnknownTransaction_ShouldThrowTransactionNotFoundException() throws Exception {
+    // Act Assert — committing a transaction never begun on this Coordinator is a caller error; no
+    // COMMITTED state is written.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("unknown"))
+        .isInstanceOf(TransactionNotFoundException.class);
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+  }
+
+  @Test
+  void rollback_ShouldDriveRollbackRecordsAndReleaseWithoutWritingAbortedState() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant = registeredParticipant("tx-1");
+
+    // Act
+    consensusCommitCoordinator.rollback("tx-1");
+
+    // Assert — rollbackRecords is driven on the participant to undo its work and release its local
+    // context; no ABORTED state row is written (records are only PREPARED inside commit()).
+    verify(participant).rollbackRecords("tx-1");
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+  }
+
+  @Test
+  void rollback_UnknownTransaction_ShouldBeNoOp() throws Exception {
+    // Act — rolling back a transaction never begun (or already finished) is a lenient no-op.
+    consensusCommitCoordinator.rollback("unknown");
+
+    // Assert — no ABORTED state is written.
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+  }
+
+  @Test
+  void commit_AfterCommit_ShouldThrowTransactionNotFoundException() throws Exception {
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    consensusCommitCoordinator.commit("tx-1");
+
+    // The context was released by the first commit; a second commit no longer knows the
+    // transaction.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void registerParticipant_AfterCommit_ShouldThrowTransactionNotFoundException() throws Exception {
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    consensusCommitCoordinator.commit("tx-1");
+
+    assertThatThrownBy(
+            () -> consensusCommitCoordinator.registerParticipant("tx-1", mock(Participant.class)))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void rollback_AfterCommit_ShouldBeNoOp() throws Exception {
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Rolling back an already-committed (released) transaction is a lenient no-op, not an error.
+    consensusCommitCoordinator.rollback("tx-1");
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+  }
+
+  @Test
+  void commit_TwoParticipants_ShouldDriveFullTwoPhaseCommitInRegistrationOrder() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — prepare and validate on each, COMMITTED state written, then commitRecords on each.
+    verify(p1).prepareRecords(eq("tx-1"), anyLong());
+    verify(p2).prepareRecords(eq("tx-1"), anyLong());
+    verify(p1).validateRecords("tx-1");
+    verify(p2).validateRecords("tx-1");
+    // The committedAt the handler returns from commitState is the one passed to every participant's
+    // commitRecords, so the COMMITTED state row and the records share one timestamp.
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
+    verify(p1).commitRecords("tx-1", ANY_COMMITTED_AT);
+    verify(p2).commitRecords("tx-1", ANY_COMMITTED_AT);
+  }
+
+  @Test
+  void commit_WhenPrepareFailsOnSecondParticipant_ShouldWriteAbortedAndDriveRollback()
+      throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new PreparationConflictException("conflict on p2", "tx-1"))
+        .when(p2)
+        .prepareRecords(eq("tx-1"), anyLong());
+
+    // Act Assert — the prepare conflict surfaces as a retriable CommitConflictException ...
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(PreparationConflictException.class);
+
+    // ... ABORTED state is written and rollbackRecords is driven on both participants ...
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+    // ... and commitState / commitRecords are never reached.
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+    verify(p1, never()).commitRecords(anyString(), anyLong());
+  }
+
+  @Test
+  void
+      commit_WhenPrepareThrowsTransactionNotFoundOnSecondParticipant_ShouldAbortRollBackAndRethrow()
+          throws Exception {
+    // Arrange — the second participant no longer knows the transaction (its local context is gone).
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new TransactionNotFoundException("gone on p2", "tx-1"))
+        .when(p2)
+        .prepareRecords(eq("tx-1"), anyLong());
+
+    // Act Assert — the TransactionNotFoundException surfaces as-is (not wrapped), since a missing
+    // participant context means the transaction is gone; the facade maps it to a retriable
+    // conflict.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(TransactionNotFoundException.class);
+
+    // ... but the eager cleanup still runs: ABORTED state is written and rollbackRecords is driven
+    // on every participant ...
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+    // ... and commitState / commitRecords are never reached.
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+    verify(p1, never()).commitRecords(anyString(), anyLong());
+  }
+
+  @Test
+  void commit_WhenValidateFails_ShouldWriteAbortedAndDriveRollback() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new ValidationConflictException("validation conflict", "tx-1"))
+        .when(p1)
+        .validateRecords("tx-1");
+
+    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(ValidationConflictException.class);
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+  }
+
+  @Test
+  void commit_WhenPrepareFailsWithNonConflict_ShouldWrapAsCommitExceptionAndDriveRollback()
+      throws Exception {
+    // Arrange — a plain (non-conflict) PreparationException, e.g. an I/O failure during prepare
+    // rather than a write conflict.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new PreparationException("prepare failed", "tx-1"))
+        .when(p1)
+        .prepareRecords(eq("tx-1"), anyLong());
+
+    // Act Assert — a non-conflict prepare failure surfaces as a non-retriable CommitException (NOT
+    // a retriable CommitConflictException), and the abort path still runs.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitException.class)
+        .isNotInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(PreparationException.class);
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+  }
+
+  @Test
+  void commit_WhenValidateFailsWithNonConflict_ShouldWrapAsCommitExceptionAndDriveRollback()
+      throws Exception {
+    // Arrange — a plain (non-conflict) ValidationException.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new ValidationException("validation failed", "tx-1")).when(p1).validateRecords("tx-1");
+
+    // Act Assert — a non-conflict validate failure surfaces as a non-retriable CommitException, and
+    // the abort path still runs.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitException.class)
+        .isNotInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(ValidationException.class);
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+  }
+
+  @Test
+  void commit_WhenCommitRecordsThrows_ShouldSwallowAndComplete() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
+
+    // Act Assert — commitRecords is best-effort: the failure is swallowed and commit completes.
+    consensusCommitCoordinator.commit("tx-1");
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
+  }
+
+  @Test
+  void commit_WhenRollbackRecordsThrows_ShouldSwallowAndPropagateOriginal() throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new PreparationConflictException("conflict", "tx-1"))
+        .when(p1)
+        .prepareRecords(eq("tx-1"), anyLong());
+    doThrow(new RuntimeException("network blip")).when(p1).rollbackRecords("tx-1");
+
+    // Act Assert — rollbackRecords failure is swallowed; the prepare conflict still surfaces (as a
+    // CommitConflictException).
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(PreparationConflictException.class);
+  }
+
+  @Test
+  void commit_TwoParticipants_WhenCommitRecordsThrowsOnFirst_ShouldStillCommitSecond()
+      throws Exception {
+    // Arrange — both participants commit successfully through prepare/validate/commitState; the
+    // first participant's best-effort commitRecords then fails.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
+
+    // Act — commitRecords is best-effort, so the first participant's failure is swallowed.
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — the second participant's commitRecords is still driven despite the first failing.
+    verify(p1).commitRecords(eq("tx-1"), anyLong());
+    verify(p2).commitRecords(eq("tx-1"), anyLong());
+  }
+
+  @Test
+  void commit_TwoParticipants_WhenRollbackRecordsThrowsOnFirst_ShouldStillRollBackSecond()
+      throws Exception {
+    // Arrange — drive the abort path via a validate conflict on the second participant, then make
+    // the first participant's best-effort rollbackRecords fail.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new ValidationConflictException("conflict", "tx-1")).when(p2).validateRecords("tx-1");
+    doThrow(new RuntimeException("network blip")).when(p1).rollbackRecords("tx-1");
+
+    // Act Assert — the validate conflict still surfaces as a retriable CommitConflictException ...
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class);
+
+    // ... and the second participant's rollbackRecords is still driven despite the first failing.
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+  }
+
+  @Test
+  void commit_WhenAbortStateWriteFailsUnknown_ShouldPropagateUnknownStatusAndNotRollBack()
+      throws Exception {
+    // Arrange — prepare fails, and writing the ABORTED state genuinely fails with unknown status
+    // (a real coordinator failure, not a mere putState conflict, which the handler would resolve to
+    // ABORTED).
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1");
+    doThrow(new PreparationConflictException("conflict", "tx-1"))
+        .when(p1)
+        .prepareRecords(eq("tx-1"), anyLong());
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .abortState(anyString(), any());
+
+    // Act Assert — the ABORTED write's unknown status surfaces (not the retryable prepare
+    // conflict), and records are NOT rolled back: the Coordinator state is the source of truth, so
+    // lazy recovery reconciles later. Mirrors CommitHandler#abortStateAndRollbackRecordsIfNeeded.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(p1, never()).rollbackRecords(anyString());
+  }
+
+  @Test
+  void registerParticipant_WhenDuplicateParticipantId_ShouldBeNoOp() throws Exception {
+    // Arrange — one participant with a given ID is already registered.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant original = registeredParticipant("tx-1", "participant-1");
+    Participant duplicate = mock(Participant.class);
+    when(duplicate.getId()).thenReturn("participant-1");
+
+    // Act — registering a second participant that returns the same getId() is a no-op.
+    consensusCommitCoordinator.registerParticipant("tx-1", duplicate);
+
+    // Assert — the duplicate is never joined, and only the original participant is tracked (a
+    // subsequent commit drives the original, not the duplicate).
+    verify(duplicate, never()).join(anyString(), anyBoolean(), anyMap());
+    consensusCommitCoordinator.commit("tx-1");
+    verify(original).prepareRecords(eq("tx-1"), anyLong());
+    verify(duplicate, never()).prepareRecords(anyString(), anyLong());
+  }
+
+  @Test
+  void
+      commit_TwoParticipantsWithWrites_WithWriteOmission_ShouldEncodeWriteSetGroupedByParticipantId()
+          throws Exception {
+    // Arrange — coordinator-write omission on read-only is enabled, but both participants return a
+    // non-empty write set (hasWrites=true), so the COMMITTED state IS written and the
+    // per-participant
+    // write sets are aggregated and stamped with the owning participant id.
+    when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
+    consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    registeredParticipantWithWrites(
+        "tx-1",
+        "participant-1",
+        writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 1), Optional.empty()),
+        writeSetEntry(WriteSetEntry.Type.DELETE, Key.ofInt("pk", 2), Optional.empty()));
+    registeredParticipantWithWrites(
+        "tx-1",
+        "participant-2",
+        writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 3), Optional.empty()));
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — the COMMITTED state is written (hasWrites=true overrides write omission) with a
+    // WriteSet that has one EntryGroup per participant, in registration order, each entry stamped
+    // with the owning participant id and the right entry type.
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), captor.capture());
+    WriteSet writeSet = captor.getValue();
+    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+
+    EntryGroup group1 = writeSet.getEntryGroups(0);
+    assertThat(group1.getEntriesList()).hasSize(2);
+    assertThat(group1.getEntries(0).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group1.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+    assertThat(group1.getEntries(1).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group1.getEntries(1).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
+
+    EntryGroup group2 = writeSet.getEntryGroups(1);
+    assertThat(group2.getEntriesList()).hasSize(1);
+    assertThat(group2.getEntries(0).getParticipantId()).isEqualTo("participant-2");
+    assertThat(group2.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+  }
+
+  @Test
+  void commit_WithWrites_WithWriteOmission_WhenPrepareFails_ShouldWriteAbortedState()
+      throws Exception {
+    // Arrange — write omission enabled, the first participant prepares a non-empty write set
+    // (hasWrites becomes true) and the second participant then fails to prepare.
+    when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
+    consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 =
+        registeredParticipantWithWrites(
+            "tx-1",
+            "participant-1",
+            writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 1), Optional.empty()));
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new PreparationConflictException("conflict on p2", "tx-1"))
+        .when(p2)
+        .prepareRecords(eq("tx-1"), anyLong());
+
+    // Act Assert — the prepare conflict surfaces as a retriable CommitConflictException ...
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(PreparationConflictException.class);
+
+    // ... and because hasWrites is true (p1 prepared a non-empty write set before p2 failed), the
+    // ABORTED state row IS written — unlike the write-less case
+    // (commit_NoWrites_WithWriteOmission_WhenValidateFails) where it is omitted.
+    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+  }
+
+  private Participant registeredParticipant(String transactionId) throws Exception {
+    return registeredParticipant(transactionId, "participant-1");
+  }
+
+  private Participant registeredParticipant(String transactionId, String participantId)
+      throws Exception {
+    Participant participant = mock(Participant.class);
+    when(participant.getId()).thenReturn(participantId);
+    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(emptyPreparation());
+    consensusCommitCoordinator.registerParticipant(transactionId, participant);
+    return participant;
+  }
+
+  // A PreparationResult carrying no writes. PreparationResult has a single method (getWriteSet), so
+  // a method reference to an empty list satisfies it.
+  private static PreparationResult emptyPreparation() {
+    return Collections::emptyList;
+  }
+
+  // Registers a participant whose prepareRecords returns the given (non-empty) write set, so
+  // commit()
+  // exercises the hasWrites=true aggregation/encoding path.
+  private Participant registeredParticipantWithWrites(
+      String transactionId, String participantId, WriteSetEntry... entries) throws Exception {
+    Participant participant = mock(Participant.class);
+    when(participant.getId()).thenReturn(participantId);
+    List<WriteSetEntry> writeSet = Arrays.asList(entries);
+    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(() -> writeSet);
+    consensusCommitCoordinator.registerParticipant(transactionId, participant);
+    return participant;
+  }
+
+  // A minimal WriteSetEntry stub sufficient for encoding (includeColumns=false, so getColumns is
+  // not
+  // read). The namespace/table are stubbed non-null because the encoder sets them on the proto.
+  private static WriteSetEntry writeSetEntry(
+      WriteSetEntry.Type type, Key partitionKey, Optional<Key> clusteringKey) {
+    WriteSetEntry entry = mock(WriteSetEntry.class);
+    when(entry.getType()).thenReturn(type);
+    when(entry.getNamespaceName()).thenReturn("ns");
+    when(entry.getTableName()).thenReturn("tbl");
+    when(entry.getPartitionKey()).thenReturn(partitionKey);
+    when(entry.getClusteringKey()).thenReturn(clusteringKey);
+    return entry;
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
@@ -1,0 +1,749 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ConsensusCommitParticipantTest {
+  private static final String ANY_NAMESPACE = "ns";
+  private static final String ANY_TABLE = "tbl";
+  private static final String ANY_PARTICIPANT_ID = "participant-A";
+  private static final String ANY_TX_ID = "tx-1";
+
+  @Mock private ConsensusCommitConfig config;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+  @Mock private ParallelExecutor parallelExecutor;
+  @Mock private RecoveryExecutor recoveryExecutor;
+  @Mock private CrudHandler crud;
+  @Mock private ParticipantCommitHandler commit;
+  @Mock private ConsensusCommitOperationChecker operationChecker;
+  @Mock private TransactionTableMetadata txTableMetadata;
+
+  private ConsensusCommitParticipant participant;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(config.getParticipantId()).thenReturn(Optional.of(ANY_PARTICIPANT_ID));
+    when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("pk", DataType.INT)
+            .addColumn("v", DataType.INT)
+            .addPartitionKey("pk")
+            .build();
+    when(txTableMetadata.getTableMetadata()).thenReturn(tableMetadata);
+    when(tableMetadataManager.getTransactionTableMetadata(any())).thenReturn(txTableMetadata);
+
+    participant =
+        new ConsensusCommitParticipant(
+            config,
+            tableMetadataManager,
+            parallelExecutor,
+            recoveryExecutor,
+            crud,
+            commit,
+            operationChecker);
+  }
+
+  @Test
+  void constructor_WithoutParticipantId_ShouldThrowIllegalArgumentException() {
+    when(config.getParticipantId()).thenReturn(Optional.empty());
+    assertThatThrownBy(
+            () ->
+                new ConsensusCommitParticipant(
+                    config,
+                    tableMetadataManager,
+                    parallelExecutor,
+                    recoveryExecutor,
+                    crud,
+                    commit,
+                    operationChecker))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void join_NewTransaction_ShouldCreateContext() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    // No exception means the context was created. A subsequent CRUD operation should find it.
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+    doReturn(Optional.empty()).when(crud).get(eq(get), any(TransactionContext.class));
+    Optional<Result> result = participant.get(ANY_TX_ID, get);
+    assertThat(result).isEmpty();
+    verify(crud).get(eq(get), any(TransactionContext.class));
+  }
+
+  @Test
+  void join_WithTransactionIsolationAttribute_ShouldUseThatIsolationInsteadOfConfigDefault()
+      throws Exception {
+    // The config default is SNAPSHOT (see setUp); the attribute requests SERIALIZABLE for this tx.
+    Map<String, String> attributes = new HashMap<>();
+    ConsensusCommitOperationAttributes.setTransactionIsolation(attributes, Isolation.SERIALIZABLE);
+
+    participant.join(ANY_TX_ID, false, attributes);
+
+    assertThat(getContext(ANY_TX_ID).isolation).isEqualTo(Isolation.SERIALIZABLE);
+  }
+
+  @Test
+  void join_WithoutTransactionIsolationAttribute_ShouldUseConfigDefault() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+
+    assertThat(getContext(ANY_TX_ID).isolation).isEqualTo(Isolation.SNAPSHOT);
+  }
+
+  @Test
+  void join_SameTransactionIdTwice_ShouldThrowTransactionException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    assertThatThrownBy(() -> participant.join(ANY_TX_ID, false, Collections.emptyMap()))
+        .isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  void get_OnUnknownTransactionId_ShouldThrowTransactionNotFoundException() {
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+    assertThatThrownBy(() -> participant.get("unknown-tx", get))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void put_ShouldDelegateToCrudHandler() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+    doNothing().when(crud).put(any(Put.class), any(TransactionContext.class));
+
+    participant.put(ANY_TX_ID, put);
+
+    verify(crud).put(eq(put), any(TransactionContext.class));
+  }
+
+  @Test
+  void put_OnReadOnlyTransaction_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+
+    assertThatThrownBy(() -> participant.put(ANY_TX_ID, put))
+        .isInstanceOf(IllegalStateException.class);
+    verify(crud, never()).put(any(Put.class), any(TransactionContext.class));
+  }
+
+  @Test
+  void update_WithoutConditionAndCrudThrowsUnsatisfiedCondition_ShouldDoNothing() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+    // The record does not satisfy the implicit PutIfExists. With no user condition, this is a
+    // no-op (the record does not exist), so the exception is swallowed.
+    doThrow(UnsatisfiedConditionException.class)
+        .when(crud)
+        .put(any(Put.class), any(TransactionContext.class));
+
+    assertThatCode(() -> participant.update(ANY_TX_ID, update)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void update_WithUpdateIfConditionAndCrudThrowsUnsatisfiedCondition_ShouldThrowConverted()
+      throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .condition(
+                ConditionBuilder.updateIf(ConditionBuilder.column("v").isEqualToInt(1)).build())
+            .build();
+    UnsatisfiedConditionException crudException = mock(UnsatisfiedConditionException.class);
+    when(crudException.getMessage()).thenReturn("PutIf");
+    doThrow(crudException).when(crud).put(any(Put.class), any(TransactionContext.class));
+
+    // The user supplied an UpdateIf condition, so the failure is rethrown with the message
+    // converted back from the internal PutIf wording to UpdateIf.
+    assertThatThrownBy(() -> participant.update(ANY_TX_ID, update))
+        .isInstanceOf(UnsatisfiedConditionException.class)
+        .hasMessageContaining("UpdateIf")
+        .hasMessageNotContaining("PutIf");
+  }
+
+  @Test
+  void delete_OnReadOnlyTransaction_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+
+    assertThatThrownBy(() -> participant.delete(ANY_TX_ID, delete))
+        .isInstanceOf(IllegalStateException.class);
+    verify(crud, never()).delete(any(Delete.class), any(TransactionContext.class));
+  }
+
+  @Test
+  void mutate_OnReadOnlyTransaction_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+
+    assertThatThrownBy(() -> participant.mutate(ANY_TX_ID, Collections.singletonList(insert)))
+        .isInstanceOf(IllegalStateException.class);
+    verify(crud, never()).put(any(Put.class), any(TransactionContext.class));
+  }
+
+  @Test
+  void batch_WithMutationOnReadOnlyTransaction_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 2))
+            .intValue("v", 100)
+            .build();
+
+    assertThatThrownBy(() -> participant.batch(ANY_TX_ID, Collections.singletonList(insert)))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void get_OnReadOnlyTransaction_ShouldBeAllowed() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+    when(crud.get(any(Get.class), any(TransactionContext.class))).thenReturn(Optional.empty());
+
+    assertThat(participant.get(ANY_TX_ID, get)).isEmpty();
+    verify(crud).get(eq(get), any(TransactionContext.class));
+  }
+
+  @Test
+  void prepareRecords_OnUnknownTransactionId_ShouldThrowTransactionNotFoundException() {
+    // An absent local context (e.g., expired) surfaces as not-found.
+    assertThatThrownBy(() -> participant.prepareRecords("unknown-tx", 1234L))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void prepareRecords_WhenScannerNotClosed_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+
+    // Open a scanner and leave it unclosed: register a non-closed scanner into the transaction
+    // context, mirroring what the real CrudHandler.getScanner does.
+    ConsensusCommitScanner openScanner = mock(ConsensusCommitScanner.class);
+    when(openScanner.isClosed()).thenReturn(false);
+    when(crud.getScanner(any(Scan.class), any(TransactionContext.class)))
+        .thenAnswer(
+            invocation -> {
+              TransactionContext context = invocation.getArgument(1);
+              context.scanners.add(openScanner);
+              return openScanner;
+            });
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+    participant.getScanner(ANY_TX_ID, scan);
+
+    // prepareRecords must reject a transaction that still has an open scanner ...
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 1000L))
+        .isInstanceOf(IllegalStateException.class);
+    // ... and the record-level prepare is never driven.
+    verify(commit, never()).prepareRecords(any(TransactionContext.class), anyLong());
+  }
+
+  private static Scan anyScan() {
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE)
+        .partitionKey(Key.ofInt("pk", 1))
+        .build();
+  }
+
+  // Registers a (non-closed) raw scanner with the transaction context, mirroring the real
+  // CrudHandler.getScanner, and returns the scanner the participant hands back (a pc-synchronized
+  // wrapper around it).
+  private TransactionCrudOperable.Scanner openScanner(ConsensusCommitScanner rawScanner)
+      throws Exception {
+    when(rawScanner.isClosed()).thenReturn(false);
+    when(crud.getScanner(any(Scan.class), any(TransactionContext.class)))
+        .thenAnswer(
+            invocation -> {
+              TransactionContext context = invocation.getArgument(1);
+              context.scanners.add(rawScanner);
+              return rawScanner;
+            });
+    return participant.getScanner(ANY_TX_ID, anyScan());
+  }
+
+  @Test
+  void getScanner_ReturnedScanner_ShouldDelegateToRawScanner() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+    ConsensusCommitScanner raw = mock(ConsensusCommitScanner.class);
+    when(raw.one()).thenReturn(Optional.empty());
+    TransactionCrudOperable.Scanner scanner = openScanner(raw);
+
+    scanner.one();
+    scanner.close();
+
+    verify(raw).one();
+    verify(raw).close();
+  }
+
+  @Test
+  void scanner_AfterContextReleased_ShouldThrowCrudConflictException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    TransactionCrudOperable.Scanner scanner = openScanner(mock(ConsensusCommitScanner.class));
+
+    // rollbackRecords releases (and removes) the context. A subsequent iteration of the previously
+    // obtained scanner must not read through the released context; it fails with a retriable
+    // conflict instead.
+    participant.rollbackRecords(ANY_TX_ID);
+
+    assertThatThrownBy(scanner::one).isInstanceOf(CrudConflictException.class);
+    assertThatThrownBy(scanner::all).isInstanceOf(CrudConflictException.class);
+    // Iteration must be guarded too: iterator() drives the wrapper's one() per element, so a
+    // released context surfaces the retriable conflict (wrapped, since Iterator throws no checked
+    // exception) rather than reading through the released, closed underlying scanner.
+    assertThatThrownBy(() -> scanner.iterator().hasNext())
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  void scannerIteration_ShouldBeMutuallyExclusiveWithContextRelease() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+
+    CountDownLatch insideOne = new CountDownLatch(1);
+    CountDownLatch releaseOne = new CountDownLatch(1);
+    ConsensusCommitScanner raw = mock(ConsensusCommitScanner.class);
+    // The raw one() blocks while the iterating thread holds the pc monitor, so a concurrent
+    // rollbackRecords (which also locks pc to close scanners and release the context) cannot run
+    // until iteration finishes.
+    when(raw.one())
+        .thenAnswer(
+            invocation -> {
+              insideOne.countDown();
+              releaseOne.await();
+              return Optional.empty();
+            });
+    TransactionCrudOperable.Scanner scanner = openScanner(raw);
+
+    Thread iterating =
+        new Thread(
+            () -> {
+              try {
+                scanner.one();
+              } catch (Exception ignored) {
+                // not relevant to this test
+              }
+            });
+    iterating.start();
+    assertThat(insideOne.await(2, TimeUnit.SECONDS)).isTrue();
+
+    AtomicBoolean rolledBack = new AtomicBoolean(false);
+    Thread rollingBack =
+        new Thread(
+            () -> {
+              try {
+                participant.rollbackRecords(ANY_TX_ID);
+                rolledBack.set(true);
+              } catch (Exception ignored) {
+                // not relevant to this test
+              }
+            });
+    rollingBack.start();
+
+    // While the iterating thread is inside one() (holding pc), rollbackRecords must be blocked.
+    Thread.sleep(300);
+    assertThat(rolledBack.get()).isFalse();
+
+    // Let iteration finish; rollbackRecords can then acquire pc and complete.
+    releaseOne.countDown();
+    iterating.join(2000);
+    rollingBack.join(2000);
+    assertThat(rolledBack.get()).isTrue();
+  }
+
+  @Test
+  void prepareRecords_ReadOnlyWithNoWrites_ShouldReturnEmptyWriteSet() throws Exception {
+    participant.join(ANY_TX_ID, true, Collections.emptyMap());
+
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+
+    List<TwoPhaseCommit.WriteSetEntry> entries =
+        participant.prepareRecords(ANY_TX_ID, 1000L).getWriteSet();
+    assertThat(entries).isEmpty();
+    verify(commit).prepareRecords(any(TransactionContext.class), eq(1000L));
+  }
+
+  @Test
+  void prepareRecords_WithWriteAndDelete_ShouldReturnEntriesStampedWithParticipantId()
+      throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 2))
+            .build();
+    // Stub CrudHandler.put/delete to actually populate the snapshot via the context.
+    doNothing().when(crud).put(any(Put.class), any(TransactionContext.class));
+    doNothing().when(crud).delete(any(Delete.class), any(TransactionContext.class));
+    participant.insert(ANY_TX_ID, insert);
+    participant.delete(ANY_TX_ID, delete);
+
+    // CrudHandler is mocked, so the snapshot stays empty unless we populate it directly. Reach
+    // into the per-tx Snapshot and inject a write + delete, mirroring what the real CrudHandler
+    // would do for the insert + delete above.
+    TransactionContext context = getContext(ANY_TX_ID);
+    Put put = buildPutFromInsert(insert);
+    context.snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    context.snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
+
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+
+    List<TwoPhaseCommit.WriteSetEntry> entries =
+        participant.prepareRecords(ANY_TX_ID, 2000L).getWriteSet();
+    assertThat(entries).hasSize(2);
+    assertThat(participant.getId()).isEqualTo(ANY_PARTICIPANT_ID);
+    assertThat(entries)
+        .extracting(TwoPhaseCommit.WriteSetEntry::getType)
+        .containsExactlyInAnyOrder(
+            TwoPhaseCommit.WriteSetEntry.Type.WRITE, TwoPhaseCommit.WriteSetEntry.Type.DELETE);
+    assertThat(entries)
+        .allSatisfy(
+            e -> {
+              assertThat(e.getNamespaceName()).isEqualTo(ANY_NAMESPACE);
+              assertThat(e.getTableName()).isEqualTo(ANY_TABLE);
+            });
+  }
+
+  @Test
+  void prepareRecords_AfterPrepare_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    // A second prepare is out of phase (no idempotency under the strict state machine).
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 2000L))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void get_AfterPrepare_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .build();
+    // CRUD after the two-phase commit phase has started is out of phase.
+    assertThatThrownBy(() -> participant.get(ANY_TX_ID, get))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void prepareRecords_PreparationConflict_ShouldPropagateAndKeepContext() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doThrow(new PreparationConflictException("boom", ANY_TX_ID))
+        .when(commit)
+        .prepareRecords(any(TransactionContext.class), anyLong());
+
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 3000L))
+        .isInstanceOf(PreparationConflictException.class);
+
+    // Context kept; caller may still call rollbackRecords.
+    assertThat(getContext(ANY_TX_ID)).isNotNull();
+  }
+
+  @Test
+  void prepareRecords_WhenImplicitPreReadConflicts_ShouldThrowPreparationConflictException()
+      throws Exception {
+    // A conflict during the implicit pre-read must surface as a retriable PreparationConflict
+    // (not a plain PreparationException), and commit.prepareRecords must not be reached.
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    doThrow(new CrudConflictException("pre-read conflict", ANY_TX_ID))
+        .when(crud)
+        .readIfImplicitPreReadEnabled(any(TransactionContext.class));
+
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 1000L))
+        .isInstanceOf(PreparationConflictException.class);
+    verify(commit, never()).prepareRecords(any(TransactionContext.class), anyLong());
+  }
+
+  @Test
+  void prepareRecords_WhenImplicitPreReadFails_ShouldThrowNonConflictPreparationException()
+      throws Exception {
+    // A non-conflict failure during the implicit pre-read must surface as a (non-retriable)
+    // PreparationException, not a PreparationConflictException.
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    doThrow(new CrudException("pre-read failed", ANY_TX_ID))
+        .when(crud)
+        .readIfImplicitPreReadEnabled(any(TransactionContext.class));
+
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 1000L))
+        .isInstanceOf(PreparationException.class)
+        .isNotInstanceOf(PreparationConflictException.class);
+    verify(commit, never()).prepareRecords(any(TransactionContext.class), anyLong());
+  }
+
+  @Test
+  void commitRecords_WhenValidated_ShouldCommitAndRemoveContext() throws Exception {
+    // The normal protocol path the Coordinator drives is prepare -> validate -> commit, so
+    // commitRecords is invoked from the VALIDATED state (not directly from PREPARED).
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepareAndValidate(ANY_TX_ID);
+    participant.commitRecords(ANY_TX_ID, 5000L);
+    verify(commit).commitRecords(any(TransactionContext.class), eq(5000L));
+    // The context is removed after commit.
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void rollbackRecords_WhenValidated_ShouldRollBackRecordsAndRemoveContext() throws Exception {
+    // VALIDATED still counts as prepared (isPrepared()), so a rollback from this state must undo
+    // the PREPARED records in storage, like the PREPARED case.
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepareAndValidate(ANY_TX_ID);
+    participant.rollbackRecords(ANY_TX_ID);
+    verify(commit).rollbackRecords(any(TransactionContext.class));
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void rollbackRecords_AfterPrepareThrewPartway_ShouldRollBackPreparedRecords() throws Exception {
+    // A partial prepare (prepareRecords throws after writing some PREPARED records) must still
+    // leave
+    // the transaction marked PREPARED so rollbackRecords undoes those records in storage.
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doThrow(new PreparationConflictException("boom", ANY_TX_ID))
+        .when(commit)
+        .prepareRecords(any(TransactionContext.class), anyLong());
+    assertThatThrownBy(() -> participant.prepareRecords(ANY_TX_ID, 3000L))
+        .isInstanceOf(PreparationConflictException.class);
+
+    participant.rollbackRecords(ANY_TX_ID);
+
+    // The storage rollback runs even though prepareRecords did not complete.
+    verify(commit).rollbackRecords(any(TransactionContext.class));
+  }
+
+  @Test
+  void validateRecords_ShouldDelegateToParticipantCommitHandler() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    doNothing().when(commit).validateRecords(any(TransactionContext.class));
+    participant.validateRecords(ANY_TX_ID);
+    verify(commit).validateRecords(any(TransactionContext.class));
+  }
+
+  @Test
+  void validateRecords_BeforePrepare_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void validateRecords_UnknownTransactionId_ShouldThrowTransactionNotFoundException() {
+    // An absent local context (e.g., expired) surfaces as not-found.
+    assertThatThrownBy(() -> participant.validateRecords("unknown-tx"))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void commitRecords_ShouldRemoveContext() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    participant.commitRecords(ANY_TX_ID, 5000L);
+    verify(commit).commitRecords(any(TransactionContext.class), eq(5000L));
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void commitRecords_BeforePrepare_ShouldThrowIllegalStateException() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    assertThatThrownBy(() -> participant.commitRecords(ANY_TX_ID, 5000L))
+        .isInstanceOf(IllegalStateException.class);
+    verify(commit, never()).commitRecords(any(TransactionContext.class), anyLong());
+  }
+
+  @Test
+  void commitRecords_UnknownTransactionId_ShouldThrowTransactionNotFoundException() {
+    // An absent local context (e.g., expired between prepare and commit) surfaces as not-found; the
+    // Coordinator drives this step best-effort and lazy recovery reconciles.
+    assertThatThrownBy(() -> participant.commitRecords("unknown-tx", 5000L))
+        .isInstanceOf(TransactionNotFoundException.class);
+    verify(commit, never()).commitRecords(any(TransactionContext.class), anyLong());
+  }
+
+  @Test
+  void rollbackRecords_WhenPrepared_ShouldRollBackRecordsAndRemoveContext() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    participant.rollbackRecords(ANY_TX_ID);
+    // Prepared, so the PREPARED records are rolled back in storage; the context is removed.
+    verify(commit).rollbackRecords(any(TransactionContext.class));
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void rollbackRecords_WhenNotPrepared_ShouldReleaseContextWithoutStorageRollback()
+      throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    participant.rollbackRecords(ANY_TX_ID);
+    // Never prepared (still in the CRUD phase): no PREPARED records in storage, so no storage
+    // rollback — only the in-memory context is released.
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void rollbackRecords_UnknownTransactionId_ShouldThrowTransactionNotFoundException() {
+    // An absent local context (e.g., expired) surfaces as not-found; the Coordinator drives this
+    // step best-effort and lazy recovery reconciles.
+    assertThatThrownBy(() -> participant.rollbackRecords("unknown-tx"))
+        .isInstanceOf(TransactionNotFoundException.class);
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+  }
+
+  // Drives the transaction to the PREPARED state with the handlers stubbed to no-op.
+  private void prepare(String txId) throws Exception {
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+    participant.prepareRecords(txId, 1000L);
+  }
+
+  // Drives the transaction to the VALIDATED state — the normal path the Coordinator drives before
+  // commitRecords/rollbackRecords (prepare -> validate -> commit/rollback).
+  private void prepareAndValidate(String txId) throws Exception {
+    prepare(txId);
+    doNothing().when(commit).validateRecords(any(TransactionContext.class));
+    participant.validateRecords(txId);
+  }
+
+  private TransactionContext getContext(String txId) throws Exception {
+    // Reach into the participant via reflection — preferred over exposing a getter only used in
+    // tests. The contexts map is the participant's intentionally-internal state.
+    java.lang.reflect.Field field = ConsensusCommitParticipant.class.getDeclaredField("contexts");
+    field.setAccessible(true);
+    java.util.Map<?, ?> map = (java.util.Map<?, ?>) field.get(participant);
+    Object pc = map.get(txId);
+    if (pc == null) {
+      return null;
+    }
+    java.lang.reflect.Method method = pc.getClass().getDeclaredMethod("context");
+    method.setAccessible(true);
+    return (TransactionContext) method.invoke(pc);
+  }
+
+  private Put buildPutFromInsert(Insert insert) {
+    return ConsensusCommitUtils.createPutForInsert(insert);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoderTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoderTest.java
@@ -11,15 +11,24 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
+import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -442,5 +451,113 @@ class WriteSetEncoderTest {
     assertThat(putEntry.getColumnsList()).hasSize(1);
     assertThat(putEntry.getColumns(0).getName()).isEqualTo("v");
     assertThat(putEntry.getColumns(0).getTextValue().getValue()).isEqualTo("user-value");
+  }
+
+  @Test
+  void
+      encodeFromWriteSetEntries_GivenWriteSetsFromMultipleParticipants_ShouldGroupByParticipantAndStampParticipantId() {
+    // Arrange — p1 owns two entries, p2 owns one; map iteration order is p1 then p2.
+    TwoPhaseCommit.WriteSetEntry p1Write =
+        writeSetEntry(
+            TwoPhaseCommit.WriteSetEntry.Type.WRITE,
+            Key.ofText("pk", "a"),
+            Optional.of(Key.ofInt("ck", 1)));
+    TwoPhaseCommit.WriteSetEntry p2Write =
+        writeSetEntry(
+            TwoPhaseCommit.WriteSetEntry.Type.WRITE, Key.ofText("pk", "b"), Optional.empty());
+    TwoPhaseCommit.WriteSetEntry p1Delete =
+        writeSetEntry(
+            TwoPhaseCommit.WriteSetEntry.Type.DELETE,
+            Key.ofText("pk", "c"),
+            Optional.of(Key.ofInt("ck", 2)));
+
+    Map<String, List<TwoPhaseCommit.WriteSetEntry>> writeSetsByParticipant = new LinkedHashMap<>();
+    writeSetsByParticipant.put("p1", Arrays.asList(p1Write, p1Delete));
+    writeSetsByParticipant.put("p2", Collections.singletonList(p2Write));
+
+    // Act
+    WriteSet writeSet =
+        WriteSetEncoder.encodeFromWriteSetEntries(
+            writeSetsByParticipant, /* includeColumns= */ false);
+
+    // Assert — two groups in map iteration order (p1, then p2); p1 holds both its entries.
+    assertThat(writeSet.getSchemaVersion()).isEqualTo(1);
+    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+
+    EntryGroup p1Group = writeSet.getEntryGroups(0);
+    assertThat(p1Group.hasChildId()).isFalse();
+    assertThat(p1Group.getEntriesList()).hasSize(2);
+    Entry p1FirstEntry = p1Group.getEntries(0);
+    assertThat(p1FirstEntry.getParticipantId()).isEqualTo("p1");
+    assertThat(p1FirstEntry.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+    assertThat(p1FirstEntry.getNamespaceName()).isEqualTo(NAMESPACE);
+    assertThat(p1FirstEntry.getTableName()).isEqualTo(TABLE);
+    assertThat(p1FirstEntry.hasClusteringKey()).isTrue();
+    // includeColumns=false: non-key columns are not persisted.
+    assertThat(p1FirstEntry.getColumnsList()).isEmpty();
+    Entry p1SecondEntry = p1Group.getEntries(1);
+    assertThat(p1SecondEntry.getParticipantId()).isEqualTo("p1");
+    assertThat(p1SecondEntry.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
+
+    EntryGroup p2Group = writeSet.getEntryGroups(1);
+    assertThat(p2Group.getEntriesList()).hasSize(1);
+    Entry p2Entry = p2Group.getEntries(0);
+    assertThat(p2Entry.getParticipantId()).isEqualTo("p2");
+    assertThat(p2Entry.hasClusteringKey()).isFalse();
+  }
+
+  @Test
+  void encodeFromWriteSetEntries_WhenIncludeColumns_ShouldEncodeNonKeyColumnsOfWriteEntries() {
+    // Arrange — a WRITE entry carrying one non-key column (the participant already filtered out any
+    // ConsensusCommit-internal columns).
+    TwoPhaseCommit.WriteSetEntry write =
+        writeSetEntry(
+            TwoPhaseCommit.WriteSetEntry.Type.WRITE, Key.ofText("pk", "a"), Optional.empty());
+    when(write.getColumns()).thenReturn(Collections.singletonList(TextColumn.of("v", "val")));
+    Map<String, List<TwoPhaseCommit.WriteSetEntry>> writeSetsByParticipant = new LinkedHashMap<>();
+    writeSetsByParticipant.put("p1", Collections.singletonList(write));
+
+    // Act
+    WriteSet writeSet =
+        WriteSetEncoder.encodeFromWriteSetEntries(
+            writeSetsByParticipant, /* includeColumns= */ true);
+
+    // Assert — the non-key column is encoded on the entry.
+    Entry entry = writeSet.getEntryGroups(0).getEntries(0);
+    assertThat(entry.getColumnsList()).hasSize(1);
+    assertThat(entry.getColumns(0).getName()).isEqualTo("v");
+    assertThat(entry.getColumns(0).getTextValue().getValue()).isEqualTo("val");
+  }
+
+  @Test
+  void encodeFromWriteSetEntries_WhenAParticipantHasNoEntries_ShouldSkipThatParticipant() {
+    // Arrange — p1 owns one entry, p2 owns none (e.g. a read-only participant). The empty
+    // participant must not contribute an EntryGroup.
+    TwoPhaseCommit.WriteSetEntry p1Write =
+        writeSetEntry(
+            TwoPhaseCommit.WriteSetEntry.Type.WRITE, Key.ofText("pk", "a"), Optional.empty());
+    Map<String, List<TwoPhaseCommit.WriteSetEntry>> writeSetsByParticipant = new LinkedHashMap<>();
+    writeSetsByParticipant.put("p1", Collections.singletonList(p1Write));
+    writeSetsByParticipant.put("p2", Collections.emptyList());
+
+    // Act
+    WriteSet writeSet =
+        WriteSetEncoder.encodeFromWriteSetEntries(
+            writeSetsByParticipant, /* includeColumns= */ false);
+
+    // Assert — only p1's group is emitted; the empty p2 is skipped.
+    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
+    assertThat(writeSet.getEntryGroups(0).getEntries(0).getParticipantId()).isEqualTo("p1");
+  }
+
+  private static TwoPhaseCommit.WriteSetEntry writeSetEntry(
+      TwoPhaseCommit.WriteSetEntry.Type type, Key partitionKey, Optional<Key> clusteringKey) {
+    TwoPhaseCommit.WriteSetEntry entry = mock(TwoPhaseCommit.WriteSetEntry.class);
+    when(entry.getType()).thenReturn(type);
+    when(entry.getNamespaceName()).thenReturn(NAMESPACE);
+    when(entry.getTableName()).thenReturn(TABLE);
+    when(entry.getPartitionKey()).thenReturn(partitionKey);
+    when(entry.getClusteringKey()).thenReturn(clusteringKey);
+    return entry;
   }
 }


### PR DESCRIPTION
## Description

This PR implements the consensus-commit-backed `TwoPhaseCommit.Coordinator` and `TwoPhaseCommit.Participant`, wires them into the transaction providers, and adds a single-phase facade so existing `DistributedTransaction(Manager)` callers keep working unchanged.

## Related issues and/or PRs

- `TwoPhaseCommit.Coordinator` and `TwoPhaseCommit.Participant` are introduced in #3660.
- Depends on #3663, which widens `DistributedTransactionManager.join` to throw `TransactionException` (the facade's `join` propagates registration failures through it).

## Changes made

- Add `participant_id` to the `WriteSet` persistence proto and to `ConsensusCommitConfig`.
- Add a `WriteSetEncoder` entry-point for encoding aggregated `WriteSetEntry`s.
- Add `ConsensusCommitCoordinator` implementing the lifecycle role (`begin` / `registerParticipant` / `commit` / `rollback`). `commit` collapses prepare/validate failures into commit-level exceptions (`CommitConflictException` / `CommitException`), mirroring `CommitHandler`. `registerParticipant` is idempotent per participant ID: registering a participant whose `getId()` is already registered is a no-op (it is not joined again), since `commit` keys each participant's write set by its ID.
- Add `ConsensusCommitParticipant` implementing the CRUD role (`join` + CRUD + `prepareRecords` / `validateRecords` / `commitRecords` / `rollbackRecords`), with a strict per-transaction lifecycle state machine. `getScanner` returns a scanner whose `one()` / `all()` / `iterator()` / `close()` are serialized on the per-transaction lock — the same monitor a context release (commit / rollback) holds when it closes the scanners — so iteration of the not-thread-safe underlying scanner cannot race a concurrent release; an iteration that loses that race surfaces a retriable `CrudConflictException`.
- Honor a per-transaction isolation level supplied via the `cc-transaction-isolation` attribute at `join` (falling back to the configured default), matching `ConsensusCommitManager`.
- Wire the `TwoPhaseCommit.Coordinator` / `Participant` factories into the transaction providers and expose them through `ProviderManager` and `TransactionFactory` (`getTwoPhaseCommitCoordinator` / `getTwoPhaseCommitParticipant`). `DistributedTransactionProvider#createTwoPhaseCommitCoordinator` / `#createTwoPhaseCommitParticipant` throw `UnsupportedOperationException` when the transaction manager does not support the two-phase commit interface (JDBC and single-CRUD-operation transactions, using `CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED` / `SINGLE_CRUD_OPERATION_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED`); the `ProviderManager` / `TransactionFactory` accessors propagate that exception.
- Add `TwoPhaseCommitBackedDistributedTransaction` and `TwoPhaseCommitBackedDistributedTransactionManager` as a single-phase facade over the new roles. The by-ID Coordinator-state operations that the `TwoPhaseCommit.Coordinator` interface does not expose — `getState`, `rollback(String)` / `abort(String)`, `finishTransaction`, `recoverRecord`, and `resume` — throw `UnsupportedOperationException`.
- Move `TRANSACTION_NOT_FOUND` to the concurrency error category and reuse it for the Coordinator/Participant transaction-not-found paths (CoreError).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Unit tests are added/updated for the new components: `ConsensusCommitCoordinatorTest`, `ConsensusCommitParticipantTest`, `WriteSetEncoderTest`, `TwoPhaseCommitBackedDistributedTransactionManagerTest`, `ConsensusCommitConfigTest`, and `SynchronizedScannerTest`.
- The Coordinator's per-participant skip optimization (skipping `validateRecords` / `commitRecords` where unnecessary) is intentionally **not** in this PR; it lands separately in #3664.
- Group commit and one-phase commit are out of scope for the new Coordinator.

## Release notes

N/A




