### PR TITLE
Backport to branch(3) : Refactor Coordinator: externalize State timestamp and unify the id-based API

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -457,7 +457,9 @@ public class CommitHandler {
       throws CommitConflictException, UnknownTransactionStatusException {
     String id = context.transactionId;
     try {
-      Coordinator.State state = new Coordinator.State(id, writeSet, TransactionState.COMMITTED);
+      Coordinator.State state =
+          new Coordinator.State(
+              id, writeSet, TransactionState.COMMITTED, System.currentTimeMillis());
       coordinator.putState(state);
       logger.debug(
           "Transaction {} is committed successfully at {}", id, System.currentTimeMillis());
@@ -539,7 +541,8 @@ public class CommitHandler {
   private TransactionState abortStateInternal(String id, @Nullable WriteSet writeSet)
       throws UnknownTransactionStatusException {
     try {
-      Coordinator.State state = new Coordinator.State(id, writeSet, TransactionState.ABORTED);
+      Coordinator.State state =
+          new Coordinator.State(id, writeSet, TransactionState.ABORTED, System.currentTimeMillis());
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
@@ -612,11 +615,11 @@ public class CommitHandler {
    * DistributedTransactionManager.rollback(String)} / {@code abort(String)} path), where only the
    * transaction ID is known.
    *
-   * <p>This delegates to {@link Coordinator#putStateForLazyRecoveryRollback(String)}, which
-   * branches on the given ID: for a group commit full key it uses the same two-step protocol as
-   * lazy recovery, writing the parent-ID conflict marker before the full-ID ABORTED record so the
-   * abort wins against an in-flight normal group commit (which writes the COMMITTED state under the
-   * parent ID); for a non-group-commit ID it just writes the ABORTED record.
+   * <p>This delegates to {@link Coordinator#forceAbort(String)}, which branches on the given ID:
+   * for a group commit full key it uses the same two-step protocol as lazy recovery, writing the
+   * parent-ID conflict marker before the full-ID ABORTED record so the abort wins against an
+   * in-flight normal group commit (which writes the COMMITTED state under the parent ID); for a
+   * non-group-commit ID it just writes the ABORTED record.
    *
    * @param id the transaction ID
    * @return the resulting transaction state — either {@link TransactionState#ABORTED} or, if a
@@ -627,7 +630,7 @@ public class CommitHandler {
   public TransactionState abortStateForRollback(String id)
       throws UnknownTransactionStatusException {
     try {
-      coordinator.putStateForLazyRecoveryRollback(id);
+      coordinator.forceAbort(id);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
       // Resolves the final transaction state after our ABORTED putIfNotExists lost the race, for

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -9,6 +9,7 @@ import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
+import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.Emittable;
 import com.scalar.db.util.groupcommit.GroupCommitConflictException;
@@ -23,6 +24,8 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class CommitHandlerWithGroupCommit extends CommitHandler {
   private static final Logger logger = LoggerFactory.getLogger(CommitHandlerWithGroupCommit.class);
+  private static final CoordinatorGroupCommitKeyManipulator KEY_MANIPULATOR =
+      new CoordinatorGroupCommitKeyManipulator();
   private final CoordinatorGroupCommitter groupCommitter;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -181,10 +184,16 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       }
 
       // These transactions are contained in a normal group that has multiple transactions.
-      // Therefore, the transaction states should be put together in Coordinator.State.
-      List<String> transactionIds = new ArrayList<>(contexts.size());
+      // Therefore, the transaction states should be put together in Coordinator.State. The State
+      // carries the child IDs derived from each transaction's full ID; the parent ID is the row's
+      // partition key.
+      if (KEY_MANIPULATOR.isFullKey(parentId)) {
+        throw new AssertionError(
+            "emitNormalGroup is only for normal group commits that use a parent ID as the key");
+      }
+      List<String> childIds = new ArrayList<>(contexts.size());
       for (TransactionContext context : contexts) {
-        transactionIds.add(context.transactionId);
+        childIds.add(KEY_MANIPULATOR.keysFromFullKey(context.transactionId).childKey);
       }
 
       // Skip WriteSet encoding when write-set logging is disabled — the column is not part of the
@@ -193,12 +202,13 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
           coordinatorWriteSetLoggingEnabled
               ? writeSetEncoder.encodeMultiGroupWriteSet(contexts, false)
               : null;
-      coordinator.putStateForGroupCommit(
-          parentId,
-          transactionIds,
-          writeSet,
-          TransactionState.COMMITTED,
-          System.currentTimeMillis());
+      coordinator.putState(
+          new State(
+              parentId,
+              childIds,
+              writeSet,
+              TransactionState.COMMITTED,
+              System.currentTimeMillis()));
 
       logger.debug(
           "Transaction {} (parent ID) is committed successfully at {}",
@@ -217,7 +227,8 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
           coordinatorWriteSetLoggingEnabled
               ? writeSetEncoder.encodeSingleGroupWriteSet(context, false)
               : null;
-      coordinator.putState(new State(fullId, writeSet, TransactionState.COMMITTED));
+      coordinator.putState(
+          new State(fullId, writeSet, TransactionState.COMMITTED, System.currentTimeMillis()));
 
       logger.debug(
           "Transaction {} is committed successfully at {}", fullId, System.currentTimeMillis());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -674,10 +674,11 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       }
     }
 
-    // Perform the Coordinator state cleanup (delete the state row). state.getId() is the parent ID
-    // for group-commit rows because Coordinator#getState(fullChildId) routes through
-    // getStateForGroupCommit() and returns the parent row, so the delete targets the right row in
-    // both single and group cases.
+    // Perform the Coordinator state cleanup (delete the state row). state.getId() is the key the
+    // row actually lives under: the parent ID for a normal group commit, or the full ID for a
+    // single or delayed commit (Coordinator#getState routes a full child ID through
+    // getStateForGroupCommit and returns the resolved row). Coordinator#deleteState handles full
+    // keys internally, so the delete targets the right row in both cases.
     // Coordinator#deleteState is unconditional and benign on a concurrent delete.
     try {
       coordinator.deleteState(state.getId());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -25,7 +25,6 @@ import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.Coord
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -37,6 +36,70 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the Coordinator table, the single source of truth for each transaction's final state
+ * ({@link TransactionState#COMMITTED} or {@link TransactionState#ABORTED}). Every coordinator-state
+ * write in the system funnels through this class, so the conflict-safety of the whole protocol is
+ * decided here. All writes are conditional (put-if-not-exists on the {@code tx_id} partition key),
+ * so two writers targeting the same key race and exactly one wins with a {@link
+ * CoordinatorConflictException}; the loser then reads the persisted state and follows it.
+ *
+ * <h3>Key scheme</h3>
+ *
+ * The {@code tx_id} partition key is either a plain transaction ID or, when coordinator group
+ * commit is enabled, a group-commit key distinguished by {@code KEY_MANIPULATOR.isFullKey(id)}:
+ *
+ * <ul>
+ *   <li><b>parent ID</b> — the key for a <i>normal group</i>: one record under the parent ID lists
+ *       the child IDs of all transactions committed together (written by {@code
+ *       CommitHandlerWithGroupCommit.Emitter#emitNormalGroup} via {@link #putState}).
+ *   <li><b>full ID</b> ({@code parent + child}) — the key for a transaction committed on its own: a
+ *       <i>delayed</i> group commit, or a transaction whose lifecycle abort writes under its own
+ *       full ID.
+ * </ul>
+ *
+ * <h3>Write paths (non-group-commit)</h3>
+ *
+ * When group commit is disabled, every {@code tx_id} is a plain ID and there is only one possible
+ * key per transaction, so a single {@link #putState} is always safe:
+ *
+ * <ul>
+ *   <li>commit / abort during a transaction's own lifecycle — {@code CommitHandler.commitState} /
+ *       {@code abortState} write {@code putState(txId, COMMITTED|ABORTED)}.
+ *   <li>lazy recovery and manager-level rollback/abort by ID — {@link #forceAbort} takes the
+ *       non-full branch and writes {@code putState(txId, ABORTED)}.
+ * </ul>
+ *
+ * <h3>Write paths (group commit)</h3>
+ *
+ * With group commit enabled a transaction may be committed under <i>either</i> key, so an abort
+ * must be careful not to write under a key that does not conflict with the commit:
+ *
+ * <ul>
+ *   <li><b>normal group commit</b> — {@code CommitHandlerWithGroupCommit.Emitter#emitNormalGroup}
+ *       writes {@code COMMITTED} under the parent ID via {@link #putState}.
+ *   <li><b>delayed group commit</b> — {@code CommitHandlerWithGroupCommit.Emitter#emitDelayedGroup}
+ *       writes {@code putState(fullId, COMMITTED)}.
+ *   <li><b>lifecycle abort</b> ({@link CommitHandlerWithGroupCommit#abortState}) — writes {@code
+ *       putState(fullId, ABORTED)}. Safe because the caller first removes the slot from the group
+ *       committer (so a normal group commit can no longer list this child under the parent ID), and
+ *       against a delayed commit it conflicts on the same full ID.
+ *   <li><b>lazy recovery / manager-level rollback-or-abort by ID</b> — {@link #forceAbort} runs the
+ *       two-step protocol: write the parent-ID conflict marker (empty {@code tx_child_ids}) first,
+ *       then the full-ID {@code ABORTED} record. Needed because the caller does <i>not</i> own the
+ *       slot and cannot remove it, so an in-flight normal group commit could still write {@code
+ *       COMMITTED} under the parent ID. See {@link #forceAbort} for the full case analysis.
+ * </ul>
+ *
+ * <h3>Invariant for a plain single-{@code putState} abort</h3>
+ *
+ * Writing {@code ABORTED} with one {@link #putState} is correct only when no concurrent group
+ * commit can write {@code COMMITTED} under the parent ID for that transaction — i.e. <i>either</i>
+ * the ID is not a group-commit full key (group commit disabled, or the two-phase-commit interface,
+ * which forbids group commit), <i>or</i> the caller has already removed the slot from the group
+ * committer (the lifecycle-abort path above). When neither holds (a manager-level abort/rollback by
+ * ID), the two-step {@link #forceAbort} must be used instead.
+ */
 @ThreadSafe
 public class Coordinator {
   public static final String NAMESPACE = "coordinator";
@@ -117,7 +180,7 @@ public class Coordinator {
 
     String parentId = idForGroupCommit.parentKey;
     String childId = idForGroupCommit.childKey;
-    Optional<State> state = getStateByParentId(parentId);
+    Optional<State> state = getStateInternal(parentId);
     // The current implementation is optimized for cases where most transactions are
     // group-committed. It first looks up a transaction state using the parent ID with a single read
     // operation. If no matching transaction state is found (i.e., the transaction was delayed and
@@ -134,7 +197,7 @@ public class Coordinator {
       return stateContainingTargetTxId;
     }
 
-    return getStateByFullId(fullId);
+    return getStateInternal(fullId);
   }
 
   private Optional<Coordinator.State> getStateInternal(String id) throws CoordinatorException {
@@ -142,82 +205,21 @@ public class Coordinator {
     return get(get, id);
   }
 
-  /**
-   * Gets the coordinator state by the parent ID for the coordinator group commit. Note: The scope
-   * of this method has public visibility, but is intended for internal use. Also, the method only
-   * calls {@link #getStateInternal(String)} with the parent ID, but it exists as a separate method
-   * for clarifying this specific use case.
-   *
-   * @param parentId the parent ID of the coordinator state for the coordinator group commit
-   * @return the coordinator state
-   * @throws CoordinatorException if the coordinator state cannot be retrieved
-   */
-  public Optional<Coordinator.State> getStateByParentId(String parentId)
-      throws CoordinatorException {
-    return getStateInternal(parentId);
-  }
-
-  /**
-   * Gets the coordinator state by the full ID for the coordinator group commit. Note: The scope of
-   * this method has public visibility, but is intended for internal use. Also, the method only
-   * calls {@link #getStateInternal(String)} with the parent ID, but it exists as a separate method
-   * for clarifying this specific use case.
-   *
-   * @param fullId the parent ID of the coordinator state for the coordinator group commit
-   * @return the coordinator state
-   * @throws CoordinatorException if the coordinator state cannot be retrieved
-   */
-  public Optional<Coordinator.State> getStateByFullId(String fullId) throws CoordinatorException {
-    return getStateInternal(fullId);
-  }
-
   public void putState(Coordinator.State state) throws CoordinatorException {
     Put put = createPutWith(state);
     put(put, state.getId());
   }
 
-  void putStateForGroupCommit(
-      String parentId, List<String> fullIds, TransactionState transactionState, long createdAt)
-      throws CoordinatorException {
-    putStateForGroupCommit(parentId, fullIds, null, transactionState, createdAt);
-  }
-
-  void putStateForGroupCommit(
-      String parentId,
-      List<String> fullIds,
-      @Nullable WriteSet writeSet,
-      TransactionState transactionState,
-      long createdAt)
-      throws CoordinatorException {
-
-    if (KEY_MANIPULATOR.isFullKey(parentId)) {
-      throw new AssertionError(
-          "This method is only for normal group commits that use a parent ID as the key");
-    }
-
-    // Put the state that contains a parent ID as the key and multiple child transaction IDs.
-    List<String> childIds = new ArrayList<>(fullIds.size());
-    for (String fullId : fullIds) {
-      Keys<String, String, String> keys = KEY_MANIPULATOR.keysFromFullKey(fullId);
-      childIds.add(keys.childKey);
-    }
-    State state = new State(parentId, childIds, writeSet, transactionState, createdAt);
-
-    Put put = createPutWith(state);
-    put(put, state.getId());
-  }
-
-  public void putStateForLazyRecoveryRollback(String id) throws CoordinatorException {
+  public void forceAbort(String id) throws CoordinatorException {
     if (KEY_MANIPULATOR.isFullKey(id)) {
-      putStateForLazyRecoveryRollbackForGroupCommit(id);
+      forceAbortForGroupCommit(id);
       return;
     }
 
-    putState(new Coordinator.State(id, TransactionState.ABORTED));
+    putState(new Coordinator.State(id, TransactionState.ABORTED, System.currentTimeMillis()));
   }
 
-  private void putStateForLazyRecoveryRollbackForGroupCommit(String id)
-      throws CoordinatorException {
+  private void forceAbortForGroupCommit(String id) throws CoordinatorException {
     // Lazy recoveries don't know which the transaction that created the PREPARE record is using, a
     // parent ID or a full ID as `tx_id` partition key.
     //
@@ -277,12 +279,10 @@ public class Coordinator {
     try {
       // This record is to prevent a group commit that has the same parent ID considering case #a
       // regardless if the transaction is actually in a group commit (case #a) or a delayed commit
-      // (case #b).
-      putStateForGroupCommit(
-          keys.parentKey,
-          Collections.emptyList(),
-          TransactionState.ABORTED,
-          System.currentTimeMillis());
+      // (case #b). The parent-id row carries no childIds because lazy recovery has no membership
+      // info to record; it only needs the put-if-not-exists conflict against an in-flight normal
+      // group commit.
+      putState(new State(keys.parentKey, TransactionState.ABORTED, System.currentTimeMillis()));
     } catch (CoordinatorConflictException e) {
       // The group commit finished already, although there may be ongoing delayed groups.
 
@@ -318,7 +318,7 @@ public class Coordinator {
     }
 
     // This record is to intend the transaction is aborted.
-    putState(new Coordinator.State(id, TransactionState.ABORTED));
+    putState(new Coordinator.State(id, TransactionState.ABORTED, System.currentTimeMillis()));
   }
 
   @VisibleForTesting
@@ -418,20 +418,40 @@ public class Coordinator {
   }
 
   /**
-   * Deletes the coordinator state row for the given transaction id. The delete is unconditional —
-   * if the row was already removed, this is a benign no-op at the storage layer and no exception is
-   * propagated. Storage errors surface as {@link CoordinatorException}; the caller is itself a
-   * retryable API, so no internal retry is performed here.
+   * Deletes the coordinator state row for the given transaction id.
+   *
+   * <p>If {@code id} is a group-commit full key, the actual row may live under the parent key (when
+   * the transaction was committed in a normal group) or under the full key (when it was
+   * delayed-committed or had been forced-aborted under the full key). To stay symmetric with {@link
+   * #getState(String)}, this method internally resolves the row location: when {@code id} is a full
+   * key, it looks up the actual row via {@code getState} and deletes whichever key {@link
+   * State#getId} returns. Non-full ids are deleted at their literal partition key.
+   *
+   * <p>The delete is unconditional — if the row is already gone (concurrent cleanup, no row ever
+   * existed) this is a benign no-op at the storage layer and no exception is propagated. Storage
+   * errors surface as {@link CoordinatorException}; the caller is itself a retryable API, so no
+   * internal retry is performed here.
    *
    * @param id the transaction id whose state row should be deleted
    * @throws CoordinatorException if the storage layer fails to delete the row
    */
   public void deleteState(String id) throws CoordinatorException {
+    String actualKey;
+    if (KEY_MANIPULATOR.isFullKey(id)) {
+      // For a full key, resolve to whichever row actually holds this transaction's state. When the
+      // tx was committed in a normal group, state.getId() is the parent key; when delayed or
+      // forced-aborted under the full key, it is the full key. If no row exists, fall through and
+      // attempt the literal delete (which is a no-op against storage).
+      Optional<State> state = getState(id);
+      actualKey = state.map(State::getId).orElse(id);
+    } else {
+      actualKey = id;
+    }
     Delete delete =
         Delete.newBuilder()
             .namespace(coordinatorNamespace)
             .table(TABLE)
-            .partitionKey(Key.ofText(Attribute.ID, id))
+            .partitionKey(Key.ofText(Attribute.ID, actualKey))
             .consistency(Consistency.LINEARIZABLE)
             .build();
     try {
@@ -474,29 +494,16 @@ public class Coordinator {
       createdAt = result.getBigInt(Attribute.CREATED_AT);
     }
 
-    public State(String id, TransactionState state) {
-      this(id, state, System.currentTimeMillis());
-    }
-
-    public State(String id, List<String> childIds, TransactionState state) {
-      this(id, childIds, null, state, System.currentTimeMillis());
-    }
-
-    public State(String id, @Nullable WriteSet writeSet, TransactionState state) {
-      this(id, EMPTY_CHILD_IDS, writeSet, state, System.currentTimeMillis());
-    }
-
-    @VisibleForTesting
-    State(String id, TransactionState state, long createdAt) {
+    public State(String id, TransactionState state, long createdAt) {
       this(id, EMPTY_CHILD_IDS, null, state, createdAt);
     }
 
-    @VisibleForTesting
-    State(String id, List<String> childIds, TransactionState state, long createdAt) {
-      this(id, childIds, null, state, createdAt);
+    public State(String id, @Nullable WriteSet writeSet, TransactionState state, long createdAt) {
+      this(id, EMPTY_CHILD_IDS, writeSet, state, createdAt);
     }
 
-    private State(
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public State(
         String id,
         List<String> childIds,
         @Nullable WriteSet writeSet,
@@ -569,17 +576,16 @@ public class Coordinator {
         return false;
       }
       State other = (State) o;
-      // NOTICE: createdAt is not taken into account
       return Objects.equals(id, other.id)
           && Objects.equals(childIds, other.childIds)
           && Objects.equals(writeSet, other.writeSet)
-          && state == other.state;
+          && state == other.state
+          && createdAt == other.createdAt;
     }
 
     @Override
     public int hashCode() {
-      // NOTICE: createdAt is not taken into account
-      return Objects.hash(id, childIds, writeSet, state);
+      return Objects.hash(id, childIds, writeSet, state, createdAt);
     }
 
     @Nullable

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -257,7 +257,7 @@ public class RecoveryHandler {
    */
   boolean tryAbortExpiredTransaction(String id) throws CoordinatorException {
     try {
-      coordinator.putStateForLazyRecoveryRollback(id);
+      coordinator.forceAbort(id);
       return true;
     } catch (CoordinatorConflictException e) {
       logger.info(
@@ -314,7 +314,7 @@ public class RecoveryHandler {
     }
 
     try {
-      coordinator.putStateForLazyRecoveryRollback(txId);
+      coordinator.forceAbort(txId);
     } catch (CoordinatorConflictException e) {
       TransactionTableMetadata tableMetadata =
           getTransactionTableMetadata(tableMetadataManager, selection);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -541,12 +542,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -571,12 +574,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -601,12 +606,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -621,12 +628,16 @@ public class CommitHandlerTest {
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     doReturn(
             Optional.of(
                 new Coordinator.State(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)))
+                    anyId(),
+                    expectedSingleGroupWriteSet(snapshot),
+                    TransactionState.ABORTED,
+                    System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
@@ -642,12 +653,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -657,20 +670,20 @@ public class CommitHandlerTest {
   public void abortStateForRollback_ShouldPutStateForLazyRecoveryRollbackAndReturnAborted()
       throws CoordinatorException, UnknownTransactionStatusException {
     // Arrange
-    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyId());
+    doNothing().when(coordinator).forceAbort(anyId());
 
     // Act
     TransactionState result = handler.abortStateForRollback(anyId());
 
     // Assert
-    // The abort delegates to Coordinator#putStateForLazyRecoveryRollback rather than a plain
+    // The abort delegates to Coordinator#forceAbort rather than a plain
     // putState. That method branches on the ID: it writes the parent-ID conflict marker before the
     // full-ID record for a group commit full key (so the abort wins against an in-flight group
     // commit), and falls back to a single putState for a non-group-commit ID. Which branch runs
     // here depends on anyId(): a non-group-commit ID in this base class, a group commit full key in
     // the group commit subclass that overrides anyId().
     assertThat(result).isEqualTo(TransactionState.ABORTED);
-    verify(coordinator).putStateForLazyRecoveryRollback(anyId());
+    verify(coordinator).forceAbort(anyId());
     verify(coordinator, never()).putState(any());
   }
 
@@ -678,10 +691,11 @@ public class CommitHandlerTest {
   public void abortStateForRollback_WhenConflictAndCommittedStatePersisted_ShouldReturnCommitted()
       throws CoordinatorException, UnknownTransactionStatusException {
     // Arrange
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyId());
-    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
 
@@ -702,9 +716,7 @@ public class CommitHandlerTest {
     // UnknownTransactionStatusException is thrown, preserving the original conflict as the cause.
 
     // Arrange
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyId());
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
 
     // Act Assert
@@ -718,7 +730,7 @@ public class CommitHandlerTest {
   public void abortStateForRollback_WhenCoordinatorExceptionThrown_ShouldThrowUnknown()
       throws CoordinatorException {
     // Arrange
-    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(anyId());
+    doThrow(CoordinatorException.class).when(coordinator).forceAbort(anyId());
 
     // Act Assert
     assertThatThrownBy(() -> handler.abortStateForRollback(anyId()))
@@ -731,7 +743,10 @@ public class CommitHandlerTest {
           throws CoordinatorException, UnknownTransactionStatusException {
     // Arrange
     doThrow(CoordinatorConflictException.class).when(coordinator).putState(any());
-    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED)))
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
 
@@ -775,8 +790,9 @@ public class CommitHandlerTest {
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
@@ -796,12 +812,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -817,8 +835,9 @@ public class CommitHandlerTest {
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
@@ -833,12 +852,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -854,8 +875,9 @@ public class CommitHandlerTest {
     doThrow(CoordinatorException.class)
         .when(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
 
@@ -869,12 +891,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler, never()).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -900,12 +924,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -931,12 +957,14 @@ public class CommitHandlerTest {
     // `putState(ABORT)` must be called.
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -953,8 +981,11 @@ public class CommitHandlerTest {
     doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
-    doReturn(Optional.of(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED)))
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
+    doReturn(
+            Optional.of(
+                new Coordinator.State(
+                    anyId(), writeSet, TransactionState.ABORTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
     doNothing().when(handler).rollbackRecords(any(TransactionContext.class));
@@ -969,9 +1000,9 @@ public class CommitHandlerTest {
     // An exception is thrown before group commit even when it's enabled. So, the normal
     // `putState(ABORT)` must be called.
     verify(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.COMMITTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -989,7 +1020,7 @@ public class CommitHandlerTest {
     doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
@@ -1008,9 +1039,9 @@ public class CommitHandlerTest {
     // An exception is thrown before group commit even when it's enabled. So, the normal
     // `putState(ABORT)` must be called.
     verify(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.COMMITTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -1028,7 +1059,7 @@ public class CommitHandlerTest {
     doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     doThrow(CoordinatorException.class).when(coordinator).getState(anyId());
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
@@ -1042,9 +1073,9 @@ public class CommitHandlerTest {
     // An exception is thrown before group commit even when it's enabled. So, the normal
     // `putState(ABORT)` must be called.
     verify(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.COMMITTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
@@ -1062,7 +1093,7 @@ public class CommitHandlerTest {
     doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorException.class)
         .when(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SERIALIZABLE, false, false);
 
@@ -1075,9 +1106,9 @@ public class CommitHandlerTest {
     // An exception is thrown before group commit even when it's enabled. So, the normal
     // `putState(ABORT)` must be called.
     verify(coordinator)
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.ABORTED)));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), writeSet, TransactionState.COMMITTED));
+        .putState(argThat(stateMatcher(anyId(), writeSet, TransactionState.COMMITTED)));
     verify(handler, never()).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -1095,7 +1126,10 @@ public class CommitHandlerTest {
     doReturn(
             Optional.of(
                 new Coordinator.State(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)))
+                    anyId(),
+                    expectedSingleGroupWriteSet(snapshot),
+                    TransactionState.COMMITTED,
+                    System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
     TransactionContext context =
@@ -1124,7 +1158,10 @@ public class CommitHandlerTest {
     doReturn(
             Optional.of(
                 new Coordinator.State(
-                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)))
+                    anyId(),
+                    expectedSingleGroupWriteSet(snapshot),
+                    TransactionState.ABORTED,
+                    System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
     TransactionContext context =
@@ -1281,12 +1318,14 @@ public class CommitHandlerTest {
     verify(storage, never()).mutate(anyList());
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(any());
   }
@@ -1310,12 +1349,14 @@ public class CommitHandlerTest {
     verify(storage, times(2)).mutate(anyList());
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(coordinator, never())
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.COMMITTED)));
     verify(handler).rollbackRecords(context);
     verify(handler).onFailureBeforeCommit(context);
   }
@@ -1392,8 +1433,9 @@ public class CommitHandlerTest {
     verify(storage, never()).mutate(anyList());
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
   }
@@ -1420,8 +1462,9 @@ public class CommitHandlerTest {
     verify(storage, never()).mutate(anyList());
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), TransactionState.ABORTED)));
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
   }
@@ -1785,8 +1828,7 @@ public class CommitHandlerTest {
     handlerWithoutWriteSetLogging.commitState(context);
 
     // Assert
-    verify(coordinator)
-        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.COMMITTED));
+    verify(coordinator).putState(argThat(stateMatcher(anyId(), null, TransactionState.COMMITTED)));
   }
 
   @Test
@@ -1803,8 +1845,7 @@ public class CommitHandlerTest {
     handlerWithoutWriteSetLogging.abortState(context);
 
     // Assert
-    verify(coordinator)
-        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.ABORTED));
+    verify(coordinator).putState(argThat(stateMatcher(anyId(), null, TransactionState.ABORTED)));
   }
 
   @Test
@@ -1827,10 +1868,9 @@ public class CommitHandlerTest {
         .isInstanceOf(CommitException.class);
 
     // Assert
-    verify(coordinator)
-        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.ABORTED));
+    verify(coordinator).putState(argThat(stateMatcher(anyId(), null, TransactionState.ABORTED)));
     verify(coordinator, never())
-        .putState(new Coordinator.State(anyId(), (WriteSet) null, TransactionState.COMMITTED));
+        .putState(argThat(stateMatcher(anyId(), null, TransactionState.COMMITTED)));
     verify(handlerWithoutWriteSetLogging).rollbackRecords(context);
     verify(handlerWithoutWriteSetLogging).onFailureBeforeCommit(context);
   }
@@ -1841,7 +1881,7 @@ public class CommitHandlerTest {
     doThrow(exceptionClass)
         .when(coordinator)
         .putState(
-            new Coordinator.State(anyId(), expectedSingleGroupWriteSet(snapshot), targetState));
+            argThat(stateMatcher(anyId(), expectedSingleGroupWriteSet(snapshot), targetState)));
   }
 
   protected void doNothingWhenCoordinatorPutState() throws CoordinatorException {
@@ -1852,8 +1892,23 @@ public class CommitHandlerTest {
       TransactionState expectedTransactionState, Snapshot snapshot) throws CoordinatorException {
     verify(coordinator)
         .putState(
-            new Coordinator.State(
-                anyId(), expectedSingleGroupWriteSet(snapshot), expectedTransactionState));
+            argThat(
+                stateMatcher(
+                    anyId(), expectedSingleGroupWriteSet(snapshot), expectedTransactionState)));
+  }
+
+  /**
+   * Mockito matcher that compares Coordinator.State by id, writeSet, and state -- ignoring
+   * createdAt. Useful when the production code stamps a real-time timestamp the test cannot
+   * reproduce exactly.
+   */
+  private static org.mockito.ArgumentMatcher<Coordinator.State> stateMatcher(
+      String id, WriteSet writeSet, TransactionState state) {
+    return actual ->
+        actual != null
+            && java.util.Objects.equals(actual.getId(), id)
+            && actual.getWriteSet().equals(java.util.Optional.ofNullable(writeSet))
+            && actual.getState() == state;
   }
 
   private void verifyBeforePreparationHook(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -4,9 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -123,36 +122,46 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
 
     doThrow(exceptionClass)
         .when(coordinator)
-        .putStateForGroupCommit(
-            eq(anyGroupCommitParentId()),
-            anyList(),
-            any(WriteSet.class),
-            eq(targetState),
-            anyLong());
+        .putState(argThat(groupCommitStateMatcher(anyGroupCommitParentId(), targetState)));
   }
 
   @Override
   protected void doNothingWhenCoordinatorPutState() throws CoordinatorException {
-    doNothing()
-        .when(coordinator)
-        .putStateForGroupCommit(
-            anyString(), anyList(), any(WriteSet.class), any(TransactionState.class), anyLong());
+    doNothing().when(coordinator).putState(any(Coordinator.State.class));
   }
 
   @Override
   protected void verifyCoordinatorPutState(
       TransactionState expectedTransactionState, Snapshot snapshot) throws CoordinatorException {
 
-    verify(coordinator)
-        .putStateForGroupCommit(
-            eq(anyGroupCommitParentId()),
-            groupCommitFullIdsArgumentCaptor.capture(),
-            any(WriteSet.class),
-            eq(expectedTransactionState),
-            anyLong());
-    List<String> fullIds = groupCommitFullIdsArgumentCaptor.getValue();
-    assertThat(fullIds.size()).isEqualTo(1);
-    assertThat(fullIds.get(0)).isEqualTo(anyId());
+    org.mockito.ArgumentCaptor<Coordinator.State> captor =
+        org.mockito.ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinator).putState(captor.capture());
+    Coordinator.State captured = captor.getValue();
+    assertThat(captured.getId()).isEqualTo(anyGroupCommitParentId());
+    assertThat(captured.getState()).isEqualTo(expectedTransactionState);
+    List<String> childIds = captured.getChildIds();
+    assertThat(childIds.size()).isEqualTo(1);
+    // The State's child IDs are the *child* portion of each full transaction id; verify the
+    // captured value matches the child of anyId().
+    assertThat(childIds.get(0))
+        .isEqualTo(
+            new CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator()
+                .keysFromFullKey(anyId())
+                .childKey);
+  }
+
+  /**
+   * Matcher for the group-commit parent-row State emitted by Emitter#emitNormalGroup: the id equals
+   * the parent key, childIds are non-empty (one entry per tx), and the txState matches.
+   */
+  private static org.mockito.ArgumentMatcher<Coordinator.State> groupCommitStateMatcher(
+      String parentId, TransactionState state) {
+    return actual ->
+        actual != null
+            && parentId.equals(actual.getId())
+            && !actual.getChildIds().isEmpty()
+            && actual.getState() == state;
   }
 
   @ParameterizedTest
@@ -330,8 +339,6 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     // Assert
     verify(storage, never()).mutate(anyList());
     verify(coordinator, never()).putState(any());
-    verify(coordinator, never())
-        .putStateForGroupCommit(anyString(), anyList(), any(WriteSet.class), any(), anyLong());
     verify(handler, never()).abortState(any());
     verify(handler, never()).rollbackRecords(any());
     verify(handler).onFailureBeforeCommit(any());
@@ -665,17 +672,16 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     // Act
     emitter.emitNormalGroup(parentId, Arrays.asList(context1, context2));
 
-    // Assert — capture the WriteSet content.
-    ArgumentCaptor<WriteSet> writeSetCaptor = ArgumentCaptor.forClass(WriteSet.class);
-    verify(coordinatorMock)
-        .putStateForGroupCommit(
-            eq(parentId),
-            anyList(),
-            writeSetCaptor.capture(),
-            eq(TransactionState.COMMITTED),
-            anyLong());
+    // Assert — capture the State and inspect its WriteSet content.
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
 
-    WriteSet captured = writeSetCaptor.getValue();
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(capturedState.getWriteSet()).isPresent();
+    WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
     assertThat(captured.getEntryGroupsList()).hasSize(2);
     assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("child-1");
@@ -714,16 +720,14 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     emitter.emitNormalGroup(parentId, Arrays.asList(writingContext, readOnlyContext));
 
     // Assert — only the writing child appears in entry_groups.
-    ArgumentCaptor<WriteSet> writeSetCaptor = ArgumentCaptor.forClass(WriteSet.class);
-    verify(coordinatorMock)
-        .putStateForGroupCommit(
-            eq(parentId),
-            anyList(),
-            writeSetCaptor.capture(),
-            eq(TransactionState.COMMITTED),
-            anyLong());
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getWriteSet()).isPresent();
 
-    WriteSet captured = writeSetCaptor.getValue();
+    WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getEntryGroupsList()).hasSize(1);
     assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("writing");
   }
@@ -749,23 +753,20 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     emitter.emitNormalGroup(parentId, Collections.singletonList(context));
 
     // Assert — WriteSet is still non-null with schema_version set, but has no EntryGroups.
-    ArgumentCaptor<WriteSet> writeSetCaptor = ArgumentCaptor.forClass(WriteSet.class);
-    verify(coordinatorMock)
-        .putStateForGroupCommit(
-            eq(parentId),
-            anyList(),
-            writeSetCaptor.capture(),
-            eq(TransactionState.COMMITTED),
-            anyLong());
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getWriteSet()).isPresent();
 
-    WriteSet captured = writeSetCaptor.getValue();
+    WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
     assertThat(captured.getEntryGroupsList()).isEmpty();
   }
 
   @Test
-  void emitter_emitNormalGroup_WithEmptyContexts_ShouldNotCallPutStateForGroupCommit()
-      throws Exception {
+  void emitter_emitNormalGroup_WithEmptyContexts_ShouldNotCallPutState() throws Exception {
     groupCommitter.remove(anyId());
 
     // Arrange
@@ -780,11 +781,9 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     // with an empty context list.
     emitter.emitNormalGroup(parentId, Collections.emptyList());
 
-    // Assert — putStateForGroupCommit must not be called; otherwise a spurious COMMITTED parent
-    // row would be written.
-    verify(coordinatorMock, never())
-        .putStateForGroupCommit(
-            anyString(), anyList(), any(WriteSet.class), any(TransactionState.class), anyLong());
+    // Assert — putState must not be called; otherwise a spurious COMMITTED parent row would be
+    // written.
+    verify(coordinatorMock, never()).putState(any(Coordinator.State.class));
   }
 
   @Test
@@ -881,15 +880,16 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     // Act
     emitter.emitNormalGroup(parentId, Collections.singletonList(context));
 
-    // Assert — putStateForGroupCommit is invoked with a null WriteSet so the BLOB column is
+    // Assert — putState is invoked with a State carrying no WriteSet so the BLOB column is
     // not populated (the column is not part of the Coordinator schema in this configuration).
-    verify(coordinatorMock)
-        .putStateForGroupCommit(
-            eq(parentId),
-            anyList(),
-            (WriteSet) eq(null),
-            eq(TransactionState.COMMITTED),
-            anyLong());
+    ArgumentCaptor<Coordinator.State> stateCaptor =
+        ArgumentCaptor.forClass(Coordinator.State.class);
+    verify(coordinatorMock).putState(stateCaptor.capture());
+
+    Coordinator.State capturedState = stateCaptor.getValue();
+    assertThat(capturedState.getId()).isEqualTo(parentId);
+    assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(capturedState.getWriteSet()).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -658,7 +658,8 @@ public class ConsensusCommitManagerTest {
   public void check_StateReturned_ReturnTheState() throws CoordinatorException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(new State(ANY_TX_ID, expected)));
+    when(coordinator.getState(ANY_TX_ID))
+        .thenReturn(Optional.of(new State(ANY_TX_ID, expected, System.currentTimeMillis())));
 
     // Act
     TransactionState actual = manager.getState(ANY_TX_ID);
@@ -1886,7 +1887,12 @@ public class ConsensusCommitManagerTest {
   public void finishTransaction_CommittedTransactionWithSinglePut_ShouldRecoverAndDeleteState()
       throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
@@ -1907,7 +1913,12 @@ public class ConsensusCommitManagerTest {
   public void finishTransaction_AbortedTransactionWithSinglePut_ShouldRecoverAndDeleteState()
       throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.ABORTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.ABORTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
@@ -1951,7 +1962,8 @@ public class ConsensusCommitManagerTest {
             .build();
     String fullChildId2 = keyManipulator.fullKey(parentId, "child-2");
     String fullChildId3 = keyManipulator.fullKey(parentId, "child-3");
-    State state = new State(parentId, writeSet, TransactionState.COMMITTED);
+    State state =
+        new State(parentId, writeSet, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(fullChildId1)).thenReturn(Optional.of(state));
     Result r1 = preparedRecord(fullChildId1);
     Result r2 = preparedRecord(fullChildId2);
@@ -1994,7 +2006,7 @@ public class ConsensusCommitManagerTest {
     // Arrange — State whose tx_write_set is NULL (terminated via
     // DistributedTransactionManager#rollback()/abort(), lazy-recovery abort, pre-feature row,
     // etc.).
-    State state = new State(ANY_TX_ID, TransactionState.ABORTED);
+    State state = new State(ANY_TX_ID, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
 
     // Act
@@ -2025,7 +2037,12 @@ public class ConsensusCommitManagerTest {
   public void finishTransaction_StorageGetFails_ShouldThrowTransactionExceptionWithCause()
       throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     com.scalar.db.exception.storage.ExecutionException cause =
         new com.scalar.db.exception.storage.ExecutionException("storage down");
@@ -2041,7 +2058,12 @@ public class ConsensusCommitManagerTest {
   @Test
   public void finishTransaction_RecordAlreadyGone_ShouldSkipEntryAndDeleteState() throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     when(storage.get(any(Get.class))).thenReturn(Optional.empty());
 
@@ -2064,7 +2086,8 @@ public class ConsensusCommitManagerTest {
         com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet.newBuilder()
             .setSchemaVersion(1)
             .build();
-    State state = new State(ANY_TX_ID, emptyWriteSet, TransactionState.COMMITTED);
+    State state =
+        new State(ANY_TX_ID, emptyWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
 
     // Act
@@ -2082,7 +2105,12 @@ public class ConsensusCommitManagerTest {
       throws Exception {
     // Arrange — Record's tx_state is already COMMITTED (someone else recovered it). The recovery
     // mutation would no-op via NoMutationException, so we filter it out up front.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result finalizedRecord = mock(Result.class);
     when(finalizedRecord.getText(Attribute.ID)).thenReturn(ANY_TX_ID);
@@ -2105,7 +2133,12 @@ public class ConsensusCommitManagerTest {
     // Arrange — Record's tx_id no longer matches the transaction we are finishing because an
     // unrelated transaction has since overwritten it. Recovery would no-op via NoMutationException
     // on the tx_id mismatch, so we filter it out up front.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result overwrittenRecord = preparedRecord("some-other-tx-id");
     when(storage.get(any(Get.class))).thenReturn(Optional.of(overwrittenRecord));
@@ -2124,7 +2157,12 @@ public class ConsensusCommitManagerTest {
       finishTransaction_RecoverFailsWithExecutionException_ShouldThrowTransactionExceptionWithCause()
           throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
@@ -2146,7 +2184,12 @@ public class ConsensusCommitManagerTest {
       finishTransaction_DeleteStateFailsWithCoordinatorException_ShouldThrowTransactionExceptionWithCause()
           throws Exception {
     // Arrange
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
@@ -2165,7 +2208,12 @@ public class ConsensusCommitManagerTest {
           throws Exception {
     // Arrange — first call fails on storage.get with a transient error; the state row is left
     // intact. Second call sees the state row again and proceeds to completion.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     com.scalar.db.exception.storage.ExecutionException firstAttemptCause =
         new com.scalar.db.exception.storage.ExecutionException("transient storage hiccup");
@@ -2193,7 +2241,12 @@ public class ConsensusCommitManagerTest {
     // recovery handler rolls them back when the state row is ABORTED, or rolls them forward —
     // composing a Delete — when it is COMMITTED). This test exercises the DELETED-state branch
     // of shouldRecover via the happy COMMITTED-state path.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result deletedRecord = mock(Result.class);
     when(deletedRecord.getText(Attribute.ID)).thenReturn(ANY_TX_ID);
@@ -2220,7 +2273,12 @@ public class ConsensusCommitManagerTest {
     // record through to executeSynchronously, where the recovery handler rolls it back to its
     // before-image. This exercises the DELETED-state branch of shouldRecover via the ABORTED-state
     // path.
-    State state = new State(ANY_TX_ID, writeSetWithSinglePutEntry(), TransactionState.ABORTED);
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithSinglePutEntry(),
+            TransactionState.ABORTED,
+            System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     Result deletedRecord = mock(Result.class);
     when(deletedRecord.getText(Attribute.ID)).thenReturn(ANY_TX_ID);
@@ -2260,7 +2318,7 @@ public class ConsensusCommitManagerTest {
     // Arrange
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
-    State state = new State(ANY_TX_ID, TransactionState.COMMITTED);
+    State state = new State(ANY_TX_ID, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     when(recoveryExecutor.executeSynchronously(
             any(Get.class), any(TransactionResult.class), eq(Optional.of(state))))
@@ -2296,7 +2354,7 @@ public class ConsensusCommitManagerTest {
     // Arrange
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
-    State state = new State(ANY_TX_ID, TransactionState.ABORTED);
+    State state = new State(ANY_TX_ID, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     when(recoveryExecutor.executeSynchronously(
             any(Get.class), any(TransactionResult.class), eq(Optional.of(state))))
@@ -2442,7 +2500,7 @@ public class ConsensusCommitManagerTest {
     // Arrange
     Result record = preparedRecord(ANY_TX_ID);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(record));
-    State state = new State(ANY_TX_ID, TransactionState.COMMITTED);
+    State state = new State(ANY_TX_ID, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
     com.scalar.db.exception.storage.ExecutionException cause =
         new com.scalar.db.exception.storage.ExecutionException("recovery storage down");

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -3,10 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -61,7 +58,6 @@ public class CoordinatorTest {
   @Mock private DistributedStorage storage;
   @Mock private ConsensusCommitConfig config;
   private Coordinator coordinator;
-  @Captor private ArgumentCaptor<State> stateArgumentCaptor;
   @Captor private ArgumentCaptor<Get> getArgumentCaptor;
 
   @BeforeEach
@@ -106,9 +102,9 @@ public class CoordinatorTest {
   }
 
   @Test
-  public void getStateByParentId_GroupCommitParentIdGiven_ShouldReturnStateUsingItParent()
+  public void getState_ParentIdGiven_ShouldReadParentRowDirectly()
       throws ExecutionException, CoordinatorException {
-    // Arrange
+    // Arrange — parent IDs are non-full keys, so getState routes through the literal read path.
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -128,42 +124,13 @@ public class CoordinatorTest {
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
-    Optional<Coordinator.State> state = coordinator.getStateByParentId(parentId);
+    Optional<Coordinator.State> state = coordinator.getState(parentId);
 
     // Assert
     assertThat(state).isPresent();
     assertThat(state.get().getId()).isEqualTo(parentId);
     assertThat(state.get().getChildIds()).isEqualTo(Arrays.asList(childIdsStr.split(",")));
     assertThat(state.get().getChildIdsAsString()).isEqualTo(childIdsStr);
-    Assertions.assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
-    assertThat(state.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
-  }
-
-  @Test
-  public void getStateByFullId_GroupCommitFullIdGiven_ShouldReturnStateUsingItParent()
-      throws ExecutionException, CoordinatorException {
-    // Arrange
-    CoordinatorGroupCommitKeyManipulator keyManipulator =
-        new CoordinatorGroupCommitKeyManipulator();
-    String fullId =
-        keyManipulator.fullKey(keyManipulator.generateParentKey(), UUID.randomUUID().toString());
-
-    Result result = mock(Result.class);
-    when(result.getText(Attribute.ID)).thenReturn(fullId);
-    when(result.contains(Attribute.CHILD_IDS)).thenReturn(true);
-    when(result.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
-    when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.ABORTED.get());
-    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
-    when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
-
-    // Act
-    Optional<Coordinator.State> state = coordinator.getStateByFullId(fullId);
-
-    // Assert
-    assertThat(state).isPresent();
-    assertThat(state.get().getId()).isEqualTo(fullId);
-    assertThat(state.get().getChildIds()).isEmpty();
-    assertThat(state.get().getChildIdsAsString()).isEmpty();
     Assertions.assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
     assertThat(state.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
   }
@@ -628,150 +595,21 @@ public class CoordinatorTest {
     verify(spiedCoordinator).getStateForGroupCommit(fullId);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = TransactionState.class,
-      names = {"COMMITTED", "ABORTED"})
-  public void putStateForGroupCommit_ParentIdGiven_ShouldPutWithCorrectValues(
-      TransactionState transactionState) throws ExecutionException, CoordinatorException {
-    // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
-    CoordinatorGroupCommitKeyManipulator keyManipulator =
-        new CoordinatorGroupCommitKeyManipulator();
-    String parentId = keyManipulator.generateParentKey();
-    String childId1 = UUID.randomUUID().toString();
-    String childId2 = UUID.randomUUID().toString();
-    List<String> fullIds =
-        Arrays.asList(
-            keyManipulator.fullKey(parentId, childId1), keyManipulator.fullKey(parentId, childId2));
-    long current = System.currentTimeMillis();
-    doNothing().when(storage).put(any(Put.class));
-
-    // Act
-    spiedCoordinator.putStateForGroupCommit(parentId, fullIds, transactionState, current);
-
-    // Assert
-    verify(spiedCoordinator).createPutWith(stateArgumentCaptor.capture());
-    State state = stateArgumentCaptor.getValue();
-    assertThat(state.getId()).isEqualTo(parentId);
-    assertThat(state.getChildIds()).hasSize(2);
-    assertThat(state.getChildIds().get(0)).isEqualTo(childId1);
-    assertThat(state.getChildIds().get(1)).isEqualTo(childId2);
-    assertThat(state.getChildIdsAsString()).isEqualTo(childId1 + "," + childId2);
-    assertThat(state.getState()).isEqualTo(transactionState);
-    assertThat(state.getCreatedAt()).isEqualTo(current);
-  }
-
-  @ParameterizedTest
-  @EnumSource(
-      value = TransactionState.class,
-      names = {"COMMITTED", "ABORTED"})
-  public void putStateForGroupCommit_FullIdGiven_ShouldThrowAssertionError(
-      TransactionState transactionState) throws ExecutionException {
-    // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
-    CoordinatorGroupCommitKeyManipulator keyManipulator =
-        new CoordinatorGroupCommitKeyManipulator();
-    String parentId = keyManipulator.generateParentKey();
-    String childId = UUID.randomUUID().toString();
-    String fullId = keyManipulator.fullKey(parentId, childId);
-    List<String> fullIds = Collections.singletonList(fullId);
-    long current = System.currentTimeMillis();
-    doNothing().when(storage).put(any(Put.class));
-
-    // Act
-    // Assert
-    assertThatThrownBy(
-            () ->
-                spiedCoordinator.putStateForGroupCommit(fullId, fullIds, transactionState, current))
-        .isInstanceOf(AssertionError.class);
-  }
-
-  @ParameterizedTest
-  @EnumSource(
-      value = TransactionState.class,
-      names = {"COMMITTED", "ABORTED"})
-  public void
-      putStateForGroupCommit_StateGivenAndExceptionThrownInPut_ShouldThrowCoordinatorException(
-          TransactionState transactionState) throws ExecutionException {
-    // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
-    CoordinatorGroupCommitKeyManipulator keyManipulator =
-        new CoordinatorGroupCommitKeyManipulator();
-    String parentId = keyManipulator.generateParentKey();
-    String childId1 = UUID.randomUUID().toString();
-    String childId2 = UUID.randomUUID().toString();
-    List<String> fullIds =
-        Arrays.asList(
-            keyManipulator.fullKey(parentId, childId1), keyManipulator.fullKey(parentId, childId2));
-    long current = System.currentTimeMillis();
-    ExecutionException toThrow = mock(ExecutionException.class);
-    doThrow(toThrow).when(storage).put(any(Put.class));
-
-    // Act
-    // Assert
-    assertThatThrownBy(
-            () ->
-                spiedCoordinator.putStateForGroupCommit(
-                    parentId, fullIds, transactionState, current))
-        .isInstanceOf(CoordinatorException.class);
-    verify(spiedCoordinator).createPutWith(stateArgumentCaptor.capture());
-
-    State state = stateArgumentCaptor.getValue();
-    assertThat(state.getId()).isEqualTo(parentId);
-    assertThat(state.getChildIds()).hasSize(2);
-    assertThat(state.getChildIds().get(0)).isEqualTo(childId1);
-    assertThat(state.getChildIds().get(1)).isEqualTo(childId2);
-    assertThat(state.getChildIdsAsString()).isEqualTo(childId1 + "," + childId2);
-    assertThat(state.getState()).isEqualTo(transactionState);
-    assertThat(state.getCreatedAt()).isEqualTo(current);
-  }
-
-  @ParameterizedTest
-  @EnumSource(
-      value = TransactionState.class,
-      names = {"COMMITTED", "ABORTED"})
-  public void
-      putStateForGroupCommit_StateWithChildIdsContainingDelimiterGiven_ShouldThrowIllegalArgumentException(
-          TransactionState transactionState) throws ExecutionException {
-    // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
-    CoordinatorGroupCommitKeyManipulator keyManipulator =
-        new CoordinatorGroupCommitKeyManipulator();
-    String parentId = keyManipulator.generateParentKey();
-    List<String> fullIds =
-        Arrays.asList(
-            keyManipulator.fullKey(parentId, UUID.randomUUID().toString()),
-            keyManipulator.fullKey(parentId, UUID.randomUUID().toString().replaceFirst("-", ",")));
-    long current = System.currentTimeMillis();
-    ExecutionException toThrow = mock(ExecutionException.class);
-    doThrow(toThrow).when(storage).put(any(Put.class));
-
-    // Act
-    // Assert
-    assertThatThrownBy(
-            () ->
-                spiedCoordinator.putStateForGroupCommit(
-                    parentId, fullIds, transactionState, current))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
   @Test
-  void putStateForLazyRecoveryRollback_NormalIdGiven_ShouldCallPutState()
-      throws CoordinatorException {
+  void forceAbort_NormalIdGiven_ShouldCallPutState() throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
 
     // Act
-    spiedCoordinator.putStateForLazyRecoveryRollback(ANY_ID_1);
+    spiedCoordinator.forceAbort(ANY_ID_1);
 
     // Assert
-    verify(spiedCoordinator).putState(new State(ANY_ID_1, TransactionState.ABORTED));
+    verify(spiedCoordinator).putState(argThat(stateMatcher(ANY_ID_1, TransactionState.ABORTED)));
   }
 
   @Test
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsNotCommitted_ShouldInsertTwoRecordsWithParentIdAndFullId()
+      forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsNotCommitted_ShouldInsertTwoRecordsWithParentIdAndFullId()
           throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
@@ -781,23 +619,22 @@ public class CoordinatorTest {
     String fullId = keyManipulator.fullKey(parentId, ANY_ID_1);
 
     // Act
-    spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
+    spiedCoordinator.forceAbort(fullId);
 
     // Assert
     // The parent-ID conflict marker must be written before the full-ID ABORTED record. This way the
     // abort conflicts with, and wins against, an in-flight normal group commit, which writes the
     // COMMITTED state under the parent ID.
     InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder.verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
     inOrder
         .verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @Test
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsCommitted_ShouldThrowCoordinatorConflictException()
+      forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsCommitted_ShouldThrowCoordinatorConflictException()
           throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
@@ -808,32 +645,37 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(
             Optional.of(
                 new State(
                     parentId,
                     Collections.singletonList(ANY_ID_1),
+                    null,
                     TransactionState.COMMITTED,
                     System.currentTimeMillis())))
         .when(spiedCoordinator)
         .getState(parentId);
 
     // Act
-    assertThatThrownBy(() -> spiedCoordinator.putStateForLazyRecoveryRollback(fullId))
+    assertThatThrownBy(() -> spiedCoordinator.forceAbort(fullId))
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
-    verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator, never()).putState(new State(fullId, TransactionState.ABORTED));
+    verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
+    verify(spiedCoordinator, never())
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @Test
-  void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsAbort_ShouldDoNothing()
-          throws CoordinatorException {
+  void forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsAbort_ShouldDoNothing()
+      throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
@@ -843,25 +685,31 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(
             Optional.of(
                 new State(
                     parentId,
                     Collections.singletonList(ANY_ID_1),
+                    null,
                     TransactionState.ABORTED,
                     System.currentTimeMillis())))
         .when(spiedCoordinator)
         .getState(parentId);
 
     // Act
-    spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
+    spiedCoordinator.forceAbort(fullId);
 
     // Assert
-    verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator, never()).putState(new State(fullId, TransactionState.ABORTED));
+    verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
+    verify(spiedCoordinator, never())
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @ParameterizedTest
@@ -869,7 +717,7 @@ public class CoordinatorTest {
       value = TransactionState.class,
       names = {"COMMITTED", "ABORTED"})
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitFinished_ShouldInsertRecordWithFullId(
+      forceAbort_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitFinished_ShouldInsertRecordWithFullId(
           TransactionState transactionState) throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
@@ -880,29 +728,35 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(
             Optional.of(
                 new State(
                     parentId,
                     Collections.singletonList("other-id"),
+                    null,
                     transactionState,
                     System.currentTimeMillis())))
         .when(spiedCoordinator)
         .getState(parentId);
 
     // Act
-    spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
+    spiedCoordinator.forceAbort(fullId);
 
     // Assert
     // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
-    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    // forceAbort_...WhenGroupCommitIsNotCommitted_... above).
     InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder.verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
     inOrder
         .verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @ParameterizedTest
@@ -910,7 +764,7 @@ public class CoordinatorTest {
       value = TransactionState.class,
       names = {"COMMITTED", "ABORTED"})
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitAndDelayedGroupCommitFinished_ShouldCoordinatorConflictException(
+      forceAbort_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitAndDelayedGroupCommitFinished_ShouldCoordinatorConflictException(
           TransactionState transactionState) throws CoordinatorException {
     // Arrange
     Coordinator spiedCoordinator = spy(coordinator);
@@ -921,38 +775,44 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(
             Optional.of(
                 new State(
                     parentId,
                     Collections.singletonList("other-id"),
+                    null,
                     transactionState,
                     System.currentTimeMillis())))
         .when(spiedCoordinator)
         .getState(parentId);
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putState(new State(fullId, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
 
     // Act
-    assertThatThrownBy(() -> spiedCoordinator.putStateForLazyRecoveryRollback(fullId))
+    assertThatThrownBy(() -> spiedCoordinator.forceAbort(fullId))
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
     // The parent-ID conflict marker must be written before the full-ID ABORTED record (see
-    // putStateForLazyRecoveryRollback_...WhenGroupCommitIsNotCommitted_... above).
+    // forceAbort_...WhenGroupCommitIsNotCommitted_... above).
     InOrder inOrder = inOrder(spiedCoordinator);
+    inOrder.verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
     inOrder
         .verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    inOrder.verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @Test
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord_ShouldInsertRecordWithFullId()
+      forceAbort_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord_ShouldInsertRecordWithFullId()
           throws CoordinatorException {
     // The parent-id insert conflicts because a finished group-commit row existed, but the
     // Coordinator state cleanup process removed it before we re-read it. With no full-ID record,
@@ -968,22 +828,26 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(Optional.empty()).when(spiedCoordinator).getState(parentId);
 
     // Act
-    spiedCoordinator.putStateForLazyRecoveryRollback(fullId);
+    spiedCoordinator.forceAbort(fullId);
 
     // Assert
-    verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
+    verify(spiedCoordinator).putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @Test
   void
-      putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndTransactionCommittedWithFullId_ShouldThrowCoordinatorConflictException()
+      forceAbort_FullIdGivenWhenParentRowAlreadyCleanedUpAndTransactionCommittedWithFullId_ShouldThrowCoordinatorConflictException()
           throws CoordinatorException {
     // The parent row was cleaned up after our parent-id insert conflicted, but this transaction
     // actually committed via a full-ID record (a delayed, standalone commit). Falling through to
@@ -999,21 +863,25 @@ public class CoordinatorTest {
 
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && !new CoordinatorGroupCommitKeyManipulator().isFullKey(s.getId())
+                        && s.getChildIds().isEmpty()
+                        && s.getState() == TransactionState.ABORTED));
     doReturn(Optional.empty()).when(spiedCoordinator).getState(parentId);
     doThrow(CoordinatorConflictException.class)
         .when(spiedCoordinator)
-        .putState(new State(fullId, TransactionState.ABORTED));
+        .putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
 
     // Act
-    assertThatThrownBy(() -> spiedCoordinator.putStateForLazyRecoveryRollback(fullId))
+    assertThatThrownBy(() -> spiedCoordinator.forceAbort(fullId))
         .isInstanceOf(CoordinatorConflictException.class);
 
     // Assert
-    verify(spiedCoordinator)
-        .putStateForGroupCommit(
-            eq(parentId), eq(Collections.emptyList()), eq(TransactionState.ABORTED), anyLong());
-    verify(spiedCoordinator).putState(new State(fullId, TransactionState.ABORTED));
+    verify(spiedCoordinator).putState(argThat(parentMarkerMatcher(parentId)));
+    verify(spiedCoordinator).putState(argThat(stateMatcher(fullId, TransactionState.ABORTED)));
   }
 
   @Test
@@ -1038,7 +906,9 @@ public class CoordinatorTest {
             .setSchemaVersion(1)
             .addEntryGroups(EntryGroup.newBuilder().addEntries(writeEntry))
             .build();
-    State state = new State(ANY_ID_1, originalWriteSet, TransactionState.COMMITTED);
+    State state =
+        new State(
+            ANY_ID_1, originalWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());
 
     // Serialize via createPutWith
     Put put = coordinator.createPutWith(state);
@@ -1066,7 +936,7 @@ public class CoordinatorTest {
   @Test
   public void state_NullWriteSet_ShouldNotPersistColumn() {
     // Arrange — State with null writeSet (lazy-recovery abort, etc.)
-    State state = new State(ANY_ID_1, TransactionState.ABORTED);
+    State state = new State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
 
     // Act
     Put put = coordinator.createPutWith(state);
@@ -1104,7 +974,8 @@ public class CoordinatorTest {
     List<String> childIds = Arrays.asList("child-1", "child-2");
 
     // Act
-    State state = new State(ANY_ID_1, childIds, TransactionState.COMMITTED);
+    State state =
+        new State(ANY_ID_1, childIds, null, TransactionState.COMMITTED, System.currentTimeMillis());
 
     // Assert
     assertThat(state.getId()).isEqualTo(ANY_ID_1);
@@ -1120,7 +991,8 @@ public class CoordinatorTest {
     // schema_version, mirroring what WriteSetEncoder#encodeSingleGroupWriteSet emits for
     // read-only commits.
     WriteSet emptyWriteSet = WriteSet.newBuilder().setSchemaVersion(1).build();
-    State state = new State(ANY_ID_1, emptyWriteSet, TransactionState.COMMITTED);
+    State state =
+        new State(ANY_ID_1, emptyWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());
 
     // Serialize
     Put put = coordinator.createPutWith(state);
@@ -1170,16 +1042,57 @@ public class CoordinatorTest {
             .setSchemaVersion(1)
             .addEntryGroups(EntryGroup.newBuilder().setChildId("child-1"))
             .build();
-    State stateWithNullWriteSet = new State(ANY_ID_1, TransactionState.COMMITTED);
-    State stateWithWriteSet1 = new State(ANY_ID_1, writeSet1, TransactionState.COMMITTED);
-    State stateWithWriteSet1Again = new State(ANY_ID_1, writeSet1, TransactionState.COMMITTED);
-    State stateWithWriteSet2 = new State(ANY_ID_1, writeSet2, TransactionState.COMMITTED);
+    long createdAt = System.currentTimeMillis();
+    State stateWithNullWriteSet = new State(ANY_ID_1, TransactionState.COMMITTED, createdAt);
+    State stateWithWriteSet1 =
+        new State(ANY_ID_1, writeSet1, TransactionState.COMMITTED, createdAt);
+    State stateWithWriteSet1Again =
+        new State(ANY_ID_1, writeSet1, TransactionState.COMMITTED, createdAt);
+    State stateWithWriteSet2 =
+        new State(ANY_ID_1, writeSet2, TransactionState.COMMITTED, createdAt);
 
     // Assert
     assertThat(stateWithNullWriteSet).isNotEqualTo(stateWithWriteSet1);
     assertThat(stateWithWriteSet1).isNotEqualTo(stateWithWriteSet2);
     assertThat(stateWithWriteSet1).isEqualTo(stateWithWriteSet1Again);
     assertThat(stateWithWriteSet1.hashCode()).isEqualTo(stateWithWriteSet1Again.hashCode());
+  }
+
+  @Test
+  public void state_EqualityWithDifferentCreatedAt_ShouldNotBeEqual() {
+    // Arrange — same id, childIds, writeSet, state but different createdAt
+    State s1 = new State(ANY_ID_1, TransactionState.COMMITTED, 100L);
+    State s2 = new State(ANY_ID_1, TransactionState.COMMITTED, 200L);
+
+    // Assert — createdAt is part of equality
+    assertThat(s1).isNotEqualTo(s2);
+    assertThat(s1.hashCode()).isNotEqualTo(s2.hashCode());
+  }
+
+  @Test
+  public void state_EqualityWithSameCreatedAt_ShouldBeEqual() {
+    // Arrange — same fields including createdAt
+    long createdAt = 12345L;
+    State s1 = new State(ANY_ID_1, TransactionState.COMMITTED, createdAt);
+    State s2 = new State(ANY_ID_1, TransactionState.COMMITTED, createdAt);
+
+    // Assert
+    assertThat(s1).isEqualTo(s2);
+    assertThat(s1.hashCode()).isEqualTo(s2.hashCode());
+  }
+
+  @Test
+  public void newState_ChildIdContainingDelimiterGiven_ShouldThrowIllegalArgumentException() {
+    // Act + Assert
+    assertThatThrownBy(
+            () ->
+                new Coordinator.State(
+                    ANY_ID_1,
+                    Collections.singletonList("child" + "," + "id"),
+                    null,
+                    TransactionState.COMMITTED,
+                    ANY_TIME_1))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -1232,5 +1145,173 @@ public class CoordinatorTest {
     assertThatThrownBy(() -> coordinator.deleteState(ANY_ID_1))
         .isInstanceOf(CoordinatorException.class)
         .hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void deleteState_FullKeyGivenAndCommittedInNormalGroup_ShouldDeleteAtParentKey()
+      throws ExecutionException, CoordinatorException {
+    // Arrange
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String childId = UUID.randomUUID().toString();
+    String fullId = keyManipulator.fullKey(parentId, childId);
+
+    // The transaction was committed in a normal group, so its state lives under the parent key with
+    // the child ID listed in tx_child_ids.
+    Result resultForGroupCommitState = mock(Result.class);
+    when(resultForGroupCommitState.getText(Attribute.ID)).thenReturn(parentId);
+    when(resultForGroupCommitState.contains(Attribute.CHILD_IDS)).thenReturn(true);
+    when(resultForGroupCommitState.getText(Attribute.CHILD_IDS)).thenReturn(childId);
+    when(resultForGroupCommitState.getInt(Attribute.STATE))
+        .thenReturn(TransactionState.COMMITTED.get());
+    when(resultForGroupCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
+    when(resultForGroupCommitState.isNull(Attribute.WRITE_SET)).thenReturn(true);
+    doReturn(Optional.of(resultForGroupCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(parentId));
+    doNothing().when(storage).delete(any(Delete.class));
+
+    // Act
+    coordinator.deleteState(fullId);
+
+    // Assert — the delete must target the parent key (where the row actually lives), not the full
+    // key the caller passed.
+    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
+    verify(storage).delete(captor.capture());
+    assertThat(captor.getValue().getPartitionKey().getTextValue(0)).isEqualTo(parentId);
+  }
+
+  @Test
+  public void deleteState_FullKeyGivenAndCommittedAsDelayedGroup_ShouldDeleteAtFullKey()
+      throws ExecutionException, CoordinatorException {
+    // Arrange
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String childId = UUID.randomUUID().toString();
+    String fullId = keyManipulator.fullKey(parentId, childId);
+
+    // The transaction was delayed-committed (or force-aborted) under its own full key. There is no
+    // row under the parent key, so getState falls back to the full key.
+    Result resultForSingleCommitState = mock(Result.class);
+    when(resultForSingleCommitState.getText(Attribute.ID)).thenReturn(fullId);
+    when(resultForSingleCommitState.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(resultForSingleCommitState.getInt(Attribute.STATE))
+        .thenReturn(TransactionState.COMMITTED.get());
+    when(resultForSingleCommitState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
+    when(resultForSingleCommitState.isNull(Attribute.WRITE_SET)).thenReturn(true);
+    doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(parentId));
+    doReturn(Optional.of(resultForSingleCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(fullId));
+    doNothing().when(storage).delete(any(Delete.class));
+
+    // Act
+    coordinator.deleteState(fullId);
+
+    // Assert — the delete must target the full key.
+    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
+    verify(storage).delete(captor.capture());
+    assertThat(captor.getValue().getPartitionKey().getTextValue(0)).isEqualTo(fullId);
+  }
+
+  @Test
+  public void
+      deleteState_FullKeyGivenAndDelayedCommittedWhileSiblingForceAbortedParentMarkerExists_ShouldDeleteAtFullKey()
+          throws ExecutionException, CoordinatorException {
+    // Scenario: a group {A, B} under parentId. Sibling A was force-aborted by full ID, which writes
+    // a parent-key conflict marker (ABORTED, empty child_ids) plus a full-key ABORTED row for A.
+    // The marker blocks the normal group commit, but B can still be delayed-committed under its own
+    // full key. So both a parent marker row and B's full-key COMMITTED row coexist.
+    //
+    //      id     |  child_ids  |   state    |  write_set
+    // ------------+-------------+------------+------------
+    //  parentId   |     []      |  ABORTED   |    null      <- A's forceAbort parent marker
+    //  fullId (B) |     []      |  COMMITTED |  present      <- B's delayed commit
+    //
+    // finishTransaction(fullId_B) resolves to B's full-key row and deletes it; the parent marker
+    // must not misroute the delete.
+    // Arrange
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String childId = UUID.randomUUID().toString();
+    String fullId = keyManipulator.fullKey(parentId, childId);
+
+    // Parent marker row written by the sibling's forceAbort: ABORTED with empty child_ids.
+    Result parentMarker = mock(Result.class);
+    when(parentMarker.getText(Attribute.ID)).thenReturn(parentId);
+    when(parentMarker.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(parentMarker.getInt(Attribute.STATE)).thenReturn(TransactionState.ABORTED.get());
+    when(parentMarker.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
+    when(parentMarker.isNull(Attribute.WRITE_SET)).thenReturn(true);
+
+    // B's own delayed-commit row under the full key.
+    Result fullKeyState = mock(Result.class);
+    when(fullKeyState.getText(Attribute.ID)).thenReturn(fullId);
+    when(fullKeyState.getText(Attribute.CHILD_IDS)).thenReturn(EMPTY_CHILD_IDS);
+    when(fullKeyState.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
+    when(fullKeyState.getBigInt(Attribute.CREATED_AT)).thenReturn(ANY_TIME_1);
+    when(fullKeyState.isNull(Attribute.WRITE_SET)).thenReturn(true);
+
+    doReturn(Optional.of(parentMarker)).when(storage).get(coordinator.createGetWith(parentId));
+    doReturn(Optional.of(fullKeyState)).when(storage).get(coordinator.createGetWith(fullId));
+    doNothing().when(storage).delete(any(Delete.class));
+
+    // Act + Assert — getState skips the parent marker (childId not listed) and resolves to the full
+    // key, so the delete must target the full key, not the parent marker.
+    assertThat(coordinator.getState(fullId).map(Coordinator.State::getId)).hasValue(fullId);
+    coordinator.deleteState(fullId);
+
+    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
+    verify(storage).delete(captor.capture());
+    assertThat(captor.getValue().getPartitionKey().getTextValue(0)).isEqualTo(fullId);
+  }
+
+  @Test
+  public void deleteState_FullKeyGivenAndNoStateRowExists_ShouldDeleteAtFullKey()
+      throws ExecutionException, CoordinatorException {
+    // Arrange
+    CoordinatorGroupCommitKeyManipulator keyManipulator =
+        new CoordinatorGroupCommitKeyManipulator();
+    String parentId = keyManipulator.generateParentKey();
+    String childId = UUID.randomUUID().toString();
+    String fullId = keyManipulator.fullKey(parentId, childId);
+
+    // No row exists under either key (e.g. concurrent cleanup already removed it). getState returns
+    // empty, so deleteState falls back to the literal full key and the delete is a benign no-op.
+    doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(parentId));
+    doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(fullId));
+    doNothing().when(storage).delete(any(Delete.class));
+
+    // Act
+    coordinator.deleteState(fullId);
+
+    // Assert
+    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
+    verify(storage).delete(captor.capture());
+    assertThat(captor.getValue().getPartitionKey().getTextValue(0)).isEqualTo(fullId);
+  }
+
+  /**
+   * Mockito matcher that compares Coordinator.State by id and TransactionState only — ignoring
+   * createdAt. Used to verify putState calls without relying on the production code's wall-clock
+   * timestamp.
+   */
+  private static org.mockito.ArgumentMatcher<State> stateMatcher(
+      String id, TransactionState state) {
+    return actual -> actual != null && id.equals(actual.getId()) && actual.getState() == state;
+  }
+
+  // The parent-ID conflict marker written by the first step of forceAbort's two-step protocol must
+  // carry empty childIds: a non-empty list would make getState route an unrelated full-key lookup
+  // to this marker via getChildIds().contains(childKey).
+  private static org.mockito.ArgumentMatcher<State> parentMarkerMatcher(String parentId) {
+    return actual ->
+        actual != null
+            && parentId.equals(actual.getId())
+            && actual.getState() == TransactionState.ABORTED
+            && actual.getChildIds().isEmpty();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -443,7 +443,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange: writing the ABORTED state conflicts because the transaction committed concurrently
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State committedState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State committedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(committedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
@@ -475,7 +476,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange: writing the ABORTED state conflicts because another actor aborted the transaction
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(abortedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
@@ -662,7 +664,8 @@ public class RecoveryExecutorTest {
     // new writer's coordinator state is ABORTED, so the record is resolved (rolled back) for it.
     TransactionResult original = prepareResult(TransactionState.PREPARED);
     TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
     when(recovery.isTransactionExpired(original)).thenReturn(true);
@@ -730,7 +733,8 @@ public class RecoveryExecutorTest {
     // transaction, whose coordinator state is ABORTED, so the record is rolled back for it.
     TransactionResult original = prepareResult(TransactionState.PREPARED);
     TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
     when(recovery.isTransactionExpired(original)).thenReturn(true);
@@ -901,7 +905,8 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -930,7 +935,8 @@ public class RecoveryExecutorTest {
     // Arrange
     TransactionResult transactionResult =
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -958,7 +964,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State commitState =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     executor = spy(executor);
@@ -988,7 +995,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
-    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State commitState =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     // Act
@@ -1128,7 +1136,8 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -1157,7 +1166,8 @@ public class RecoveryExecutorTest {
     // Arrange
     TransactionResult transactionResult =
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
-    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    Coordinator.State abortedState =
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -1185,7 +1195,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State commitState =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     executor = spy(executor);
@@ -1215,7 +1226,8 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
-    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State commitState =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     // Act
@@ -1325,7 +1337,9 @@ public class RecoveryExecutorTest {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED));
+        Optional.of(
+            new Coordinator.State(
+                ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis()));
     when(recovery.recover(selection, transactionResult, state)).thenReturn(true);
 
     // Act
@@ -1357,7 +1371,8 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State state = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    Coordinator.State state =
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
 
     // Act — the present-state overload is used by finishTransaction and returns nothing.
     executor.executeSynchronously(selection, transactionResult, state);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -111,7 +111,9 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED));
+        Optional.of(
+            new Coordinator.State(
+                ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -129,7 +131,9 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED));
+        Optional.of(
+            new Coordinator.State(
+                ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     CommitMutationComposer composer = mock(CommitMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -151,7 +155,9 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED));
+        Optional.of(
+            new Coordinator.State(
+                ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     CommitMutationComposer composer = mock(CommitMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -173,7 +179,8 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+        Optional.of(
+            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -191,7 +198,8 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+        Optional.of(
+            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     RollbackMutationComposer composer = mock(RollbackMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -214,7 +222,8 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+        Optional.of(
+            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     RollbackMutationComposer composer = mock(RollbackMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -245,8 +254,7 @@ public class RecoveryHandlerTest {
 
     // Assert — the writer may still be in flight, so the record is not recovered.
     assertThat(recovered).isFalse();
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
   }
 
@@ -267,7 +275,7 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(recovered).isTrue();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler).rollbackRecord(selection, result);
   }
 
@@ -280,12 +288,13 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyString());
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     // A concurrent actor already aborted the writer; the re-read returns that ABORTED state.
     when(coordinator.getState(ANY_ID_1))
-        .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED)));
+        .thenReturn(
+            Optional.of(
+                new Coordinator.State(
+                    ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis())));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -294,7 +303,7 @@ public class RecoveryHandlerTest {
     // Assert — recover guarantees the record is resolved: it is rolled back to match the winner's
     // ABORTED outcome.
     assertThat(recovered).isTrue();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler).rollbackRecord(selection, result);
   }
 
@@ -307,13 +316,14 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyString());
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     // A concurrent commit won the race; the re-read sees COMMITTED, which must be reported
     // instead of a false ABORTED.
     when(coordinator.getState(ANY_ID_1))
-        .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED)));
+        .thenReturn(
+            Optional.of(
+                new Coordinator.State(
+                    ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis())));
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -322,7 +332,7 @@ public class RecoveryHandlerTest {
     // Assert — recover guarantees the record is resolved: it is rolled forward to match the
     // winner's COMMITTED outcome.
     assertThat(recovered).isTrue();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler).rollforwardRecord(selection, result);
     verify(handler, never()).rollbackRecord(selection, result);
   }
@@ -339,9 +349,7 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyString());
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
 
     // Act
@@ -349,7 +357,7 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(recovered).isTrue();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -363,16 +371,14 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doThrow(CoordinatorException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyString());
+    doThrow(CoordinatorException.class).when(coordinator).forceAbort(anyString());
 
     // Act
     assertThatThrownBy(() -> handler.recover(selection, result, state))
         .isInstanceOf(CoordinatorException.class);
 
     // Assert
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler, never()).rollbackRecord(selection, result);
   }
 
@@ -395,7 +401,7 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(recovered).isTrue();
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -417,7 +423,7 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(recovered).isTrue();
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -441,7 +447,7 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(recovered).isTrue();
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -463,7 +469,7 @@ public class RecoveryHandlerTest {
     handler.tryRecover(selection, result, state);
 
     // Assert
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -484,7 +490,7 @@ public class RecoveryHandlerTest {
     handler.tryRecover(selection, result, state);
 
     // Assert
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -507,7 +513,7 @@ public class RecoveryHandlerTest {
     handler.tryRecover(selection, result, state);
 
     // Assert
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
     verify(handler, never()).rollforwardRecord(selection, result);
   }
@@ -527,7 +533,7 @@ public class RecoveryHandlerTest {
     // Act Assert
     assertThatThrownBy(() -> handler.recover(selection, result, state))
         .isInstanceOf(ExecutionException.class);
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
   }
 
@@ -546,7 +552,7 @@ public class RecoveryHandlerTest {
     // Act Assert
     assertThatThrownBy(() -> handler.tryRecover(selection, result, state))
         .isInstanceOf(ExecutionException.class);
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollbackRecord(selection, result);
   }
 
@@ -558,29 +564,27 @@ public class RecoveryHandlerTest {
 
     // Assert
     assertThat(aborted).isTrue();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
   }
 
   @Test
   public void tryAbortExpiredTransaction_Conflict_ShouldReturnFalse() throws CoordinatorException {
     // Arrange
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(ANY_ID_1);
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(ANY_ID_1);
 
     // Act
     boolean aborted = handler.tryAbortExpiredTransaction(ANY_ID_1);
 
     // Assert
     assertThat(aborted).isFalse();
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
   }
 
   @Test
   public void tryAbortExpiredTransaction_CoordinatorException_ShouldThrow()
       throws CoordinatorException {
     // Arrange
-    doThrow(CoordinatorException.class).when(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    doThrow(CoordinatorException.class).when(coordinator).forceAbort(ANY_ID_1);
 
     // Act Assert
     assertThatThrownBy(() -> handler.tryAbortExpiredTransaction(ANY_ID_1))
@@ -596,7 +600,8 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED);
+    Coordinator.State state =
+        new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis());
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -605,7 +610,7 @@ public class RecoveryHandlerTest {
     // Assert — rolled forward, and the coordinator is never touched.
     verify(handler).rollforwardRecord(selection, result);
     verify(coordinator, never()).getState(anyString());
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
   }
 
   @Test
@@ -613,7 +618,8 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
+    Coordinator.State state =
+        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -622,7 +628,7 @@ public class RecoveryHandlerTest {
     // Assert — rolled back, and the coordinator is never touched.
     verify(handler).rollbackRecord(selection, result);
     verify(coordinator, never()).getState(anyString());
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
   }
 
   // ------------------------------------------------------------
@@ -635,7 +641,9 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED));
+        Optional.of(
+            new Coordinator.State(
+                ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -651,7 +659,8 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
     Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+        Optional.of(
+            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -672,15 +681,13 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doThrow(CoordinatorConflictException.class)
-        .when(coordinator)
-        .putStateForLazyRecoveryRollback(anyString());
+    doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
 
     // Act
     handler.tryRecover(selection, result, state);
 
     // Assert — no coordinator re-read and no roll.
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(coordinator, never()).getState(anyString());
     verify(handler, never()).rollforwardRecord(selection, result);
     verify(handler, never()).rollbackRecord(selection, result);
@@ -698,7 +705,7 @@ public class RecoveryHandlerTest {
     handler.tryRecover(selection, result, state);
 
     // Assert
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(handler, never()).rollforwardRecord(selection, result);
     verify(handler, never()).rollbackRecord(selection, result);
   }
@@ -712,14 +719,14 @@ public class RecoveryHandlerTest {
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     Optional<Coordinator.State> state = Optional.empty();
-    doNothing().when(coordinator).putStateForLazyRecoveryRollback(anyString());
+    doNothing().when(coordinator).forceAbort(anyString());
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
     handler.tryRecover(selection, result, state);
 
     // Assert
-    verify(coordinator).putStateForLazyRecoveryRollback(ANY_ID_1);
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(handler).rollbackRecord(selection, result);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -418,7 +418,8 @@ public class TwoPhaseConsensusCommitManagerTest {
   public void check_StateReturned_ReturnTheState() throws CoordinatorException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;
-    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(new State(ANY_TX_ID, expected)));
+    when(coordinator.getState(ANY_TX_ID))
+        .thenReturn(Optional.of(new State(ANY_TX_ID, expected, System.currentTimeMillis())));
 
     // Act
     TransactionState actual = manager.getState(ANY_TX_ID);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -278,7 +278,8 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     if (coordinatorState == null) {
       return;
     }
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, coordinatorState);
+    Coordinator.State state =
+        new Coordinator.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
     coordinator.putState(state);
   }
 
@@ -647,7 +648,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
     // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
@@ -839,7 +840,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
     // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -278,7 +278,8 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     if (coordinatorState == null) {
       return;
     }
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, coordinatorState);
+    Coordinator.State state =
+        new Coordinator.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
     coordinator.putState(state);
   }
 
@@ -724,7 +725,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
     // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
@@ -954,7 +955,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // ABORTED coordinator state is written) before returning the result, then rolls the record back
     // in the background. tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ANY_ID_1);
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ANY_ID_1);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -10,9 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -1752,14 +1751,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
       // via tryRecover()
       verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
       // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
@@ -2351,14 +2350,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
       // via tryRecover()
       verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
       // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
@@ -2554,7 +2553,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // before the result is returned, then the record is rolled back in the background.
     // tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ongoingTxId);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
@@ -2738,7 +2737,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         INITIAL_BALANCE,
         ANY_ID_2,
         current);
-    coordinator.putState(new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED));
+    coordinator.putState(
+        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -2812,7 +2812,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         INITIAL_BALANCE,
         ANY_ID_2,
         current);
-    coordinator.putState(new Coordinator.State(ANY_ID_2, TransactionState.ABORTED));
+    coordinator.putState(
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -2865,7 +2866,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         INITIAL_BALANCE,
         ANY_ID_2,
         current);
-    coordinator.putState(new Coordinator.State(ANY_ID_2, TransactionState.ABORTED));
+    coordinator.putState(
+        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -3080,7 +3082,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .build();
     storage.put(put);
 
-    coordinator.putState(new Coordinator.State(ANY_ID_2, coordinatorState));
+    coordinator.putState(
+        new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
   }
 
   private void
@@ -3312,7 +3315,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // before the records are returned, then the record is rolled back in the background.
     // tryRecover() is not used on this path.
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(coordinator).forceAbort(ongoingTxId);
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
   }
@@ -3663,7 +3666,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       return ANY_ID_2;
     }
 
-    coordinator.putState(new Coordinator.State(ANY_ID_2, coordinatorState));
+    coordinator.putState(
+        new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
     return ANY_ID_2;
   }
 
@@ -3701,7 +3705,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws CoordinatorException {
     doAnswer(
             invocation -> {
-              coordinator.putState(new Coordinator.State(ongoingTxId, TransactionState.COMMITTED));
+              coordinator.putState(
+                  new Coordinator.State(
+                      ongoingTxId, TransactionState.COMMITTED, System.currentTimeMillis()));
               return Optional.empty();
             })
         .doCallRealMethod()
@@ -3902,7 +3908,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
       }
       verify(recovery, never()).tryAbortExpiredTransaction(anyString());
-      verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+      verify(coordinator, never()).forceAbort(anyString());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // SNAPSHOT/SERIALIZABLE resolve from the physical re-read, which sees the committed
@@ -3914,7 +3920,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
 
       verify(recovery, never()).tryAbortExpiredTransaction(anyString());
-      verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+      verify(coordinator, never()).forceAbort(anyString());
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -4087,7 +4093,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
 
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(coordinator).forceAbort(ongoingTxId);
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -4150,9 +4156,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   // attempt: the record is still physically PREPARED, the writer already committed via group commit
   // (a COMMITTED parent row with this child's ID existed), and the coordinator cleanup process
   // removed the parent row in the small window between our parent-id insert conflicting and the
-  // subsequent re-read inside putStateForLazyRecoveryRollbackForGroupCommit. The fall-through then
+  // subsequent re-read inside forceAbortForGroupCommit. The fall-through then
   // writes a spurious full-ID ABORTED coordinator state -- the same outcome as the unit test
-  // putStateForLazyRecoveryRollback_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord.
+  // forceAbort_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord.
   // Crucially, the record is already rolled forward at conflict time (rollRecordForwardToCommitted
   // models the writer's commit), so the background rollback is a conditional no-op and the data
   // record stays committed despite the spurious ABORTED.
@@ -4173,7 +4179,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                   "simulated conflict: group-commit parent row was committed");
             })
         .when(coordinator)
-        .putStateForGroupCommit(anyString(), anyList(), any(), anyLong());
+        .putState(any(Coordinator.State.class));
 
     // The coordinator cleanup process removed the parent row in the window between the conflict
     // and the re-read -- return empty to model the cleaned-up state. The fall-through then writes
@@ -4236,7 +4242,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(result.getInt(BALANCE)).isEqualTo(NEW_BALANCE);
 
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(coordinator).forceAbort(ongoingTxId);
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -4322,7 +4328,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws CoordinatorException {
     // The re-preparing transaction is aborted, so resolving it rolls the record back to its
     // before-image, restoring the intervening committed value as the record's committed image.
-    coordinator.putState(new Coordinator.State(REPREPARING_TX_ID, TransactionState.ABORTED));
+    coordinator.putState(
+        new Coordinator.State(
+            REPREPARING_TX_ID, TransactionState.ABORTED, System.currentTimeMillis()));
     doAnswer(
             invocation -> {
               rePrepareRecordByDifferentTransaction();
@@ -4414,7 +4422,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(result.getVersion()).isEqualTo(2);
 
     verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-    verify(coordinator).putStateForLazyRecoveryRollback(ongoingTxId);
+    verify(coordinator).forceAbort(ongoingTxId);
     verify(recovery, never()).tryAbortExpiredTransaction(REPREPARING_TX_ID);
     verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -4579,7 +4587,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
     }
     verify(recovery, never()).tryAbortExpiredTransaction(anyString());
-    verify(coordinator, never()).putStateForLazyRecoveryRollback(anyString());
+    verify(coordinator, never()).forceAbort(anyString());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -4895,14 +4903,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     if (isolation == Isolation.READ_COMMITTED) {
       // In READ_COMMITTED isolation, the record is recovered in the background via tryRecover()
       verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
       // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
@@ -5148,14 +5156,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     if (isolation == Isolation.READ_COMMITTED) {
       // In READ_COMMITTED isolation, the record is recovered in the background via tryRecover()
       verify(recovery).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else {
       // In SNAPSHOT or SERIALIZABLE isolation, the expired transaction is aborted synchronously
       // (its ABORTED coordinator state is written) before the before-image is returned, then the
       // record is rolled back in the background. tryRecover() is not used on this path.
       verify(recovery).tryAbortExpiredTransaction(ongoingTxId);
-      verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+      verify(coordinator).forceAbort(ongoingTxId);
       verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
@@ -9555,13 +9563,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator)
-              .putStateForGroupCommit(
-                  anyString(),
-                  anyList(),
-                  any(WriteSet.class),
-                  any(TransactionState.class),
-                  anyLong());
+          verify(coordinator).putState(any(Coordinator.State.class));
           return;
         }
         verify(coordinator).putState(any(Coordinator.State.class));
@@ -9582,13 +9584,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -9669,13 +9665,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator)
-              .putStateForGroupCommit(
-                  anyString(),
-                  anyList(),
-                  any(WriteSet.class),
-                  any(TransactionState.class),
-                  anyLong());
+          verify(coordinator).putState(any(Coordinator.State.class));
         } else {
           verify(coordinator).putState(any(Coordinator.State.class));
         }
@@ -9695,13 +9685,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -9783,13 +9767,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator)
-            .putStateForGroupCommit(
-                anyString(),
-                anyList(),
-                any(WriteSet.class),
-                any(TransactionState.class),
-                anyLong());
+        verify(coordinator).putState(any(Coordinator.State.class));
       } else {
         verify(coordinator).putState(any(Coordinator.State.class));
       }
@@ -9805,13 +9783,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -9829,13 +9801,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
             // commit-state should occur
             if (isGroupCommitEnabled()) {
-              verify(coordinator)
-                  .putStateForGroupCommit(
-                      anyString(),
-                      anyList(),
-                      any(WriteSet.class),
-                      any(TransactionState.class),
-                      anyLong());
+              verify(coordinator).putState(any(Coordinator.State.class));
             } else {
               verify(coordinator).putState(any(Coordinator.State.class));
             }
@@ -9938,13 +9904,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator)
-              .putStateForGroupCommit(
-                  anyString(),
-                  anyList(),
-                  any(WriteSet.class),
-                  any(TransactionState.class),
-                  anyLong());
+          verify(coordinator).putState(any(Coordinator.State.class));
           return;
         }
         verify(coordinator).putState(any(Coordinator.State.class));
@@ -9965,13 +9925,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -10074,13 +10028,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator)
-              .putStateForGroupCommit(
-                  anyString(),
-                  anyList(),
-                  any(WriteSet.class),
-                  any(TransactionState.class),
-                  anyLong());
+          verify(coordinator).putState(any(Coordinator.State.class));
         } else {
           verify(coordinator).putState(any(Coordinator.State.class));
         }
@@ -10100,13 +10048,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -10210,13 +10152,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator)
-            .putStateForGroupCommit(
-                anyString(),
-                anyList(),
-                any(WriteSet.class),
-                any(TransactionState.class),
-                anyLong());
+        verify(coordinator).putState(any(Coordinator.State.class));
       } else {
         verify(coordinator).putState(any(Coordinator.State.class));
       }
@@ -10232,13 +10168,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator)
-                .putStateForGroupCommit(
-                    anyString(),
-                    anyList(),
-                    any(WriteSet.class),
-                    any(TransactionState.class),
-                    anyLong());
+            verify(coordinator).putState(any(Coordinator.State.class));
           } else {
             verify(coordinator).putState(any(Coordinator.State.class));
           }
@@ -10256,13 +10186,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
             // commit-state should occur
             if (isGroupCommitEnabled()) {
-              verify(coordinator)
-                  .putStateForGroupCommit(
-                      anyString(),
-                      anyList(),
-                      any(WriteSet.class),
-                      any(TransactionState.class),
-                      anyLong());
+              verify(coordinator).putState(any(Coordinator.State.class));
             } else {
               verify(coordinator).putState(any(Coordinator.State.class));
             }
@@ -10360,13 +10284,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator)
-            .putStateForGroupCommit(
-                anyString(),
-                anyList(),
-                any(WriteSet.class),
-                any(TransactionState.class),
-                anyLong());
+        verify(coordinator).putState(any(Coordinator.State.class));
         return;
       }
       verify(coordinator).putState(any(Coordinator.State.class));
@@ -10387,17 +10305,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       verify(storage, times(2)).mutate(anyList());
 
       // commit-state should occur
-      if (isGroupCommitEnabled()) {
-        verify(coordinator)
-            .putStateForGroupCommit(
-                anyString(),
-                anyList(),
-                any(WriteSet.class),
-                any(TransactionState.class),
-                anyLong());
-      } else {
-        verify(coordinator).putState(any(Coordinator.State.class));
-      }
+      verify(coordinator).putState(any(Coordinator.State.class));
     }
 
     Optional<Result> result1 =
@@ -10837,8 +10745,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
               return invocation.callRealMethod();
             })
         .when(coordinator)
-        .putStateForGroupCommit(
-            eq(parentId), anyList(), any(), eq(TransactionState.COMMITTED), anyLong());
+        .putState(
+            argThat(
+                s ->
+                    s != null
+                        && s.getId().equals(parentId)
+                        && s.getState() == TransactionState.COMMITTED));
 
     // Act Assert
     assertThatCode(transaction::commit).isInstanceOf(CommitConflictException.class);
@@ -10938,7 +10850,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                     .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 0))
                     .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 1)))
             .build();
-    coordinator.putState(new Coordinator.State(txId, writeSet, TransactionState.ABORTED));
+    coordinator.putState(
+        new Coordinator.State(
+            txId, writeSet, TransactionState.ABORTED, System.currentTimeMillis()));
 
     // Sanity check
     Optional<Result> rawBefore = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11029,8 +10943,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                     .setChildId(ANY_ID_2)
                     .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 1, 0)))
             .build();
-    coordinator.putStateForGroupCommit(
-        parentId, Arrays.asList(fullTxId1, fullTxId2), writeSet, TransactionState.COMMITTED, now);
+    CoordinatorGroupCommitKeyManipulator km = new CoordinatorGroupCommitKeyManipulator();
+    List<String> childIds =
+        Arrays.asList(
+            km.keysFromFullKey(fullTxId1).childKey, km.keysFromFullKey(fullTxId2).childKey);
+    coordinator.putState(
+        new Coordinator.State(parentId, childIds, writeSet, TransactionState.COMMITTED, now));
 
     // Sanity check
     Optional<Coordinator.State> stateBefore = coordinator.getState(fullTxId1);
@@ -11330,7 +11248,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange — record (0,0) is PREPARED by a group-commit transaction (its tx_id is a full
     // group-commit key) with no Coordinator state and an expired prepared-at. This is an abandoned
     // group-commit writer (the group never reached commit). recoverRecord must abort it through the
-    // group-commit-aware path (Coordinator.putStateForLazyRecoveryRollbackForGroupCommit), which
+    // group-commit-aware path (Coordinator.forceAbortForGroupCommit), which
     // writes both the lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same
     // rows that conflict-protect against a racing real group commit. This is the expired
     // counterpart
@@ -11558,19 +11476,23 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     switch (commitType) {
       case NORMAL_COMMIT:
-        Coordinator.State state = new Coordinator.State(ANY_ID_2, coordinatorState);
+        Coordinator.State state =
+            new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis());
         coordinator.putState(state);
         break;
       case GROUP_COMMIT:
         Keys<String, String, String> keys = keyManipulator.keysFromFullKey(ongoingTxId);
-        coordinator.putStateForGroupCommit(
-            keys.parentKey,
-            Collections.singletonList(keys.fullKey),
-            coordinatorState,
-            System.currentTimeMillis());
+        coordinator.putState(
+            new Coordinator.State(
+                keys.parentKey,
+                Collections.singletonList(keys.childKey),
+                null,
+                coordinatorState,
+                System.currentTimeMillis()));
         break;
       case DELAYED_GROUP_COMMIT:
-        coordinator.putState(new Coordinator.State(ongoingTxId, coordinatorState));
+        coordinator.putState(
+            new Coordinator.State(ongoingTxId, coordinatorState, System.currentTimeMillis()));
         break;
     }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -2487,7 +2487,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     if (coordinatorState == null) {
       return;
     }
-    State state = new State(ANY_ID_2, coordinatorState);
+    State state = new State(ANY_ID_2, coordinatorState, System.currentTimeMillis());
     coordinatorForStorage1.putState(state);
   }
 


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3652
- **Commit to backport:** a46d71e16a0f41604b8c57327c0e72f3581818eb

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3652 &&
git cherry-pick --no-rerere-autoupdate -m1 a46d71e16a0f41604b8c57327c0e72f3581818eb
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!