### PR TITLE
Disable secondary-index Get tests for Object Storage

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitSpecificIntegrationTestWithObjectStorage.java
@@ -317,4 +317,26 @@ public class ConsensusCommitSpecificIntegrationTestWithObjectStorage
   @Disabled("Object Storage does not support index-related operations")
   public void
       commit_GetScannerWithScanAllIndexConditionInSerializable_WhenBeforeIndexHasPreparedRecordFromOtherTransaction_ShouldThrowCommitConflictException() {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void get_GetWithIndexForTransientDeletedAndPreparedRecords_ShouldResolveToSingleRecord(
+      Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForTransientDeletedAndPreparedRecordsWhenWriterAborted_ShouldResolveToNoRecord(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void
+      get_GetWithIndexForExistingCommittedRecordAndTransientPreparedRecord_ShouldReturnCommittedRecordInAllIsolations(
+          Isolation isolation) {}
+
+  @Override
+  @Disabled("Object Storage does not support index-related operations")
+  public void get_GetWithIndexMatchingMultipleCommittedRecords_ShouldThrowIllegalArgumentException(
+      Isolation isolation) {}
 }


### PR DESCRIPTION
## Description

The full CI run ([28697501820](https://github.com/scalar-labs/scalardb/actions/runs/28697501820)) failed with 12 test failures in the Blob Storage (Object Storage) integration tests, all throwing `IllegalArgumentException` from `OperationChecker` / `ConsensusCommitOperationChecker`.

The cause is that PR #3607 added four secondary-index `Get` tests to `ConsensusCommitSpecificIntegrationTestBase`, but did not add the corresponding `@Disabled` overrides in the Object Storage subclass. Object Storage does not support index-related operations, so these tests fail as soon as an index `Get` is issued. The subclass already disables all other index-related tests the same way; these four were simply missed.

This failure only surfaces in the manually triggered full CI (`workflow_dispatch`), which is why it was not caught when #3607 was merged.

## Related issues and/or PRs

- Follow-up to #3607, which introduced the four tests.

## Changes made

- Added four `@Disabled("Object Storage does not support index-related operations")` overrides to `ConsensusCommitSpecificIntegrationTestWithObjectStorage` for:
  - `get_GetWithIndexForTransientDeletedAndPreparedRecords_ShouldResolveToSingleRecord`
  - `get_GetWithIndexForTransientDeletedAndPreparedRecordsWhenWriterAborted_ShouldResolveToNoRecord`
  - `get_GetWithIndexForExistingCommittedRecordAndTransientPreparedRecord_ShouldReturnCommittedRecordInAllIsolations`
  - `get_GetWithIndexMatchingMultipleCommittedRecords_ShouldThrowIllegalArgumentException`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR only addresses the Object Storage failures. The same full CI run also shows unrelated `Lock wait timeout exceeded` failures in the MySQL/MariaDB `InHighestIsolation` (SERIALIZABLE) scan-recovery tests, which are being investigated separately.

## Release notes

N/A