### PR TITLE
Fix ConsensusCommit scan-recovery integration tests on JDBC engines under the highest isolation level

### DIFF
--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -251,7 +251,7 @@ jdbc:
   - label: sqlite_3
     display_name: SQLite 3
     setup: sudo apt-get install -y sqlite3
-    run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
+    run: ./gradlew integrationTestJdbc "-Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000&journal_mode=WAL"
 
   - label: tidb_%VERSION%
     display_name: TiDB %VERSION%

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabase.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
@@ -17,14 +18,26 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabase
     extends ConsensusCommitSpecificIntegrationTestBase {
 
   private JdbcAdminTestUtils jdbcAdminTestUtils;
+  private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
     Properties properties = ConsensusCommitJdbcEnv.getProperties(testName);
+    rdbEngine = RdbEngineFactory.create(new JdbcConfig(new DatabaseConfig(properties)));
     if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
       jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
     }
     return properties;
+  }
+
+  @Override
+  protected boolean isConcurrentWriteToRowUnderOpenScanSupported() {
+    // SQL Server and Db2 use lock-based concurrency even at their default isolation (READ
+    // COMMITTED), so an open scan keeps a shared lock that blocks the scan-path recovery
+    // simulation's concurrent write to a scanned row, and their lock wait is effectively unbounded,
+    // so it hangs. MySQL and MariaDB are MVCC at this class's (default) isolation and do not block;
+    // they only block under SERIALIZABLE (see the highest-isolation subclass).
+    return !(JdbcTestUtils.isSqlServer(rdbEngine) || JdbcTestUtils.isDb2(rdbEngine));
   }
 
   @AfterAll

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
@@ -72,8 +72,7 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsol
     // the scan still holds blocks until the scan finishes. The scan-path finalize/cleanup-race
     // recovery tests simulate exactly such a write from within lazy recovery while the scanner is
     // open, so they self-deadlock on these engines.
-    return !(JdbcTestUtils.isMysql(rdbEngine)
-        || JdbcTestUtils.isMariaDB(rdbEngine)
+    return !((JdbcTestUtils.isMysql(rdbEngine) && !JdbcTestUtils.isTidb(rdbEngine))
         || JdbcTestUtils.isSqlServer(rdbEngine)
         || JdbcTestUtils.isDb2(rdbEngine));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.java
@@ -18,6 +18,7 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsol
     extends ConsensusCommitSpecificIntegrationTestBase {
 
   private JdbcAdminTestUtils jdbcAdminTestUtils;
+  private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
@@ -25,13 +26,14 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsol
 
     // Set the isolation level to the highest level
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    RdbEngineStrategy rdbEngine = RdbEngineFactory.create(config);
-    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
-      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
-    }
+    rdbEngine = RdbEngineFactory.create(config);
     properties.setProperty(
         JdbcConfig.ISOLATION_LEVEL,
         JdbcTestUtils.getIsolationLevel(rdbEngine.getHighestIsolationLevel()).name());
+
+    if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
+      jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
+    }
 
     return properties;
   }
@@ -61,6 +63,19 @@ public class ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsol
       return;
     }
     super.truncateCoordinatorTables();
+  }
+
+  @Override
+  protected boolean isConcurrentWriteToRowUnderOpenScanSupported() {
+    // MySQL, MariaDB, SQL Server and Db2 take shared/range locks for an open scan under
+    // SERIALIZABLE (the highest isolation level this class sets), so a concurrent write to a row
+    // the scan still holds blocks until the scan finishes. The scan-path finalize/cleanup-race
+    // recovery tests simulate exactly such a write from within lazy recovery while the scanner is
+    // open, so they self-deadlock on these engines.
+    return !(JdbcTestUtils.isMysql(rdbEngine)
+        || JdbcTestUtils.isMariaDB(rdbEngine)
+        || JdbcTestUtils.isSqlServer(rdbEngine)
+        || JdbcTestUtils.isDb2(rdbEngine));
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdbcDatabase.java
@@ -18,6 +18,7 @@ public class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdb
     extends ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestBase {
 
   private JdbcAdminTestUtils jdbcAdminTestUtils;
+  private RdbEngineStrategy rdbEngine;
 
   @Override
   protected Properties getProperties(String testName) {
@@ -25,7 +26,7 @@ public class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdb
 
     // Set the isolation level for consistency reads for virtual tables
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
-    RdbEngineStrategy rdbEngine = RdbEngineFactory.create(config);
+    rdbEngine = RdbEngineFactory.create(config);
     if (JdbcEnv.isYugabyte() && jdbcAdminTestUtils == null) {
       jdbcAdminTestUtils = new JdbcAdminTestUtils(properties);
     }
@@ -36,6 +37,16 @@ public class ConsensusCommitSpecificWithMetadataDecouplingIntegrationTestWithJdb
             .name());
 
     return properties;
+  }
+
+  @Override
+  protected boolean isConcurrentWriteToRowUnderOpenScanSupported() {
+    // SQL Server and Db2 use lock-based concurrency even at READ COMMITTED, so an open scan keeps a
+    // shared lock that blocks the scan-path recovery simulation's concurrent write to a scanned row
+    // (indefinitely, as their lock wait is unbounded). MySQL and MariaDB are MVCC at this class's
+    // isolation and do not block; they only block under SERIALIZABLE (see the highest-isolation
+    // subclass).
+    return !(JdbcTestUtils.isSqlServer(rdbEngine) || JdbcTestUtils.isDb2(rdbEngine));
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -197,7 +198,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @AfterEach
   public void tearDown() {
-    recoveryExecutor.close();
+    if (recoveryExecutor != null) {
+      recoveryExecutor.close();
+    }
     if (groupCommitter != null) {
       groupCommitter.close();
     }
@@ -2513,11 +2516,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // (BALANCE=NEW_BALANCE) leave two physical rows belonging to the same writer transaction: a
     // DELETED record (the deleted one) and a PREPARED record (the inserted one). A single-row index
     // Get would throw GET_OPERATION_USED_FOR_NON_EXACT_MATCH_SELECTION here. Reading via a Scan
-    // with
-    // index lets lazy recovery (coordinator COMMITTED -> roll forward) resolve the transient
-    // duplicate so that exactly one record (the inserted one) survives.
-    // (This example happens to share a partition key, but the bug is about distinct primary keys
-    // sharing an index value, not about clustering keys.)
+    // with index lets lazy recovery (coordinator COMMITTED -> roll forward) resolve the transient
+    // duplicate so that exactly one record (the inserted one) survives. (This example happens to
+    // share a partition key, but the bug is about distinct primary keys sharing an index value, not
+    // about clustering keys.)
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
     // Old record being deleted (account_type 0); its committed before-image is INITIAL_BALANCE.
@@ -2550,8 +2552,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Act
     Get get = prepareGetWithIndex(namespace1, TABLE_1, NEW_BALANCE);
     // The key assertion is that this does NOT throw
-    // GET_OPERATION_USED_FOR_NON_EXACT_MATCH_SELECTION
-    // even though two physical rows transiently match the index value.
+    // GET_OPERATION_USED_FOR_NON_EXACT_MATCH_SELECTION even though two physical rows transiently
+    // match the index value.
     Optional<Result> result = transaction.get(get);
 
     // Assert
@@ -2590,8 +2592,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // The same transient DELETED(old) + PREPARED(new) duplicate as the rollforward case, but the
     // writer transaction ABORTED. Both rows roll back to their committed before-image
     // (BALANCE=INITIAL_BALANCE), which no longer matches the queried index value NEW_BALANCE, so
-    // the
-    // index Get resolves to no record in every isolation - and still never throws
+    // the index Get resolves to no record in every isolation - and still never throws
     // GET_OPERATION_USED_FOR_NON_EXACT_MATCH_SELECTION. (Correctness invariant case 2.)
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -2651,11 +2652,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     // An already-committed record (account_type 0, BALANCE=NEW_BALANCE) exists. A concurrent
     // transaction's in-flight insert (account_type 1, PREPARED, same BALANCE) transiently shares
-    // the
-    // index value, then aborts. A single-row index Get would throw
+    // the index value, then aborts. A single-row index Get would throw
     // GET_OPERATION_USED_FOR_NON_EXACT_MATCH_SELECTION on the two physical rows; resolving via a
-    // Scan
-    // with index returns the existing committed record in every isolation -- including
+    // Scan with index returns the existing committed record in every isolation -- including
     // READ_COMMITTED, since the surviving record is genuinely committed (no before-image needed).
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long current = System.currentTimeMillis();
@@ -3659,6 +3658,34 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         true, isolation);
   }
 
+  /**
+   * Whether the storage engine allows a concurrent write to a row that an open scan cursor is still
+   * reading. The scan-path variants of the finalize/cleanup-race recovery tests synchronously write
+   * the scanned row from within lazy recovery while the storage scanner is still open. Engines that
+   * take shared/range locks for a scan under the highest isolation level (MySQL, MariaDB, SQL
+   * Server, Db2) block that write until the scan finishes, so the simulation self-deadlocks and
+   * times out. Returns {@code true} by default; the highest-isolation JDBC subclass overrides it to
+   * {@code false} for those engines. The Get variants are unaffected because a point Get releases
+   * its connection immediately.
+   */
+  protected boolean isConcurrentWriteToRowUnderOpenScanSupported() {
+    return true;
+  }
+
+  /**
+   * Skips a scan-path recovery-simulation test on engines that cannot support a concurrent write to
+   * a row an open scan is still reading. These tests synchronously write the scanned row from
+   * within lazy recovery while the storage scanner is still open, which self-deadlocks on
+   * pessimistic-lock engines under the highest isolation level. The Get path is unaffected because
+   * a point Get releases its connection immediately. See {@link
+   * #isConcurrentWriteToRowUnderOpenScanSupported()}.
+   */
+  private void assumeConcurrentWriteToRowUnderOpenScanSupported(Selection s) {
+    if (s instanceof Scan) {
+      assumeTrue(isConcurrentWriteToRowUnderOpenScanSupported());
+    }
+  }
+
   // Sets up the cleanup race for the transaction that wrote a record: the read path looks up the
   // coordinator state and finds none. Intercept only that first lookup to roll the record forward
   // to its committed after-image (a real write) as a side effect, modeling the writer committing,
@@ -3745,6 +3772,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           boolean readOnly,
           CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
+    assumeConcurrentWriteToRowUnderOpenScanSupported(s);
+
     // Arrange
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
@@ -3860,6 +3889,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordFinalizedAndCleanedUpDuringAbort_ShouldReturnCommittedValue(
           Selection s, boolean useScanner, Isolation isolation, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
+    assumeConcurrentWriteToRowUnderOpenScanSupported(s);
+
     // Arrange — a prepared record with no coordinator state, expired. The cleanup race is injected
     // into the abort attempt itself (see simulateRecordFinalizedAndCleanedUpDuringAbort).
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
@@ -3966,12 +3997,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   // attempt: the record is still physically PREPARED, the writer already committed via group commit
   // (a COMMITTED parent row with this child's ID existed), and the coordinator cleanup process
   // removed the parent row in the small window between our parent-id insert conflicting and the
-  // subsequent re-read inside forceAbortForGroupCommit. The fall-through then
-  // writes a spurious full-ID ABORTED coordinator state -- the same outcome as the unit test
-  // forceAbort_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord.
-  // Crucially, the record is already rolled forward at conflict time (rollRecordForwardToCommitted
-  // models the writer's commit), so the background rollback is a conditional no-op and the data
-  // record stays committed despite the spurious ABORTED.
+  // subsequent re-read inside forceAbortForGroupCommit. The fall-through then writes a spurious
+  // full-ID ABORTED coordinator state -- the same outcome as the unit test
+  // forceAbort_FullIdGivenWhenParentRowAlreadyCleanedUpAndNoFullIdRecord. Crucially, the record is
+  // already rolled forward at conflict time (rollRecordForwardToCommitted models the writer's
+  // commit), so the background rollback is a conditional no-op and the data record stays committed
+  // despite the spurious ABORTED.
   private void simulateGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback(String ongoingTxId)
       throws CoordinatorException {
     CoordinatorGroupCommitKeyManipulator keyManipulator =
@@ -4001,6 +4032,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       selection_SelectionGivenForPreparedWhenGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback_ShouldReturnCommittedValue(
           Selection s, boolean useScanner, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
+    assumeConcurrentWriteToRowUnderOpenScanSupported(s);
+
     // Arrange — a prepared record under a group-commit full ID with no coordinator state, expired.
     // The group-commit parent-row cleanup race is injected via
     // simulateGroupCommitParentRowCleanedUpDuringLazyRecoveryRollback.
@@ -4186,6 +4219,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpiredButRecordRePreparedByDifferentTxDuringAbort_ShouldReturnInterveningCommittedValue(
           Selection s, boolean useScanner, Isolation isolation, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
+    assumeConcurrentWriteToRowUnderOpenScanSupported(s);
+
     // Arrange — a prepared record with no coordinator state, expired. The ABA cleanup race is
     // injected into the abort attempt itself (see
     // simulateRecordRePreparedByDifferentTxDuringAbort).
@@ -4335,6 +4370,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           boolean readOnly,
           CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
+    assumeConcurrentWriteToRowUnderOpenScanSupported(s);
+
     // Arrange — a prepared DELETE with no coordinator state, expired.
     ConsensusCommitManager manager = createConsensusCommitManager(isolation);
     long preparedAt = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
@@ -11113,12 +11150,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange — record (0,0) is PREPARED by a group-commit transaction (its tx_id is a full
     // group-commit key) with no Coordinator state and an expired prepared-at. This is an abandoned
     // group-commit writer (the group never reached commit). recoverRecord must abort it through the
-    // group-commit-aware path (Coordinator.forceAbortForGroupCommit), which
-    // writes both the lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same
-    // rows that conflict-protect against a racing real group commit. This is the expired
-    // counterpart
-    // of the not-expired test above and confirms recoverRecord drives the no-state group-commit
-    // branch identically to lazy recovery.
+    // group-commit-aware path (Coordinator.forceAbortForGroupCommit), which writes both the
+    // lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same rows that
+    // conflict-protect against a racing real group commit. This is the expired counterpart of the
+    // not-expired test above and confirms recoverRecord drives the no-state group-commit branch
+    // identically to lazy recovery.
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
     String txId =
         populatePreparedRecordAndCoordinatorStateRecord(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -3661,11 +3661,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   /**
    * Whether the storage engine allows a concurrent write to a row that an open scan cursor is still
    * reading. The scan-path variants of the finalize/cleanup-race recovery tests synchronously write
-   * the scanned row from within lazy recovery while the storage scanner is still open. Engines that
-   * take shared/range locks for a scan under the highest isolation level (MySQL, MariaDB, SQL
-   * Server, Db2) block that write until the scan finishes, so the simulation self-deadlocks and
-   * times out. Returns {@code true} by default; the highest-isolation JDBC subclass overrides it to
-   * {@code false} for those engines. The Get variants are unaffected because a point Get releases
+   * the scanned row from within lazy recovery while the storage scanner is still open. On engines
+   * that hold a lock for an open scan, that write blocks until the scan finishes and the simulation
+   * self-deadlocks.
+   *
+   * <p>Returns {@code true} by default; subclasses override it to {@code false} for the engines
+   * that cannot support such a write. The Get variants are unaffected because a point Get releases
    * its connection immediately.
    */
   protected boolean isConcurrentWriteToRowUnderOpenScanSupported() {
@@ -3675,10 +3676,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   /**
    * Skips a scan-path recovery-simulation test on engines that cannot support a concurrent write to
    * a row an open scan is still reading. These tests synchronously write the scanned row from
-   * within lazy recovery while the storage scanner is still open, which self-deadlocks on
-   * pessimistic-lock engines under the highest isolation level. The Get path is unaffected because
-   * a point Get releases its connection immediately. See {@link
-   * #isConcurrentWriteToRowUnderOpenScanSupported()}.
+   * within lazy recovery while the storage scanner is still open, which self-deadlocks on engines
+   * that hold a lock for an open scan. The Get path is unaffected because a point Get releases its
+   * connection immediately. See {@link #isConcurrentWriteToRowUnderOpenScanSupported()}.
    */
   private void assumeConcurrentWriteToRowUnderOpenScanSupported(Selection s) {
     if (s instanceof Scan) {


### PR DESCRIPTION
## Description

The manually triggered full CI run ([28697501820](https://github.com/scalar-labs/scalardb/actions/runs/28697501820)) failed or hung on **MySQL, MariaDB, SQL Server, Db2 and SQLite** in the `scan`/`getScanner` ConsensusCommit recovery-scenario integration tests.

Root cause: several of these scenarios simulate a finalize/cleanup race by **synchronously writing the scanned record from within lazy recovery while the storage scanner that read it is still open**. On engines that keep a shared/range lock for an open scan, that write blocks on the scan's own lock and the simulation self-deadlocks. Which engines block depends on their concurrency control:

- **MySQL / MariaDB** are MVCC below SERIALIZABLE and take shared read locks only under SERIALIZABLE, so only the **highest-isolation** test class is affected (surfaces as a lock-wait timeout).
- **SQL Server / Db2** are lock-based at **every** isolation level (including their default READ COMMITTED), so **every** JDBC test class that runs these scenarios is affected. Their lock wait is effectively unbounded, so the write blocks forever and the job **hangs** to the CI timeout.
- **PostgreSQL, Oracle and TiDB** use MVCC/SSI (no shared read locks) and are unaffected. **SQLite** uses whole-file locking and is handled via WAL mode.

**This is a test-only issue — production is not affected.** Production never synchronously writes a scanned row during recovery: the real synchronous recovery write during a scan targets the coordinator-state table (a different table, no lock conflict with the scan), and the record roll-forward/rollback is asynchronous and awaited only at commit, which first requires all scanners to be closed (`areAllScannersClosed()` guard, so the locks are already released). Empirically, the plain (non-simulated) scan-recovery tests, which exercise this real path, did **not** hang on SQL Server/Db2 — only the mock-write scenarios did.

## Related issues and/or PRs

- The scan-recovery scenarios were introduced by #3607 and #3650.

## Changes made

- Add an overridable `isConcurrentWriteToRowUnderOpenScanSupported()` predicate (default `true` in `ConsensusCommitSpecificIntegrationTestBase`), reached through a shared `assumeConcurrentWriteToRowUnderOpenScanSupported(Selection)` helper, and skip the scan-path variants of the finalize/cleanup-race simulations (including the group-commit-only `GroupCommitParentRow` scenario) where the engine blocks:
  - **highest-isolation JDBC class**: MySQL, MariaDB, SQL Server, Db2 (all take locks under SERIALIZABLE);
  - **default and metadata-decoupling JDBC classes**: SQL Server and Db2 only (MySQL/MariaDB are MVCC there and keep running).
  The resolved `RdbEngine` is used (`JdbcTestUtils.isMysql`/`isMariaDB`/`isSqlServer`/`isDb2`), so **TiDB** (which uses the `jdbc:mysql:` URL but resolves to a distinct `RdbEngine` whose highest isolation is `REPEATABLE_READ`) is correctly excluded. The `Get` variants keep covering the recovery decision logic on every engine — a point `Get` releases its connection immediately, so it never deadlocks.
- **Run the SQLite integration tests in WAL mode** (`journal_mode=WAL` in `ci/tests-config.yaml`), which lets a reader and a writer proceed concurrently, resolving SQLite **without skipping any tests**.
- Make `tearDown()` null-safe for `recoveryExecutor` (a test can now be skipped before `createConsensusCommitManager()` initializes it), matching the existing `groupCommitter` null-guard.
- Reflow a few test comments that had awkward mid-sentence line breaks.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
