### PR TITLE
Add releaseContext to TwoPhaseCommit for no-storage context release

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
@@ -205,6 +205,24 @@ public interface TwoPhaseCommit {
     void rollback(String transactionId) throws RollbackException;
 
     /**
+     * Releases the Coordinator's in-memory state for the transaction without touching storage.
+     *
+     * <p>This is a reap-only terminal used to reclaim an in-memory context that did not reach a
+     * normal {@link #commit} / {@link #rollback} — for example, an abandoned transaction, or one
+     * reaped on idle by a decorator. It discards only this Coordinator's per-transaction state; it
+     * does <strong>not</strong> drive the participants and does <strong>not</strong> write any
+     * Coordinator state row or mutate records. The transaction's durable outcome is left to lazy
+     * recovery, which relies on the Coordinator state row if one was already written (its absence
+     * is resolved as an abort).
+     *
+     * <p>An unknown transaction ID (never begun, or already finished) is a no-op. A decorator may
+     * treat this as a terminal step, releasing any per-transaction resources it holds.
+     *
+     * @param transactionId the canonical transaction ID returned by {@link #begin}
+     */
+    void releaseContext(String transactionId);
+
+    /**
      * Closes the Coordinator and releases any resources it holds.
      *
      * <p>Does not commit or roll back transactions that are still in flight; their in-memory state
@@ -231,7 +249,7 @@ public interface TwoPhaseCommit {
    * required either. It is also discarded on a timeout if {@link Coordinator#commit} or {@link
    * Coordinator#rollback} is never reached.
    *
-   * <p>The methods on this interface have two different intended callers:
+   * <p>The methods on this interface have three different intended callers:
    *
    * <ul>
    *   <li>CRUD methods ({@link #get}, {@link #scan}, {@link #getScanner}, {@link #put(String,
@@ -241,6 +259,9 @@ public interface TwoPhaseCommit {
    *   <li>Lifecycle and record-level two-phase commit methods ({@link #join}, {@link
    *       #prepareRecords}, {@link #validateRecords}, {@link #commitRecords}, {@link
    *       #rollbackRecords}) are invoked by {@link Coordinator}.
+   *   <li>{@link #releaseContext} is invoked by neither — it is a reap-only terminal driven by a
+   *       context-reaper/decorator to reclaim an abandoned or idle-reaped context without touching
+   *       storage.
    * </ul>
    *
    * <p>Operations must follow the transaction's lifecycle: CRUD while the transaction is open, then
@@ -551,6 +572,23 @@ public interface TwoPhaseCommit {
      *     no-op
      */
     void rollbackRecords(String transactionId) throws RollbackException;
+
+    /**
+     * Releases the participant's in-memory context for the transaction without touching storage.
+     *
+     * <p>This is a reap-only terminal used to reclaim a local context that did not reach {@link
+     * #commitRecords} / {@link #rollbackRecords} — for example, an abandoned transaction, or one
+     * reaped on idle by a decorator. It closes any scanners and discards the in-memory snapshot for
+     * the transaction; it does <strong>not</strong> roll back or commit any PREPARED records —
+     * those are reconciled by lazy recovery on a subsequent read.
+     *
+     * <p>An unknown transaction — never joined, or whose context was already released — is a no-op.
+     * A decorator may treat this as a terminal step, releasing any per-transaction resources it
+     * holds.
+     *
+     * @param transactionId the canonical transaction ID
+     */
+    void releaseContext(String transactionId);
 
     /**
      * Closes the Participant and releases any resources it holds.

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -281,6 +281,28 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   }
 
   @Override
+  public void releaseContext(String transactionId) {
+    CoordinatorContext context = contexts.get(transactionId);
+    if (context == null) {
+      // Unknown or already-released transaction: nothing to release.
+      return;
+    }
+    synchronized (context) {
+      if (context.isReleased()) {
+        // Already terminated by a concurrent commit/rollback/release; nothing to do.
+        return;
+      }
+      // Reap-only terminal: discard this Coordinator's in-memory state only. Unlike rollback(), the
+      // participants are NOT contacted (each role reaps its own context independently), and no
+      // Coordinator state row is written and no record is mutated — the durable outcome is left to
+      // lazy recovery, which uses the Coordinator state row if one was already written (its absence
+      // is resolved as an abort).
+      context.markReleased();
+      releaseResources(transactionId);
+    }
+  }
+
+  @Override
   public void close() {
     storage.close();
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -500,6 +500,32 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
     }
   }
 
+  @Override
+  public void releaseContext(String transactionId) {
+    ParticipantContext pc = contexts.get(transactionId);
+    if (pc == null) {
+      // Unknown or already-released transaction: nothing to release.
+      return;
+    }
+    synchronized (pc) {
+      if (pc.isReleased()) {
+        // Released by a concurrent terminal step after we fetched the reference; nothing to do.
+        return;
+      }
+      TransactionContext context = pc.context();
+      try {
+        // Reap-only terminal: close scanners and discard the in-memory snapshot WITHOUT touching
+        // storage. Even if the transaction is PREPARED, we must not roll its records back here (the
+        // outcome may be undetermined or COMMITTED); lazy recovery reconciles them on a later read.
+        context.closeScanners();
+      } catch (CrudException e) {
+        logger.warn("Failed to close the scanner. Transaction ID: {}", transactionId, e);
+      } finally {
+        release(transactionId, pc);
+      }
+    }
+  }
+
   // Releases a participant context: marks it RELEASED (visible under the lock to a concurrent op
   // that obtained the reference before the removal) and removes it from the map. The caller must
   // hold {@code synchronized(pc)}.

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -214,8 +214,7 @@ class ConsensusCommitCoordinatorTest {
   void commit_WhenCommitStateConflicts_ShouldRollBackPreparedRecordsOnEachParticipant()
       throws Exception {
     // Arrange — prepare/validate succeed on both participants, but the COMMITTED-state write loses
-    // a
-    // putState race that resolves to ABORTED (CommitConflictException).
+    // a putState race that resolves to ABORTED (CommitConflictException).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
     Participant p2 = registeredWritingParticipant("tx-1", "participant-2");
@@ -341,6 +340,35 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
+  void releaseContext_ShouldReleaseContextWithoutDrivingParticipantsOrWritingState()
+      throws Exception {
+    // Arrange
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant participant = registeredWritingParticipant("tx-1", "participant-1");
+
+    // Act
+    consensusCommitCoordinator.releaseContext("tx-1");
+
+    // Assert — reap-only terminal: the participant is NOT contacted (role-local), no Coordinator
+    // state row is written, and the context is released so a subsequent commit no longer knows the
+    // transaction.
+    verify(participant, never()).rollbackRecords(anyString());
+    verify(participant, never()).commitRecords(anyString(), anyLong());
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void releaseContext_UnknownTransaction_ShouldBeNoOp() throws Exception {
+    // Releasing a transaction never begun (or already finished) is a lenient no-op.
+    consensusCommitCoordinator.releaseContext("unknown");
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+    verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
+  }
+
+  @Test
   void commit_AfterCommit_ShouldThrowTransactionNotFoundException() throws Exception {
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     consensusCommitCoordinator.commit("tx-1");
@@ -368,6 +396,18 @@ class ConsensusCommitCoordinatorTest {
 
     // Rolling back an already-committed (released) transaction is a lenient no-op, not an error.
     consensusCommitCoordinator.rollback("tx-1");
+    verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
+  }
+
+  @Test
+  void releaseContext_AfterCommit_ShouldBeNoOp() throws Exception {
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    consensusCommitCoordinator.commit("tx-1");
+
+    // Releasing the context of an already-committed (released) transaction is a lenient no-op: the
+    // context was already discarded by commit, so there is nothing to release and no abort is
+    // written.
+    consensusCommitCoordinator.releaseContext("tx-1");
     verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
@@ -700,8 +700,7 @@ class ConsensusCommitParticipantTest {
   @Test
   void rollbackRecords_AfterPrepareThrewPartway_ShouldRollBackPreparedRecords() throws Exception {
     // A partial prepare (prepareRecords throws after writing some PREPARED records) must still
-    // leave
-    // the transaction marked PREPARED so rollbackRecords undoes those records in storage.
+    // leave the transaction marked PREPARED so rollbackRecords undoes those records in storage.
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
     doNothing().when(crud).readIfImplicitPreReadEnabled(any(TransactionContext.class));
     doNothing().when(crud).waitForRecoveryCompletionIfNecessary(any(TransactionContext.class));
@@ -798,18 +797,69 @@ class ConsensusCommitParticipantTest {
   void rollbackRecords_UnknownTransactionId_ShouldBeNoOp() {
     // Unlike the other record-level steps, rollbackRecords is lenient: an absent context (never
     // joined, already released when later steps were skipped, or a prior rollback) leaves nothing
-    // to
-    // undo, so it is a no-op rather than an error.
+    // to undo, so it is a no-op rather than an error.
     participant.rollbackRecords("unknown-tx");
     verify(commit, never()).rollbackRecords(any(TransactionContext.class));
   }
 
+  @Test
+  void releaseContext_WhenPrepared_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+
+    participant.releaseContext(ANY_TX_ID);
+
+    // Reap-only terminal: even though the transaction is PREPARED, the records are NOT rolled back
+    // in storage (lazy recovery reconciles them); only the in-memory context is released.
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+    assertThat(getContext(ANY_TX_ID)).isNull();
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void releaseContext_WhenValidated_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+    prepare(ANY_TX_ID);
+    doNothing().when(commit).validateRecords(any(TransactionContext.class));
+    participant.validateRecords(ANY_TX_ID);
+
+    participant.releaseContext(ANY_TX_ID);
+
+    // Reap-only terminal: even a VALIDATED (write-bearing, commitRecords not yet driven) context is
+    // NOT rolled back in storage — lazy recovery reconciles its PREPARED records; only the
+    // in-memory context is released. VALIDATED is the primary reaper target state.
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+    assertThat(getContext(ANY_TX_ID)).isNull();
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void releaseContext_WhenActive_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+    participant.join(ANY_TX_ID, false, Collections.emptyMap());
+
+    participant.releaseContext(ANY_TX_ID);
+
+    // Reap-only terminal on an ACTIVE (never prepared) context: only an in-memory snapshot exists,
+    // so there is nothing to roll back in storage — the context is simply released.
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+    assertThat(getContext(ANY_TX_ID)).isNull();
+    assertThatThrownBy(() -> participant.validateRecords(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void releaseContext_UnknownTransactionId_ShouldBeNoOp() {
+    // An absent context (never joined, or already released) leaves nothing to release: a no-op.
+    participant.releaseContext("unknown-tx");
+    verify(commit, never()).rollbackRecords(any(TransactionContext.class));
+  }
+
   // Drives the transaction to the PREPARED state with the handlers stubbed to no-op. Injects a
-  // write
-  // into the snapshot so the participant has writes: a write-bearing participant stays alive
-  // through
-  // prepare and validate (a write-less one self-releases early under the skip-optimization), which
-  // is the state the lifecycle tests below exercise.
+  // write into the snapshot so the participant has writes: a write-bearing participant stays alive
+  // through prepare and validate (a write-less one self-releases early under the
+  // skip-optimization), which is the state the lifecycle tests below exercise.
   private void prepare(String txId) throws Exception {
     Put put =
         Put.newBuilder()

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
@@ -968,9 +968,8 @@ public class CoordinatorStateAccessorTest {
   @Test
   public void state_EmptyWriteSet_ShouldPersistColumnWithNonEmptyBytes()
       throws CoordinatorException {
-    // Arrange — State with an empty (but non-null) WriteSet that explicitly carries
-    // schema_version, mirroring what WriteSetEncoder#encodeSingleGroupWriteSet emits for
-    // read-only commits.
+    // Arrange — State with an empty (but non-null) WriteSet that explicitly carries schema_version,
+    // mirroring what WriteSetEncoder#encodeSingleGroupWriteSet emits for read-only commits.
     WriteSet emptyWriteSet = WriteSet.newBuilder().setSchemaVersion(1).build();
     State state =
         new State(ANY_ID_1, emptyWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -865,11 +865,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange: the coordinator state stays absent and expired, and every physical re-read shows a
     // DIFFERENT transaction has re-prepared the record (modeled by ping-ponging between two ids),
-    // so
-    // the loop keeps taking the re-prepare branch until MAX_RESOLUTION_ATTEMPTS is reached and a
+    // so the loop keeps taking the re-prepare branch until MAX_RESOLUTION_ATTEMPTS is reached and a
     // CrudConflictException is thrown. This exercises the retry limit via the re-prepare branch
-    // (the
-    // abort-conflict branch is covered by AbortKeepsConflicting above).
+    // (the abort-conflict branch is covered by AbortKeepsConflicting above).
     TransactionResult original = prepareResult(TransactionState.PREPARED);
     TransactionResult rePreparedAs1 = prepareResult(TransactionState.PREPARED, ANY_ID_1);
     TransactionResult rePreparedAs2 = prepareResult(TransactionState.PREPARED, ANY_ID_2);
@@ -898,8 +896,7 @@ public class RecoveryExecutorTest {
         .isInstanceOf(CrudConflictException.class);
 
     // The loop runs exactly MAX_RESOLUTION_ATTEMPTS passes, re-reading on each, and never aborts
-    // (it
-    // always takes the re-prepare branch).
+    // (it always takes the re-prepare branch).
     verify(storage, times(RecoveryExecutor.MAX_RESOLUTION_ATTEMPTS)).get(any(Get.class));
     verify(recovery, never()).tryAbortExpiredTransaction(any());
   }


### PR DESCRIPTION
## Description

The forthcoming per-role context-reaper decorators need a way to reclaim an abandoned or idle transaction's role-local state **without** mutating storage — a plain rollback would be both unnecessary (the durable Coordinator state is the source of truth) and, for a PREPARED participant, wrong. This PR adds that primitive: a reap-only terminal `releaseContext(transactionId)` on both `TwoPhaseCommit` roles.

## Related issues and/or PRs

- `TwoPhaseCommit.Coordinator` / `TwoPhaseCommit.Participant` are introduced in #3660 and implemented in #3662.
- Depends on #3667 (move `AbstractDistributedTransactionProvider` to `common`).

## Changes made

- Add `releaseContext(String transactionId)` to `TwoPhaseCommit.Coordinator` and `TwoPhaseCommit.Participant`, implemented natively in `ConsensusCommitCoordinator` / `ConsensusCommitParticipant`.
- It releases only the role's in-memory state: the Coordinator drops its own context (it does **not** drive the participants), and the Participant closes its scanners and discards its snapshot — with no storage mutation. A PREPARED participant is **not** rolled back; its records are reconciled by lazy recovery via the Coordinator state row.
- An unknown or already-released transaction is a lenient no-op, mirroring `rollbackRecords` / `rollback`.
- `commit()` is unchanged; no caller is added in this PR.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- `TwoPhaseCommit` is an internal interface (breaking changes are expected; users should not depend on it). Adding `releaseContext` is an internal API addition with no user-facing surface.
- Unit tests for the native `releaseContext` are added to `ConsensusCommitCoordinatorTest` / `ConsensusCommitParticipantTest`.

## Release notes

N/A
