### PR TITLE
Widen DistributedTransactionManager.join to throw TransactionException

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -415,8 +415,12 @@ public interface DistributedTransactionManager
    * @return {@link DistributedTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
    *     transaction ID is not found. You can retry the transaction from the beginning
+   * @throws TransactionException if the transaction fails to join due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but you may not be able to
+   *     join the transaction due to nontransient faults
    */
-  default DistributedTransaction join(String txId) throws TransactionNotFoundException {
+  default DistributedTransaction join(String txId)
+      throws TransactionNotFoundException, TransactionException {
     return resume(txId);
   }
 

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -11,6 +11,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.List;
@@ -64,7 +65,7 @@ public abstract class AbstractDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction join(String txId) throws TransactionNotFoundException {
+  public DistributedTransaction join(String txId) throws TransactionException {
     throw new UnsupportedOperationException("join is not supported in this implementation");
   }
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -212,7 +212,7 @@ public abstract class DecoratedDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction join(String txId) throws TransactionNotFoundException {
+  public DistributedTransaction join(String txId) throws TransactionException {
     return transactionManager.join(txId);
   }
 


### PR DESCRIPTION
## Description

`DistributedTransactionManager.join(String)` previously declared only `TransactionNotFoundException`. That forced implementations to mask any non-not-found failure encountered while joining (for example, a transient fault) as `TransactionNotFoundException`, losing the real cause. The upcoming Coordinator-backed transaction manager registers a participant into an existing transaction during `join` and needs to surface registration failures faithfully rather than disguising them as not-found. This PR widens the `join` contract to `TransactionException` so implementations can report join failures accurately.

## Related issues and/or PRs

N/A

## Changes made

- Widened `DistributedTransactionManager.join(String)` from `throws TransactionNotFoundException` to `throws TransactionException`. `TransactionNotFoundException` remains documented for the not-found case.
- Widened `AbstractDistributedTransactionManager.join` accordingly, so subclasses can throw `TransactionException` (a Java override cannot declare a broader checked exception than the superclass method it overrides; without this, subclasses would be capped at `TransactionNotFoundException`).
- Widened `DecoratedDistributedTransactionManager.join` so it propagates the wider exception from the wrapped manager.
- Implementations that genuinely throw only `TransactionNotFoundException` keep the narrower signature.

**Breaking change:** callers that catch only `TransactionNotFoundException` from `join` must now also handle `TransactionException`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This is a pure exception-signature widening with no behavioral change. The widened contract is exercised by its consumer (the Coordinator-backed transaction manager) in #3662, so no dedicated tests are added in this PR.
- Stacked PR: the "dependent changes merged and published" item is checked on the understanding that this PR merges in stack order after its base (#3661).
- Cross-repo: any `DistributedTransactionManager` implementation or decorator outside this repository that overrides `join` may need to adopt the widened signature.

## Release notes

N/A
