### PR TITLE
Add core TwoPhaseCommit role decorators (attribute propagation and active transaction management)

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -70,10 +70,6 @@ public abstract class AbstractDistributedTransactionProvider
   public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
     TwoPhaseCommit.Coordinator coordinator = createRawTwoPhaseCommitCoordinator(config);
 
-    if (coordinator == null) {
-      return null;
-    }
-
     if (config.isActiveTransactionManagementEnabled()) {
       // Wrap the coordinator for active transaction management. This must be the outermost wrapping
       // so that the idle-expiry reap traverses every inner decorator via releaseContext.
@@ -91,10 +87,6 @@ public abstract class AbstractDistributedTransactionProvider
   @Override
   public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
     TwoPhaseCommit.Participant participant = createRawTwoPhaseCommitParticipant(config);
-
-    if (participant == null) {
-      return null;
-    }
 
     if (config.isAttributePropagationEnabled()) {
       // Wrap the participant for transaction-scoped attribute propagation

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -11,7 +11,8 @@ public abstract class AbstractDistributedTransactionProvider
     implements DistributedTransactionProvider {
 
   @Override
-  public DistributedTransactionManager createDistributedTransactionManager(DatabaseConfig config) {
+  public final DistributedTransactionManager createDistributedTransactionManager(
+      DatabaseConfig config) {
     DistributedTransactionManager transactionManager =
         createRawDistributedTransactionManager(config);
 
@@ -41,7 +42,7 @@ public abstract class AbstractDistributedTransactionProvider
 
   @Nullable
   @Override
-  public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
+  public final TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     TwoPhaseCommitTransactionManager transactionManager =
         createRawTwoPhaseCommitTransactionManager(config);
@@ -63,11 +64,12 @@ public abstract class AbstractDistributedTransactionProvider
     return transactionManager;
   }
 
+  @Nullable
   protected abstract TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config);
 
   @Override
-  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+  public final TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
     TwoPhaseCommit.Coordinator coordinator = createRawTwoPhaseCommitCoordinator(config);
 
     if (config.isActiveTransactionManagementEnabled()) {
@@ -85,7 +87,7 @@ public abstract class AbstractDistributedTransactionProvider
       DatabaseConfig config);
 
   @Override
-  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+  public final TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
     TwoPhaseCommit.Participant participant = createRawTwoPhaseCommitParticipant(config);
 
     if (config.isAttributePropagationEnabled()) {

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -2,6 +2,7 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
+import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import javax.annotation.Nullable;
@@ -63,5 +64,54 @@ public abstract class AbstractDistributedTransactionProvider
   }
 
   protected abstract TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
+      DatabaseConfig config);
+
+  @Override
+  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    TwoPhaseCommit.Coordinator coordinator = createRawTwoPhaseCommitCoordinator(config);
+
+    if (coordinator == null) {
+      return null;
+    }
+
+    if (config.isActiveTransactionManagementEnabled()) {
+      // Wrap the coordinator for active transaction management. This must be the outermost wrapping
+      // so that the idle-expiry reap traverses every inner decorator via releaseContext.
+      coordinator =
+          new ActiveTransactionManagedTwoPhaseCommitCoordinator(
+              coordinator, config.getActiveTransactionManagementExpirationTimeMillis());
+    }
+
+    return coordinator;
+  }
+
+  protected abstract TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(
+      DatabaseConfig config);
+
+  @Override
+  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+    TwoPhaseCommit.Participant participant = createRawTwoPhaseCommitParticipant(config);
+
+    if (participant == null) {
+      return null;
+    }
+
+    if (config.isAttributePropagationEnabled()) {
+      // Wrap the participant for transaction-scoped attribute propagation
+      participant = new AttributePropagatingTwoPhaseCommitParticipant(participant);
+    }
+
+    if (config.isActiveTransactionManagementEnabled()) {
+      // Wrap the participant for active transaction management. This must be the outermost wrapping
+      // so that the idle-expiry reap traverses every inner decorator via releaseContext.
+      participant =
+          new ActiveTransactionManagedTwoPhaseCommitParticipant(
+              participant, config.getActiveTransactionManagementExpirationTimeMillis());
+    }
+
+    return participant;
+  }
+
+  protected abstract TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(
       DatabaseConfig config);
 }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -46,9 +46,9 @@ public class ActiveTransactionManagedDistributedTransactionManager
   public ActiveTransactionManagedDistributedTransactionManager(
       DistributedTransactionManager transactionManager,
       long expirationTimeMillis,
-      ActiveTransactionRegistry.TransactionRollback<DistributedTransaction> rollbackFunction) {
+      ActiveTransactionRegistry.ExpirationHandler<DistributedTransaction> expirationHandler) {
     super(transactionManager);
-    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, rollbackFunction);
+    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, expirationHandler);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -1,0 +1,129 @@
+package com.scalar.db.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link TwoPhaseCommit.Coordinator} decorator that reaps the contexts of inactive transactions.
+ *
+ * <p>Each transaction is tracked from {@link #begin} until its terminal step ({@link #commit} /
+ * {@link #rollback} / {@link #releaseContext}). When a transaction stays inactive longer than the
+ * configured expiration time, this decorator calls {@link
+ * TwoPhaseCommit.Coordinator#releaseContext} on the wrapped coordinator to free its role-local
+ * resources without performing any storage rollback. A subsequent {@code commit}/{@code rollback}
+ * for a reaped transaction therefore fails with {@link TransactionNotFoundException}, which is
+ * retriable from the client's perspective; the records left behind are recovered lazily by the
+ * usual recovery path.
+ *
+ * <p>Inactivity is measured from the last <em>coordinator-observed</em> call ({@code begin} or
+ * {@code registerParticipant}). The coordinator does not see the CRUD operations a transaction
+ * issues against its participants, so for a transaction that only performs CRUD the expiration time
+ * effectively bounds its total lifetime rather than its true idle time. Size the expiration time as
+ * the maximum allowed transaction duration accordingly. The participant-side {@link
+ * ActiveTransactionManagedTwoPhaseCommitParticipant} reaps on true idle time because it does
+ * observe the CRUD operations.
+ *
+ * <p>This decorator is intended to be the outermost coordinator decorator so that the reap
+ * traverses the inner decorators via {@code releaseContext}.
+ *
+ * <p>Thread safety: the {@link ThreadSafe} guarantee here relies on the wrapped coordinator
+ * serializing its own per-transaction work. The reaper thread's {@code releaseContext} call may run
+ * concurrently with an in-flight {@code commit}/{@code rollback} for the same transaction id; the
+ * wrapped role is responsible for making those mutually exclusive (e.g. {@code
+ * ConsensusCommitCoordinator} synchronizes every per-transaction method, including {@code
+ * releaseContext}, on a per-context monitor). A wrapped coordinator that does not serialize
+ * per-transaction calls would break this guarantee with no signal at this layer.
+ */
+@ThreadSafe
+public class ActiveTransactionManagedTwoPhaseCommitCoordinator
+    extends DecoratedTwoPhaseCommitCoordinator {
+
+  private final ActiveTransactionRegistry<String> registry;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ActiveTransactionManagedTwoPhaseCommitCoordinator(
+      TwoPhaseCommit.Coordinator coordinator, long expirationTimeMillis) {
+    super(coordinator);
+    // The registry stores the transaction ID itself; on expiry it is handed back so we can release
+    // the corresponding context on the wrapped coordinator.
+    this.registry =
+        new ActiveTransactionRegistry<>(expirationTimeMillis, coordinator::releaseContext);
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @VisibleForTesting
+  ActiveTransactionManagedTwoPhaseCommitCoordinator(
+      TwoPhaseCommit.Coordinator coordinator, ActiveTransactionRegistry<String> registry) {
+    super(coordinator);
+    this.registry = registry;
+  }
+
+  @Override
+  public String begin(
+      @Nullable String transactionId,
+      boolean readOnly,
+      Map<String, String> attributes,
+      @Nullable TwoPhaseCommit.Participant participant)
+      throws TransactionException {
+    String id = super.begin(transactionId, readOnly, attributes, participant);
+    // The wrapped coordinator is the authoritative guard for transaction-ID uniqueness (begin
+    // throws TRANSACTION_ALREADY_EXISTS on a duplicate), so a successful super.begin means the ID
+    // was free; the add return value is intentionally ignored.
+    registry.add(id, id);
+    return id;
+  }
+
+  @Override
+  public void registerParticipant(String transactionId, TwoPhaseCommit.Participant participant)
+      throws TransactionException {
+    // Refresh before delegating, consistent with the participant decorator's CRUD methods, so a
+    // slow registration counts as activity. This only narrows the window for a concurrent idle-reap
+    // (it cannot fully close it — the reaper's expiry check and eviction are not serialized with
+    // this call); a reap that does race is harmless, since the wrapped coordinator serializes
+    // releaseContext against this call (it becomes a no-op once registration completes).
+    registry.touch(transactionId);
+    super.registerParticipant(transactionId, participant);
+  }
+
+  @Override
+  public void commit(String transactionId)
+      throws CommitException, UnknownTransactionStatusException, TransactionNotFoundException {
+    try {
+      super.commit(transactionId);
+    } finally {
+      // Remove on every outcome, including CommitException / UnknownTransactionStatusException.
+      // This intentionally differs from the manager-side decorator, which keeps the entry when
+      // commit throws so that idle expiry later rolls it back: the coordinator's durable state
+      // record (not this in-memory entry) is the source of truth for recovery, so keeping the
+      // entry would only produce a spurious expiry WARN and a no-op releaseContext.
+      registry.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void rollback(String transactionId) throws RollbackException {
+    try {
+      super.rollback(transactionId);
+    } finally {
+      registry.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void releaseContext(String transactionId) {
+    try {
+      super.releaseContext(transactionId);
+    } finally {
+      registry.remove(transactionId);
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -1,0 +1,252 @@
+package com.scalar.db.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.ValidationException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link TwoPhaseCommit.Participant} decorator that reaps the contexts of inactive transactions.
+ *
+ * <p>Each transaction is tracked from {@link #join} until its terminal step ({@link #commitRecords}
+ * / {@link #rollbackRecords} / {@link #releaseContext}). Every CRUD operation and record-level step
+ * refreshes the transaction's idle timer, so inactivity here is measured as true idle time. When a
+ * transaction stays inactive longer than the configured expiration time, this decorator calls
+ * {@link TwoPhaseCommit.Participant#releaseContext} on the wrapped participant to free its
+ * role-local resources (e.g. open scanners, the snapshot) without performing any storage rollback,
+ * even when the records are prepared. The records left behind are recovered lazily by the usual
+ * recovery path.
+ *
+ * <p>This decorator is intended to be the outermost participant decorator so that the reap
+ * traverses the inner decorators via {@code releaseContext}. It is the participant-side counterpart
+ * of {@link ActiveTransactionManagedTwoPhaseCommitCoordinator}.
+ *
+ * <p>A write-less participant does not always reach {@link #commitRecords}: the Coordinator skips
+ * the steps a participant no longer needs, so for such a participant the last driven step is {@link
+ * #prepareRecords} (when no validation is required) or {@link #validateRecords} (when it is). To
+ * avoid leaking a registry entry until idle expiry (and the spurious expiry WARN that follows),
+ * this decorator removes the entry at whichever step is terminal, using {@link
+ * TwoPhaseCommit.PreparationResult#isCommitRequired} and {@link
+ * TwoPhaseCommit.PreparationResult#isValidationRequired} reported at {@code prepareRecords} to
+ * decide where the terminal step lands. The decision is carried across the prepare-to-validate gap
+ * by a flag on the registry entry itself ({@link TrackedTransaction#terminalAtValidate}), so it
+ * shares the entry's lifecycle and adds no separate state to clean up.
+ *
+ * <p>Thread safety: the {@link ThreadSafe} guarantee here relies on the wrapped participant
+ * serializing its own per-transaction work. The reaper thread's {@code releaseContext} call may run
+ * concurrently with an in-flight CRUD or record-level call for the same transaction id; the wrapped
+ * role is responsible for making those mutually exclusive (e.g. {@code ConsensusCommitParticipant}
+ * synchronizes every per-transaction method, including {@code releaseContext}, on a per-context
+ * monitor). A wrapped participant that does not serialize per-transaction calls would break this
+ * guarantee with no signal at this layer.
+ */
+@ThreadSafe
+public class ActiveTransactionManagedTwoPhaseCommitParticipant
+    extends DecoratedTwoPhaseCommitParticipant {
+
+  private final ActiveTransactionRegistry<TrackedTransaction> registry;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ActiveTransactionManagedTwoPhaseCommitParticipant(
+      TwoPhaseCommit.Participant participant, long expirationTimeMillis) {
+    super(participant);
+    // The registry stores a small per-transaction entry carrying the transaction ID and the
+    // terminal-at-validate flag; on expiry it is handed back so we can release the corresponding
+    // context on the wrapped participant.
+    this.registry =
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, tracked -> participant.releaseContext(tracked.transactionId));
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @VisibleForTesting
+  ActiveTransactionManagedTwoPhaseCommitParticipant(
+      TwoPhaseCommit.Participant participant,
+      ActiveTransactionRegistry<TrackedTransaction> registry) {
+    super(participant);
+    this.registry = registry;
+  }
+
+  @Override
+  public void join(String transactionId, boolean readOnly, Map<String, String> attributes)
+      throws TransactionException {
+    super.join(transactionId, readOnly, attributes);
+    // The wrapped participant is the authoritative guard for transaction-ID uniqueness (join throws
+    // TRANSACTION_ALREADY_EXISTS on a duplicate), so a successful super.join means the ID was free;
+    // the add return value is intentionally ignored.
+    registry.add(transactionId, new TrackedTransaction(transactionId));
+  }
+
+  @Override
+  public Optional<Result> get(String transactionId, Get get)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    return super.get(transactionId, get);
+  }
+
+  @Override
+  public List<Result> scan(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    return super.scan(transactionId, scan);
+  }
+
+  @Override
+  public TransactionCrudOperable.Scanner getScanner(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    return super.getScanner(transactionId, scan);
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+  @Deprecated
+  @Override
+  public void put(String transactionId, Put put)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.put(transactionId, put);
+  }
+
+  @Override
+  public void insert(String transactionId, Insert insert)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.insert(transactionId, insert);
+  }
+
+  @Override
+  public void upsert(String transactionId, Upsert upsert)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.upsert(transactionId, upsert);
+  }
+
+  @Override
+  public void update(String transactionId, Update update)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.update(transactionId, update);
+  }
+
+  @Override
+  public void delete(String transactionId, Delete delete)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.delete(transactionId, delete);
+  }
+
+  @Override
+  public void mutate(String transactionId, List<? extends Mutation> mutations)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.mutate(transactionId, mutations);
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(
+      String transactionId, List<? extends Operation> operations)
+      throws CrudException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    return super.batch(transactionId, operations);
+  }
+
+  @Override
+  public TwoPhaseCommit.PreparationResult prepareRecords(String transactionId, long preparedAt)
+      throws PreparationException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    TwoPhaseCommit.PreparationResult result = super.prepareRecords(transactionId, preparedAt);
+    if (result.isCommitRequired()) {
+      // Intentionally nothing to do here: commitRecords will be driven and is the terminal step,
+      // and its override removes the entry. Kept as an explicit arm so all three terminal-step
+      // cases read in protocol order.
+    } else if (result.isValidationRequired()) {
+      // Write-less but validating: validateRecords is the terminal step. Flag the entry so
+      // validateRecords removes it.
+      registry.get(transactionId).ifPresent(tracked -> tracked.terminalAtValidate = true);
+    } else {
+      // Neither validate nor commit will be driven: prepareRecords is the terminal step.
+      registry.remove(transactionId);
+    }
+    return result;
+  }
+
+  @Override
+  public void validateRecords(String transactionId)
+      throws ValidationException, TransactionNotFoundException {
+    registry.touch(transactionId);
+    super.validateRecords(transactionId);
+    // Only on success: if validateRecords was the terminal step, remove the entry now. On failure
+    // the transaction aborts and rollbackRecords (which removes the entry) is driven instead.
+    Optional<TrackedTransaction> tracked = registry.get(transactionId);
+    if (tracked.isPresent() && tracked.get().terminalAtValidate) {
+      registry.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void commitRecords(String transactionId, long committedAt)
+      throws CommitException, TransactionNotFoundException {
+    try {
+      super.commitRecords(transactionId, committedAt);
+    } finally {
+      registry.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void rollbackRecords(String transactionId) throws RollbackException {
+    try {
+      super.rollbackRecords(transactionId);
+    } finally {
+      registry.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void releaseContext(String transactionId) {
+    try {
+      super.releaseContext(transactionId);
+    } finally {
+      registry.remove(transactionId);
+    }
+  }
+
+  /**
+   * A registry entry tracking one transaction: its ID (used to release the context on expiry) and
+   * whether {@link #validateRecords} is its terminal step. The flag is written at {@code
+   * prepareRecords} and read at {@code validateRecords}; it lives and dies with the registry entry.
+   */
+  private static final class TrackedTransaction {
+    private final String transactionId;
+
+    // volatile is required, not incidental: the flag is written at prepareRecords and read at
+    // validateRecords, which may run on different threads. Do not drop volatile.
+    private volatile boolean terminalAtValidate;
+
+    private TrackedTransaction(String transactionId) {
+      this.transactionId = transactionId;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -48,9 +48,9 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   public ActiveTransactionManagedTwoPhaseCommitTransactionManager(
       TwoPhaseCommitTransactionManager transactionManager,
       long expirationTimeMillis,
-      ActiveTransactionRegistry.TransactionRollback<TwoPhaseCommitTransaction> rollbackFunction) {
+      ActiveTransactionRegistry.ExpirationHandler<TwoPhaseCommitTransaction> expirationHandler) {
     super(transactionManager);
-    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, rollbackFunction);
+    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, expirationHandler);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
@@ -24,10 +24,10 @@ public class ActiveTransactionRegistry<T> {
    * Constructs an ActiveTransactionRegistry.
    *
    * @param expirationTimeMillis the expiration time in milliseconds
-   * @param rollbackFunction the function to rollback a transaction
+   * @param expirationHandler the handler invoked when a transaction expires
    */
   public ActiveTransactionRegistry(
-      long expirationTimeMillis, TransactionRollback<T> rollbackFunction) {
+      long expirationTimeMillis, ExpirationHandler<T> expirationHandler) {
     this.activeTransactions =
         new ActiveExpiringMap<>(
             expirationTimeMillis,
@@ -35,9 +35,9 @@ public class ActiveTransactionRegistry<T> {
             (id, t) -> {
               logger.warn("The transaction is expired. Transaction ID: {}", id);
               try {
-                rollbackFunction.rollback(t);
+                expirationHandler.onExpired(t);
               } catch (Exception e) {
-                logger.warn("Rollback failed. Transaction ID: {}", id, e);
+                logger.warn("Failed to handle the expired transaction. Transaction ID: {}", id, e);
               }
             });
   }
@@ -74,12 +74,23 @@ public class ActiveTransactionRegistry<T> {
   }
 
   /**
-   * Functional interface for rolling back a transaction.
+   * Refreshes the expiration timer of a transaction, treating it as recently active. Does nothing
+   * if no transaction with the given ID is registered.
+   *
+   * @param id the transaction ID
+   */
+  public void touch(String id) {
+    activeTransactions.updateExpirationTime(id);
+  }
+
+  /**
+   * Functional interface invoked when a transaction expires, to dispose of its resources (e.g.,
+   * roll it back, or release its context without a storage rollback).
    *
    * @param <T> the type of transaction
    */
   @FunctionalInterface
-  public interface TransactionRollback<T> {
-    void rollback(T transaction) throws Exception;
+  public interface ExpirationHandler<T> {
+    void onExpired(T transaction) throws Exception;
   }
 }

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingDistributedTransactionManager.java
@@ -3,28 +3,20 @@ package com.scalar.db.common;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DeleteBuilder;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.GetBuilder;
 import com.scalar.db.api.Insert;
-import com.scalar.db.api.InsertBuilder;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanBuilder;
 import com.scalar.db.api.Update;
-import com.scalar.db.api.UpdateBuilder;
 import com.scalar.db.api.Upsert;
-import com.scalar.db.api.UpsertBuilder;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.TransactionException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -189,144 +181,12 @@ public class AttributePropagatingDistributedTransactionManager
       return super.batch(this.<Operation>mergeAttributesForEach(operations));
     }
 
-    @SuppressWarnings({"unchecked", "ReferenceEquality"})
     private <T extends Operation> List<T> mergeAttributesForEach(List<? extends T> operations) {
-      // Allocates a new list only when some element actually needs merging. Returns the original
-      // list (same reference) when every element is forwarded unchanged so a common case of "no tx
-      // attribute needs to be added on any operation" avoids allocating a list copy.
-      for (int i = 0; i < operations.size(); i++) {
-        T operation = operations.get(i);
-        T mergedOperation = mergeAttributes(operation);
-        if (mergedOperation == operation) {
-          continue;
-        }
-        // Found an operation that needed merging: allocate the new list, backfill the prior
-        // unchanged elements, and merge the remaining elements.
-        List<T> merged = new ArrayList<>(operations.size());
-        merged.addAll(operations.subList(0, i));
-        merged.add(mergedOperation);
-        for (int j = i + 1; j < operations.size(); j++) {
-          merged.add(mergeAttributes(operations.get(j)));
-        }
-        return merged;
-      }
-      return (List<T>) operations;
+      return OperationAttributeMerger.mergeEach(operations, transactionAttributes);
     }
 
-    @SuppressWarnings("unchecked")
     private <T extends Operation> T mergeAttributes(T operation) {
-      if (containsAllTransactionAttributeKeys(operation)) {
-        return operation;
-      }
-      if (operation instanceof Put) {
-        return (T) mergeAttributesIntoPut((Put) operation);
-      }
-      if (operation instanceof Insert) {
-        return (T) mergeAttributesIntoInsert((Insert) operation);
-      }
-      if (operation instanceof Upsert) {
-        return (T) mergeAttributesIntoUpsert((Upsert) operation);
-      }
-      if (operation instanceof Update) {
-        return (T) mergeAttributesIntoUpdate((Update) operation);
-      }
-      if (operation instanceof Delete) {
-        return (T) mergeAttributesIntoDelete((Delete) operation);
-      }
-      if (operation instanceof Get) {
-        return (T) mergeAttributesIntoGet((Get) operation);
-      }
-      if (operation instanceof Scan) {
-        return (T) mergeAttributesIntoScan((Scan) operation);
-      }
-      return operation;
-    }
-
-    private boolean containsAllTransactionAttributeKeys(Operation operation) {
-      Map<String, String> operationAttributes = operation.getAttributes();
-      for (String key : transactionAttributes.keySet()) {
-        if (!operationAttributes.containsKey(key)) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    private Put mergeAttributesIntoPut(Put put) {
-      Map<String, String> existing = put.getAttributes();
-      PutBuilder.BuildableFromExisting builder = Put.newBuilder(put);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Insert mergeAttributesIntoInsert(Insert insert) {
-      Map<String, String> existing = insert.getAttributes();
-      InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Upsert mergeAttributesIntoUpsert(Upsert upsert) {
-      Map<String, String> existing = upsert.getAttributes();
-      UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Update mergeAttributesIntoUpdate(Update update) {
-      Map<String, String> existing = update.getAttributes();
-      UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Delete mergeAttributesIntoDelete(Delete delete) {
-      Map<String, String> existing = delete.getAttributes();
-      DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Get mergeAttributesIntoGet(Get get) {
-      Map<String, String> existing = get.getAttributes();
-      GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
-    }
-
-    private Scan mergeAttributesIntoScan(Scan scan) {
-      Map<String, String> existing = scan.getAttributes();
-      ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan);
-      for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
-        if (!existing.containsKey(entry.getKey())) {
-          builder.attribute(entry.getKey(), entry.getValue());
-        }
-      }
-      return builder.build();
+      return OperationAttributeMerger.merge(operation, transactionAttributes);
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -54,10 +54,14 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>The captured attributes are released only on a step driven through this decorator. A
  * transaction abandoned before any such step (e.g. a crashed client that never prepares, rolls
  * back, or is released) leaves its entry until the JVM exits. This is reaped only when {@link
- * ActiveTransactionManagedTwoPhaseCommitParticipant} wraps this decorator (its idle-expiry calls
- * {@code releaseContext}, which clears the entry); the leak is in lockstep with the wrapped
- * participant's own per-transaction context, which active transaction management exists to reap.
- * Enable active transaction management whenever this decorator is used.
+ * ActiveTransactionManagedTwoPhaseCommitParticipant} wraps this decorator <em>and</em> idle expiry
+ * is actually running — which requires both active transaction management to be enabled and a
+ * positive {@code scalar.db.active_transaction_management.expiration_time_millis} (a non-positive
+ * value, which is the default, disables the reaper). Only then does idle expiry call {@code
+ * releaseContext} and clear the entry. The leak is in lockstep with the wrapped participant's own
+ * per-transaction context, which active transaction management reaps under the same precondition.
+ * Enable active transaction management with a positive expiration time whenever this decorator is
+ * used.
  */
 @ThreadSafe
 public class AttributePropagatingTwoPhaseCommitParticipant

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -1,0 +1,175 @@
+package com.scalar.db.common;
+
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link TwoPhaseCommit.Participant} decorator that propagates the transaction-scoped attributes
+ * supplied at {@link #join} into every CRUD operation issued for that transaction.
+ *
+ * <p>Begin-attributes reach the participant via {@link
+ * TwoPhaseCommit.Coordinator#registerParticipant} → {@code join}; this decorator captures them
+ * (keyed by transaction ID) and merges them into each operation before delegating, with an
+ * attribute set directly on the operation winning over the transaction-scoped one (see {@link
+ * OperationAttributeMerger}). It therefore sits <em>outside</em> any decorator that reads operation
+ * attributes (e.g. ABAC). The captured attributes are dropped on the transaction's terminal step
+ * ({@code commitRecords} / {@code rollbackRecords} / {@code releaseContext}).
+ *
+ * <p>The record-level steps ({@code prepareRecords} / {@code validateRecords}) and non-CRUD methods
+ * are forwarded unchanged.
+ *
+ * <p>The captured attributes are released only on a terminal step driven through this decorator. A
+ * transaction abandoned without one (e.g. a crashed client) leaves its entry until the JVM exits.
+ * This is reaped only when {@link ActiveTransactionManagedTwoPhaseCommitParticipant} wraps this
+ * decorator (its idle-expiry calls {@code releaseContext}, which clears the entry); the leak is in
+ * lockstep with the wrapped participant's own per-transaction context, which active transaction
+ * management exists to reap. Enable active transaction management whenever this decorator is used.
+ */
+@ThreadSafe
+public class AttributePropagatingTwoPhaseCommitParticipant
+    extends DecoratedTwoPhaseCommitParticipant {
+
+  private final ConcurrentMap<String, Map<String, String>> transactionAttributes =
+      new ConcurrentHashMap<>();
+
+  public AttributePropagatingTwoPhaseCommitParticipant(TwoPhaseCommit.Participant participant) {
+    super(participant);
+  }
+
+  @Override
+  public void join(String transactionId, boolean readOnly, Map<String, String> attributes)
+      throws TransactionException {
+    super.join(transactionId, readOnly, attributes);
+    // Capture only after a successful join so a failed join leaves no stale entry. Skip empty
+    // attributes so there is nothing to merge later.
+    if (!attributes.isEmpty()) {
+      transactionAttributes.put(transactionId, ImmutableMap.copyOf(attributes));
+    }
+  }
+
+  @Override
+  public Optional<Result> get(String transactionId, Get get)
+      throws CrudException, TransactionNotFoundException {
+    return super.get(transactionId, merge(transactionId, get));
+  }
+
+  @Override
+  public List<Result> scan(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    return super.scan(transactionId, merge(transactionId, scan));
+  }
+
+  @Override
+  public TransactionCrudOperable.Scanner getScanner(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    return super.getScanner(transactionId, merge(transactionId, scan));
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+  @Deprecated
+  @Override
+  public void put(String transactionId, Put put)
+      throws CrudException, TransactionNotFoundException {
+    super.put(transactionId, merge(transactionId, put));
+  }
+
+  @Override
+  public void insert(String transactionId, Insert insert)
+      throws CrudException, TransactionNotFoundException {
+    super.insert(transactionId, merge(transactionId, insert));
+  }
+
+  @Override
+  public void upsert(String transactionId, Upsert upsert)
+      throws CrudException, TransactionNotFoundException {
+    super.upsert(transactionId, merge(transactionId, upsert));
+  }
+
+  @Override
+  public void update(String transactionId, Update update)
+      throws CrudException, TransactionNotFoundException {
+    super.update(transactionId, merge(transactionId, update));
+  }
+
+  @Override
+  public void delete(String transactionId, Delete delete)
+      throws CrudException, TransactionNotFoundException {
+    super.delete(transactionId, merge(transactionId, delete));
+  }
+
+  @Override
+  public void mutate(String transactionId, List<? extends Mutation> mutations)
+      throws CrudException, TransactionNotFoundException {
+    super.mutate(
+        transactionId, OperationAttributeMerger.mergeEach(mutations, attributesFor(transactionId)));
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(
+      String transactionId, List<? extends Operation> operations)
+      throws CrudException, TransactionNotFoundException {
+    return super.batch(
+        transactionId,
+        OperationAttributeMerger.mergeEach(operations, attributesFor(transactionId)));
+  }
+
+  @Override
+  public void commitRecords(String transactionId, long committedAt)
+      throws CommitException, TransactionNotFoundException {
+    try {
+      super.commitRecords(transactionId, committedAt);
+    } finally {
+      transactionAttributes.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void rollbackRecords(String transactionId) throws RollbackException {
+    try {
+      super.rollbackRecords(transactionId);
+    } finally {
+      transactionAttributes.remove(transactionId);
+    }
+  }
+
+  @Override
+  public void releaseContext(String transactionId) {
+    try {
+      super.releaseContext(transactionId);
+    } finally {
+      transactionAttributes.remove(transactionId);
+    }
+  }
+
+  private <T extends Operation> T merge(String transactionId, T operation) {
+    return OperationAttributeMerger.merge(operation, attributesFor(transactionId));
+  }
+
+  private Map<String, String> attributesFor(String transactionId) {
+    return transactionAttributes.getOrDefault(transactionId, Collections.emptyMap());
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -14,8 +14,8 @@ import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
-import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
@@ -36,18 +36,28 @@ import javax.annotation.concurrent.ThreadSafe;
  * (keyed by transaction ID) and merges them into each operation before delegating, with an
  * attribute set directly on the operation winning over the transaction-scoped one (see {@link
  * OperationAttributeMerger}). It therefore sits <em>outside</em> any decorator that reads operation
- * attributes (e.g. ABAC). The captured attributes are dropped on the transaction's terminal step
- * ({@code commitRecords} / {@code rollbackRecords} / {@code releaseContext}).
+ * attributes (e.g. ABAC).
  *
- * <p>The record-level steps ({@code prepareRecords} / {@code validateRecords}) and non-CRUD methods
- * are forwarded unchanged.
+ * <p>The captured attributes are needed only while CRUD operations are still issued, so they are
+ * dropped as soon as the CRUD phase ends. {@code prepareRecords} is that boundary: no CRUD is
+ * accepted once a transaction has been prepared, so this decorator drops the attributes there.
+ * Dropping at {@code prepareRecords} rather than at {@code commitRecords} matters because the
+ * Coordinator skips {@code commitRecords} (and possibly {@code validateRecords}) for a write-less
+ * participant — including every read-only transaction — so a normally-committed write-less
+ * transaction would otherwise never reach a terminal step that clears its entry. The attributes are
+ * also dropped on {@code rollbackRecords} and {@code releaseContext} to cover transactions that are
+ * rolled back or reaped before ever preparing.
  *
- * <p>The captured attributes are released only on a terminal step driven through this decorator. A
- * transaction abandoned without one (e.g. a crashed client) leaves its entry until the JVM exits.
- * This is reaped only when {@link ActiveTransactionManagedTwoPhaseCommitParticipant} wraps this
- * decorator (its idle-expiry calls {@code releaseContext}, which clears the entry); the leak is in
- * lockstep with the wrapped participant's own per-transaction context, which active transaction
- * management exists to reap. Enable active transaction management whenever this decorator is used.
+ * <p>The record-level step {@code validateRecords} and non-CRUD methods are forwarded unchanged;
+ * they do not read the transaction-scoped attributes.
+ *
+ * <p>The captured attributes are released only on a step driven through this decorator. A
+ * transaction abandoned before any such step (e.g. a crashed client that never prepares, rolls
+ * back, or is released) leaves its entry until the JVM exits. This is reaped only when {@link
+ * ActiveTransactionManagedTwoPhaseCommitParticipant} wraps this decorator (its idle-expiry calls
+ * {@code releaseContext}, which clears the entry); the leak is in lockstep with the wrapped
+ * participant's own per-transaction context, which active transaction management exists to reap.
+ * Enable active transaction management whenever this decorator is used.
  */
 @ThreadSafe
 public class AttributePropagatingTwoPhaseCommitParticipant
@@ -138,11 +148,15 @@ public class AttributePropagatingTwoPhaseCommitParticipant
   }
 
   @Override
-  public void commitRecords(String transactionId, long committedAt)
-      throws CommitException, TransactionNotFoundException {
+  public TwoPhaseCommit.PreparationResult prepareRecords(String transactionId, long preparedAt)
+      throws PreparationException, TransactionNotFoundException {
     try {
-      super.commitRecords(transactionId, committedAt);
+      return super.prepareRecords(transactionId, preparedAt);
     } finally {
+      // prepareRecords ends the CRUD phase (no CRUD is accepted once prepared), so the captured
+      // attributes are no longer needed and are dropped here. Dropping here rather than at
+      // commitRecords also covers write-less transactions (including every read-only one), whose
+      // commitRecords the Coordinator skips; commitRecords is therefore not a terminal step here.
       transactionAttributes.remove(transactionId);
     }
   }

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
@@ -1,0 +1,65 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link TwoPhaseCommit.Coordinator} that forwards every method to a wrapped coordinator.
+ *
+ * <p>Base class for coordinator decorators: subclasses override only the methods they need and
+ * inherit plain delegation for the rest. It is the coordinator-side counterpart of {@link
+ * DecoratedTwoPhaseCommitParticipant}.
+ */
+public abstract class DecoratedTwoPhaseCommitCoordinator implements TwoPhaseCommit.Coordinator {
+
+  private final TwoPhaseCommit.Coordinator coordinator;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  protected DecoratedTwoPhaseCommitCoordinator(TwoPhaseCommit.Coordinator coordinator) {
+    this.coordinator = coordinator;
+  }
+
+  @Override
+  public String begin(
+      @Nullable String transactionId,
+      boolean readOnly,
+      Map<String, String> attributes,
+      @Nullable TwoPhaseCommit.Participant participant)
+      throws TransactionException {
+    return coordinator.begin(transactionId, readOnly, attributes, participant);
+  }
+
+  @Override
+  public void registerParticipant(String transactionId, TwoPhaseCommit.Participant participant)
+      throws TransactionException {
+    coordinator.registerParticipant(transactionId, participant);
+  }
+
+  @Override
+  public void commit(String transactionId)
+      throws CommitException, UnknownTransactionStatusException, TransactionNotFoundException {
+    coordinator.commit(transactionId);
+  }
+
+  @Override
+  public void rollback(String transactionId) throws RollbackException {
+    coordinator.rollback(transactionId);
+  }
+
+  @Override
+  public void releaseContext(String transactionId) {
+    coordinator.releaseContext(transactionId);
+  }
+
+  @Override
+  public void close() {
+    coordinator.close();
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
@@ -1,0 +1,150 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import com.scalar.db.exception.transaction.ValidationException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A {@link TwoPhaseCommit.Participant} that forwards every method to a wrapped participant.
+ *
+ * <p>Base class for participant decorators: subclasses override only the methods they need and
+ * inherit plain delegation for the rest. It is the id-based {@link TwoPhaseCommit.Participant}
+ * counterpart of the manager-API {@link DecoratedDistributedTransactionManager}.
+ */
+public abstract class DecoratedTwoPhaseCommitParticipant implements TwoPhaseCommit.Participant {
+
+  private final TwoPhaseCommit.Participant participant;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  protected DecoratedTwoPhaseCommitParticipant(TwoPhaseCommit.Participant participant) {
+    this.participant = participant;
+  }
+
+  @Override
+  public String getId() {
+    return participant.getId();
+  }
+
+  @Override
+  public void join(String transactionId, boolean readOnly, Map<String, String> attributes)
+      throws TransactionException {
+    participant.join(transactionId, readOnly, attributes);
+  }
+
+  @Override
+  public Optional<Result> get(String transactionId, Get get)
+      throws CrudException, TransactionNotFoundException {
+    return participant.get(transactionId, get);
+  }
+
+  @Override
+  public List<Result> scan(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    return participant.scan(transactionId, scan);
+  }
+
+  @Override
+  public TransactionCrudOperable.Scanner getScanner(String transactionId, Scan scan)
+      throws CrudException, TransactionNotFoundException {
+    return participant.getScanner(transactionId, scan);
+  }
+
+  /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+  @Deprecated
+  @Override
+  public void put(String transactionId, Put put)
+      throws CrudException, TransactionNotFoundException {
+    participant.put(transactionId, put);
+  }
+
+  @Override
+  public void insert(String transactionId, Insert insert)
+      throws CrudException, TransactionNotFoundException {
+    participant.insert(transactionId, insert);
+  }
+
+  @Override
+  public void upsert(String transactionId, Upsert upsert)
+      throws CrudException, TransactionNotFoundException {
+    participant.upsert(transactionId, upsert);
+  }
+
+  @Override
+  public void update(String transactionId, Update update)
+      throws CrudException, TransactionNotFoundException {
+    participant.update(transactionId, update);
+  }
+
+  @Override
+  public void delete(String transactionId, Delete delete)
+      throws CrudException, TransactionNotFoundException {
+    participant.delete(transactionId, delete);
+  }
+
+  @Override
+  public void mutate(String transactionId, List<? extends Mutation> mutations)
+      throws CrudException, TransactionNotFoundException {
+    participant.mutate(transactionId, mutations);
+  }
+
+  @Override
+  public List<CrudOperable.BatchResult> batch(
+      String transactionId, List<? extends Operation> operations)
+      throws CrudException, TransactionNotFoundException {
+    return participant.batch(transactionId, operations);
+  }
+
+  @Override
+  public TwoPhaseCommit.PreparationResult prepareRecords(String transactionId, long preparedAt)
+      throws PreparationException, TransactionNotFoundException {
+    return participant.prepareRecords(transactionId, preparedAt);
+  }
+
+  @Override
+  public void validateRecords(String transactionId)
+      throws ValidationException, TransactionNotFoundException {
+    participant.validateRecords(transactionId);
+  }
+
+  @Override
+  public void commitRecords(String transactionId, long committedAt)
+      throws CommitException, TransactionNotFoundException {
+    participant.commitRecords(transactionId, committedAt);
+  }
+
+  @Override
+  public void rollbackRecords(String transactionId) throws RollbackException {
+    participant.rollbackRecords(transactionId);
+  }
+
+  @Override
+  public void releaseContext(String transactionId) {
+    participant.releaseContext(transactionId);
+  }
+
+  @Override
+  public void close() {
+    participant.close();
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/OperationAttributeMerger.java
+++ b/core/src/main/java/com/scalar/db/common/OperationAttributeMerger.java
@@ -1,0 +1,185 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.GetBuilder;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.InsertBuilder;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateBuilder;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.api.UpsertBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Merges transaction-scoped attributes into an {@link Operation}.
+ *
+ * <p>For each transaction attribute, the value is added to the operation only when the operation
+ * does not already carry an attribute with that name — i.e., an attribute set directly on the
+ * operation wins over the transaction-scoped one. The same operation subtype is returned.
+ *
+ * <p>This is the single implementation shared by the attribute-propagating decorators (the
+ * manager-shaped {@link AttributePropagatingDistributedTransactionManager} and the id-based {@code
+ * TwoPhaseCommit.Participant} decorator).
+ */
+final class OperationAttributeMerger {
+
+  private OperationAttributeMerger() {}
+
+  @SuppressWarnings("unchecked")
+  static <T extends Operation> T merge(T operation, Map<String, String> transactionAttributes) {
+    if (transactionAttributes.isEmpty() || containsAllKeys(operation, transactionAttributes)) {
+      return operation;
+    }
+    if (operation instanceof Put) {
+      return (T) mergeIntoPut((Put) operation, transactionAttributes);
+    }
+    if (operation instanceof Insert) {
+      return (T) mergeIntoInsert((Insert) operation, transactionAttributes);
+    }
+    if (operation instanceof Upsert) {
+      return (T) mergeIntoUpsert((Upsert) operation, transactionAttributes);
+    }
+    if (operation instanceof Update) {
+      return (T) mergeIntoUpdate((Update) operation, transactionAttributes);
+    }
+    if (operation instanceof Delete) {
+      return (T) mergeIntoDelete((Delete) operation, transactionAttributes);
+    }
+    if (operation instanceof Get) {
+      return (T) mergeIntoGet((Get) operation, transactionAttributes);
+    }
+    if (operation instanceof Scan) {
+      return (T) mergeIntoScan((Scan) operation, transactionAttributes);
+    }
+    return operation;
+  }
+
+  /**
+   * Merges the transaction-scoped attributes into each operation in the list, with the same
+   * per-operation semantics as {@link #merge}. Allocates a new list only when at least one
+   * operation actually needs merging; otherwise the original list (same reference) is returned, so
+   * the common case of "no transaction attribute needs to be added on any operation" avoids a list
+   * copy.
+   */
+  @SuppressWarnings({"unchecked", "ReferenceEquality"})
+  static <T extends Operation> List<T> mergeEach(
+      List<? extends T> operations, Map<String, String> transactionAttributes) {
+    if (transactionAttributes.isEmpty()) {
+      return (List<T>) operations;
+    }
+    for (int i = 0; i < operations.size(); i++) {
+      T operation = operations.get(i);
+      T mergedOperation = merge(operation, transactionAttributes);
+      if (mergedOperation == operation) {
+        continue;
+      }
+      // Found an operation that needed merging: allocate the new list, backfill the prior unchanged
+      // elements, and merge the remaining elements.
+      List<T> merged = new ArrayList<>(operations.size());
+      merged.addAll(operations.subList(0, i));
+      merged.add(mergedOperation);
+      for (int j = i + 1; j < operations.size(); j++) {
+        merged.add(merge(operations.get(j), transactionAttributes));
+      }
+      return merged;
+    }
+    return (List<T>) operations;
+  }
+
+  private static boolean containsAllKeys(
+      Operation operation, Map<String, String> transactionAttributes) {
+    Map<String, String> operationAttributes = operation.getAttributes();
+    for (String key : transactionAttributes.keySet()) {
+      if (!operationAttributes.containsKey(key)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Put mergeIntoPut(Put put, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = put.getAttributes();
+    PutBuilder.BuildableFromExisting builder = Put.newBuilder(put);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Insert mergeIntoInsert(Insert insert, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = insert.getAttributes();
+    InsertBuilder.BuildableFromExisting builder = Insert.newBuilder(insert);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Upsert mergeIntoUpsert(Upsert upsert, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = upsert.getAttributes();
+    UpsertBuilder.BuildableFromExisting builder = Upsert.newBuilder(upsert);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Update mergeIntoUpdate(Update update, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = update.getAttributes();
+    UpdateBuilder.BuildableFromExisting builder = Update.newBuilder(update);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Delete mergeIntoDelete(Delete delete, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = delete.getAttributes();
+    DeleteBuilder.BuildableFromExisting builder = Delete.newBuilder(delete);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Get mergeIntoGet(Get get, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = get.getAttributes();
+    GetBuilder.BuildableGetOrGetWithIndexFromExisting builder = Get.newBuilder(get);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+
+  private static Scan mergeIntoScan(Scan scan, Map<String, String> transactionAttributes) {
+    Map<String, String> existing = scan.getAttributes();
+    ScanBuilder.BuildableScanOrScanAllFromExisting builder = Scan.newBuilder(scan);
+    for (Map.Entry<String, String> entry : transactionAttributes.entrySet()) {
+      if (!existing.containsKey(entry.getKey())) {
+        builder.attribute(entry.getKey(), entry.getValue());
+      }
+    }
+    return builder.build();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -32,12 +32,12 @@ public class ConsensusCommitProvider extends AbstractDistributedTransactionProvi
   }
 
   @Override
-  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+  public TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(DatabaseConfig config) {
     return new ConsensusCommitCoordinator(config);
   }
 
   @Override
-  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+  public TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(DatabaseConfig config) {
     return new ConsensusCommitParticipant(config);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -36,13 +36,13 @@ public class JdbcTransactionProvider extends AbstractDistributedTransactionProvi
   }
 
   @Override
-  public TwoPhaseCommit.Coordinator createTwoPhaseCommitCoordinator(DatabaseConfig config) {
+  public TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(DatabaseConfig config) {
     throw new UnsupportedOperationException(
         CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
   }
 
   @Override
-  public TwoPhaseCommit.Participant createTwoPhaseCommitParticipant(DatabaseConfig config) {
+  public TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(DatabaseConfig config) {
     throw new UnsupportedOperationException(
         CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
   }

--- a/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
@@ -1,0 +1,227 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.Key;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AbstractDistributedTransactionProviderTest {
+
+  private TwoPhaseCommit.Coordinator rawCoordinator;
+  private TwoPhaseCommit.Participant rawParticipant;
+  private AbstractDistributedTransactionProvider provider;
+  private DatabaseConfig config;
+
+  @BeforeEach
+  void setUp() {
+    rawCoordinator = mock(TwoPhaseCommit.Coordinator.class);
+    rawParticipant = mock(TwoPhaseCommit.Participant.class);
+    provider =
+        new AbstractDistributedTransactionProvider() {
+          @Override
+          public String getName() {
+            return "test";
+          }
+
+          @Override
+          protected DistributedTransactionManager createRawDistributedTransactionManager(
+              DatabaseConfig config) {
+            return mock(DistributedTransactionManager.class);
+          }
+
+          @Override
+          public DistributedTransactionAdmin createDistributedTransactionAdmin(
+              DatabaseConfig config) {
+            return mock(DistributedTransactionAdmin.class);
+          }
+
+          @Override
+          protected TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
+              DatabaseConfig config) {
+            return mock(TwoPhaseCommitTransactionManager.class);
+          }
+
+          @Override
+          protected TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(
+              DatabaseConfig config) {
+            return rawCoordinator;
+          }
+
+          @Override
+          protected TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(
+              DatabaseConfig config) {
+            return rawParticipant;
+          }
+        };
+
+    config = mock(DatabaseConfig.class);
+    // A non-positive expiration keeps the active-transaction registry from starting a reaper
+    // thread.
+    when(config.getActiveTransactionManagementExpirationTimeMillis()).thenReturn(-1L);
+  }
+
+  @Test
+  void createTwoPhaseCommitCoordinator_WhenActiveTransactionManagementDisabled_ShouldReturnRaw() {
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(false);
+
+    TwoPhaseCommit.Coordinator coordinator = provider.createTwoPhaseCommitCoordinator(config);
+
+    assertThat(coordinator).isSameAs(rawCoordinator);
+  }
+
+  @Test
+  void createTwoPhaseCommitCoordinator_WhenActiveTransactionManagementEnabled_ShouldWrap() {
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Coordinator coordinator = provider.createTwoPhaseCommitCoordinator(config);
+
+    assertThat(coordinator).isInstanceOf(ActiveTransactionManagedTwoPhaseCommitCoordinator.class);
+  }
+
+  @Test
+  void createTwoPhaseCommitCoordinator_WhenRawCoordinatorIsNull_ShouldReturnNull() {
+    // Active transaction management is enabled to prove the null short-circuits before wrapping.
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Coordinator coordinator =
+        unsupportedProvider().createTwoPhaseCommitCoordinator(config);
+
+    assertThat(coordinator).isNull();
+  }
+
+  @Test
+  void createTwoPhaseCommitParticipant_WhenAllDisabled_ShouldReturnRaw() {
+    when(config.isAttributePropagationEnabled()).thenReturn(false);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(false);
+
+    TwoPhaseCommit.Participant participant = provider.createTwoPhaseCommitParticipant(config);
+
+    assertThat(participant).isSameAs(rawParticipant);
+  }
+
+  @Test
+  void createTwoPhaseCommitParticipant_WhenOnlyAttributePropagationEnabled_ShouldWrapWithIt() {
+    when(config.isAttributePropagationEnabled()).thenReturn(true);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(false);
+
+    TwoPhaseCommit.Participant participant = provider.createTwoPhaseCommitParticipant(config);
+
+    assertThat(participant).isInstanceOf(AttributePropagatingTwoPhaseCommitParticipant.class);
+  }
+
+  @Test
+  void
+      createTwoPhaseCommitParticipant_WhenOnlyActiveTransactionManagementEnabled_ShouldWrapWithIt() {
+    when(config.isAttributePropagationEnabled()).thenReturn(false);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Participant participant = provider.createTwoPhaseCommitParticipant(config);
+
+    assertThat(participant).isInstanceOf(ActiveTransactionManagedTwoPhaseCommitParticipant.class);
+  }
+
+  @Test
+  void createTwoPhaseCommitParticipant_WhenActiveTransactionManagementEnabled_ShouldBeOutermost() {
+    when(config.isAttributePropagationEnabled()).thenReturn(true);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Participant participant = provider.createTwoPhaseCommitParticipant(config);
+
+    // Active transaction management is the outermost wrapping.
+    assertThat(participant).isInstanceOf(ActiveTransactionManagedTwoPhaseCommitParticipant.class);
+  }
+
+  @Test
+  void
+      createTwoPhaseCommitParticipant_WhenBothEnabled_ShouldPropagateAttributesInsideActiveManagement()
+          throws Exception {
+    when(config.isAttributePropagationEnabled()).thenReturn(true);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Participant participant = provider.createTwoPhaseCommitParticipant(config);
+
+    // Drive a join carrying a transaction attribute, then a CRUD op, through the full stack. The
+    // outermost-type check above does not catch a dropped attribute-propagation layer (the type
+    // would still match); this behavioral check does, by confirming the attribute reaches the raw
+    // participant — proving the AttributePropagating layer is present and sits inside active
+    // transaction management.
+    participant.join("tx-1", false, Collections.singletonMap("k", "v"));
+    Insert insert =
+        Insert.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    participant.insert("tx-1", insert);
+
+    ArgumentCaptor<Insert> captor = ArgumentCaptor.forClass(Insert.class);
+    verify(rawParticipant).insert(eq("tx-1"), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void createTwoPhaseCommitParticipant_WhenRawParticipantIsNull_ShouldReturnNull() {
+    // Both wrappings are enabled to prove the null short-circuits before either wrapping.
+    when(config.isAttributePropagationEnabled()).thenReturn(true);
+    when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
+
+    TwoPhaseCommit.Participant participant =
+        unsupportedProvider().createTwoPhaseCommitParticipant(config);
+
+    assertThat(participant).isNull();
+  }
+
+  // A provider that does not support the two-phase commit interface: its raw factory methods return
+  // null.
+  private AbstractDistributedTransactionProvider unsupportedProvider() {
+    return new AbstractDistributedTransactionProvider() {
+      @Override
+      public String getName() {
+        return "unsupported";
+      }
+
+      @Override
+      protected DistributedTransactionManager createRawDistributedTransactionManager(
+          DatabaseConfig config) {
+        return mock(DistributedTransactionManager.class);
+      }
+
+      @Override
+      public DistributedTransactionAdmin createDistributedTransactionAdmin(DatabaseConfig config) {
+        return mock(DistributedTransactionAdmin.class);
+      }
+
+      @Override
+      protected TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
+          DatabaseConfig config) {
+        return null;
+      }
+
+      @Override
+      protected TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(
+          DatabaseConfig config) {
+        return null;
+      }
+
+      @Override
+      protected TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(
+          DatabaseConfig config) {
+        return null;
+      }
+    };
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -92,14 +93,12 @@ class AbstractDistributedTransactionProviderTest {
   }
 
   @Test
-  void createTwoPhaseCommitCoordinator_WhenRawCoordinatorIsNull_ShouldReturnNull() {
-    // Active transaction management is enabled to prove the null short-circuits before wrapping.
+  void createTwoPhaseCommitCoordinator_WhenUnsupported_ShouldThrowUnsupportedOperationException() {
+    // Active transaction management is enabled to prove the raw factory throws before wrapping.
     when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
 
-    TwoPhaseCommit.Coordinator coordinator =
-        unsupportedProvider().createTwoPhaseCommitCoordinator(config);
-
-    assertThat(coordinator).isNull();
+    assertThatThrownBy(() -> unsupportedProvider().createTwoPhaseCommitCoordinator(config))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
@@ -174,19 +173,18 @@ class AbstractDistributedTransactionProviderTest {
   }
 
   @Test
-  void createTwoPhaseCommitParticipant_WhenRawParticipantIsNull_ShouldReturnNull() {
-    // Both wrappings are enabled to prove the null short-circuits before either wrapping.
+  void createTwoPhaseCommitParticipant_WhenUnsupported_ShouldThrowUnsupportedOperationException() {
+    // Both wrappings are enabled to prove the raw factory throws before either wrapping.
     when(config.isAttributePropagationEnabled()).thenReturn(true);
     when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
 
-    TwoPhaseCommit.Participant participant =
-        unsupportedProvider().createTwoPhaseCommitParticipant(config);
-
-    assertThat(participant).isNull();
+    assertThatThrownBy(() -> unsupportedProvider().createTwoPhaseCommitParticipant(config))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
-  // A provider that does not support the two-phase commit interface: its raw factory methods return
-  // null.
+  // A provider that does not support the two-phase commit interface: its raw two-phase-commit
+  // factory
+  // methods throw UnsupportedOperationException.
   private AbstractDistributedTransactionProvider unsupportedProvider() {
     return new AbstractDistributedTransactionProvider() {
       @Override
@@ -214,13 +212,13 @@ class AbstractDistributedTransactionProviderTest {
       @Override
       protected TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(
           DatabaseConfig config) {
-        return null;
+        throw new UnsupportedOperationException();
       }
 
       @Override
       protected TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(
           DatabaseConfig config) {
-        return null;
+        throw new UnsupportedOperationException();
       }
     };
   }

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -1,0 +1,166 @@
+package com.scalar.db.common;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
+
+  private static final String TX = "tx-1";
+
+  // A short expiration so reaping fires quickly; the registry sweeps roughly every second.
+  private static final long EXPIRATION_MILLIS = 100;
+
+  // Long enough to cover at least one post-expiration sweep, used to assert reaping does NOT
+  // happen.
+  private static final long PAST_SWEEP_MILLIS = 1500;
+
+  @Mock private TwoPhaseCommit.Coordinator delegate;
+  @Mock private TwoPhaseCommit.Participant participant;
+  private ActiveTransactionManagedTwoPhaseCommitCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(delegate.begin(any(), eq(false), any(), any())).thenReturn(TX);
+    coordinator =
+        new ActiveTransactionManagedTwoPhaseCommitCoordinator(delegate, EXPIRATION_MILLIS);
+  }
+
+  @Test
+  void begin_ShouldDelegateAndRegister_ThenReapReleasesContextOnDelegate() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+
+    verify(delegate).begin(null, false, Collections.emptyMap(), null);
+    // After the idle expiration, the reaper releases the context on the wrapped coordinator.
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+  }
+
+  @Test
+  void registerParticipant_ShouldDelegate() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+
+    coordinator.registerParticipant(TX, participant);
+
+    verify(delegate).registerParticipant(TX, participant);
+  }
+
+  @Test
+  void commit_ShouldStopReaping() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+
+    coordinator.commit(TX);
+
+    verify(delegate).commit(TX);
+    // The transaction is no longer tracked, so the reaper must not release its context.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void rollback_ShouldStopReaping() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+
+    coordinator.rollback(TX);
+
+    verify(delegate).rollback(TX);
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void commit_WhenDelegateThrows_ShouldStillStopReaping() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+    doThrow(new CommitException("boom", TX)).when(delegate).commit(TX);
+
+    try {
+      coordinator.commit(TX);
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // The finally block deregistered the transaction even though commit threw, so the reaper must
+    // not subsequently release its context (no double reap).
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void rollback_WhenDelegateThrows_ShouldStillStopReaping() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+    doThrow(new RollbackException("boom", TX)).when(delegate).rollback(TX);
+
+    try {
+      coordinator.rollback(TX);
+    } catch (RollbackException ignored) {
+      // expected
+    }
+
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void releaseContext_ShouldDelegateOnceAndStopReaping() throws Exception {
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+
+    coordinator.releaseContext(TX);
+
+    // The reaper must not call releaseContext again after the client already released it.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate).releaseContext(TX);
+  }
+
+  @Test
+  void begin_WhenDelegateThrows_ShouldNotRegister() throws Exception {
+    doThrow(new TransactionException("boom", TX))
+        .when(delegate)
+        .begin(any(), eq(true), any(), any());
+
+    try {
+      coordinator.begin(null, true, Collections.emptyMap(), null);
+    } catch (TransactionException ignored) {
+      // expected
+    }
+
+    // A failed begin registered nothing, so the reaper must not release any context.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void begin_ShouldRegister_AndRegisterParticipant_ShouldRefreshIdleTimer() throws Exception {
+    // Deterministic wiring check (no Thread.sleep): begin registers the transaction and
+    // registerParticipant refreshes the idle timer via registry.touch(id) — the only
+    // coordinator-side call that extends a transaction's life. A mock registry verifies these
+    // directly, so a dropped touch() (which would let an active transaction be reaped) is caught
+    // immediately. The registerParticipant_ShouldDelegate test asserts delegation only and stays
+    // green without it.
+
+    ActiveTransactionRegistry<String> registry = mock(ActiveTransactionRegistry.class);
+    ActiveTransactionManagedTwoPhaseCommitCoordinator c =
+        new ActiveTransactionManagedTwoPhaseCommitCoordinator(delegate, registry);
+
+    c.begin(null, false, Collections.emptyMap(), null); // delegate.begin is stubbed to return TX
+    c.registerParticipant(TX, participant);
+
+    verify(registry).add(TX, TX); // begin tracks the transaction
+    verify(registry).touch(TX); // registerParticipant refreshes the idle timer
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -1,0 +1,362 @@
+package com.scalar.db.common;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.io.Key;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
+
+  private static final String NS = "ns";
+  private static final String TBL = "tbl";
+  private static final String TX = "tx-1";
+
+  // A short expiration so reaping fires quickly; the registry sweeps roughly every second.
+  private static final long EXPIRATION_MILLIS = 100;
+
+  // Long enough to cover at least one post-expiration sweep, used to assert reaping does NOT
+  // happen.
+  private static final long PAST_SWEEP_MILLIS = 1500;
+
+  @Mock private TwoPhaseCommit.Participant delegate;
+  private ActiveTransactionManagedTwoPhaseCommitParticipant participant;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    participant =
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(delegate, EXPIRATION_MILLIS);
+  }
+
+  private static Get get() {
+    return Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+  }
+
+  private static Insert insert() {
+    return Insert.newBuilder()
+        .namespace(NS)
+        .table(TBL)
+        .partitionKey(Key.ofInt("pk", 1))
+        .intValue("v", 1)
+        .build();
+  }
+
+  @Test
+  void join_ShouldDelegateAndRegister_ThenReapReleasesContextOnDelegate() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+
+    verify(delegate).join(TX, false, Collections.emptyMap());
+    // After the idle expiration, the reaper releases the context on the wrapped participant.
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+  }
+
+  @Test
+  void get_ShouldDelegate() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    Get get = get();
+
+    participant.get(TX, get);
+
+    verify(delegate).get(TX, get);
+  }
+
+  @Test
+  void insert_ShouldDelegate() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    Insert insert = insert();
+
+    participant.insert(TX, insert);
+
+    verify(delegate).insert(TX, insert);
+  }
+
+  @Test
+  void getScanner_ShouldDelegate() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+
+    participant.getScanner(TX, scan);
+
+    verify(delegate).getScanner(TX, scan);
+  }
+
+  // Stubs the wrapped participant's prepareRecords to report the given terminality, so the
+  // decorator
+  // can decide where this transaction's terminal step lands.
+  private void stubPrepare(boolean commitRequired, boolean validationRequired) throws Exception {
+    TwoPhaseCommit.PreparationResult result = mock(TwoPhaseCommit.PreparationResult.class);
+    when(result.isCommitRequired()).thenReturn(commitRequired);
+    when(result.isValidationRequired()).thenReturn(validationRequired);
+    when(delegate.prepareRecords(eq(TX), anyLong())).thenReturn(result);
+  }
+
+  @Test
+  void prepareRecords_ShouldDelegate() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(true, false); // commit required, so the entry stays until commitRecords
+
+    participant.prepareRecords(TX, 100L);
+
+    verify(delegate).prepareRecords(TX, 100L);
+  }
+
+  @Test
+  void prepareRecords_WriteLessAndNoValidation_ShouldStopReapingAtPrepare() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(false, false);
+
+    participant.prepareRecords(TX, 100L);
+
+    // prepareRecords is this participant's terminal step, so the entry is removed now: the reaper
+    // never releases the context (and logs no spurious expiry warning).
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void prepareRecords_WriteLessButValidationRequired_ShouldStopReapingAtValidate()
+      throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(false, true);
+
+    participant.prepareRecords(TX, 100L);
+    participant.validateRecords(TX); // terminal step for a write-less, validating participant
+
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void commitRequired_ShouldStopReapingAtCommit() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(true, true);
+
+    participant.prepareRecords(TX, 100L);
+    participant.validateRecords(TX); // not terminal: commitRecords is still to come
+    participant.commitRecords(TX, 1L); // terminal step
+
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void rollbackRecords_AfterValidateTerminalFlagged_ShouldStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(false, true); // flags the entry terminal-at-validate
+    participant.prepareRecords(TX, 100L);
+
+    // Abort before validate: rollbackRecords removes the entry (and with it the flag).
+    participant.rollbackRecords(TX);
+
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void validateRecords_WhenDelegateThrows_AndNoRollback_ShouldRemainReapable() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(false, true); // write-less but validating: validateRecords is the terminal step
+    participant.prepareRecords(TX, 100L);
+    doThrow(new ValidationException("boom", TX)).when(delegate).validateRecords(TX);
+
+    try {
+      participant.validateRecords(TX);
+    } catch (ValidationException ignored) {
+      // expected
+    }
+
+    // Removal is success-only: a failed validateRecords must NOT remove the entry (the abort path's
+    // rollbackRecords owns cleanup). With no rollback driven here, the entry survives, so the
+    // reaper
+    // still releases the context. This distinguishes "not removed on failure" from "removed": had
+    // the failure wrongly removed the entry, releaseContext would never fire and this would time
+    // out.
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+  }
+
+  @Test
+  void validateRecords_WhenDelegateThrows_ThenRollbackRecords_ShouldStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    stubPrepare(false, true); // write-less but validating: validateRecords is the terminal step
+    participant.prepareRecords(TX, 100L);
+    doThrow(new ValidationException("boom", TX)).when(delegate).validateRecords(TX);
+
+    try {
+      participant.validateRecords(TX);
+    } catch (ValidationException ignored) {
+      // expected
+    }
+
+    // The documented abort path: validateRecords failed, so the transaction aborts and
+    // rollbackRecords is driven, which removes the entry. The reaper must then not release it.
+    participant.rollbackRecords(TX);
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void commitRecords_ShouldStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+
+    participant.commitRecords(TX, 1L);
+
+    verify(delegate).commitRecords(TX, 1L);
+    // The transaction is no longer tracked, so the reaper must not release its context.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void rollbackRecords_ShouldStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+
+    participant.rollbackRecords(TX);
+
+    verify(delegate).rollbackRecords(TX);
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void commitRecords_WhenDelegateThrows_ShouldStillStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    doThrow(new CommitException("boom", TX)).when(delegate).commitRecords(TX, 1L);
+
+    try {
+      participant.commitRecords(TX, 1L);
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // The finally block deregistered the transaction even though commitRecords threw, so the
+    // reaper must not subsequently release its context (no double reap).
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void rollbackRecords_WhenDelegateThrows_ShouldStillStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    doThrow(new RollbackException("boom", TX)).when(delegate).rollbackRecords(TX);
+
+    try {
+      participant.rollbackRecords(TX);
+    } catch (RollbackException ignored) {
+      // expected
+    }
+
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(TX);
+  }
+
+  @Test
+  void releaseContext_ShouldDelegateOnceAndStopReaping() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+
+    participant.releaseContext(TX);
+
+    // The reaper must not call releaseContext again after the client already released it.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate).releaseContext(TX);
+  }
+
+  @Test
+  void join_WhenDelegateThrows_ShouldNotRegister() throws Exception {
+    doThrow(new TransactionException("boom", TX)).when(delegate).join(eq(TX), eq(false), any());
+
+    try {
+      participant.join(TX, false, Collections.emptyMap());
+    } catch (TransactionException ignored) {
+      // expected
+    }
+
+    // A failed join registered nothing, so the reaper must not release any context.
+    Thread.sleep(PAST_SWEEP_MILLIS);
+    verify(delegate, never()).releaseContext(any());
+  }
+
+  // Deterministic wiring check (no Thread.sleep): every CRUD and record-level override must refresh
+  // the idle timer via registry.touch(id). A mock registry verifies the call directly, so a dropped
+  // touch() in any of these methods is caught immediately rather than silently shortening the
+  // transaction's lifetime. This is the regression guard the *_ShouldDelegate tests do not provide:
+  // those assert delegation only and stay green even if touch() is removed.
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
+  void everyCrudAndRecordStep_ShouldRefreshIdleTimer_ByCallingTouch() throws Exception {
+    ActiveTransactionRegistry registry = mock(ActiveTransactionRegistry.class);
+    // validateRecords reads the entry back; return empty so it takes the no-op (non-terminal) path.
+    when(registry.get(TX)).thenReturn(Optional.empty());
+    ActiveTransactionManagedTwoPhaseCommitParticipant p =
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(delegate, registry);
+
+    Get get = get();
+    Insert insert = insert();
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    Update update =
+        Update.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    Delete delete =
+        Delete.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    stubPrepare(true, false); // commit required: prepareRecords leaves the entry for commitRecords
+
+    p.get(TX, get);
+    p.scan(TX, scan);
+    p.getScanner(TX, scan);
+    p.put(TX, put); // deprecated, but still a touch()-bearing override that must be guarded
+    p.insert(TX, insert);
+    p.upsert(TX, upsert);
+    p.update(TX, update);
+    p.delete(TX, delete);
+    p.mutate(TX, Collections.singletonList(insert));
+    p.batch(TX, Collections.singletonList(insert));
+    p.prepareRecords(TX, 100L);
+    p.validateRecords(TX);
+
+    // One touch per operation above; if any override drops its touch(), this count fails.
+    verify(registry, times(12)).touch(TX);
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
@@ -296,31 +296,15 @@ class AttributePropagatingTwoPhaseCommitParticipantTest {
   }
 
   @Test
-  void commitRecords_ForOneTransaction_ShouldNotDropAnotherTransactionsAttributes()
-      throws Exception {
-    participant.join("tx-1", false, attrs("k", "v1"));
-    participant.join("tx-2", false, attrs("k", "v2"));
-
-    participant.commitRecords("tx-1", 1L);
-
-    // tx-2 is untouched by tx-1's terminal step: its attributes still merge.
-    participant.get("tx-2", get());
-    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
-    verify(delegate).get(eq("tx-2"), captor.capture());
-    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v2");
-  }
-
-  @Test
-  void commitRecords_ShouldDropTheCapturedAttributes() throws Exception {
+  void commitRecords_ShouldForwardWithoutAttributeLogic() throws Exception {
     participant.join(TX, false, attrs("k", "v"));
 
     participant.commitRecords(TX, 1L);
 
-    // After the terminal step the attributes are gone: a later op for the same id merges nothing.
-    participant.get(TX, get());
-    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
-    verify(delegate).get(eq(TX), captor.capture());
-    assertThat(captor.getValue().getAttributes()).isEmpty();
+    // The captured attributes are dropped at prepareRecords, which always precedes commitRecords,
+    // so
+    // commitRecords itself is pure forwarding with no attribute handling.
+    verify(delegate).commitRecords(TX, 1L);
   }
 
   @Test
@@ -362,12 +346,46 @@ class AttributePropagatingTwoPhaseCommitParticipantTest {
   }
 
   @Test
-  void prepareRecords_ShouldForwardWithoutAttributeLogic() throws Exception {
+  void prepareRecords_ShouldForwardAndDropTheCapturedAttributes() throws Exception {
     participant.join(TX, false, attrs("k", "v"));
 
     participant.prepareRecords(TX, 100L);
 
-    // Record-level steps are pure forwarding; no attribute handling.
     verify(delegate).prepareRecords(TX, 100L);
+
+    // prepareRecords ends the CRUD phase, so the captured attributes are dropped here. This is the
+    // terminal step for a write-less transaction, whose commitRecords the Coordinator skips: a
+    // later
+    // op for the same id merges nothing.
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void prepareRecords_ForOneTransaction_ShouldNotDropAnotherTransactionsAttributes()
+      throws Exception {
+    participant.join("tx-1", false, attrs("k", "v1"));
+    participant.join("tx-2", false, attrs("k", "v2"));
+
+    participant.prepareRecords("tx-1", 100L);
+
+    // tx-2 is untouched by tx-1's terminal step: its attributes still merge.
+    participant.get("tx-2", get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq("tx-2"), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v2");
+  }
+
+  @Test
+  void validateRecords_ShouldForwardWithoutAttributeLogic() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.validateRecords(TX);
+
+    // validateRecords is pure forwarding; it does not read or drop the transaction-scoped
+    // attributes.
+    verify(delegate).validateRecords(TX);
   }
 }

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
@@ -1,0 +1,373 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AttributePropagatingTwoPhaseCommitParticipantTest {
+
+  private static final String NS = "ns";
+  private static final String TBL = "tbl";
+  private static final String TX = "tx-1";
+
+  @Mock private TwoPhaseCommit.Participant delegate;
+  private AttributePropagatingTwoPhaseCommitParticipant participant;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    participant = new AttributePropagatingTwoPhaseCommitParticipant(delegate);
+  }
+
+  private static Get get() {
+    return Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+  }
+
+  private static Insert insert() {
+    return Insert.newBuilder()
+        .namespace(NS)
+        .table(TBL)
+        .partitionKey(Key.ofInt("pk", 1))
+        .intValue("v", 1)
+        .build();
+  }
+
+  private static Map<String, String> attrs(String k, String v) {
+    Map<String, String> m = new HashMap<>();
+    m.put(k, v);
+    return m;
+  }
+
+  @Test
+  void get_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.get(TX, get());
+
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void get_WhenOperationAlreadyHasTheAttribute_ShouldKeepOperationValue() throws Exception {
+    participant.join(TX, false, attrs("k", "tx-value"));
+    Get getWithAttribute = Get.newBuilder(get()).attribute("k", "op-value").build();
+
+    participant.get(TX, getWithAttribute);
+
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    // Operation-level attribute wins over the transaction-scoped one.
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "op-value");
+  }
+
+  @Test
+  void get_AfterJoinWithEmptyAttributes_ShouldForwardOperationUnchanged() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    Get original = get();
+
+    participant.get(TX, original);
+
+    // No transaction attributes → the operation is forwarded as-is (no attributes added).
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void insert_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.insert(TX, insert());
+
+    ArgumentCaptor<Insert> captor = ArgumentCaptor.forClass(Insert.class);
+    verify(delegate).insert(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void put_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+
+    participant.put(TX, put);
+
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(delegate).put(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void upsert_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+
+    participant.upsert(TX, upsert);
+
+    ArgumentCaptor<Upsert> captor = ArgumentCaptor.forClass(Upsert.class);
+    verify(delegate).upsert(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void update_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Update update =
+        Update.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+
+    participant.update(TX, update);
+
+    ArgumentCaptor<Update> captor = ArgumentCaptor.forClass(Update.class);
+    verify(delegate).update(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void delete_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Delete delete =
+        Delete.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    participant.delete(TX, delete);
+
+    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
+    verify(delegate).delete(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void scan_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+
+    participant.scan(TX, scan);
+
+    ArgumentCaptor<Scan> captor = ArgumentCaptor.forClass(Scan.class);
+    verify(delegate).scan(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void getScanner_AfterJoinWithAttributes_ShouldMergeAttributesIntoOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+
+    participant.getScanner(TX, scan);
+
+    ArgumentCaptor<Scan> captor = ArgumentCaptor.forClass(Scan.class);
+    verify(delegate).getScanner(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mutate_AfterJoinWithAttributes_ShouldMergeAttributesIntoEachOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    Delete delete =
+        Delete.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 2)).build();
+
+    participant.mutate(TX, Arrays.asList(put, delete));
+
+    ArgumentCaptor<List<? extends Mutation>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).mutate(eq(TX), captor.capture());
+    for (Mutation mutation : captor.getValue()) {
+      assertThat(mutation.getAttributes()).containsEntry("k", "v");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void batch_AfterJoinWithAttributes_ShouldMergeAttributesIntoEachOperation() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.batch(TX, Arrays.asList(get(), insert()));
+
+    ArgumentCaptor<List<? extends Operation>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).batch(eq(TX), captor.capture());
+    for (Operation operation : captor.getValue()) {
+      assertThat(operation.getAttributes()).containsEntry("k", "v");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mutate_AfterJoinWithEmptyAttributes_ShouldForwardTheSameListUnchanged() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    Put put =
+        Put.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    Delete delete =
+        Delete.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 2)).build();
+    List<Mutation> mutations = Arrays.asList(put, delete);
+
+    participant.mutate(TX, mutations);
+
+    // No transaction attributes → the empty-attributes fast path forwards the original list without
+    // allocating a copy.
+    ArgumentCaptor<List<? extends Mutation>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).mutate(eq(TX), captor.capture());
+    assertThat(captor.getValue()).isSameAs(mutations);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void batch_AfterJoinWithEmptyAttributes_ShouldForwardTheSameListUnchanged() throws Exception {
+    participant.join(TX, false, Collections.emptyMap());
+    List<Operation> operations = Arrays.asList(get(), insert());
+
+    participant.batch(TX, operations);
+
+    ArgumentCaptor<List<? extends Operation>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).batch(eq(TX), captor.capture());
+    assertThat(captor.getValue()).isSameAs(operations);
+  }
+
+  @Test
+  void get_WithTwoTransactions_ShouldMergeEachTransactionsOwnAttributes() throws Exception {
+    participant.join("tx-1", false, attrs("k", "v1"));
+    participant.join("tx-2", false, attrs("k", "v2"));
+
+    participant.get("tx-1", get());
+    participant.get("tx-2", get());
+
+    ArgumentCaptor<Get> captor1 = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq("tx-1"), captor1.capture());
+    assertThat(captor1.getValue().getAttributes()).containsEntry("k", "v1");
+
+    ArgumentCaptor<Get> captor2 = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq("tx-2"), captor2.capture());
+    assertThat(captor2.getValue().getAttributes()).containsEntry("k", "v2");
+  }
+
+  @Test
+  void commitRecords_ForOneTransaction_ShouldNotDropAnotherTransactionsAttributes()
+      throws Exception {
+    participant.join("tx-1", false, attrs("k", "v1"));
+    participant.join("tx-2", false, attrs("k", "v2"));
+
+    participant.commitRecords("tx-1", 1L);
+
+    // tx-2 is untouched by tx-1's terminal step: its attributes still merge.
+    participant.get("tx-2", get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq("tx-2"), captor.capture());
+    assertThat(captor.getValue().getAttributes()).containsEntry("k", "v2");
+  }
+
+  @Test
+  void commitRecords_ShouldDropTheCapturedAttributes() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.commitRecords(TX, 1L);
+
+    // After the terminal step the attributes are gone: a later op for the same id merges nothing.
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void rollbackRecords_ShouldDropTheCapturedAttributes() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.rollbackRecords(TX);
+
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void releaseContext_ShouldDropTheCapturedAttributes() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.releaseContext(TX);
+
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void join_WhenDelegateThrows_ShouldNotCaptureAttributes() throws Exception {
+    doThrow(new TransactionException("boom", TX)).when(delegate).join(eq(TX), eq(false), any());
+
+    assertThatThrownBy(() -> participant.join(TX, false, attrs("k", "v")))
+        .isInstanceOf(TransactionException.class);
+
+    // A failed join stored nothing, so a later op for the same id merges nothing.
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void prepareRecords_ShouldForwardWithoutAttributeLogic() throws Exception {
+    participant.join(TX, false, attrs("k", "v"));
+
+    participant.prepareRecords(TX, 100L);
+
+    // Record-level steps are pure forwarding; no attribute handling.
+    verify(delegate).prepareRecords(TX, 100L);
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
@@ -1,0 +1,67 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.TwoPhaseCommit;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class DecoratedTwoPhaseCommitCoordinatorTest {
+
+  private static final String TX = "tx-1";
+
+  @Mock private TwoPhaseCommit.Coordinator delegate;
+  @Mock private TwoPhaseCommit.Participant participant;
+  private DecoratedTwoPhaseCommitCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    // A no-op subclass that adds nothing — every method should delegate to the wrapped coordinator.
+    coordinator = new DecoratedTwoPhaseCommitCoordinator(delegate) {};
+  }
+
+  @Test
+  void begin_ShouldDelegate() throws Exception {
+    when(delegate.begin(any(), eq(false), eq(Collections.emptyMap()), any())).thenReturn(TX);
+    assertThat(coordinator.begin(null, false, Collections.emptyMap(), null)).isEqualTo(TX);
+    verify(delegate).begin(null, false, Collections.emptyMap(), null);
+  }
+
+  @Test
+  void registerParticipant_ShouldDelegate() throws Exception {
+    coordinator.registerParticipant(TX, participant);
+    verify(delegate).registerParticipant(TX, participant);
+  }
+
+  @Test
+  void commit_ShouldDelegate() throws Exception {
+    coordinator.commit(TX);
+    verify(delegate).commit(TX);
+  }
+
+  @Test
+  void rollback_ShouldDelegate() throws Exception {
+    coordinator.rollback(TX);
+    verify(delegate).rollback(TX);
+  }
+
+  @Test
+  void releaseContext_ShouldDelegate() {
+    coordinator.releaseContext(TX);
+    verify(delegate).releaseContext(TX);
+  }
+
+  @Test
+  void close_ShouldDelegate() {
+    coordinator.close();
+    verify(delegate).close();
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
@@ -1,0 +1,113 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.io.Key;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class DecoratedTwoPhaseCommitParticipantTest {
+
+  private static final String NS = "ns";
+  private static final String TBL = "tbl";
+  private static final String TX = "tx-1";
+
+  @Mock private TwoPhaseCommit.Participant delegate;
+  private DecoratedTwoPhaseCommitParticipant participant;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    // A no-op subclass that adds nothing — every method should delegate to the wrapped participant.
+    participant = new DecoratedTwoPhaseCommitParticipant(delegate) {};
+  }
+
+  @Test
+  void getId_ShouldDelegate() {
+    when(delegate.getId()).thenReturn("participant-1");
+    assertThat(participant.getId()).isEqualTo("participant-1");
+    verify(delegate).getId();
+  }
+
+  @Test
+  void join_ShouldDelegate() throws Exception {
+    participant.join(TX, true, Collections.emptyMap());
+    verify(delegate).join(TX, true, Collections.emptyMap());
+  }
+
+  @Test
+  void get_ShouldDelegate() throws Exception {
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+    when(delegate.get(eq(TX), any(Get.class))).thenReturn(Optional.empty());
+    assertThat(participant.get(TX, get)).isEmpty();
+    verify(delegate).get(TX, get);
+  }
+
+  @Test
+  void scan_ShouldDelegate() throws Exception {
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+    participant.scan(TX, scan);
+    verify(delegate).scan(TX, scan);
+  }
+
+  @Test
+  void insert_ShouldDelegate() throws Exception {
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .intValue("v", 1)
+            .build();
+    participant.insert(TX, insert);
+    verify(delegate).insert(TX, insert);
+  }
+
+  @Test
+  void prepareRecords_ShouldDelegate() throws Exception {
+    participant.prepareRecords(TX, 100L);
+    verify(delegate).prepareRecords(TX, 100L);
+  }
+
+  @Test
+  void validateRecords_ShouldDelegate() throws Exception {
+    participant.validateRecords(TX);
+    verify(delegate).validateRecords(TX);
+  }
+
+  @Test
+  void commitRecords_ShouldDelegate() throws Exception {
+    participant.commitRecords(TX, 200L);
+    verify(delegate).commitRecords(TX, 200L);
+  }
+
+  @Test
+  void rollbackRecords_ShouldDelegate() throws Exception {
+    participant.rollbackRecords(TX);
+    verify(delegate).rollbackRecords(TX);
+  }
+
+  @Test
+  void releaseContext_ShouldDelegate() {
+    participant.releaseContext(TX);
+    verify(delegate).releaseContext(TX);
+  }
+
+  @Test
+  void close_ShouldDelegate() {
+    participant.close();
+    verify(delegate).close();
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/OperationAttributeMergerTest.java
+++ b/core/src/test/java/com/scalar/db/common/OperationAttributeMergerTest.java
@@ -1,0 +1,183 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OperationAttributeMergerTest {
+
+  private static final String NS = "ns";
+  private static final String TBL = "tbl";
+
+  private static Map<String, String> attrs(String k, String v) {
+    Map<String, String> m = new HashMap<>();
+    m.put(k, v);
+    return m;
+  }
+
+  private static Get getWithoutAttr() {
+    return Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+  }
+
+  private static Get getWithAttr(String k, String v) {
+    return Get.newBuilder()
+        .namespace(NS)
+        .table(TBL)
+        .partitionKey(Key.ofInt("pk", 1))
+        .attribute(k, v)
+        .build();
+  }
+
+  @Test
+  void merge_WhenOperationMissingKey_ShouldAddTransactionAttribute() {
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    Get merged = OperationAttributeMerger.merge(get, attrs("k", "v"));
+
+    assertThat(merged.getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void merge_WhenOperationHasKey_ShouldKeepOperationValue() {
+    Get get =
+        Get.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .attribute("k", "op-value")
+            .build();
+
+    Get merged = OperationAttributeMerger.merge(get, attrs("k", "tx-value"));
+
+    assertThat(merged.getAttributes()).containsEntry("k", "op-value");
+  }
+
+  @Test
+  void merge_WhenOperationHasSomeButNotAllKeys_ShouldFillMissingAndKeepExisting() {
+    Get get =
+        Get.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .attribute("k1", "op-value")
+            .build();
+    Map<String, String> transactionAttributes = new HashMap<>();
+    transactionAttributes.put("k1", "tx-value-1");
+    transactionAttributes.put("k2", "tx-value-2");
+
+    Get merged = OperationAttributeMerger.merge(get, transactionAttributes);
+
+    // Partial overlap: the operation already carries k1 (kept, operation wins) while the missing k2
+    // is filled from the transaction. Exercises the per-key guard, not just the all-or-nothing
+    // path.
+    assertThat(merged.getAttributes()).containsEntry("k1", "op-value");
+    assertThat(merged.getAttributes()).containsEntry("k2", "tx-value-2");
+  }
+
+  @Test
+  void merge_WhenNoTransactionAttributes_ShouldReturnSameOperation() {
+    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
+
+    Get merged = OperationAttributeMerger.merge(get, Collections.emptyMap());
+
+    // Empty attributes: the operation is returned unchanged (same reference).
+    assertThat(merged).isSameAs(get);
+  }
+
+  @Test
+  void merge_WhenOperationAlreadyHasAllKeys_ShouldReturnSameOperation() {
+    Get get =
+        Get.newBuilder()
+            .namespace(NS)
+            .table(TBL)
+            .partitionKey(Key.ofInt("pk", 1))
+            .attribute("k", "op-value")
+            .build();
+
+    Get merged = OperationAttributeMerger.merge(get, attrs("k", "tx-value"));
+
+    // The operation already carries every transaction-attribute key → returned unchanged (same
+    // reference), nothing to merge.
+    assertThat(merged).isSameAs(get);
+  }
+
+  @Test
+  void merge_ShouldPreserveOperationSubtypeForEachType() {
+    Key pk = Key.ofInt("pk", 1);
+    Map<String, String> a = attrs("k", "v");
+
+    Put put = Put.newBuilder().namespace(NS).table(TBL).partitionKey(pk).intValue("v", 1).build();
+    Insert insert =
+        Insert.newBuilder().namespace(NS).table(TBL).partitionKey(pk).intValue("v", 1).build();
+    Upsert upsert =
+        Upsert.newBuilder().namespace(NS).table(TBL).partitionKey(pk).intValue("v", 1).build();
+    Update update =
+        Update.newBuilder().namespace(NS).table(TBL).partitionKey(pk).intValue("v", 1).build();
+    Delete delete = Delete.newBuilder().namespace(NS).table(TBL).partitionKey(pk).build();
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+
+    assertThat(OperationAttributeMerger.merge(put, a)).isInstanceOf(Put.class);
+    assertThat(OperationAttributeMerger.merge(put, a).getAttributes()).containsEntry("k", "v");
+    assertThat(OperationAttributeMerger.merge(insert, a)).isInstanceOf(Insert.class);
+    assertThat(OperationAttributeMerger.merge(insert, a).getAttributes()).containsEntry("k", "v");
+    assertThat(OperationAttributeMerger.merge(upsert, a)).isInstanceOf(Upsert.class);
+    assertThat(OperationAttributeMerger.merge(upsert, a).getAttributes()).containsEntry("k", "v");
+    assertThat(OperationAttributeMerger.merge(update, a)).isInstanceOf(Update.class);
+    assertThat(OperationAttributeMerger.merge(update, a).getAttributes()).containsEntry("k", "v");
+    assertThat(OperationAttributeMerger.merge(delete, a)).isInstanceOf(Delete.class);
+    assertThat(OperationAttributeMerger.merge(delete, a).getAttributes()).containsEntry("k", "v");
+    assertThat(OperationAttributeMerger.merge(scan, a)).isInstanceOf(Scan.class);
+    assertThat(OperationAttributeMerger.merge(scan, a).getAttributes()).containsEntry("k", "v");
+  }
+
+  @Test
+  void mergeEach_WhenNoTransactionAttributes_ShouldReturnSameListReference() {
+    List<Get> operations = Arrays.asList(getWithoutAttr(), getWithoutAttr());
+
+    List<Get> merged = OperationAttributeMerger.mergeEach(operations, Collections.emptyMap());
+
+    // No transaction attributes: nothing to merge, so the original list is returned (no copy).
+    assertThat(merged).isSameAs(operations);
+  }
+
+  @Test
+  void mergeEach_WhenNoOperationNeedsMerging_ShouldReturnSameListReference() {
+    List<Get> operations = Arrays.asList(getWithAttr("k", "a"), getWithAttr("k", "b"));
+
+    List<Get> merged = OperationAttributeMerger.mergeEach(operations, attrs("k", "tx"));
+
+    // Every operation already carries the transaction-attribute key → no element changes, so the
+    // original list is returned (no copy).
+    assertThat(merged).isSameAs(operations);
+  }
+
+  @Test
+  void mergeEach_WhenSomeOperationsNeedMerging_ShouldCopyPreservingOrderAndUnchangedElements() {
+    Get has = getWithAttr("k", "op"); // already carries the key → kept as-is
+    Get missing = getWithoutAttr(); // missing the key → merged
+    List<Get> operations = Arrays.asList(has, missing);
+
+    List<Get> merged = OperationAttributeMerger.mergeEach(operations, attrs("k", "tx"));
+
+    // At least one element changed: a new list is allocated, order preserved, the unchanged element
+    // kept by reference, and the missing-key element gets the transaction attribute.
+    assertThat(merged).isNotSameAs(operations);
+    assertThat(merged).hasSize(2);
+    assertThat(merged.get(0)).isSameAs(has);
+    assertThat(merged.get(0).getAttributes()).containsEntry("k", "op");
+    assertThat(merged.get(1).getAttributes()).containsEntry("k", "tx");
+  }
+}

--- a/core/src/test/java/com/scalar/db/util/ActiveExpiringMapTest.java
+++ b/core/src/test/java/com/scalar/db/util/ActiveExpiringMapTest.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
@@ -206,6 +207,31 @@ public class ActiveExpiringMapTest {
 
     // Assert
     assertThat(lastUpdateTimeAfterUpdate).isGreaterThan(lastUpdateTimeBeforeUpdate);
+  }
+
+  @Test
+  public void valueExpirationThread_ShouldNotEvictRecentlyUpdatedValue_ButEvictsIdleValue() {
+    // Arrange: a 300ms lifetime with a 25ms sweep interval. This asserts the contract the higher
+    // layers rely on — refreshing the expiration time (via touch/updateExpirationTime) actually
+    // prevents the background reaper from evicting an entry — not merely that the timestamp field
+    // moves (covered by updateExpirationTime_ShouldBehaveCorrectly).
+    Set<String> expired = ConcurrentHashMap.newKeySet();
+    ActiveExpiringMap<String, String> activeExpiringMap =
+        new ActiveExpiringMap<>(300, 25, (k, v) -> expired.add(k));
+    activeExpiringMap.put("touched", "v");
+    activeExpiringMap.put("idle", "v");
+
+    // Act: keep refreshing "touched" across more than one lifetime window; never touch "idle".
+    for (int i = 0; i < 6; i++) {
+      Uninterruptibles.sleepUninterruptibly(80, TimeUnit.MILLISECONDS);
+      activeExpiringMap.updateExpirationTime("touched");
+    }
+
+    // Assert: the reaper evicted the idle value and fired its handler, but honored the refreshed
+    // timer of the touched value, which is still present.
+    assertThat(expired).contains("idle");
+    assertThat(expired).doesNotContain("touched");
+    assertThat(activeExpiringMap.get("touched")).hasValue("v");
   }
 
   @Test


### PR DESCRIPTION
## Description

The legacy manager-shaped transaction API gets cross-cutting behavior — transaction-scoped attribute propagation and active-transaction (idle) management — from core-side decorators. This PR adds the equivalent decorators for the new id-based `TwoPhaseCommit` Coordinator/Participant roles, their forwarding bases, and the provider wiring that applies them, so deployments built on these roles get the same behavior without re-implementing it per role.

## Related issues and/or PRs

- `TwoPhaseCommit.Coordinator` / `TwoPhaseCommit.Participant` are introduced in #3660 and implemented in #3662.
- Builds on the reap-only `releaseContext` primitive added in #3668.

## Changes made

- **Forwarding bases** `DecoratedTwoPhaseCommitParticipant` / `DecoratedTwoPhaseCommitCoordinator`: role decorators override only the methods they need (id-based counterparts of the manager-API `DecoratedDistributedTransactionManager`).
- **`OperationAttributeMerger`**: the per-operation-type attribute-merge logic extracted from `AttributePropagatingDistributedTransaction` (operation value wins on key clash), plus a `mergeEach` helper for list merging that allocates a new list only when some element actually needs merging. Both the legacy manager-shaped decorator and the new participant decorator route through it (single implementation; legacy behavior unchanged, guarded by the existing tests).
- **`AttributePropagatingTwoPhaseCommitParticipant`**: captures the begin-attributes at `join` (keyed by transaction id) and merges them into every CRUD operation before delegating, so it sits outside any decorator that reads operation attributes (e.g. ABAC). Captured attributes are dropped on the transaction's terminal step (`commitRecords` / `rollbackRecords` / `releaseContext`).
- **`ActiveTransactionManagedTwoPhaseCommitCoordinator` / `...Participant`** (with `ActiveTransactionRegistry#touch`): track each transaction from `begin`/`join` until its terminal step and, on idle expiry, call `releaseContext` on the wrapped role (no storage rollback) instead of rollback, so records are recovered lazily. The participant reaps on true idle time (every CRUD/record step refreshes the timer); the coordinator measures idle from the last coordinator-observed call (`begin`/`registerParticipant`), since it does not observe CRUD against participants. Both are intended to be the outermost decorator so the reap traverses the inner decorators via `releaseContext`.
- Generalized `ActiveTransactionRegistry`'s expiration callback (`TransactionRollback#rollback` → `ExpirationHandler#onExpired`) so it serves any disposal action, not just rollback; the existing `ActiveTransactionManaged{DistributedTransaction,TwoPhaseCommitTransaction}Manager` are updated to the renamed handler with no behavior change.
- **`AbstractDistributedTransactionProvider` wiring**: `createTwoPhaseCommitCoordinator` wraps with the active-transaction-management decorator when enabled; `createTwoPhaseCommitParticipant` wraps with attribute propagation (inner) then active transaction management (outermost) when enabled, mirroring `createDistributedTransactionManager`. Subclasses provide the raw role instances via the new `createRawTwoPhaseCommit{Coordinator,Participant}` abstracts. When a raw factory returns `null` (a transaction manager that does not support the two-phase commit interface, e.g. JDBC or single-CRUD-operation), the wrapper short-circuits and returns `null` before any wrapping, mirroring `createTwoPhaseCommitTransactionManager`. The coordinator gets no attribute-propagation wrapping (no CRUD), and neither role gets state-management wrapping (handled natively).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- These decorators are generic over the `TwoPhaseCommit` interface; their `@ThreadSafe` guarantee relies on the wrapped role serializing its own per-transaction work (as `ConsensusCommit{Coordinator,Participant}` do on a per-context monitor), since the reaper may call `releaseContext` concurrently with an in-flight call for the same transaction id.
- Unit tests are added/updated for the forwarding bases, the merger (incl. `mergeEach`), both attribute-propagation decorators, both active-transaction-management reapers, the provider wiring (including the unsupported-manager null short-circuit), and the `ActiveExpiringMap` refresh-vs-eviction contract.

## Release notes

N/A

