### PR TITLE
Backport to branch(3.16) : Fix ConsensusCommit scan-recovery integration tests on JDBC engines under the highest isolation level

### DIFF
--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -214,7 +214,7 @@ jdbc:
   - label: sqlite_3
     display_name: SQLite 3
     setup: sudo apt-get install -y sqlite3
-    run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
+    run: ./gradlew integrationTestJdbc "-Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000&journal_mode=WAL"
 
   - label: yugabytedb
     display_name: YugabyteDB 2025.2


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3679
- **Commit to backport:** 546dd831499e5c2a95197159f1f0cff96f4882d7

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-3679 &&
git cherry-pick --no-rerere-autoupdate -m1 546dd831499e5c2a95197159f1f0cff96f4882d7
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!