### PR TITLE
Skip unnecessary validate and commit steps per participant in the TwoPhaseCommit Coordinator

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
@@ -223,9 +223,13 @@ public interface TwoPhaseCommit {
    * record-level two-phase commit steps.
    *
    * <p>Each participant maintains a local context (snapshot, read set, write set) keyed by
-   * transaction ID. The context is created by {@link #join} and discarded after the transaction
-   * terminates—via {@link #commitRecords}, {@link #rollbackRecords}, or a timeout if {@link
-   * Coordinator#commit} or {@link Coordinator#rollback} is never reached.
+   * transaction ID. The context is created by {@link #join} and discarded once the participant has
+   * run the last step the Coordinator drives for it. For a participant with writes that is the
+   * commit (via {@link #commitRecords}) or the abort (via {@link #rollbackRecords}); for a
+   * write-less participant the Coordinator may skip those steps, so the context is discarded
+   * earlier — at {@link #validateRecords}, or at {@link #prepareRecords} when validation is not
+   * required either. It is also discarded on a timeout if {@link Coordinator#commit} or {@link
+   * Coordinator#rollback} is never reached.
    *
    * <p>The methods on this interface have two different intended callers:
    *
@@ -484,8 +488,8 @@ public interface TwoPhaseCommit {
      * Performs the validation phase of the transaction.
      *
      * <p>Invoked by {@link Coordinator#commit} between {@link #prepareRecords} and the COMMITTED
-     * state write. Required for SERIALIZABLE isolation; a no-op or cheap check for snapshot
-     * isolation.
+     * state write. The Coordinator may skip this call when the prepare result reports that this
+     * participant does not require validation (see {@link PreparationResult#isValidationRequired}).
      *
      * @param transactionId the canonical transaction ID
      * @throws ValidationConflictException if the transaction fails to validate due to transient
@@ -503,7 +507,8 @@ public interface TwoPhaseCommit {
      *
      * <p>Invoked by {@link Coordinator#commit} during the commit phase, once the transaction's
      * outcome has been durably decided. Marks the participant's PREPARED records COMMITTED,
-     * stamping {@code committed_at}.
+     * stamping {@code committed_at}. The Coordinator may skip this call for a participant that
+     * produced no writes (an empty {@link PreparationResult#getWriteSet}).
      *
      * <p>The participant reports failures by throwing, but the Coordinator drives this step
      * best-effort: it does not retry inline and relies on lazy recovery to commit the affected
@@ -535,16 +540,17 @@ public interface TwoPhaseCommit {
      * records on a subsequent read. On successful return, the participant discards its local
      * context for the transaction.
      *
+     * <p>Unlike the other record-level steps, an unknown transaction — one this participant never
+     * joined, or whose context it has already released (for example, a write-less participant that
+     * released early when its later steps were skipped, or a prior rollback) — is a no-op rather
+     * than an error: there is nothing left to undo.
+     *
      * @param transactionId the canonical transaction ID
-     * @throws RollbackException if rolling back the records fails due to transient or nontransient
-     *     faults
-     * @throws TransactionNotFoundException if the transaction is not found on this participant
-     *     (e.g., its context expired). The outcome was already decided; the Coordinator absorbs
-     *     this best-effort and lazy recovery reconciles the records, so there is nothing for the
-     *     caller to retry
+     * @throws RollbackException if rolling back the records of a known transaction fails due to
+     *     transient or nontransient faults; never thrown for an unknown transaction, which is a
+     *     no-op
      */
-    void rollbackRecords(String transactionId)
-        throws RollbackException, TransactionNotFoundException;
+    void rollbackRecords(String transactionId) throws RollbackException;
 
     /**
      * Closes the Participant and releases any resources it holds.
@@ -559,9 +565,11 @@ public interface TwoPhaseCommit {
   /**
    * The result of a participant's prepare phase, returned by {@link Participant#prepareRecords}.
    *
-   * <p>Currently carries only the write set the participant produced while preparing. It exists as
-   * a dedicated envelope so the prepare phase can return additional information in the future
-   * without changing the method signature.
+   * <p>It lets the participant report what the Coordinator needs to drive the rest of the protocol
+   * — the write set to record, whether this participant still requires validation, and whether its
+   * records still require committing — so the Coordinator can skip steps that would have nothing to
+   * do (see {@link Participant}). It is a dedicated envelope so the prepare phase can report
+   * additional information in the future without changing the method signature.
    */
   interface PreparationResult {
 
@@ -571,6 +579,33 @@ public interface TwoPhaseCommit {
      * @return the write set; empty if the participant has no writes
      */
     List<WriteSetEntry> getWriteSet();
+
+    /**
+     * Returns whether this participant still requires {@link Participant#validateRecords} for this
+     * transaction. When {@code false}, the Coordinator may skip validating this participant.
+     *
+     * <p>Validation is only meaningful under SERIALIZABLE isolation; under SNAPSHOT isolation it is
+     * a no-op, so an implementation returns {@code false}. Even under SERIALIZABLE it can be
+     * skipped when the participant read nothing that needs re-checking at commit time (for example,
+     * a participant whose reads are all covered by its own writes).
+     *
+     * @return {@code true} if validation is required for this participant
+     */
+    boolean isValidationRequired();
+
+    /**
+     * Returns whether this participant still requires {@link Participant#commitRecords} for this
+     * transaction. When {@code false}, the Coordinator may skip committing this participant.
+     *
+     * <p>A participant that produced no records to commit (an empty {@link #getWriteSet}) does not
+     * require committing. This is the single source of truth for the commit-step skip decision: the
+     * Coordinator drives {@code commitRecords} only when this returns {@code true}, and a
+     * participant whose last driven step is therefore not {@code commitRecords} releases its own
+     * context at that earlier step.
+     *
+     * @return {@code true} if committing is required for this participant
+     */
+    boolean isCommitRequired();
   }
 
   /** A single record-level write or delete in a transaction's write set. */

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommit.Participant;
+import com.scalar.db.api.TwoPhaseCommit.PreparationResult;
 import com.scalar.db.api.TwoPhaseCommit.WriteSetEntry;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
@@ -161,30 +162,52 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
         // A write-less transaction (every participant returns an empty write set) writes no
         // COMMITTED Coordinator state row when coordinator-write omission on read-only is enabled.
         // Only the commit-success path is gated on this; the abort path always writes ABORTED (see
-        // abortAndRollbackRecords). The record-level steps (prepareRecords / commitRecords /
-        // rollbackRecords) are still driven on every participant so their local contexts are
-        // released.
+        // abortAndRollbackRecords).
         boolean hasWrites = false;
+
+        // Drive only the steps each participant still needs (mirroring CommitHandler, minus the
+        // one-phase fast path): validateRecords only where the prepare result reports it required,
+        // and commitRecords only where the prepare result reports it required. A participant whose
+        // later steps are all skipped releases its own context at its last driven step, so the
+        // Coordinator must not drive it again.
+        List<Participant> toValidate = new ArrayList<>(participants.size());
+        List<Participant> toCommit = new ArrayList<>(participants.size());
 
         long preparedAt = System.currentTimeMillis();
         try {
           for (Participant participant : participants) {
-            List<WriteSetEntry> entries =
-                participant.prepareRecords(transactionId, preparedAt).getWriteSet();
+            PreparationResult result = participant.prepareRecords(transactionId, preparedAt);
+            List<WriteSetEntry> entries = result.getWriteSet();
+            // hasWrites tracks whether any participant produced PREPARED records; it gates writing
+            // the COMMITTED Coordinator state row.
             if (!entries.isEmpty()) {
               hasWrites = true;
+            }
+            // Drive validateRecords only on participants that still require it; a participant that
+            // does not has already self-released its context if validateRecords was its last step.
+            if (result.isValidationRequired()) {
+              toValidate.add(participant);
+            }
+            // Drive commitRecords only on participants that still require it. A write-less
+            // participant requires no commit and has already self-released its context
+            // (commitRecords would be a no-op); isCommitRequired is kept in agreement with that
+            // self-release. See ConsensusCommitParticipant#prepareRecords / #validateRecords.
+            if (result.isCommitRequired()) {
+              toCommit.add(participant);
             }
             writeSetsByParticipant
                 .computeIfAbsent(participant.getId(), k -> new ArrayList<>())
                 .addAll(entries);
           }
-          for (Participant participant : participants) {
+          for (Participant participant : toValidate) {
             participant.validateRecords(transactionId);
           }
         } catch (PreparationException | ValidationException e) {
-          // Prepare or validate failed. Abort the transaction and roll back the PREPARED records on
-          // every participant. The prepare/validate phases are internal to commit(), so the failure
-          // is reported as a commit-level exception: a conflict as CommitConflictException so the
+          // Prepare or validate failed. Abort the transaction and roll back every participant:
+          // writers undo their PREPARED records; others (not yet prepared, or already
+          // self-released) just release, and rollbackRecords is a no-op for an already-released
+          // participant. The prepare/validate phases are internal to commit(), so the failure is
+          // reported as a commit-level exception: a conflict as CommitConflictException so the
           // caller's retry logic still sees it as retriable, anything else as CommitException.
           abortAndRollbackRecords(transactionId, participants);
           if (e instanceof PreparationConflictException
@@ -206,19 +229,19 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
             committedAt = commitState(transactionId, writeSetsByParticipant);
           } catch (CommitConflictException e) {
             // The COMMITTED-state write lost a putState race that resolved to ABORTED: the
-            // transaction is aborted. Roll back the PREPARED records on every participant before
-            // surfacing it.
-            for (Participant participant : participants) {
+            // transaction is aborted. Only participants with writes still hold PREPARED records
+            // (and a live context); roll those back before surfacing it.
+            for (Participant participant : toCommit) {
               bestEffortRollbackRecords(participant, transactionId);
             }
             throw e;
           }
         } else {
-          // Write-less transaction with the Coordinator write omitted: committedAt is an unused
-          // placeholder for the (no-op) commitRecords calls below.
+          // Write-less transaction with the Coordinator write omitted: no participant has writes,
+          // so toCommit is empty and committedAt is an unused placeholder.
           committedAt = preparedAt;
         }
-        for (Participant participant : participants) {
+        for (Participant participant : toCommit) {
           bestEffortCommitRecords(participant, transactionId, committedAt);
         }
       } finally {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -55,8 +55,11 @@ import org.slf4j.LoggerFactory;
  * Consensus-commit-backed {@link TwoPhaseCommit.Participant} implementation.
  *
  * <p>Maintains a per-transaction {@link TransactionContext} keyed by the canonical transaction ID
- * supplied by the Coordinator. The context is created by {@link #join} and removed after {@link
- * #commitRecords} or {@link #rollbackRecords} returns.
+ * supplied by the Coordinator. The context is created by {@link #join} and removed once the
+ * participant has run the last step the Coordinator drives for it: {@link #commitRecords} or {@link
+ * #rollbackRecords} for a participant with writes, or an earlier step for a write-less participant
+ * whose later steps the Coordinator skips — {@link #validateRecords}, or {@link #prepareRecords}
+ * when validation is not required either.
  *
  * <p>This implementation requires a stable {@code participantId} (see {@link
  * ConsensusCommitConfig#PARTICIPANT_ID}) so that {@link TwoPhaseCommit.WriteSetEntry} instances
@@ -410,7 +413,23 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
         // status). Mirrors TwoPhaseConsensusCommit.prepare, which sets needRollback in a finally.
         pc.toPrepared();
       }
-      return new PreparationResultImpl(buildWriteSetEntries(context));
+      List<TwoPhaseCommit.WriteSetEntry> writeSet = buildWriteSetEntries(context);
+      boolean validationRequired = context.isValidationRequired();
+      // commitRecords is required iff this participant has writes to commit. Derive it from the
+      // same snapshot predicate validateRecords uses for its self-release, so the commit-step skip
+      // and the validate-step self-release stay in lockstep on a single source. This drives the
+      // Coordinator's commit-step skip via PreparationResult#isCommitRequired.
+      boolean commitRequired = context.snapshot.hasWritesOrDeletes();
+      // The Coordinator skips validateRecords when validation is not required and commitRecords
+      // when commit is not required. When both are skipped, prepareRecords is this participant's
+      // last step, so release the context now (a write-less participant has written no PREPARED
+      // record). The status thus goes ACTIVE -> PREPARED -> RELEASED within this synchronized
+      // block; the transient PREPARED is harmless because a concurrent rollbackRecords sees
+      // RELEASED and no-ops.
+      if (!validationRequired && !commitRequired) {
+        release(transactionId, pc);
+      }
+      return new PreparationResultImpl(writeSet, validationRequired, commitRequired);
     }
   }
 
@@ -420,8 +439,20 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
     ParticipantContext pc = getParticipantContext(transactionId);
     synchronized (pc) {
       pc.checkPrepared();
-      commit.validateRecords(pc.context());
-      pc.toValidated();
+      TransactionContext context = pc.context();
+      commit.validateRecords(context);
+      if (context.snapshot.hasWritesOrDeletes()) {
+        pc.toValidated();
+      } else {
+        // The Coordinator skips commitRecords for a write-less participant, so validateRecords is
+        // this participant's last step. Release the context now (no PREPARED records to commit).
+        // This stays in agreement with the Coordinator's commit-step skip by construction: both
+        // this self-release and PreparationResult#isCommitRequired derive from
+        // snapshot.hasWritesOrDeletes(), so the Coordinator skips commitRecords exactly when this
+        // branch has already released the context (otherwise it could drive commitRecords on a
+        // released context -> TNF).
+        release(transactionId, pc);
+      }
     }
   }
 
@@ -436,17 +467,25 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
       } finally {
         // The Coordinator has durably decided COMMITTED; release the context even on failure (lazy
         // recovery commits the records via the COMMITTED Coordinator state).
-        pc.toReleased();
-        contexts.remove(transactionId, pc);
+        release(transactionId, pc);
       }
     }
   }
 
   @Override
-  public void rollbackRecords(String transactionId) throws TransactionNotFoundException {
-    ParticipantContext pc = getParticipantContext(transactionId);
+  public void rollbackRecords(String transactionId) {
+    ParticipantContext pc = contexts.get(transactionId);
+    if (pc == null) {
+      // Unknown or already-released transaction (e.g., a write-less participant that released early
+      // when its later steps were skipped, or a prior rollback): nothing to undo. Lenient no-op,
+      // mirroring Coordinator#rollback.
+      return;
+    }
     synchronized (pc) {
-      pc.checkAlive();
+      if (pc.isReleased()) {
+        // Released by a concurrent terminal step after we fetched the reference; nothing to undo.
+        return;
+      }
       TransactionContext context = pc.context();
       try {
         try {
@@ -460,10 +499,17 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
           commit.rollbackRecords(context);
         }
       } finally {
-        pc.toReleased();
-        contexts.remove(transactionId, pc);
+        release(transactionId, pc);
       }
     }
+  }
+
+  // Releases a participant context: marks it RELEASED (visible under the lock to a concurrent op
+  // that obtained the reference before the removal) and removes it from the map. The caller must
+  // hold {@code synchronized(pc)}.
+  private void release(String transactionId, ParticipantContext pc) {
+    pc.toReleased();
+    contexts.remove(transactionId, pc);
   }
 
   // Resolves the participant context for a known transaction, or throws if none is registered
@@ -499,6 +545,12 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
   private List<TwoPhaseCommit.WriteSetEntry> buildWriteSetEntries(TransactionContext context) {
     Snapshot snapshot = context.snapshot;
     List<TwoPhaseCommit.WriteSetEntry> entries = new ArrayList<>();
+    // Returns empty iff !snapshot.hasWritesOrDeletes(), so the write set shipped to the Coordinator
+    // is empty exactly for a write-less participant. The Coordinator gates writing the COMMITTED
+    // state row on this write set being non-empty (its hasWrites), which must agree with
+    // isCommitRequired and the validate-step self-release (both derived from
+    // snapshot.hasWritesOrDeletes()); preserve this empty-iff-write-less guarantee if this method
+    // ever starts filtering entries.
     if (!snapshot.hasWritesOrDeletes()) {
       return entries;
     }
@@ -557,14 +609,31 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
 
   private static final class PreparationResultImpl implements TwoPhaseCommit.PreparationResult {
     private final List<TwoPhaseCommit.WriteSetEntry> writeSet;
+    private final boolean validationRequired;
+    private final boolean commitRequired;
 
-    PreparationResultImpl(List<TwoPhaseCommit.WriteSetEntry> writeSet) {
+    PreparationResultImpl(
+        List<TwoPhaseCommit.WriteSetEntry> writeSet,
+        boolean validationRequired,
+        boolean commitRequired) {
       this.writeSet = writeSet;
+      this.validationRequired = validationRequired;
+      this.commitRequired = commitRequired;
     }
 
     @Override
     public List<TwoPhaseCommit.WriteSetEntry> getWriteSet() {
       return writeSet;
+    }
+
+    @Override
+    public boolean isValidationRequired() {
+      return validationRequired;
+    }
+
+    @Override
+    public boolean isCommitRequired() {
+      return commitRequired;
     }
   }
 
@@ -702,11 +771,13 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
    * single-phase paths ({@code ConsensusCommit} / {@code ConsensusCommitManager}), which have no
    * such lifecycle.
    *
-   * <p>The entry is removed from {@link #contexts} at {@code commitRecords} / {@code
-   * rollbackRecords} (no terminal retention). {@link Status#RELEASED} is not for retention: it only
-   * lets a concurrent in-flight operation that obtained its reference before the removal observe
-   * the termination (under the lock) and fail with {@link TransactionNotFoundException} instead of
-   * acting on a finished transaction.
+   * <p>The entry is removed from {@link #contexts} at the participant's last driven step (no
+   * terminal retention): {@code commitRecords} / {@code rollbackRecords} for a participant with
+   * writes, or an earlier step ({@code validateRecords}, or {@code prepareRecords} when validation
+   * is not required either) for a write-less participant whose later steps the Coordinator skips.
+   * {@link Status#RELEASED} is not for retention: it only lets a concurrent in-flight operation
+   * that obtained its reference before the removal observe the termination (under the lock) and
+   * fail with {@link TransactionNotFoundException} instead of acting on a finished transaction.
    *
    * <p>Not internally synchronized: every status read/transition below must be performed while
    * synchronized on the instance (the participant holds {@code synchronized(context)} across check,
@@ -769,6 +840,11 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
     /** Whether records have been PREPARED in storage (so a rollback must undo them). */
     boolean isPrepared() {
       return status == Status.PREPARED || status == Status.VALIDATED;
+    }
+
+    /** Whether the context has already been released (terminated). */
+    boolean isReleased() {
+      return status == Status.RELEASED;
     }
 
     void toPrepared() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -415,11 +415,7 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
       }
       List<TwoPhaseCommit.WriteSetEntry> writeSet = buildWriteSetEntries(context);
       boolean validationRequired = context.isValidationRequired();
-      // commitRecords is required iff this participant has writes to commit. Derive it from the
-      // same snapshot predicate validateRecords uses for its self-release, so the commit-step skip
-      // and the validate-step self-release stay in lockstep on a single source. This drives the
-      // Coordinator's commit-step skip via PreparationResult#isCommitRequired.
-      boolean commitRequired = context.snapshot.hasWritesOrDeletes();
+      boolean commitRequired = context.isCommitRequired();
       // The Coordinator skips validateRecords when validation is not required and commitRecords
       // when commit is not required. When both are skipped, prepareRecords is this participant's
       // last step, so release the context now (a write-less participant has written no PREPARED
@@ -441,14 +437,14 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
       pc.checkPrepared();
       TransactionContext context = pc.context();
       commit.validateRecords(context);
-      if (context.snapshot.hasWritesOrDeletes()) {
+      if (context.isCommitRequired()) {
         pc.toValidated();
       } else {
         // The Coordinator skips commitRecords for a write-less participant, so validateRecords is
         // this participant's last step. Release the context now (no PREPARED records to commit).
         // This stays in agreement with the Coordinator's commit-step skip by construction: both
         // this self-release and PreparationResult#isCommitRequired derive from
-        // snapshot.hasWritesOrDeletes(), so the Coordinator skips commitRecords exactly when this
+        // context.isCommitRequired(), so the Coordinator skips commitRecords exactly when this
         // branch has already released the context (otherwise it could drive commitRecords on a
         // released context -> TNF).
         release(transactionId, pc);
@@ -549,8 +545,8 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
     // is empty exactly for a write-less participant. The Coordinator gates writing the COMMITTED
     // state row on this write set being non-empty (its hasWrites), which must agree with
     // isCommitRequired and the validate-step self-release (both derived from
-    // snapshot.hasWritesOrDeletes()); preserve this empty-iff-write-less guarantee if this method
-    // ever starts filtering entries.
+    // context.isCommitRequired(), i.e. snapshot.hasWritesOrDeletes()); preserve this
+    // empty-iff-write-less guarantee if this method ever starts filtering entries.
     if (!snapshot.hasWritesOrDeletes()) {
       return entries;
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionContext.java
@@ -97,6 +97,14 @@ public class TransactionContext {
             });
   }
 
+  public boolean isCommitRequired() {
+    // commitRecords is required iff this transaction has writes or deletes to commit. In the
+    // TwoPhaseCommit protocol this is the single source the participant uses both to drive the
+    // Coordinator's commit-step skip (via PreparationResult#isCommitRequired) and to decide the
+    // validate-step self-release, so those two stay in lockstep.
+    return snapshot.hasWritesOrDeletes();
+  }
+
   public boolean areAllScannersClosed() {
     return scanners.stream().allMatch(ConsensusCommitScanner::isClosed);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -26,6 +26,7 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
@@ -112,7 +113,9 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap(), null);
     Participant participant = mock(Participant.class);
     when(participant.getId()).thenReturn("participant-1");
-    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(emptyPreparation());
+    // A writer that also requires validation, so all of its record-level steps are driven.
+    when(participant.prepareRecords(anyString(), anyLong()))
+        .thenReturn(preparation(writeSet(), true));
 
     // Act
     consensusCommitCoordinator.registerParticipant("tx-1", participant);
@@ -214,8 +217,8 @@ class ConsensusCommitCoordinatorTest {
     // a
     // putState race that resolves to ABORTED (CommitConflictException).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1", "participant-1");
-    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
+    Participant p2 = registeredWritingParticipant("tx-1", "participant-2");
     doThrow(new CommitConflictException("conflict", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -224,7 +227,8 @@ class ConsensusCommitCoordinatorTest {
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class);
 
-    // ... and the PREPARED records are rolled back on every participant before it surfaces ...
+    // ... and the PREPARED records are rolled back on every writing participant before it surfaces
+    // ...
     verify(p1).rollbackRecords("tx-1");
     verify(p2).rollbackRecords("tx-1");
     // ... while commitRecords is never reached.
@@ -233,11 +237,34 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void commit_NoWrites_WithWriteOmission_ShouldSkipCommitStateButStillDriveRecords()
+  void commit_WhenCommitStateConflicts_ShouldRollBackOnlyWritingParticipants() throws Exception {
+    // Arrange — commitState loses a putState race (CommitConflictException). The writer holds
+    // PREPARED records and a live context; the write-less participant already self-released at
+    // prepareRecords, so the Coordinator rolls back only toCommit (the writer), not every
+    // participant.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant writer = registeredWritingParticipant("tx-1", "participant-1");
+    Participant writeLess = registeredParticipant("tx-1", "participant-2");
+    doThrow(new CommitConflictException("conflict", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+
+    // Act Assert — the conflict propagates ...
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class);
+
+    // ... only the writing participant is rolled back; the self-released one is left untouched.
+    verify(writer).rollbackRecords("tx-1");
+    verify(writeLess, never()).rollbackRecords(anyString());
+  }
+
+  @Test
+  void commit_NoWrites_WithWriteOmission_ShouldSkipCommitStateValidateAndCommitRecords()
       throws Exception {
     // Arrange — coordinator-write omission on read-only is enabled (the production default), and
     // the
-    // participant has no writes (prepareRecords returns an empty write set).
+    // participant has no writes and requires no validation (prepareRecords returns an empty write
+    // set with isValidationRequired() == false).
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
@@ -246,22 +273,25 @@ class ConsensusCommitCoordinatorTest {
     // Act
     consensusCommitCoordinator.commit("tx-1");
 
-    // Assert — with no writes, the COMMITTED Coordinator state row is not written ...
-    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
-    // ... but the record-level steps are still driven so the participant context is released.
+    // Assert — only prepareRecords is driven. The COMMITTED Coordinator state row is not written,
+    // and validateRecords / commitRecords are skipped (the participant released its own context at
+    // prepareRecords, its last driven step).
     verify(participant).prepareRecords(eq("tx-1"), anyLong());
-    verify(participant).validateRecords("tx-1");
-    verify(participant).commitRecords(eq("tx-1"), anyLong());
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+    verify(participant, never()).validateRecords(anyString());
+    verify(participant, never()).commitRecords(anyString(), anyLong());
   }
 
   @Test
   void commit_NoWrites_WithWriteOmission_WhenValidateFails_ShouldStillWriteAbortedAndRollback()
       throws Exception {
-    // Arrange — omission enabled, no writes observed, but validation fails.
+    // Arrange — omission enabled, no writes, but the participant requires validation and validation
+    // fails.
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant participant = registeredParticipant("tx-1");
+    Participant participant =
+        registeredParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("validation conflict", "tx-1"))
         .when(participant)
         .validateRecords("tx-1");
@@ -343,10 +373,15 @@ class ConsensusCommitCoordinatorTest {
 
   @Test
   void commit_TwoParticipants_ShouldDriveFullTwoPhaseCommitInRegistrationOrder() throws Exception {
-    // Arrange
+    // Arrange — both participants write and require validation, so every record-level step is
+    // driven.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1", "participant-1");
-    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    Participant p1 =
+        registeredParticipant(
+            "tx-1", "participant-1", preparation(writeSet(), /* validationRequired= */ true));
+    Participant p2 =
+        registeredParticipant(
+            "tx-1", "participant-2", preparation(writeSet(), /* validationRequired= */ true));
 
     // Act
     consensusCommitCoordinator.commit("tx-1");
@@ -361,6 +396,75 @@ class ConsensusCommitCoordinatorTest {
     verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
     verify(p1).commitRecords("tx-1", ANY_COMMITTED_AT);
     verify(p2).commitRecords("tx-1", ANY_COMMITTED_AT);
+  }
+
+  @Test
+  void commit_WriteOnlyParticipant_ShouldSkipValidateRecords() throws Exception {
+    // Arrange — the participant writes but does not require validation.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant =
+        registeredParticipant("tx-1", "participant-1", preparation(writeSet(), false));
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — validateRecords is skipped; the COMMITTED state row is written and commitRecords
+    // runs.
+    verify(participant).prepareRecords(eq("tx-1"), anyLong());
+    verify(participant, never()).validateRecords(anyString());
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
+    verify(participant).commitRecords(eq("tx-1"), anyLong());
+  }
+
+  @Test
+  void commit_WriteLessValidatingParticipant_ShouldSkipCommitRecords() throws Exception {
+    // Arrange — the participant has no writes but requires validation.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant =
+        registeredParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — validateRecords runs, but commitRecords is skipped (no writes to commit).
+    verify(participant).prepareRecords(eq("tx-1"), anyLong());
+    verify(participant).validateRecords("tx-1");
+    verify(participant, never()).commitRecords(anyString(), anyLong());
+  }
+
+  @Test
+  void commit_MixedParticipants_ShouldDriveOnlyEachParticipantsRequiredSteps() throws Exception {
+    // Arrange — all three participant categories in one transaction, exercising both the
+    // toValidate and toCommit list construction at once:
+    //   writer:         writes, no validation        -> prepare + commitRecords, no validate
+    //   writeLessVal:   no writes, requires validation -> prepare + validate, no commitRecords
+    //   writeLessNoVal: no writes, no validation      -> prepare only
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant writer =
+        registeredParticipant("tx-1", "participant-1", preparation(writeSet(), false));
+    Participant writeLessVal =
+        registeredParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
+    Participant writeLessNoVal =
+        registeredParticipant("tx-1", "participant-3", preparation(Collections.emptyList(), false));
+
+    // Act
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Assert — each participant gets exactly the steps it still needs.
+    verify(writer).prepareRecords(eq("tx-1"), anyLong());
+    verify(writer, never()).validateRecords(anyString());
+    verify(writer).commitRecords(eq("tx-1"), anyLong());
+
+    verify(writeLessVal).prepareRecords(eq("tx-1"), anyLong());
+    verify(writeLessVal).validateRecords("tx-1");
+    verify(writeLessVal, never()).commitRecords(anyString(), anyLong());
+
+    verify(writeLessNoVal).prepareRecords(eq("tx-1"), anyLong());
+    verify(writeLessNoVal, never()).validateRecords(anyString());
+    verify(writeLessNoVal, never()).commitRecords(anyString(), anyLong());
+
+    // A writer exists, so the COMMITTED Coordinator state row is written.
+    verify(coordinatorCommitHandler).commitState(eq("tx-1"), any());
   }
 
   @Test
@@ -418,9 +522,10 @@ class ConsensusCommitCoordinatorTest {
 
   @Test
   void commit_WhenValidateFails_ShouldWriteAbortedAndDriveRollback() throws Exception {
-    // Arrange
+    // Arrange — the participant requires validation, and validation fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1");
+    Participant p1 =
+        registeredParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("validation conflict", "tx-1"))
         .when(p1)
         .validateRecords("tx-1");
@@ -457,9 +562,14 @@ class ConsensusCommitCoordinatorTest {
   @Test
   void commit_WhenValidateFailsWithNonConflict_ShouldWrapAsCommitExceptionAndDriveRollback()
       throws Exception {
-    // Arrange — a plain (non-conflict) ValidationException.
+    // Arrange — a plain (non-conflict) ValidationException. The participant must require validation
+    // (no writes, validation required) so the Coordinator actually drives validateRecords on it.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1");
+    Participant p1 =
+        registeredParticipant(
+            "tx-1",
+            "participant-1",
+            preparation(Collections.emptyList(), /* validationRequired= */ true));
     doThrow(new ValidationException("validation failed", "tx-1")).when(p1).validateRecords("tx-1");
 
     // Act Assert — a non-conflict validate failure surfaces as a non-retriable CommitException, and
@@ -474,9 +584,10 @@ class ConsensusCommitCoordinatorTest {
 
   @Test
   void commit_WhenCommitRecordsThrows_ShouldSwallowAndComplete() throws Exception {
-    // Arrange
+    // Arrange — a writing participant, so the Coordinator drives commitRecords on it (a write-less
+    // participant would be skipped and the doThrow stub below would never fire).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1");
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
     doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
 
     // Act Assert — commitRecords is best-effort: the failure is swallowed and commit completes.
@@ -504,11 +615,12 @@ class ConsensusCommitCoordinatorTest {
   @Test
   void commit_TwoParticipants_WhenCommitRecordsThrowsOnFirst_ShouldStillCommitSecond()
       throws Exception {
-    // Arrange — both participants commit successfully through prepare/validate/commitState; the
-    // first participant's best-effort commitRecords then fails.
+    // Arrange — both participants write (so commitRecords is driven on each) and commit
+    // successfully
+    // through prepare/commitState; the first participant's best-effort commitRecords then fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
-    Participant p1 = registeredParticipant("tx-1", "participant-1");
-    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
+    Participant p2 = registeredWritingParticipant("tx-1", "participant-2");
     doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
 
     // Act — commitRecords is best-effort, so the first participant's failure is swallowed.
@@ -522,11 +634,13 @@ class ConsensusCommitCoordinatorTest {
   @Test
   void commit_TwoParticipants_WhenRollbackRecordsThrowsOnFirst_ShouldStillRollBackSecond()
       throws Exception {
-    // Arrange — drive the abort path via a validate conflict on the second participant, then make
-    // the first participant's best-effort rollbackRecords fail.
+    // Arrange — drive the abort path via a validate conflict on the second participant (which
+    // therefore must require validation), then make the first participant's best-effort
+    // rollbackRecords fail.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     Participant p1 = registeredParticipant("tx-1", "participant-1");
-    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    Participant p2 =
+        registeredParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("conflict", "tx-1")).when(p2).validateRecords("tx-1");
     doThrow(new RuntimeException("network blip")).when(p1).rollbackRecords("tx-1");
 
@@ -663,17 +777,92 @@ class ConsensusCommitCoordinatorTest {
 
   private Participant registeredParticipant(String transactionId, String participantId)
       throws Exception {
+    return registeredParticipant(transactionId, participantId, emptyPreparation());
+  }
+
+  private Participant registeredParticipant(
+      String transactionId, String participantId, PreparationResult preparationResult)
+      throws Exception {
     Participant participant = mock(Participant.class);
     when(participant.getId()).thenReturn(participantId);
-    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(emptyPreparation());
+    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(preparationResult);
     consensusCommitCoordinator.registerParticipant(transactionId, participant);
     return participant;
   }
 
-  // A PreparationResult carrying no writes. PreparationResult has a single method (getWriteSet), so
-  // a method reference to an empty list satisfies it.
+  // A registered participant that produces a write (so the Coordinator drives commitRecords on it).
+  private Participant registeredWritingParticipant(String transactionId, String participantId)
+      throws Exception {
+    return registeredParticipant(transactionId, participantId, writePreparation());
+  }
+
+  private static PreparationResult preparation(
+      List<WriteSetEntry> writeSet, boolean validationRequired) {
+    return new PreparationResult() {
+      @Override
+      public List<WriteSetEntry> getWriteSet() {
+        return writeSet;
+      }
+
+      @Override
+      public boolean isValidationRequired() {
+        return validationRequired;
+      }
+
+      @Override
+      public boolean isCommitRequired() {
+        // Mirrors ConsensusCommitParticipant: committing is required iff there are PREPARED
+        // records.
+        return !writeSet.isEmpty();
+      }
+    };
+  }
+
+  // A PreparationResult carrying no writes and not requiring validation.
   private static PreparationResult emptyPreparation() {
-    return Collections::emptyList;
+    return preparation(Collections.emptyList(), false);
+  }
+
+  // A PreparationResult carrying a single write and not requiring validation.
+  private static PreparationResult writePreparation() {
+    return preparation(writeSet(), false);
+  }
+
+  // A non-empty write set (one entry) with valid fields so the Coordinator can encode it for the
+  // COMMITTED state row. Enough to make the participant count as a writer.
+  private static List<WriteSetEntry> writeSet() {
+    return Collections.singletonList(
+        new WriteSetEntry() {
+          @Override
+          public Type getType() {
+            return Type.WRITE;
+          }
+
+          @Override
+          public String getNamespaceName() {
+            return "ns";
+          }
+
+          @Override
+          public String getTableName() {
+            return "tbl";
+          }
+
+          @Override
+          public Key getPartitionKey() {
+            return Key.ofInt("pk", 1);
+          }
+
+          @Override
+          public Optional<Key> getClusteringKey() {
+            return Optional.empty();
+          }
+
+          @Override
+          public List<Column<?>> getColumns() {
+            return Collections.emptyList();
+          }
+        });
   }
 
   // Registers a participant whose prepareRecords returns the given (non-empty) write set, so
@@ -684,7 +873,10 @@ class ConsensusCommitCoordinatorTest {
     Participant participant = mock(Participant.class);
     when(participant.getId()).thenReturn(participantId);
     List<WriteSetEntry> writeSet = Arrays.asList(entries);
-    when(participant.prepareRecords(anyString(), anyLong())).thenReturn(() -> writeSet);
+    // Non-empty write set, so isCommitRequired() is true (the Coordinator drives commitRecords and
+    // aggregates the write set); validation is not required for these encoding-focused tests.
+    when(participant.prepareRecords(anyString(), anyLong()))
+        .thenReturn(preparation(writeSet, /* validationRequired= */ false));
     consensusCommitCoordinator.registerParticipant(transactionId, participant);
     return participant;
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
@@ -32,10 +32,12 @@ import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -449,17 +451,100 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void prepareRecords_ReadOnlyWithNoWrites_ShouldReturnEmptyWriteSet() throws Exception {
+  void prepareRecords_WriteLessAndNoValidation_ShouldReturnEmptyResultAndReleaseContext()
+      throws Exception {
+    // Read-only, SNAPSHOT isolation: no writes and no validation required.
     participant.join(ANY_TX_ID, true, Collections.emptyMap());
 
     doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
     doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
     doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
 
-    List<TwoPhaseCommit.WriteSetEntry> entries =
-        participant.prepareRecords(ANY_TX_ID, 1000L).getWriteSet();
-    assertThat(entries).isEmpty();
+    TwoPhaseCommit.PreparationResult result = participant.prepareRecords(ANY_TX_ID, 1000L);
+    assertThat(result.getWriteSet()).isEmpty();
+    assertThat(result.isValidationRequired()).isFalse();
+    // No writes -> commit not required; parity with !getWriteSet().isEmpty().
+    assertThat(result.isCommitRequired()).isFalse();
     verify(commit).prepareRecords(any(TransactionContext.class), eq(1000L));
+
+    // The Coordinator will skip both validateRecords and commitRecords, so prepareRecords is this
+    // participant's last step: the context is released, and the entry removed from the map.
+    assertThat(getContext(ANY_TX_ID)).isNull();
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void prepareRecords_WriteLessButValidationRequired_ShouldKeepContextForValidation()
+      throws Exception {
+    // SERIALIZABLE with a recorded read but no writes: validation is required, so prepareRecords is
+    // not the last step and the context must survive.
+    when(config.getIsolation()).thenReturn(Isolation.SERIALIZABLE);
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    recordReadForValidation(ANY_TX_ID);
+
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+
+    TwoPhaseCommit.PreparationResult result = participant.prepareRecords(ANY_TX_ID, 1000L);
+    assertThat(result.getWriteSet()).isEmpty();
+    assertThat(result.isValidationRequired()).isTrue();
+    // No writes -> commit not required, even though validation is.
+    assertThat(result.isCommitRequired()).isFalse();
+    // Context kept, so validateRecords can run.
+    assertThat(getContext(ANY_TX_ID)).isNotNull();
+  }
+
+  @Test
+  void validateRecords_WriteLess_ShouldReleaseContext() throws Exception {
+    // A write-less participant that required validation: validateRecords is its last step (the
+    // Coordinator skips commitRecords), so it releases the context there.
+    when(config.getIsolation()).thenReturn(Isolation.SERIALIZABLE);
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    recordReadForValidation(ANY_TX_ID);
+
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+    participant.prepareRecords(ANY_TX_ID, 1000L);
+
+    participant.validateRecords(ANY_TX_ID);
+
+    verify(commit).validateRecords(any(TransactionContext.class));
+    // Released at validateRecords: a subsequent commitRecords finds no context.
+    assertThat(getContext(ANY_TX_ID)).isNull();
+    assertThatThrownBy(() -> participant.commitRecords(ANY_TX_ID, 2000L))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void validateRecords_WriteLess_WhenValidationFails_ShouldKeepContextForRollback()
+      throws Exception {
+    // A write-less SERIALIZABLE participant whose validation fails: on the throw path neither
+    // toValidated() nor the write-less release() runs, so the context must survive for the
+    // Coordinator's abort path to drive rollbackRecords on it.
+    when(config.getIsolation()).thenReturn(Isolation.SERIALIZABLE);
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    recordReadForValidation(ANY_TX_ID);
+
+    doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
+    doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
+    doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
+    participant.prepareRecords(ANY_TX_ID, 1000L);
+
+    doThrow(new ValidationConflictException("conflict", ANY_TX_ID))
+        .when(commit)
+        .validateRecords(any(TransactionContext.class));
+
+    // validateRecords surfaces the conflict ...
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(ValidationConflictException.class);
+
+    // ... and the context survives, so rollbackRecords can still undo the (write-less) prepare.
+    assertThat(getContext(ANY_TX_ID)).isNotNull();
+    participant.rollbackRecords(ANY_TX_ID);
+    verify(commit).rollbackRecords(any(TransactionContext.class));
   }
 
   @Test
@@ -498,8 +583,10 @@ class ConsensusCommitParticipantTest {
     doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
     doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
 
-    List<TwoPhaseCommit.WriteSetEntry> entries =
-        participant.prepareRecords(ANY_TX_ID, 2000L).getWriteSet();
+    TwoPhaseCommit.PreparationResult result = participant.prepareRecords(ANY_TX_ID, 2000L);
+    // Has writes -> commit required; parity with !getWriteSet().isEmpty().
+    assertThat(result.isCommitRequired()).isTrue();
+    List<TwoPhaseCommit.WriteSetEntry> entries = result.getWriteSet();
     assertThat(entries).hasSize(2);
     assertThat(participant.getId()).isEqualTo(ANY_PARTICIPANT_ID);
     assertThat(entries)
@@ -632,11 +719,15 @@ class ConsensusCommitParticipantTest {
 
   @Test
   void validateRecords_ShouldDelegateToParticipantCommitHandler() throws Exception {
+    // prepare() injects a write, so this is the write-bearing validate path: the context is marked
+    // VALIDATED and kept alive for the Coordinator to drive commitRecords (it is NOT released here,
+    // unlike the write-less path in validateRecords_WriteLess_ShouldReleaseContext).
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
     prepare(ANY_TX_ID);
     doNothing().when(commit).validateRecords(any(TransactionContext.class));
     participant.validateRecords(ANY_TX_ID);
     verify(commit).validateRecords(any(TransactionContext.class));
+    assertThat(getContext(ANY_TX_ID)).isNotNull();
   }
 
   @Test
@@ -704,16 +795,30 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void rollbackRecords_UnknownTransactionId_ShouldThrowTransactionNotFoundException() {
-    // An absent local context (e.g., expired) surfaces as not-found; the Coordinator drives this
-    // step best-effort and lazy recovery reconciles.
-    assertThatThrownBy(() -> participant.rollbackRecords("unknown-tx"))
-        .isInstanceOf(TransactionNotFoundException.class);
+  void rollbackRecords_UnknownTransactionId_ShouldBeNoOp() {
+    // Unlike the other record-level steps, rollbackRecords is lenient: an absent context (never
+    // joined, already released when later steps were skipped, or a prior rollback) leaves nothing
+    // to
+    // undo, so it is a no-op rather than an error.
+    participant.rollbackRecords("unknown-tx");
     verify(commit, never()).rollbackRecords(any(TransactionContext.class));
   }
 
-  // Drives the transaction to the PREPARED state with the handlers stubbed to no-op.
+  // Drives the transaction to the PREPARED state with the handlers stubbed to no-op. Injects a
+  // write
+  // into the snapshot so the participant has writes: a write-bearing participant stays alive
+  // through
+  // prepare and validate (a write-less one self-releases early under the skip-optimization), which
+  // is the state the lifecycle tests below exercise.
   private void prepare(String txId) throws Exception {
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 100)
+            .build();
+    getContext(txId).snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
     doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
     doNothing().when(commit).prepareRecords(any(TransactionContext.class), anyLong());
@@ -726,6 +831,13 @@ class ConsensusCommitParticipantTest {
     prepare(txId);
     doNothing().when(commit).validateRecords(any(TransactionContext.class));
     participant.validateRecords(txId);
+  }
+
+  // Records a read (a scan) in the snapshot so that, under SERIALIZABLE isolation, validation is
+  // required even without writes (Snapshot#isScanSetEmpty becomes false).
+  private void recordReadForValidation(String txId) throws Exception {
+    Scan scan = Scan.newBuilder().namespace(ANY_NAMESPACE).table(ANY_TABLE).all().build();
+    getContext(txId).snapshot.putIntoScanSet(scan, new LinkedHashMap<>());
   }
 
   private TransactionContext getContext(String txId) throws Exception {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionContextTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionContextTest.java
@@ -179,4 +179,32 @@ public class TransactionContextTest {
     // Assert
     assertThat(actual).isFalse();
   }
+
+  @Test
+  public void isCommitRequired_WhenSnapshotHasWritesOrDeletes_ShouldReturnTrue() {
+    // Arrange
+    when(snapshot.hasWritesOrDeletes()).thenReturn(true);
+    TransactionContext context =
+        new TransactionContext(ANY_ID, snapshot, Isolation.SERIALIZABLE, false, false);
+
+    // Act
+    boolean actual = context.isCommitRequired();
+
+    // Assert
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void isCommitRequired_WhenSnapshotHasNoWritesOrDeletes_ShouldReturnFalse() {
+    // Arrange
+    when(snapshot.hasWritesOrDeletes()).thenReturn(false);
+    TransactionContext context =
+        new TransactionContext(ANY_ID, snapshot, Isolation.SERIALIZABLE, false, false);
+
+    // Act
+    boolean actual = context.isCommitRequired();
+
+    // Assert
+    assertThat(actual).isFalse();
+  }
 }


### PR DESCRIPTION
## Description

The Consensus Commit `TwoPhaseCommit.Coordinator` introduced in #3662 drove `validateRecords` and `commitRecords` on every registered participant unconditionally. This PR makes the Coordinator drive only the record-level steps each participant actually needs — mirroring the single-phase `CommitHandler` (minus the one-phase fast path) — so it skips work that would have nothing to do. For remote deployments, where each participant call is an RPC, this avoids unnecessary round trips.

## Related issues and/or PRs

N/A

## Changes made

- Added `TwoPhaseCommit.PreparationResult#isValidationRequired()` and `#isCommitRequired()` so the prepare response tells the Coordinator which record-level steps a participant still needs. The participant derives both from a single source — `snapshot.hasWritesOrDeletes()` for the commit requirement — so the Coordinator's skip decision and the participant's own early context release stay in lockstep.
- The Coordinator now drives `validateRecords` only where the prepare result reports it required, and `commitRecords` only where the prepare result reports it required. (It still reads the write set itself only to decide whether to write the COMMITTED Coordinator state row.)
- A participant whose later steps are all skipped releases its own context at its last driven step: `validateRecords` for a write-less participant that requires validation, or `prepareRecords` when validation is not required either. `prepareRecords` itself can never be skipped because its result must be returned.
- `Participant#rollbackRecords` is now a lenient no-op for an unknown or already-released transaction, so the abort path can roll back every participant uniformly without tracking which ones released early.
- Added and updated unit tests for the per-participant skip behavior and the early context release.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- `TwoPhaseCommit` is an internal interface (breaking changes are expected; users should not depend on it). This PR is an internal optimization with no user-facing API change.
- One-phase commit and group commit remain out of scope.

## Release notes

N/A
