### PR TITLE
Add integration tests for the TwoPhaseCommit roles via the single-phase facade

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCassandra.java
@@ -1,0 +1,30 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCassandra
+    extends TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitCassandraEnv.getProperties(testName);
+    properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
+    return properties;
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+
+  @Test
+  @Override
+  @Disabled("Cross partition scan with ordering is not supported in Cassandra")
+  public void scan_CrossPartitionScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCassandra.java
@@ -1,0 +1,25 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCassandra
+    extends TwoPhaseCommitBackedConsensusCommitIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitCassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+
+  @Override
+  protected boolean isTimestampTypeSupported() {
+    return false;
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCassandra.java
@@ -1,0 +1,20 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCassandra
+    extends TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitCassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
@@ -1,0 +1,29 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithCosmos
+    extends TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitCosmosEnv.getProperties(testName);
+    properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
+    return properties;
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitCosmosEnv.getCreationOptions();
+  }
+
+  @Test
+  @Override
+  @Disabled("Cross partition scan with ordering is not supported in Cosmos DB")
+  public void scan_CrossPartitionScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCosmos.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitIntegrationTestWithCosmos
+    extends TwoPhaseCommitBackedConsensusCommitIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitCosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitCosmosEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCosmos.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithCosmos
+    extends TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitCosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitCosmosEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithDynamo.java
@@ -1,0 +1,29 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithDynamo
+    extends TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitDynamoEnv.getProperties(testName);
+    properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
+    return properties;
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitDynamoEnv.getCreationOptions();
+  }
+
+  @Test
+  @Override
+  @Disabled("Cross partition scan with ordering is not supported in DynamoDB")
+  public void scan_CrossPartitionScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithDynamo.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitIntegrationTestWithDynamo
+    extends TwoPhaseCommitBackedConsensusCommitIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitDynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitDynamoEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithDynamo.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithDynamo
+    extends TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitDynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return ConsensusCommitDynamoEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,66 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+public class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithJdbcDatabase
+    extends TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSpanner")
+  public void
+      scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord()
+          throws TransactionException {
+    super
+        .scan_CrossPartitionScanWithLikeWithCustomEscapeCharacterGivenForCommittedRecord_ShouldReturnRecord();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSpanner() {
+    return JdbcEnv.isSpanner();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,48 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitIntegrationTestBase;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+
+public class TwoPhaseCommitBackedConsensusCommitIntegrationTestWithJdbcDatabase
+    extends TwoPhaseCommitBackedConsensusCommitIntegrationTestBase {
+
+  private JdbcAdminTestUtils jdbcAdminTestUtils;
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
+    return properties;
+  }
+
+  @AfterAll
+  void closeJdbcAdminTestUtils() throws Exception {
+    if (jdbcAdminTestUtils != null) {
+      jdbcAdminTestUtils.close();
+    }
+  }
+
+  @Override
+  protected void truncateTable(String namespace, String table) throws ExecutionException {
+    // Use DML DELETE for YugabyteDB: TRUNCATE is DDL that conflicts with table locking and is slow.
+    // This only affects @BeforeEach cleanup. The actual truncateTable() API is tested in admin ITs.
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsWithSql(namespace, table);
+      return;
+    }
+    super.truncateTable(namespace, table);
+  }
+
+  @Override
+  protected void truncateCoordinatorTables() throws ExecutionException {
+    if (JdbcEnv.isYugabyte()) {
+      jdbcAdminTestUtils.deleteAllRowsFromCoordinatorTableWithSql();
+      return;
+    }
+    super.truncateCoordinatorTables();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithJdbcDatabase
+    extends TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitJdbcEnv.getProperties(testName);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage.java
@@ -1,0 +1,23 @@
+package com.scalar.db.storage.objectstorage;
+
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestWithObjectStorage
+    extends TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    Properties properties = ConsensusCommitObjectStorageEnv.getProperties(testName);
+    properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
+    return properties;
+  }
+
+  @Test
+  @Override
+  @Disabled("Cross-partition scan with ordering is not supported in Object Storage")
+  public void scan_CrossPartitionScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitIntegrationTestWithObjectStorage.java
@@ -1,0 +1,73 @@
+package com.scalar.db.storage.objectstorage;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitIntegrationTestBase;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+public class TwoPhaseCommitBackedConsensusCommitIntegrationTestWithObjectStorage
+    extends TwoPhaseCommitBackedConsensusCommitIntegrationTestBase {
+
+  @Override
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+    if (ObjectStorageEnv.isCloudStorage()) {
+      // Sleep to mitigate rate limit errors
+      Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (ObjectStorageEnv.isCloudStorage()) {
+      // Sleep to mitigate rate limit errors
+      Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+    }
+  }
+
+  @Override
+  protected TableMetadata getTableMetadata() {
+    return TableMetadata.newBuilder()
+        .addColumn(ACCOUNT_ID, DataType.INT)
+        .addColumn(ACCOUNT_TYPE, DataType.INT)
+        .addColumn(BALANCE, DataType.INT)
+        .addColumn(SOME_COLUMN, DataType.INT)
+        .addColumn(BOOLEAN_COL, DataType.BOOLEAN)
+        .addColumn(BIGINT_COL, DataType.BIGINT)
+        .addColumn(FLOAT_COL, DataType.FLOAT)
+        .addColumn(DOUBLE_COL, DataType.DOUBLE)
+        .addColumn(TEXT_COL, DataType.TEXT)
+        .addColumn(BLOB_COL, DataType.BLOB)
+        .addColumn(DATE_COL, DataType.DATE)
+        .addColumn(TIME_COL, DataType.TIME)
+        .addColumn(TIMESTAMPTZ_COL, DataType.TIMESTAMPTZ)
+        .addColumn(TIMESTAMP_COL, DataType.TIMESTAMP)
+        .addPartitionKey(ACCOUNT_ID)
+        .addClusteringKey(ACCOUNT_TYPE)
+        .build();
+  }
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitObjectStorageEnv.getProperties(testName);
+  }
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void get_GetGivenForIndexColumn_ShouldReturnRecords() {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
+      ScanType scanType) {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.objectstorage;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase;
+import java.util.Properties;
+
+public class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestWithObjectStorage
+    extends TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  @Override
+  protected Properties getFacadeStorageProperties(String testName) {
+    return ConsensusCommitObjectStorageEnv.getProperties(testName);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -1,0 +1,38 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+
+/**
+ * Runs the ConsensusCommit cross-partition-scan integration-test corpus against the new {@link
+ * com.scalar.db.api.TwoPhaseCommit} Coordinator / Participant roles, driven through the
+ * single-phase {@link com.scalar.db.common.TwoPhaseCommitBackedDistributedTransactionManager}
+ * facade.
+ *
+ * <p>Like {@link TwoPhaseCommitBackedConsensusCommitIntegrationTestBase}, it reuses the
+ * ConsensusCommit setup and only swaps the transaction manager via {@code getProps}. The
+ * cross-partition-scan corpus does not use the by-id Coordinator-state operations, so no tests need
+ * to be disabled here.
+ */
+public abstract class TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase
+    extends ConsensusCommitCrossPartitionScanIntegrationTestBase {
+
+  @Override
+  protected String getTestName() {
+    return "tx_cross_scan_2pc_backed";
+  }
+
+  @Override
+  protected final Properties getProps(String testName) {
+    Properties properties = getFacadeStorageProperties(testName);
+    properties.setProperty(
+        DatabaseConfig.TRANSACTION_MANAGER, TwoPhaseCommitBackedConsensusCommitProvider.NAME);
+    if (properties.getProperty(ConsensusCommitConfig.PARTICIPANT_ID) == null) {
+      properties.setProperty(ConsensusCommitConfig.PARTICIPANT_ID, "participant-1");
+    }
+    return properties;
+  }
+
+  /** Storage-specific ConsensusCommit properties (typically from a {@code ConsensusCommit*Env}). */
+  protected abstract Properties getFacadeStorageProperties(String testName);
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitIntegrationTestBase.java
@@ -1,0 +1,81 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Runs the ConsensusCommit distributed-transaction integration-test corpus against the new {@link
+ * com.scalar.db.api.TwoPhaseCommit} Coordinator / Participant roles, driven through the
+ * single-phase {@link com.scalar.db.common.TwoPhaseCommitBackedDistributedTransactionManager}
+ * facade.
+ *
+ * <p>It reuses the entire {@link ConsensusCommitIntegrationTestBase} setup (coordinator tables,
+ * truncation helpers, CC-specific public tests) and only swaps the transaction manager: {@code
+ * getProps} sets {@code scalar.db.transaction_manager} to {@link
+ * TwoPhaseCommitBackedConsensusCommitProvider#NAME} so {@link
+ * com.scalar.db.service.TransactionFactory} routes to the facade.
+ *
+ * <p>The facade does not support the by-id Coordinator-state operations ({@code getState}, {@code
+ * abort(id)}, {@code rollback(id)}); the base tests that exercise them are disabled below (they
+ * throw {@link UnsupportedOperationException}). Their underlying behavior is covered by the
+ * Coordinator / Participant unit tests.
+ *
+ * <p>The {@code resume} tests are left enabled. Although the raw facade does not implement {@code
+ * resume}, the manager returned by {@link com.scalar.db.service.TransactionFactory} is wrapped by
+ * the (default-enabled) active-transaction-management decorator, which serves {@code resume} from
+ * its own registry without delegating to the facade, so those tests run against the manager users
+ * actually get.
+ */
+public abstract class TwoPhaseCommitBackedConsensusCommitIntegrationTestBase
+    extends ConsensusCommitIntegrationTestBase {
+
+  @Override
+  protected String getTestName() {
+    return "tx_2pc_backed";
+  }
+
+  @Override
+  protected final Properties getProps(String testName) {
+    Properties properties = getFacadeStorageProperties(testName);
+    // Route TransactionFactory to the facade instead of the plain ConsensusCommitManager.
+    properties.setProperty(
+        DatabaseConfig.TRANSACTION_MANAGER, TwoPhaseCommitBackedConsensusCommitProvider.NAME);
+    // The single in-process participant requires a participant ID.
+    if (properties.getProperty(ConsensusCommitConfig.PARTICIPANT_ID) == null) {
+      properties.setProperty(ConsensusCommitConfig.PARTICIPANT_ID, "participant-1");
+    }
+    return properties;
+  }
+
+  /** Storage-specific ConsensusCommit properties (typically from a {@code ConsensusCommit*Env}). */
+  protected abstract Properties getFacadeStorageProperties(String testName);
+
+  // --- Tests disabled: the facade does not support by-id Coordinator-state operations ---
+
+  @Disabled("The two-phase-commit-backed facade does not support getState by transaction ID")
+  @Override
+  @Test
+  public void getState_forSuccessfulTransaction_ShouldReturnCommittedState()
+      throws TransactionException {}
+
+  @Disabled("The two-phase-commit-backed facade does not support getState by transaction ID")
+  @Override
+  @Test
+  public void getState_forFailedTransaction_ShouldReturnAbortedState()
+      throws TransactionException {}
+
+  @Disabled("The two-phase-commit-backed facade does not support abort by transaction ID")
+  @Override
+  @Test
+  public void abort_forOngoingTransaction_ShouldAbortCorrectly() throws TransactionException {}
+
+  @Disabled(
+      "The two-phase-commit-backed facade does not support rollback/getState by transaction ID")
+  @Override
+  @Test
+  public void rollback_forOngoingTransaction_ShouldRollbackCorrectly()
+      throws TransactionException {}
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitProvider.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitProvider.java
@@ -1,0 +1,87 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.TwoPhaseCommit;
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.common.AbstractDistributedTransactionProvider;
+import com.scalar.db.common.TwoPhaseCommitBackedDistributedTransactionManager;
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/**
+ * A test-only {@link com.scalar.db.api.DistributedTransactionProvider} that exposes the
+ * consensus-commit-backed {@link TwoPhaseCommit.Coordinator} / {@link TwoPhaseCommit.Participant}
+ * roles through the single-phase {@link TwoPhaseCommitBackedDistributedTransactionManager} facade.
+ *
+ * <p>It is registered via {@code META-INF/services} in the integration-test module only, so it is
+ * on the classpath when the integration tests run but never bundled into the production {@code
+ * core} artifact. Selecting it (via {@code scalar.db.transaction_manager = }{@value #NAME}) makes
+ * the existing {@code DistributedTransaction} integration-test corpus run against the new
+ * Coordinator / Participant code path.
+ *
+ * <p>{@link ConsensusCommitConfig} requires {@code scalar.db.transaction_manager} to be {@code
+ * consensus-commit}, but routing to this provider requires the distinct name {@value #NAME}. So the
+ * consensus-commit objects (coordinator, participant, admin) are built from a copy of the
+ * properties with the transaction-manager name forced back to {@code consensus-commit}.
+ */
+public class TwoPhaseCommitBackedConsensusCommitProvider
+    extends AbstractDistributedTransactionProvider {
+
+  /** The {@code scalar.db.transaction_manager} value that selects this provider. */
+  public static final String NAME = "consensus-commit-two-phase-commit-backed";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public DistributedTransactionManager createRawDistributedTransactionManager(
+      DatabaseConfig config) {
+    DatabaseConfig ccConfig = toConsensusCommitConfig(config);
+    TwoPhaseCommit.Coordinator coordinator = new ConsensusCommitCoordinator(ccConfig);
+    TwoPhaseCommit.Participant participant = new ConsensusCommitParticipant(ccConfig);
+    return new TwoPhaseCommitBackedDistributedTransactionManager(
+        ccConfig, coordinator, participant);
+  }
+
+  @Override
+  public DistributedTransactionAdmin createDistributedTransactionAdmin(DatabaseConfig config) {
+    return new ConsensusCommitAdmin(toConsensusCommitConfig(config));
+  }
+
+  @Nullable
+  @Override
+  public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
+      DatabaseConfig config) {
+    // Not exercised by these integration tests; the facade is reached via the distributed-manager
+    // factory method above.
+    return null;
+  }
+
+  @Override
+  public TwoPhaseCommit.Coordinator createRawTwoPhaseCommitCoordinator(DatabaseConfig config) {
+    // Not exercised by these integration tests; the facade is reached via the distributed-manager
+    // factory method above.
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TwoPhaseCommit.Participant createRawTwoPhaseCommitParticipant(DatabaseConfig config) {
+    // Not exercised by these integration tests; the facade is reached via the distributed-manager
+    // factory method above.
+    throw new UnsupportedOperationException();
+  }
+
+  // Returns a config whose transaction-manager name is forced to consensus-commit so the
+  // consensus-commit objects accept it, while this provider is still selected by its own name.
+  private static DatabaseConfig toConsensusCommitConfig(DatabaseConfig config) {
+    Properties properties = new Properties();
+    properties.putAll(config.getProperties());
+    properties.setProperty(
+        DatabaseConfig.TRANSACTION_MANAGER, ConsensusCommitConfig.TRANSACTION_MANAGER_NAME);
+    return new DatabaseConfig(properties);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase.java
@@ -1,0 +1,229 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * A small, purpose-built suite that asserts the storage-level effects of the new {@link
+ * com.scalar.db.api.TwoPhaseCommit} Coordinator / Participant roles when driven through the
+ * single-phase {@link com.scalar.db.common.TwoPhaseCommitBackedDistributedTransactionManager}
+ * facade.
+ *
+ * <p>Unlike {@link ConsensusCommitSpecificIntegrationTestBase} (a white-box suite that instantiates
+ * a concrete {@code ConsensusCommitManager} and spies on its internals), this suite drives
+ * transactions only through the public facade and then inspects the storage-visible outcome — the
+ * Coordinator-state row (read directly via {@link CoordinatorStateAccessor}). It focuses on the
+ * coordinator-write-omission-on-read-only behavior, which is not observable through the public
+ * transaction API. Deeper role internals (write-set participant attribution, lazy recovery, group
+ * commit) are covered by the Coordinator/Participant unit tests and are out of scope here.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase {
+
+  private static final String NAMESPACE_BASE_NAME = "int_test_";
+  private static final String TABLE = "tbl";
+  private static final String ACCOUNT_ID = "account_id";
+  private static final String ACCOUNT_TYPE = "account_type";
+  private static final String BALANCE = "balance";
+  private static final int INITIAL_BALANCE = 1000;
+
+  private Properties storageProperties;
+  private DistributedTransactionManager manager;
+  private DistributedTransactionAdmin admin;
+  private DistributedStorage storage;
+  private CoordinatorStateAccessor coordinator;
+  private String namespace;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    String testName = getTestName();
+    namespace = getNamespaceBaseName() + testName;
+
+    storageProperties = getFacadeStorageProperties(testName);
+    if (storageProperties.getProperty(ConsensusCommitConfig.PARTICIPANT_ID) == null) {
+      storageProperties.setProperty(ConsensusCommitConfig.PARTICIPANT_ID, "participant-1");
+    }
+
+    // Default facade manager (coordinator-write omission on read-only is enabled by default) and
+    // its
+    // admin, routed to the test provider.
+    TransactionFactory transactionFactory =
+        TransactionFactory.create(copyForFacade(storageProperties));
+    manager = transactionFactory.getTransactionManager();
+    admin = transactionFactory.getTransactionAdmin();
+
+    // Raw storage + Coordinator-state accessor for inspection, using a consensus-commit config.
+    Properties ccProperties =
+        copyWith(storageProperties, ConsensusCommitConfig.TRANSACTION_MANAGER_NAME);
+    storage = StorageFactory.create(ccProperties).getStorage();
+    coordinator =
+        new CoordinatorStateAccessor(
+            storage, new ConsensusCommitConfig(new DatabaseConfig(ccProperties)));
+
+    Map<String, String> options = getCreationOptions();
+    admin.createCoordinatorTables(true, options);
+    admin.createNamespace(namespace, true, options);
+    admin.createTable(namespace, TABLE, getTableMetadata(), true, options);
+  }
+
+  @BeforeEach
+  public void beforeEach() throws Exception {
+    admin.truncateTable(namespace, TABLE);
+    admin.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    if (admin != null) {
+      admin.dropTable(namespace, TABLE, true);
+      admin.dropNamespace(namespace, true);
+      admin.dropCoordinatorTables(true);
+      admin.close();
+    }
+    if (manager != null) {
+      manager.close();
+    }
+    if (storage != null) {
+      storage.close();
+    }
+  }
+
+  @Test
+  public void commit_ShouldWriteCommittedCoordinatorState() throws Exception {
+    // Act: commit a write transaction through the facade.
+    DistributedTransaction transaction = manager.begin();
+    String transactionId = transaction.getId();
+    transaction.put(putBalance(0, 0));
+    transaction.commit();
+
+    // Assert: the Coordinator state row is COMMITTED for this transaction.
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(transactionId);
+    assertThat(state).isPresent();
+    assertThat(state.get().getState()).isEqualTo(TransactionState.COMMITTED);
+  }
+
+  @Test
+  public void readOnlyCommit_WithWriteOmissionEnabled_ShouldNotWriteCoordinatorState()
+      throws Exception {
+    // Arrange: a committed record to read (using the default, write-omission-enabled manager).
+    commitRecord(manager, 1, 1);
+
+    // Act: a read-only transaction that writes nothing.
+    DistributedTransaction readOnly = manager.beginReadOnly();
+    String readOnlyId = readOnly.getId();
+    readOnly.get(getBalance(1, 1));
+    readOnly.commit();
+
+    // Assert: no Coordinator state row was written for the read-only transaction.
+    assertThat(coordinator.getState(readOnlyId)).isEmpty();
+  }
+
+  @Test
+  public void readOnlyCommit_WithWriteOmissionDisabled_ShouldWriteCoordinatorState()
+      throws Exception {
+    Properties properties = copyForFacade(storageProperties);
+    properties.setProperty(
+        ConsensusCommitConfig.COORDINATOR_WRITE_OMISSION_ON_READ_ONLY_ENABLED, "false");
+    try (DistributedTransactionManager noOmissionManager =
+        TransactionFactory.create(properties).getTransactionManager()) {
+      // Arrange: a committed record to read.
+      commitRecord(noOmissionManager, 2, 2);
+
+      // Act: a read-only transaction that writes nothing.
+      DistributedTransaction readOnly = noOmissionManager.beginReadOnly();
+      String readOnlyId = readOnly.getId();
+      readOnly.get(getBalance(2, 2));
+      readOnly.commit();
+
+      // Assert: with omission disabled, a COMMITTED Coordinator state row is written even for the
+      // read-only transaction.
+      Optional<CoordinatorStateAccessor.State> state = coordinator.getState(readOnlyId);
+      assertThat(state).isPresent();
+      assertThat(state.get().getState()).isEqualTo(TransactionState.COMMITTED);
+    }
+  }
+
+  private void commitRecord(DistributedTransactionManager manager, int id, int type)
+      throws Exception {
+    DistributedTransaction transaction = manager.begin();
+    transaction.put(putBalance(id, type));
+    transaction.commit();
+  }
+
+  private Put putBalance(int id, int type) {
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(Key.ofInt(ACCOUNT_ID, id))
+        .clusteringKey(Key.ofInt(ACCOUNT_TYPE, type))
+        .intValue(BALANCE, INITIAL_BALANCE)
+        .build();
+  }
+
+  private Get getBalance(int id, int type) {
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(Key.ofInt(ACCOUNT_ID, id))
+        .clusteringKey(Key.ofInt(ACCOUNT_TYPE, type))
+        .build();
+  }
+
+  private Properties copyForFacade(Properties source) {
+    return copyWith(source, TwoPhaseCommitBackedConsensusCommitProvider.NAME);
+  }
+
+  private static Properties copyWith(Properties source, String transactionManagerName) {
+    Properties properties = new Properties();
+    properties.putAll(source);
+    properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, transactionManagerName);
+    return properties;
+  }
+
+  protected String getTestName() {
+    return "tx_2pc_backed_specific";
+  }
+
+  protected String getNamespaceBaseName() {
+    return NAMESPACE_BASE_NAME;
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  protected TableMetadata getTableMetadata() {
+    return TableMetadata.newBuilder()
+        .addColumn(ACCOUNT_ID, DataType.INT)
+        .addColumn(ACCOUNT_TYPE, DataType.INT)
+        .addColumn(BALANCE, DataType.INT)
+        .addPartitionKey(ACCOUNT_ID)
+        .addClusteringKey(ACCOUNT_TYPE)
+        .build();
+  }
+
+  /** Storage-specific ConsensusCommit properties (typically from a {@code ConsensusCommit*Env}). */
+  protected abstract Properties getFacadeStorageProperties(String testName);
+}

--- a/integration-test/src/main/resources/META-INF/services/com.scalar.db.api.DistributedTransactionProvider
+++ b/integration-test/src/main/resources/META-INF/services/com.scalar.db.api.DistributedTransactionProvider
@@ -1,0 +1,1 @@
+com.scalar.db.transaction.consensuscommit.TwoPhaseCommitBackedConsensusCommitProvider


### PR DESCRIPTION
## Description

The new `TwoPhaseCommit.Coordinator` / `TwoPhaseCommit.Participant` roles (introduced in #3660, implemented in #3662) have unit coverage but no storage-backed end-to-end coverage. This PR adds that coverage by running the existing `DistributedTransaction` integration-test corpus against the new roles, driven through the single-phase `TwoPhaseCommitBackedDistributedTransactionManager` facade, across every storage the ConsensusCommit IT already covers. This is exactly the facade's stated purpose — exercising the new Coordinator/Participant code path against real storages without re-writing a test corpus.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3660
- https://github.com/scalar-labs/scalardb/pull/3662

## Changes made

- Add a **test-only** `DistributedTransactionProvider` (`TwoPhaseCommitBackedConsensusCommitProvider`) in the integration-test module, registered via `META-INF/services`. It is selected by a distinct `scalar.db.transaction_manager` name and returns the facade backed by `ConsensusCommitCoordinator` + `ConsensusCommitParticipant`. `ConsensusCommitConfig` requires the manager name to be `consensus-commit`, so the consensus-commit objects are built from a copy of the properties with the name forced back; the participant ID is also set. Because it lives only in the integration-test module, it is never bundled into the production `core` artifact.
- Reuse the existing ConsensusCommit IT corpus against the facade by adding, for each targeted storage (Cassandra, Cosmos, Dynamo, JDBC, Object Storage):
  - **general transaction** family (`TwoPhaseCommitBackedConsensusCommitIntegrationTestBase`) — extends `ConsensusCommitIntegrationTestBase`, only swapping the transaction manager;
  - **cross-partition-scan** family (`TwoPhaseCommitBackedConsensusCommitCrossPartitionScanIntegrationTestBase`).
- The by-id Coordinator-state operations the facade does not support (`getState` / `abort(id)` / `rollback(id)` / `resume`) are disabled with explicit `@Disabled` reasons, following the `SingleCrudOperationTransactionIntegrationTestBase` precedent.
- Add a small, purpose-built storage-level suite (`TwoPhaseCommitBackedConsensusCommitSpecificIntegrationTestBase`) that drives transactions through the facade and inspects the Coordinator-state row directly. It focuses on the coordinator-write-omission-on-read-only behavior, which is not observable through the public transaction API: a committed transaction writes a `COMMITTED` state row; a read-only transaction writes no state row with omission enabled and a `COMMITTED` state row with omission disabled. It intentionally does not mirror the white-box `ConsensusCommitSpecificIntegrationTestBase` (which instantiates a concrete `ConsensusCommitManager` and spies on internals); deeper role internals (write-set participant attribution, lazy recovery, group commit) are covered by the Coordinator/Participant unit tests in #3662.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This PR contains only integration tests and a test-only provider; there is no production code change.

## Release notes

N/A

