### PR TITLE
Move AbstractDistributedTransactionProvider from api to common

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -1,10 +1,8 @@
-package com.scalar.db.api;
+package com.scalar.db.common;
 
-import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
-import com.scalar.db.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
-import com.scalar.db.common.AttributePropagatingDistributedTransactionManager;
-import com.scalar.db.common.StateManagedDistributedTransactionManager;
-import com.scalar.db.common.StateManagedTwoPhaseCommitTransactionManager;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.DistributedTransactionProvider;
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import javax.annotation.Nullable;
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -1,10 +1,10 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.common.AbstractDistributedTransactionProvider;
 import com.scalar.db.config.DatabaseConfig;
 
 public class ConsensusCommitProvider extends AbstractDistributedTransactionProvider {

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -1,10 +1,10 @@
 package com.scalar.db.transaction.jdbc;
 
-import com.scalar.db.api.AbstractDistributedTransactionProvider;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.common.AbstractDistributedTransactionProvider;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;


### PR DESCRIPTION
## Description

`AbstractDistributedTransactionProvider` is an internal abstract helper base shared by the in-tree transaction providers — not part of the public API. Its sibling abstract bases (`AbstractDistributedTransaction`, `AbstractDistributedTransactionManager`, `AbstractTwoPhaseCommitTransaction`, ...) already live in `com.scalar.db.common`, so it was the odd one out in `com.scalar.db.api`. This moves it to `com.scalar.db.common` for consistency. The public SPI contract — the `DistributedTransactionProvider` interface — stays in `com.scalar.db.api`.

## Related issues and/or PRs

N/A

## Changes made

- Move `AbstractDistributedTransactionProvider` from `com.scalar.db.api` to `com.scalar.db.common`.
- Update the in-tree subclasses (`ConsensusCommitProvider`, `JdbcTransactionProvider`) to the new import.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This is a pure package move with no behavior change, so no new tests are added.
- Out-of-tree subclasses that extend this base must update their import to `com.scalar.db.common.AbstractDistributedTransactionProvider` in a paired change.

## Release notes

N/A
