### PR TITLE
Backport to branch(3) : Rename the internal Coordinator class to CoordinatorStateAccessor

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -8,7 +8,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
@@ -31,7 +31,7 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
   protected String getCoordinatorNamespaceName(String testName) {
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -3,7 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
@@ -32,7 +32,7 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   protected String getCoordinatorNamespaceName(String testName) {
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -9,7 +9,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -50,7 +50,7 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   protected String getCoordinatorNamespaceName(String testName) {
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -17,7 +17,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -57,7 +57,7 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
   protected String getCoordinatorNamespaceName(String testName) {
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -7,7 +7,7 @@ import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.db.util.AdminTestUtils;
 import com.scalar.db.util.ThrowableFunction;
 import com.zaxxer.hikari.HikariDataSource;
@@ -45,7 +45,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
       coordinatorNamespace =
           new ConsensusCommitConfig(databaseConfig)
               .getCoordinatorNamespace()
-              .orElse(Coordinator.NAMESPACE);
+              .orElse(CoordinatorStateAccessor.NAMESPACE);
     } else {
       coordinatorNamespace = null;
     }
@@ -131,7 +131,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   }
 
   public void deleteAllRowsFromCoordinatorTableWithSql() throws ExecutionException {
-    deleteAllRowsWithSql(coordinatorNamespace, Coordinator.TABLE);
+    deleteAllRowsWithSql(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
   }
 
   /**

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
@@ -3,7 +3,7 @@ package com.scalar.db.storage.multistorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Properties;
 
 public class ConsensusCommitNullMetadataIntegrationTestWithMultiStorage
@@ -37,7 +37,7 @@ public class ConsensusCommitNullMetadataIntegrationTestWithMultiStorage
 
     // Define namespace mapping from namespace1 to cassandra, from namespace2 to jdbc, and from
     // the coordinator namespace (with the test-name suffix) to cassandra
-    String coordinatorNamespace = Coordinator.NAMESPACE + "_" + testName;
+    String coordinatorNamespace = CoordinatorStateAccessor.NAMESPACE + "_" + testName;
     props.setProperty(
         MultiStorageConfig.NAMESPACE_MAPPING,
         namespace1 + ":cassandra," + namespace2 + ":jdbc," + coordinatorNamespace + ":cassandra");

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
@@ -3,7 +3,7 @@ package com.scalar.db.storage.multistorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Properties;
 
 public class ConsensusCommitSpecificIntegrationTestWithMultiStorage
@@ -37,7 +37,7 @@ public class ConsensusCommitSpecificIntegrationTestWithMultiStorage
 
     // Define namespace mapping from namespace1 to cassandra, from namespace2 to jdbc, and from
     // the coordinator namespace (with the test-name suffix) to cassandra
-    String coordinatorNamespace = Coordinator.NAMESPACE + "_" + testName;
+    String coordinatorNamespace = CoordinatorStateAccessor.NAMESPACE + "_" + testName;
     props.setProperty(
         MultiStorageConfig.NAMESPACE_MAPPING,
         namespace1 + ":cassandra," + namespace2 + ":jdbc," + coordinatorNamespace + ":cassandra");

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
@@ -2,7 +2,7 @@ package com.scalar.db.storage.multistorage;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 
@@ -37,7 +37,12 @@ public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegra
     // the coordinator namespace to cassandra
     props.setProperty(
         MultiStorageConfig.NAMESPACE_MAPPING,
-        namespace1 + ":cassandra," + namespace2 + ":jdbc," + Coordinator.NAMESPACE + ":cassandra");
+        namespace1
+            + ":cassandra,"
+            + namespace2
+            + ":jdbc,"
+            + CoordinatorStateAccessor.NAMESPACE
+            + ":cassandra");
 
     // The default storage is cassandra
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");

--- a/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/objectstorage/ConsensusCommitAdminIntegrationTestWithObjectStorage.java
@@ -4,7 +4,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 
@@ -34,7 +34,7 @@ public class ConsensusCommitAdminIntegrationTestWithObjectStorage
   protected String getCoordinatorNamespaceName(String testName) {
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -62,7 +62,7 @@ public class CommitHandler {
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CommitHandler(
       DistributedStorage storage,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor,
       MutationsGrouper mutationsGrouper,

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -27,7 +27,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CommitHandlerWithGroupCommit(
       DistributedStorage storage,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor,
       MutationsGrouper mutationsGrouper,
@@ -56,7 +56,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean coordinatorWriteSetLoggingEnabled,
       ParticipantCommitHandler participantCommitHandler,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       CoordinatorGroupCommitter groupCommitter) {
     this(
         coordinatorWriteOmissionOnReadOnlyEnabled,

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -48,7 +48,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   public ConsensusCommitAdmin(DistributedStorageAdmin admin, DatabaseConfig databaseConfig) {
     this.admin = admin;
     config = new ConsensusCommitConfig(databaseConfig);
-    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
+    coordinatorNamespace =
+        config.getCoordinatorNamespace().orElse(CoordinatorStateAccessor.NAMESPACE);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
     isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
@@ -58,7 +59,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     admin = storageFactory.getStorageAdmin();
 
     config = new ConsensusCommitConfig(databaseConfig);
-    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
+    coordinatorNamespace =
+        config.getCoordinatorNamespace().orElse(CoordinatorStateAccessor.NAMESPACE);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
     isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
@@ -70,7 +72,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
       boolean isIncludeMetadataEnabled) {
     this.config = config;
     this.admin = admin;
-    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
+    coordinatorNamespace =
+        config.getCoordinatorNamespace().orElse(CoordinatorStateAccessor.NAMESPACE);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
     isIndexEventuallyConsistentReadEnabled = config.isIndexEventuallyConsistentReadEnabled();
   }
@@ -84,7 +87,10 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
 
     admin.createNamespace(coordinatorNamespace, options);
     admin.createTable(
-        coordinatorNamespace, Coordinator.TABLE, getCoordinatorTableMetadata(), options);
+        coordinatorNamespace,
+        CoordinatorStateAccessor.TABLE,
+        getCoordinatorTableMetadata(),
+        options);
   }
 
   @Override
@@ -94,7 +100,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
           CoreError.CONSENSUS_COMMIT_COORDINATOR_TABLES_NOT_FOUND.buildMessage());
     }
 
-    admin.dropTable(coordinatorNamespace, Coordinator.TABLE);
+    admin.dropTable(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
     admin.dropNamespace(coordinatorNamespace);
   }
 
@@ -105,12 +111,12 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
           CoreError.CONSENSUS_COMMIT_COORDINATOR_TABLES_NOT_FOUND.buildMessage());
     }
 
-    admin.truncateTable(coordinatorNamespace, Coordinator.TABLE);
+    admin.truncateTable(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
   }
 
   @Override
   public boolean coordinatorTablesExist() throws ExecutionException {
-    return admin.tableExists(coordinatorNamespace, Coordinator.TABLE);
+    return admin.tableExists(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
   }
 
   @Override
@@ -330,7 +336,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     admin.createNamespace(coordinatorNamespace, true, options);
 
     // Snapshot the current Coordinator table metadata before repairTable upserts the desired one.
-    TableMetadata currentMetadata = admin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+    TableMetadata currentMetadata =
+        admin.getTableMetadata(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
 
     // Pick the desired schema:
     // - For each optional column (CHILD_IDS, WRITE_SET): include it in the desired schema if the
@@ -350,7 +357,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
         (currentMetadata != null && currentMetadata.getColumnNames().contains(Attribute.WRITE_SET))
             || config.isCoordinatorWriteSetLoggingEnabled();
     TableMetadata coordinatorTableMetadata =
-        Coordinator.buildTableMetadata(hasGroupCommitColumnInSchema, hasWriteSetColumnInSchema);
+        CoordinatorStateAccessor.buildTableMetadata(
+            hasGroupCommitColumnInSchema, hasWriteSetColumnInSchema);
 
     // Upgrade the schema (ALTER TABLE ADD COLUMN for any non-key columns the desired schema
     // requires that the existing Coordinator is missing) BEFORE repairTable. addNewColumnToTable
@@ -361,7 +369,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     // ScalarDB-side metadata even though the physical column does not yet exist.
     upgradeCoordinatorTableSchema(currentMetadata, coordinatorTableMetadata);
 
-    admin.repairTable(coordinatorNamespace, Coordinator.TABLE, coordinatorTableMetadata, options);
+    admin.repairTable(
+        coordinatorNamespace, CoordinatorStateAccessor.TABLE, coordinatorTableMetadata, options);
   }
 
   // Adds any non-key columns the desired Coordinator table schema requires that the existing
@@ -397,7 +406,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
       }
       DataType columnDataType = coordinatorTableMetadata.getColumnDataType(columnName);
       admin.addNewColumnToTable(
-          coordinatorNamespace, Coordinator.TABLE, columnName, columnDataType);
+          coordinatorNamespace, CoordinatorStateAccessor.TABLE, columnName, columnDataType);
     }
   }
 
@@ -588,7 +597,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   private TableMetadata getCoordinatorTableMetadata() {
-    return Coordinator.buildTableMetadata(
+    return CoordinatorStateAccessor.buildTableMetadata(
         config.isCoordinatorGroupCommitEnabled(), config.isCoordinatorWriteSetLoggingEnabled());
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -40,8 +40,8 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
@@ -67,7 +67,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
   private final TransactionTableMetadataManager tableMetadataManager;
-  private final Coordinator coordinator;
+  private final CoordinatorStateAccessor coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryExecutor recoveryExecutor;
   private final CrudHandler crud;
@@ -85,7 +85,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     this.storage = storage;
     this.admin = admin;
     ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     tableMetadataManager =
         new TransactionTableMetadataManager(
@@ -125,7 +125,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     admin = storageFactory.getStorageAdmin();
 
     ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     tableMetadataManager =
         new TransactionTableMetadataManager(
@@ -165,7 +165,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       DistributedStorageAdmin admin,
       ConsensusCommitConfig config,
       DatabaseConfig databaseConfig,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       ParallelExecutor parallelExecutor,
       RecoveryExecutor recoveryExecutor,
       CrudHandler crud,
@@ -676,10 +676,10 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
 
     // Perform the Coordinator state cleanup (delete the state row). state.getId() is the key the
     // row actually lives under: the parent ID for a normal group commit, or the full ID for a
-    // single or delayed commit (Coordinator#getState routes a full child ID through
-    // getStateForGroupCommit and returns the resolved row). Coordinator#deleteState handles full
-    // keys internally, so the delete targets the right row in both cases.
-    // Coordinator#deleteState is unconditional and benign on a concurrent delete.
+    // single or delayed commit (CoordinatorStateAccessor#getState routes a full child ID through
+    // getStateForGroupCommit and returns the resolved row). CoordinatorStateAccessor#deleteState
+    // handles full keys internally, so the delete targets the right row in both cases.
+    // CoordinatorStateAccessor#deleteState is unconditional and benign on a concurrent delete.
     try {
       coordinator.deleteState(state.getId());
     } catch (CoordinatorException e) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandler.java
@@ -29,10 +29,10 @@ import org.slf4j.LoggerFactory;
 class CoordinatorCommitHandler {
   private static final Logger logger = LoggerFactory.getLogger(CoordinatorCommitHandler.class);
 
-  private final Coordinator coordinator;
+  private final CoordinatorStateAccessor coordinator;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  CoordinatorCommitHandler(Coordinator coordinator) {
+  CoordinatorCommitHandler(CoordinatorStateAccessor coordinator) {
     this.coordinator = checkNotNull(coordinator);
   }
 
@@ -49,8 +49,8 @@ class CoordinatorCommitHandler {
       throws CommitConflictException, UnknownTransactionStatusException {
     try {
       long committedAt = System.currentTimeMillis();
-      Coordinator.State state =
-          new Coordinator.State(id, writeSet, TransactionState.COMMITTED, committedAt);
+      CoordinatorStateAccessor.State state =
+          new CoordinatorStateAccessor.State(id, writeSet, TransactionState.COMMITTED, committedAt);
       coordinator.putState(state);
       logger.debug("Transaction {} is committed successfully at {}", id, committedAt);
       return committedAt;
@@ -72,9 +72,9 @@ class CoordinatorCommitHandler {
   long handleCommitConflict(String id, Exception cause)
       throws CommitConflictException, UnknownTransactionStatusException {
     try {
-      Optional<Coordinator.State> s = coordinator.getState(id);
+      Optional<CoordinatorStateAccessor.State> s = coordinator.getState(id);
       if (s.isPresent()) {
-        Coordinator.State persisted = s.get();
+        CoordinatorStateAccessor.State persisted = s.get();
         if (persisted.getState() == TransactionState.ABORTED) {
           throw new CommitConflictException(
               CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHEN_COMMITTING_STATE.buildMessage(
@@ -151,8 +151,9 @@ class CoordinatorCommitHandler {
   TransactionState abortState(String id, @Nullable WriteSet writeSet)
       throws UnknownTransactionStatusException {
     try {
-      Coordinator.State state =
-          new Coordinator.State(id, writeSet, TransactionState.ABORTED, System.currentTimeMillis());
+      CoordinatorStateAccessor.State state =
+          new CoordinatorStateAccessor.State(
+              id, writeSet, TransactionState.ABORTED, System.currentTimeMillis());
       coordinator.putState(state);
       return TransactionState.ABORTED;
     } catch (CoordinatorConflictException e) {
@@ -182,8 +183,8 @@ class CoordinatorCommitHandler {
 
   /**
    * Writes the ABORTED state for a manager-level rollback/abort by transaction ID. Uses {@link
-   * Coordinator#forceAbort} so the 2-step protocol wins against an in-flight normal group commit
-   * when the id is a group-commit full key.
+   * CoordinatorStateAccessor#forceAbort} so the 2-step protocol wins against an in-flight normal
+   * group commit when the id is a group-commit full key.
    */
   TransactionState forceAbortState(String id) throws UnknownTransactionStatusException {
     try {
@@ -231,7 +232,7 @@ class CoordinatorCommitHandler {
   private Optional<TransactionState> readCoordinatorStateAfterAbortConflict(
       String id, CoordinatorConflictException e) throws UnknownTransactionStatusException {
     try {
-      return coordinator.getState(id).map(Coordinator.State::getState);
+      return coordinator.getState(id).map(CoordinatorStateAccessor.State::getState);
     } catch (CoordinatorException e1) {
       e1.addSuppressed(e);
       throw new UnknownTransactionStatusException(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommit.java
@@ -7,8 +7,8 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.CoreError;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.Emittable;
 import com.scalar.db.util.groupcommit.GroupCommitConflictException;
@@ -41,7 +41,7 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   CoordinatorCommitHandlerWithGroupCommit(
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       CoordinatorGroupCommitter groupCommitter,
       boolean coordinatorWriteSetLoggingEnabled) {
     super(coordinator);
@@ -111,10 +111,10 @@ class CoordinatorCommitHandlerWithGroupCommit extends CoordinatorCommitHandler {
 
   @VisibleForTesting
   static class Emitter implements Emittable<String, String, CoordinatorGroupCommitValue, Long> {
-    private final Coordinator coordinator;
+    private final CoordinatorStateAccessor coordinator;
     private final boolean coordinatorWriteSetLoggingEnabled;
 
-    Emitter(Coordinator coordinator, boolean coordinatorWriteSetLoggingEnabled) {
+    Emitter(CoordinatorStateAccessor coordinator, boolean coordinatorWriteSetLoggingEnabled) {
       this.coordinator = coordinator;
       this.coordinatorWriteSetLoggingEnabled = coordinatorWriteSetLoggingEnabled;
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessor.java
@@ -103,7 +103,7 @@ import org.slf4j.LoggerFactory;
  * ID), the two-step {@link #forceAbort} must be used instead.
  */
 @ThreadSafe
-public class Coordinator {
+public class CoordinatorStateAccessor {
   public static final String NAMESPACE = "coordinator";
   public static final String TABLE = "state";
 
@@ -125,7 +125,7 @@ public class Coordinator {
 
   private static final int MAX_RETRY_COUNT = 5;
   private static final long SLEEP_BASE_MILLIS = 50;
-  private static final Logger logger = LoggerFactory.getLogger(Coordinator.class);
+  private static final Logger logger = LoggerFactory.getLogger(CoordinatorStateAccessor.class);
   private static final CoordinatorGroupCommitKeyManipulator KEY_MANIPULATOR =
       new CoordinatorGroupCommitKeyManipulator();
 
@@ -138,13 +138,13 @@ public class Coordinator {
    */
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Deprecated
-  public Coordinator(DistributedStorage storage) {
+  public CoordinatorStateAccessor(DistributedStorage storage) {
     this.storage = storage;
     coordinatorNamespace = NAMESPACE;
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public Coordinator(DistributedStorage storage, ConsensusCommitConfig config) {
+  public CoordinatorStateAccessor(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(NAMESPACE);
   }
@@ -158,7 +158,7 @@ public class Coordinator {
    * @return the coordinator state
    * @throws CoordinatorException if the coordinator state cannot be retrieved
    */
-  public Optional<Coordinator.State> getState(String id) throws CoordinatorException {
+  public Optional<CoordinatorStateAccessor.State> getState(String id) throws CoordinatorException {
     if (KEY_MANIPULATOR.isFullKey(id)) {
       return getStateForGroupCommit(id);
     }
@@ -176,7 +176,8 @@ public class Coordinator {
    * @throws CoordinatorException if the coordinator state cannot be retrieved
    */
   @VisibleForTesting
-  Optional<Coordinator.State> getStateForGroupCommit(String fullId) throws CoordinatorException {
+  Optional<CoordinatorStateAccessor.State> getStateForGroupCommit(String fullId)
+      throws CoordinatorException {
     // Scan with the parent ID for a normal group that contains multiple transactions.
     Keys<String, String, String> idForGroupCommit = KEY_MANIPULATOR.keysFromFullKey(fullId);
 
@@ -202,12 +203,13 @@ public class Coordinator {
     return getStateInternal(fullId);
   }
 
-  private Optional<Coordinator.State> getStateInternal(String id) throws CoordinatorException {
+  private Optional<CoordinatorStateAccessor.State> getStateInternal(String id)
+      throws CoordinatorException {
     Get get = createGetWith(id);
     return get(get, id);
   }
 
-  public void putState(Coordinator.State state) throws CoordinatorException {
+  public void putState(CoordinatorStateAccessor.State state) throws CoordinatorException {
     Put put = createPutWith(state);
     put(put, state.getId());
   }
@@ -218,7 +220,9 @@ public class Coordinator {
       return;
     }
 
-    putState(new Coordinator.State(id, TransactionState.ABORTED, System.currentTimeMillis()));
+    putState(
+        new CoordinatorStateAccessor.State(
+            id, TransactionState.ABORTED, System.currentTimeMillis()));
   }
 
   private void forceAbortForGroupCommit(String id) throws CoordinatorException {
@@ -320,7 +324,9 @@ public class Coordinator {
     }
 
     // This record is to intend the transaction is aborted.
-    putState(new Coordinator.State(id, TransactionState.ABORTED, System.currentTimeMillis()));
+    putState(
+        new CoordinatorStateAccessor.State(
+            id, TransactionState.ABORTED, System.currentTimeMillis()));
   }
 
   @VisibleForTesting
@@ -333,7 +339,8 @@ public class Coordinator {
         .build();
   }
 
-  private Optional<Coordinator.State> get(Get get, String id) throws CoordinatorException {
+  private Optional<CoordinatorStateAccessor.State> get(Get get, String id)
+      throws CoordinatorException {
     int counter = 0;
     Exception exception = null;
     while (true) {
@@ -367,7 +374,7 @@ public class Coordinator {
   }
 
   @VisibleForTesting
-  Put createPutWith(Coordinator.State state) {
+  Put createPutWith(CoordinatorStateAccessor.State state) {
     String childIds = state.getChildIdsAsString();
     PutBuilder.Buildable builder =
         Put.newBuilder()

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -50,7 +50,7 @@ public class RecoveryExecutor implements AutoCloseable {
   @VisibleForTesting static final int MAX_RESOLUTION_ATTEMPTS = 5;
 
   private final DistributedStorage storage;
-  private final Coordinator coordinator;
+  private final CoordinatorStateAccessor coordinator;
   private final RecoveryHandler recovery;
   private final TransactionTableMetadataManager tableMetadataManager;
   private final ExecutorService executorService;
@@ -58,7 +58,7 @@ public class RecoveryExecutor implements AutoCloseable {
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public RecoveryExecutor(
       DistributedStorage storage,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       RecoveryHandler recovery,
       TransactionTableMetadataManager tableMetadataManager) {
     this.storage = Objects.requireNonNull(storage);
@@ -134,7 +134,7 @@ public class RecoveryExecutor implements AutoCloseable {
         Future<Void> future =
             executorService.submit(
                 () -> {
-                  Optional<Coordinator.State> s = getCoordinatorState(result.getId());
+                  Optional<CoordinatorStateAccessor.State> s = getCoordinatorState(result.getId());
 
                   throwUncommittedRecordExceptionIfTransactionNotExpired(
                       s, selection, result, transactionId);
@@ -192,7 +192,7 @@ public class RecoveryExecutor implements AutoCloseable {
       String txId = current.getId();
       assert txId != null;
 
-      Optional<Coordinator.State> state = getCoordinatorState(txId);
+      Optional<CoordinatorStateAccessor.State> state = getCoordinatorState(txId);
 
       if (state.isPresent()) {
         boolean rolledBack = state.get().getState() == TransactionState.ABORTED;
@@ -328,7 +328,7 @@ public class RecoveryExecutor implements AutoCloseable {
     }
   }
 
-  private Optional<Coordinator.State> getCoordinatorState(String transactionId)
+  private Optional<CoordinatorStateAccessor.State> getCoordinatorState(String transactionId)
       throws CrudException {
     try {
       return coordinator.getState(transactionId);
@@ -341,7 +341,10 @@ public class RecoveryExecutor implements AutoCloseable {
   }
 
   private Optional<TransactionResult> createRecoveredResult(
-      Coordinator.State state, Selection selection, TransactionResult result, String transactionId)
+      CoordinatorStateAccessor.State state,
+      Selection selection,
+      TransactionResult result,
+      String transactionId)
       throws CrudException {
     if (state.getState() == TransactionState.ABORTED) {
       return createRecordFromBeforeImage(selection, result, transactionId);
@@ -351,7 +354,7 @@ public class RecoveryExecutor implements AutoCloseable {
   }
 
   private void throwUncommittedRecordExceptionIfTransactionNotExpired(
-      Optional<Coordinator.State> state,
+      Optional<CoordinatorStateAccessor.State> state,
       Selection selection,
       TransactionResult result,
       String transactionId)
@@ -508,16 +511,17 @@ public class RecoveryExecutor implements AutoCloseable {
    * present. This is the entry point for callers that always hold a terminal coordinator state.
    *
    * <p>It delegates to {@link RecoveryHandler#recover(Selection, TransactionResult,
-   * Coordinator.State)}, the present-state overload that always rolls the record and never touches
-   * the coordinator — so the record is guaranteed to be recovered and {@link CoordinatorException}
-   * cannot be thrown. That overload returns nothing, so this method does too.
+   * CoordinatorStateAccessor.State)}, the present-state overload that always rolls the record and
+   * never touches the coordinator — so the record is guaranteed to be recovered and {@link
+   * CoordinatorException} cannot be thrown. That overload returns nothing, so this method does too.
    *
    * @param selection the selection that identifies the user record
    * @param result the latest known TransactionResult for the record
    * @param state the coordinator state for the transaction that wrote the record
    * @throws ExecutionException if the underlying storage read or mutation fails
    */
-  void executeSynchronously(Selection selection, TransactionResult result, Coordinator.State state)
+  void executeSynchronously(
+      Selection selection, TransactionResult result, CoordinatorStateAccessor.State state)
       throws ExecutionException {
     recovery.recover(selection, result, state);
   }
@@ -540,7 +544,7 @@ public class RecoveryExecutor implements AutoCloseable {
    * @throws CoordinatorException if reading or updating the coordinator state fails
    */
   boolean executeSynchronously(
-      Selection selection, TransactionResult result, Optional<Coordinator.State> state)
+      Selection selection, TransactionResult result, Optional<CoordinatorStateAccessor.State> state)
       throws ExecutionException, CoordinatorException {
     return recovery.recover(selection, result, state);
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -24,13 +24,13 @@ public class RecoveryHandler {
   @VisibleForTesting static final long TRANSACTION_LIFETIME_MILLIS = 15000;
   private static final Logger logger = LoggerFactory.getLogger(RecoveryHandler.class);
   private final DistributedStorage storage;
-  private final Coordinator coordinator;
+  private final CoordinatorStateAccessor coordinator;
   private final TransactionTableMetadataManager tableMetadataManager;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public RecoveryHandler(
       DistributedStorage storage,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       TransactionTableMetadataManager tableMetadataManager) {
     this.storage = checkNotNull(storage);
     this.coordinator = checkNotNull(coordinator);
@@ -64,7 +64,7 @@ public class RecoveryHandler {
    * @throws CoordinatorException if reading or updating the coordinator state fails
    */
   public void tryRecover(
-      Selection selection, TransactionResult result, Optional<Coordinator.State> state)
+      Selection selection, TransactionResult result, Optional<CoordinatorStateAccessor.State> state)
       throws ExecutionException, CoordinatorException {
     if (state.isPresent()) {
       rollRecordToState(selection, result, state.get());
@@ -103,7 +103,7 @@ public class RecoveryHandler {
    * @throws CoordinatorException if reading or updating the coordinator state fails
    */
   public boolean recover(
-      Selection selection, TransactionResult result, Optional<Coordinator.State> state)
+      Selection selection, TransactionResult result, Optional<CoordinatorStateAccessor.State> state)
       throws ExecutionException, CoordinatorException {
     if (state.isPresent()) {
       recover(selection, result, state.get());
@@ -126,7 +126,8 @@ public class RecoveryHandler {
    * @param state the present terminal coordinator state of the writer transaction
    * @throws ExecutionException if the underlying storage read or mutation fails
    */
-  public void recover(Selection selection, TransactionResult result, Coordinator.State state)
+  public void recover(
+      Selection selection, TransactionResult result, CoordinatorStateAccessor.State state)
       throws ExecutionException {
     rollRecordToState(selection, result, state);
   }
@@ -141,7 +142,7 @@ public class RecoveryHandler {
    * non-terminal state is treated as a rollback.
    */
   private void rollRecordToState(
-      Selection selection, TransactionResult result, Coordinator.State state)
+      Selection selection, TransactionResult result, CoordinatorStateAccessor.State state)
       throws ExecutionException {
     if (state.getState().equals(TransactionState.COMMITTED)) {
       rollforwardRecord(selection, result, state.getCreatedAt());
@@ -344,7 +345,7 @@ public class RecoveryHandler {
       // Guaranteed path (recover): a concurrent actor already resolved the writer. Re-read the
       // coordinator state and roll the record to the winner's outcome so it is physically resolved
       // on return.
-      Optional<Coordinator.State> rereadState = coordinator.getState(txId);
+      Optional<CoordinatorStateAccessor.State> rereadState = coordinator.getState(txId);
 
       if (rereadState.isPresent()) {
         // Roll the targeted record to the winner's outcome. This is idempotent: the underlying

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -36,7 +36,7 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import com.scalar.db.util.ThrowableFunction;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
@@ -57,7 +57,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
   private final DistributedStorageAdmin admin;
   private final ConsensusCommitConfig config;
   private final TransactionTableMetadataManager tableMetadataManager;
-  private final Coordinator coordinator;
+  private final CoordinatorStateAccessor coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryExecutor recoveryExecutor;
   private final CrudHandler crud;
@@ -75,7 +75,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     tableMetadataManager =
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
@@ -119,7 +119,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     tableMetadataManager =
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     RecoveryHandler recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     recoveryExecutor = new RecoveryExecutor(storage, coordinator, recovery, tableMetadataManager);
@@ -161,7 +161,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
       DistributedStorageAdmin admin,
       ConsensusCommitConfig config,
       DatabaseConfig databaseConfig,
-      Coordinator coordinator,
+      CoordinatorStateAccessor coordinator,
       ParallelExecutor parallelExecutor,
       RecoveryExecutor recoveryExecutor,
       CrudHandler crud,

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -53,7 +53,8 @@ public abstract class ConsensusCommitAdminTestBase {
     when(config.getCoordinatorNamespace()).thenReturn(getCoordinatorNamespaceConfig());
     when(config.isCoordinatorGroupCommitEnabled()).thenReturn(false);
     admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-    coordinatorNamespaceName = getCoordinatorNamespaceConfig().orElse(Coordinator.NAMESPACE);
+    coordinatorNamespaceName =
+        getCoordinatorNamespaceConfig().orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   protected abstract Optional<String> getCoordinatorNamespaceConfig();
@@ -72,8 +73,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, false),
             Collections.emptyMap());
   }
 
@@ -94,8 +95,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, false),
             Collections.emptyMap());
   }
 
@@ -104,7 +105,8 @@ public abstract class ConsensusCommitAdminTestBase {
       createCoordinatorTables_CoordinatorTablesAlreadyExist_shouldThrowIllegalArgumentException()
           throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(coordinatorNamespaceName, Coordinator.TABLE))
+    when(distributedStorageAdmin.tableExists(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
         .thenReturn(true);
 
     // Act Assert
@@ -126,8 +128,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, false),
             options);
   }
 
@@ -150,8 +152,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, false),
             options);
   }
 
@@ -173,8 +175,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, true),
             Collections.emptyMap());
   }
 
@@ -197,8 +199,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .createTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, true),
             Collections.emptyMap());
   }
 
@@ -206,14 +208,16 @@ public abstract class ConsensusCommitAdminTestBase {
   public void truncateCoordinatorTables_shouldTruncateCoordinatorTableProperly()
       throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(coordinatorNamespaceName, Coordinator.TABLE))
+    when(distributedStorageAdmin.tableExists(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
         .thenReturn(true);
 
     // Act
     admin.truncateCoordinatorTables();
 
     // Assert
-    verify(distributedStorageAdmin).truncateTable(coordinatorNamespaceName, Coordinator.TABLE);
+    verify(distributedStorageAdmin)
+        .truncateTable(coordinatorNamespaceName, CoordinatorStateAccessor.TABLE);
   }
 
   @Test
@@ -221,7 +225,8 @@ public abstract class ConsensusCommitAdminTestBase {
       truncateCoordinatorTables_CoordinatorTablesNotExist_shouldThrowIllegalArgumentException()
           throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(coordinatorNamespaceName, Coordinator.TABLE))
+    when(distributedStorageAdmin.tableExists(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
         .thenReturn(false);
 
     // Act Assert
@@ -232,14 +237,16 @@ public abstract class ConsensusCommitAdminTestBase {
   @Test
   public void dropCoordinatorTables_shouldDropCoordinatorTableProperly() throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(coordinatorNamespaceName, Coordinator.TABLE))
+    when(distributedStorageAdmin.tableExists(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
         .thenReturn(true);
 
     // Act
     admin.dropCoordinatorTables();
 
     // Assert
-    verify(distributedStorageAdmin).dropTable(coordinatorNamespaceName, Coordinator.TABLE);
+    verify(distributedStorageAdmin)
+        .dropTable(coordinatorNamespaceName, CoordinatorStateAccessor.TABLE);
     verify(distributedStorageAdmin).dropNamespace(coordinatorNamespaceName);
   }
 
@@ -247,7 +254,8 @@ public abstract class ConsensusCommitAdminTestBase {
   public void dropCoordinatorTables_CoordinatorTablesNotExist_shouldThrowIllegalArgumentException()
       throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(coordinatorNamespaceName, Coordinator.TABLE))
+    when(distributedStorageAdmin.tableExists(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
         .thenReturn(false);
 
     // Act Assert
@@ -265,7 +273,8 @@ public abstract class ConsensusCommitAdminTestBase {
     boolean actual = admin.coordinatorTablesExist();
 
     // Assert
-    verify(distributedStorageAdmin).tableExists(coordinatorNamespaceName, Coordinator.TABLE);
+    verify(distributedStorageAdmin)
+        .tableExists(coordinatorNamespaceName, CoordinatorStateAccessor.TABLE);
     assertThat(actual).isFalse();
   }
 
@@ -279,7 +288,8 @@ public abstract class ConsensusCommitAdminTestBase {
     boolean actual = admin.coordinatorTablesExist();
 
     // Assert
-    verify(distributedStorageAdmin).tableExists(coordinatorNamespaceName, Coordinator.TABLE);
+    verify(distributedStorageAdmin)
+        .tableExists(coordinatorNamespaceName, CoordinatorStateAccessor.TABLE);
     assertThat(actual).isTrue();
   }
 
@@ -860,8 +870,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, false),
             options);
   }
 
@@ -883,8 +893,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, false),
             options);
   }
 
@@ -905,8 +915,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, true),
             options);
   }
 
@@ -929,8 +939,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, true),
             options);
   }
 
@@ -945,8 +955,9 @@ public abstract class ConsensusCommitAdminTestBase {
 
     // The existing Coordinator table was created with group commit disabled, so it does not have
     // the CHILD_IDS column.
-    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
-        .thenReturn(Coordinator.buildTableMetadata(false, false));
+    when(distributedStorageAdmin.getTableMetadata(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
+        .thenReturn(CoordinatorStateAccessor.buildTableMetadata(false, false));
 
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -958,12 +969,15 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, false),
             options);
     verify(distributedStorageAdmin)
         .addNewColumnToTable(
-            coordinatorNamespaceName, Coordinator.TABLE, Attribute.CHILD_IDS, DataType.TEXT);
+            coordinatorNamespaceName,
+            CoordinatorStateAccessor.TABLE,
+            Attribute.CHILD_IDS,
+            DataType.TEXT);
   }
 
   @Test
@@ -977,8 +991,9 @@ public abstract class ConsensusCommitAdminTestBase {
     // group commit config independently decides whether to use that column. So repair should
     // upsert the WITH_GROUP_COMMIT_ENABLED metadata, NOT the disabled variant, and should not
     // attempt any column ALTER.
-    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
-        .thenReturn(Coordinator.buildTableMetadata(true, false));
+    when(distributedStorageAdmin.getTableMetadata(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
+        .thenReturn(CoordinatorStateAccessor.buildTableMetadata(true, false));
 
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -990,8 +1005,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(true, false),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(true, false),
             options);
     verify(distributedStorageAdmin, never()).addNewColumnToTable(any(), any(), any(), any());
   }
@@ -1007,8 +1022,9 @@ public abstract class ConsensusCommitAdminTestBase {
 
     // The existing Coordinator table was created without write-set logging, so it does not have
     // the WRITE_SET column.
-    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
-        .thenReturn(Coordinator.buildTableMetadata(false, false));
+    when(distributedStorageAdmin.getTableMetadata(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
+        .thenReturn(CoordinatorStateAccessor.buildTableMetadata(false, false));
 
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -1020,12 +1036,15 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, true),
             options);
     verify(distributedStorageAdmin)
         .addNewColumnToTable(
-            coordinatorNamespaceName, Coordinator.TABLE, Attribute.WRITE_SET, DataType.BLOB);
+            coordinatorNamespaceName,
+            CoordinatorStateAccessor.TABLE,
+            Attribute.WRITE_SET,
+            DataType.BLOB);
   }
 
   @Test
@@ -1039,8 +1058,9 @@ public abstract class ConsensusCommitAdminTestBase {
     // write_set); the runtime write-set logging config independently decides whether to use that
     // column. So repair should upsert the WITH-WRITE_SET metadata, NOT the disabled variant, and
     // should not attempt any column ALTER.
-    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
-        .thenReturn(Coordinator.buildTableMetadata(false, true));
+    when(distributedStorageAdmin.getTableMetadata(
+            coordinatorNamespaceName, CoordinatorStateAccessor.TABLE))
+        .thenReturn(CoordinatorStateAccessor.buildTableMetadata(false, true));
 
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -1052,8 +1072,8 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
-            Coordinator.TABLE,
-            Coordinator.buildTableMetadata(false, true),
+            CoordinatorStateAccessor.TABLE,
+            CoordinatorStateAccessor.buildTableMetadata(false, true),
             options);
     verify(distributedStorageAdmin, never()).addNewColumnToTable(any(), any(), any(), any());
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -44,8 +44,8 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +66,7 @@ public class ConsensusCommitManagerTest {
   @Mock private DistributedStorageAdmin admin;
   @Mock private ConsensusCommitConfig consensusCommitConfig;
   @Mock private DatabaseConfig databaseConfig;
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
   @Mock private ParallelExecutor parallelExecutor;
   @Mock private RecoveryExecutor recoveryExecutor;
   @Mock private CrudHandler crud;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerTest.java
@@ -30,7 +30,7 @@ import org.mockito.MockitoAnnotations;
 class CoordinatorCommitHandlerTest {
   private static final String ANY_ID = "id";
 
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
 
   private CoordinatorCommitHandler handler;
 
@@ -50,8 +50,9 @@ class CoordinatorCommitHandlerTest {
     handler = new CoordinatorCommitHandler(coordinator);
   }
 
-  // Mockito matcher that compares Coordinator.State by id + writeSet + state (ignores createdAt).
-  private static ArgumentMatcher<Coordinator.State> stateMatcher(
+  // Mockito matcher that compares CoordinatorStateAccessor.State by id + writeSet + state (ignores
+  // createdAt).
+  private static ArgumentMatcher<CoordinatorStateAccessor.State> stateMatcher(
       String id, WriteSet writeSet, TransactionState state) {
     return actual ->
         actual != null
@@ -66,7 +67,7 @@ class CoordinatorCommitHandlerTest {
   void commitState_WhenSuccessful_ShouldPutCommittedStateWithGivenWriteSet() throws Exception {
     // Arrange
     WriteSet writeSet = anyWriteSet();
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
 
     // Act
     handler.commitState(anyId(), writeSet);
@@ -79,7 +80,7 @@ class CoordinatorCommitHandlerTest {
   @Test
   void commitState_WhenWriteSetNull_ShouldPutCommittedStateWithoutWriteSet() throws Exception {
     // Arrange
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
 
     // Act
     handler.commitState(anyId(), null);
@@ -91,14 +92,15 @@ class CoordinatorCommitHandlerTest {
   @Test
   void commitState_ShouldStampGeneratedCommittedAtAndReturnIt() throws Exception {
     // Arrange
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
 
     // Act
     long committedAt = handler.commitState(anyId(), anyWriteSet());
 
     // Assert — the handler generates the committedAt, stamps it on the COMMITTED row, and returns
     // that same value.
-    ArgumentCaptor<Coordinator.State> captor = ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> captor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinator).putState(captor.capture());
     assertThat(captor.getValue().getCreatedAt()).isEqualTo(committedAt);
   }
@@ -111,10 +113,10 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
+        .putState(any(CoordinatorStateAccessor.State.class));
     doReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     anyId(), TransactionState.ABORTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
@@ -134,8 +136,10 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
-    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED, 999L)))
+        .putState(any(CoordinatorStateAccessor.State.class));
+    doReturn(
+            Optional.of(
+                new CoordinatorStateAccessor.State(anyId(), TransactionState.COMMITTED, 999L)))
         .when(coordinator)
         .getState(anyId());
 
@@ -154,7 +158,7 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
+        .putState(any(CoordinatorStateAccessor.State.class));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
 
     // Act Assert
@@ -165,7 +169,9 @@ class CoordinatorCommitHandlerTest {
   @Test
   void commitState_WhenCoordinatorExceptionThrown_ShouldThrowUnknown() throws Exception {
     // Arrange
-    doThrow(CoordinatorException.class).when(coordinator).putState(any(Coordinator.State.class));
+    doThrow(CoordinatorException.class)
+        .when(coordinator)
+        .putState(any(CoordinatorStateAccessor.State.class));
 
     // Act Assert
     assertThatThrownBy(() -> handler.commitState(anyId(), anyWriteSet()))
@@ -178,7 +184,7 @@ class CoordinatorCommitHandlerTest {
   void abortState_WhenSuccessful_ShouldPutAbortedStateAndReturnAborted() throws Exception {
     // Arrange
     WriteSet writeSet = anyWriteSet();
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
 
     // Act
     TransactionState result = handler.abortState(anyId(), writeSet);
@@ -192,7 +198,7 @@ class CoordinatorCommitHandlerTest {
   @Test
   void abortState_WhenWriteSetNull_ShouldPutAbortedStateWithoutWriteSet() throws Exception {
     // Arrange
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
 
     // Act
     TransactionState result = handler.abortState(anyId(), null);
@@ -207,10 +213,10 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
+        .putState(any(CoordinatorStateAccessor.State.class));
     doReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
@@ -233,7 +239,7 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
+        .putState(any(CoordinatorStateAccessor.State.class));
     doReturn(Optional.empty()).when(coordinator).getState(anyId());
 
     // Act
@@ -247,7 +253,9 @@ class CoordinatorCommitHandlerTest {
   @Test
   void abortState_WhenCoordinatorExceptionThrown_ShouldThrowUnknown() throws Exception {
     // Arrange
-    doThrow(CoordinatorException.class).when(coordinator).putState(any(Coordinator.State.class));
+    doThrow(CoordinatorException.class)
+        .when(coordinator)
+        .putState(any(CoordinatorStateAccessor.State.class));
 
     // Act Assert
     assertThatThrownBy(() -> handler.abortState(anyId(), null))
@@ -278,7 +286,7 @@ class CoordinatorCommitHandlerTest {
     doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyId());
     doReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     anyId(), TransactionState.COMMITTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
@@ -325,7 +333,7 @@ class CoordinatorCommitHandlerTest {
     // Arrange
     doReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     anyId(), TransactionState.ABORTED, System.currentTimeMillis())))
         .when(coordinator)
         .getState(anyId());
@@ -341,7 +349,9 @@ class CoordinatorCommitHandlerTest {
   void handleCommitConflict_WhenCommittedStatePersisted_ShouldReturnPersistedCommittedAt()
       throws Exception {
     // Arrange
-    doReturn(Optional.of(new Coordinator.State(anyId(), TransactionState.COMMITTED, 999L)))
+    doReturn(
+            Optional.of(
+                new CoordinatorStateAccessor.State(anyId(), TransactionState.COMMITTED, 999L)))
         .when(coordinator)
         .getState(anyId());
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
@@ -51,7 +51,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   private static final String ANY_TEXT_2 = "text2";
   private static final int ANY_INT_1 = 100;
 
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
   @Mock private TransactionTableMetadataManager tableMetadataManager;
   @Mock private ConsensusCommitConfig config;
 
@@ -258,7 +258,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitNormalGroup_WithMultipleWritingChildren_ShouldAggregatePerChild()
       throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -272,11 +272,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
             parentId, Arrays.asList(valueWithWrite(fullTxId1), valueWithWrite(fullTxId2)));
 
     // Assert
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
 
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(parentId);
     assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(capturedState.getChildIds()).containsExactly("child-1", "child-2");
@@ -297,7 +297,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitNormalGroup_WithReadOnlyChildMixed_ShouldOmitReadOnlyEntryGroups()
       throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -311,10 +311,10 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
     // Assert — only the writing child contributes an EntryGroup; the read-only child carries no
     // entries so its (empty) write set adds nothing.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(parentId);
     // The read-only child contributes no EntryGroup but is still recorded as a parent-row member
     // (child_ids), so its committed state stays resolvable during recovery.
@@ -330,7 +330,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitNormalGroup_WithAllReadOnlyChildren_ShouldStillSetSchemaVersion()
       throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -341,10 +341,10 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     emitter.emitNormalGroup(parentId, Collections.singletonList(valueReadOnly(fullTxId)));
 
     // Assert
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(parentId);
     assertThat(capturedState.getWriteSet()).isPresent();
 
@@ -356,7 +356,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   @Test
   void emitter_emitNormalGroup_WithEmptyValues_ShouldNotCallPutState() throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -370,13 +370,13 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     // written. The null return is the contract that commitState's `assert committedAt != null`
     // guard relies on.
     assertThat(committedAt).isNull();
-    verify(coordinatorMock, never()).putState(any(Coordinator.State.class));
+    verify(coordinatorMock, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @Test
   void emitter_emitDelayedGroup_WithWritingValue_ShouldPersistStateWithWriteSet() throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -387,11 +387,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     Long committedAt = emitter.emitDelayedGroup(fullTxId, valueWithWrite(fullTxId));
 
     // Assert
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
 
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(fullTxId);
     assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
     // The emit returns the committedAt it stamped on the row.
@@ -411,7 +411,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitDelayedGroup_WithReadOnlyValue_ShouldPersistStateWithEmptyWriteSet()
       throws Exception {
     // Arrange
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, true);
 
@@ -422,11 +422,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     Long committedAt = emitter.emitDelayedGroup(fullTxId, valueReadOnly(fullTxId));
 
     // Assert
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
 
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(fullTxId);
     assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(committedAt).isEqualTo(capturedState.getCreatedAt());
@@ -441,7 +441,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitNormalGroup_WhenWriteSetLoggingDisabled_ShouldPassStateWithoutWriteSet()
       throws Exception {
     // Arrange — emitter constructed with write-set logging disabled.
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, false);
 
@@ -453,11 +453,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
     // Assert — the State carries no WriteSet so the BLOB column is not populated (the column is not
     // part of the Coordinator schema in this configuration).
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
 
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(parentId);
     assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(capturedState.getWriteSet()).isEmpty();
@@ -467,7 +467,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   void emitter_emitDelayedGroup_WhenWriteSetLoggingDisabled_ShouldPassStateWithoutWriteSet()
       throws Exception {
     // Arrange — same opt-in gating, delayed-group path.
-    Coordinator coordinatorMock = mock(Coordinator.class);
+    CoordinatorStateAccessor coordinatorMock = mock(CoordinatorStateAccessor.class);
     CoordinatorCommitHandlerWithGroupCommit.Emitter emitter =
         new CoordinatorCommitHandlerWithGroupCommit.Emitter(coordinatorMock, false);
 
@@ -478,11 +478,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     emitter.emitDelayedGroup(fullTxId, valueWithWrite(fullTxId));
 
     // Assert — the persisted State carries no WriteSet.
-    ArgumentCaptor<Coordinator.State> stateCaptor =
-        ArgumentCaptor.forClass(Coordinator.State.class);
+    ArgumentCaptor<CoordinatorStateAccessor.State> stateCaptor =
+        ArgumentCaptor.forClass(CoordinatorStateAccessor.State.class);
     verify(coordinatorMock).putState(stateCaptor.capture());
 
-    Coordinator.State capturedState = stateCaptor.getValue();
+    CoordinatorStateAccessor.State capturedState = stateCaptor.getValue();
     assertThat(capturedState.getId()).isEqualTo(fullTxId);
     assertThat(capturedState.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(capturedState.getWriteSet()).isEmpty();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
@@ -27,8 +27,8 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.IntColumn;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Column;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
@@ -50,20 +50,20 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class CoordinatorTest {
+public class CoordinatorStateAccessorTest {
   private static final String ANY_ID_1 = "anyid1";
   private static final String EMPTY_CHILD_IDS = "";
   private static final long ANY_TIME_1 = 1;
 
   @Mock private DistributedStorage storage;
   @Mock private ConsensusCommitConfig config;
-  private Coordinator coordinator;
+  private CoordinatorStateAccessor coordinator;
   @Captor private ArgumentCaptor<Get> getArgumentCaptor;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class CoordinatorTest {
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
-    Optional<Coordinator.State> state = coordinator.getState(ANY_ID_1);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(ANY_ID_1);
 
     // Assert
     assertThat(state).isPresent();
@@ -124,7 +124,7 @@ public class CoordinatorTest {
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
-    Optional<Coordinator.State> state = coordinator.getState(parentId);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(parentId);
 
     // Assert
     assertThat(state).isPresent();
@@ -139,9 +139,10 @@ public class CoordinatorTest {
   public void putState_StateGiven_ShouldPutWithCorrectValues()
       throws ExecutionException, CoordinatorException {
     // Arrange
-    coordinator = spy(new Coordinator(storage, config));
+    coordinator = spy(new CoordinatorStateAccessor(storage, config));
     long current = System.currentTimeMillis();
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, TransactionState.COMMITTED, current);
     doNothing().when(storage).put(any(Put.class));
 
     // Act
@@ -155,7 +156,8 @@ public class CoordinatorTest {
   public void createPutWith_StateGiven_ShouldCreateWithCorrectValues() throws ExecutionException {
     // Arrange
     long current = System.currentTimeMillis();
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, TransactionState.COMMITTED, current);
     doNothing().when(storage).put(any(Put.class));
 
     // Act
@@ -171,17 +173,18 @@ public class CoordinatorTest {
     assertThat(put.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
     assertThat(put.getCondition()).isPresent();
     assertThat(put.getCondition().get()).isExactlyInstanceOf(PutIfNotExists.class);
-    assertThat(put.forNamespace()).hasValue(Coordinator.NAMESPACE);
-    assertThat(put.forTable()).hasValue(Coordinator.TABLE);
+    assertThat(put.forNamespace()).hasValue(CoordinatorStateAccessor.NAMESPACE);
+    assertThat(put.forTable()).hasValue(CoordinatorStateAccessor.TABLE);
   }
 
   @Test
   public void putState_StateGivenAndExceptionThrownInPut_ShouldThrowCoordinatorException()
       throws ExecutionException {
     // Arrange
-    coordinator = spy(new Coordinator(storage, config));
+    coordinator = spy(new CoordinatorStateAccessor(storage, config));
     long current = System.currentTimeMillis();
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, TransactionState.COMMITTED, current);
     ExecutionException toThrow = mock(ExecutionException.class);
     doThrow(toThrow).when(storage).put(any(Put.class));
 
@@ -197,7 +200,7 @@ public class CoordinatorTest {
       throws ExecutionException, CoordinatorException {
     // Arrange
     when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
 
     Result result = mock(Result.class);
     when(result.getText(Attribute.ID)).thenReturn(ANY_ID_1);
@@ -208,13 +211,13 @@ public class CoordinatorTest {
     when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
 
     // Act
-    Optional<Coordinator.State> state = coordinator.getState(ANY_ID_1);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(ANY_ID_1);
 
     // Assert
     ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
     verify(storage).get(captor.capture());
     assertThat(captor.getValue().forNamespace()).hasValue("changed_coordinator");
-    assertThat(captor.getValue().forTable()).hasValue(Coordinator.TABLE);
+    assertThat(captor.getValue().forTable()).hasValue(CoordinatorStateAccessor.TABLE);
 
     assertThat(state).isPresent();
     assertThat(state.get().getId()).isEqualTo(ANY_ID_1);
@@ -229,10 +232,11 @@ public class CoordinatorTest {
       throws ExecutionException, CoordinatorException {
     // Arrange
     when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
-    coordinator = spy(new Coordinator(storage, config));
+    coordinator = spy(new CoordinatorStateAccessor(storage, config));
 
     long current = System.currentTimeMillis();
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, TransactionState.COMMITTED, current);
     doNothing().when(storage).put(any(Put.class));
 
     // Act
@@ -244,7 +248,7 @@ public class CoordinatorTest {
     ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
     verify(storage).put(captor.capture());
     assertThat(captor.getValue().forNamespace()).hasValue("changed_coordinator");
-    assertThat(captor.getValue().forTable()).hasValue(Coordinator.TABLE);
+    assertThat(captor.getValue().forTable()).hasValue(CoordinatorStateAccessor.TABLE);
   }
 
   // For group commit
@@ -268,7 +272,7 @@ public class CoordinatorTest {
   public void getState_TransactionIdForGroupCommitGivenAndParentIdAndChildIdMatch_ShouldReturnState(
       TransactionState transactionState) throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -300,8 +304,8 @@ public class CoordinatorTest {
         .get(coordinator.createGetWith(parentId));
 
     // Act
-    Optional<Coordinator.State> state1 = spiedCoordinator.getState(fullId1);
-    Optional<Coordinator.State> state2 = spiedCoordinator.getState(fullId2);
+    Optional<CoordinatorStateAccessor.State> state1 = spiedCoordinator.getState(fullId1);
+    Optional<CoordinatorStateAccessor.State> state2 = spiedCoordinator.getState(fullId2);
 
     // Assert
     assertThat(state1).isEqualTo(state2);
@@ -325,7 +329,7 @@ public class CoordinatorTest {
   public void getState_TransactionIdForSingleCommitGivenAndFullIdMatches_ShouldReturnState(
       TransactionState transactionState) throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -367,7 +371,7 @@ public class CoordinatorTest {
         .get(coordinator.createGetWith(fullId));
 
     // Act
-    Optional<Coordinator.State> state = spiedCoordinator.getState(fullId);
+    Optional<CoordinatorStateAccessor.State> state = spiedCoordinator.getState(fullId);
 
     // Assert
     assertThat(state).isPresent();
@@ -389,7 +393,7 @@ public class CoordinatorTest {
   public void getState_TransactionIdForGroupCommitGivenAndOnlyParentIdMatches_ShouldReturnEmpty(
       TransactionState transactionState) throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -422,7 +426,7 @@ public class CoordinatorTest {
     doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(targetFullId));
 
     // Act
-    Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
+    Optional<CoordinatorStateAccessor.State> state = spiedCoordinator.getState(targetFullId);
 
     // Assert
     assertThat(state).isEmpty();
@@ -440,7 +444,7 @@ public class CoordinatorTest {
       getState_TransactionIdForSingleCommitGivenAndOnlyParentIdMatchesButFullIdMatches_ShouldReturnState(
           TransactionState transactionState) throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -483,7 +487,7 @@ public class CoordinatorTest {
         .get(coordinator.createGetWith(targetFullId));
 
     // Act
-    Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
+    Optional<CoordinatorStateAccessor.State> state = spiedCoordinator.getState(targetFullId);
 
     // Assert
     assertThat(state).isPresent();
@@ -505,7 +509,7 @@ public class CoordinatorTest {
   public void getState_TransactionIdGivenButNoIdMatches_ShouldReturnEmpty(
       TransactionState transactionState) throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -539,7 +543,7 @@ public class CoordinatorTest {
     doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(targetFullId));
 
     // Act
-    Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
+    Optional<CoordinatorStateAccessor.State> state = spiedCoordinator.getState(targetFullId);
 
     // Assert
     assertThat(state).isEmpty();
@@ -554,7 +558,7 @@ public class CoordinatorTest {
       getState_TransactionIdForGroupCommitGivenAndFullIdMatchesAndExceptionThrownInGet_ShouldThrowCoordinatorException()
           throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -575,7 +579,7 @@ public class CoordinatorTest {
       getState_TransactionIdForGroupCommitGivenAndParentIdMatchesAndExceptionThrownInGet_ShouldThrowCoordinatorException()
           throws ExecutionException, CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -598,7 +602,7 @@ public class CoordinatorTest {
   @Test
   void forceAbort_NormalIdGiven_ShouldCallPutState() throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
 
     // Act
     spiedCoordinator.forceAbort(ANY_ID_1);
@@ -612,7 +616,7 @@ public class CoordinatorTest {
       forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsNotCommitted_ShouldInsertTwoRecordsWithParentIdAndFullId()
           throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -637,7 +641,7 @@ public class CoordinatorTest {
       forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsCommitted_ShouldThrowCoordinatorConflictException()
           throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -677,7 +681,7 @@ public class CoordinatorTest {
   void forceAbort_FullIdGivenWhenTransactionIsInGroupCommitWhenGroupCommitIsAbort_ShouldDoNothing()
       throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -720,7 +724,7 @@ public class CoordinatorTest {
       forceAbort_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitFinished_ShouldInsertRecordWithFullId(
           TransactionState transactionState) throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -767,7 +771,7 @@ public class CoordinatorTest {
       forceAbort_FullIdGivenWhenTransactionIsInDelayedGroupCommitWhenGroupCommitAndDelayedGroupCommitFinished_ShouldCoordinatorConflictException(
           TransactionState transactionState) throws CoordinatorException {
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -820,7 +824,7 @@ public class CoordinatorTest {
     // we fall through to insert the full-ID ABORTED record instead of crashing with AssertionError.
 
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -855,7 +859,7 @@ public class CoordinatorTest {
     // the caller re-reads the committed outcome instead of treating the transaction as aborted.
 
     // Arrange
-    Coordinator spiedCoordinator = spy(coordinator);
+    CoordinatorStateAccessor spiedCoordinator = spy(coordinator);
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
@@ -1086,7 +1090,7 @@ public class CoordinatorTest {
     // Act + Assert
     assertThatThrownBy(
             () ->
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     ANY_ID_1,
                     Collections.singletonList("child" + "," + "id"),
                     null,
@@ -1108,8 +1112,8 @@ public class CoordinatorTest {
     ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
     verify(storage).delete(captor.capture());
     Delete delete = captor.getValue();
-    assertThat(delete.forNamespace()).hasValue(Coordinator.NAMESPACE);
-    assertThat(delete.forTable()).hasValue(Coordinator.TABLE);
+    assertThat(delete.forNamespace()).hasValue(CoordinatorStateAccessor.NAMESPACE);
+    assertThat(delete.forTable()).hasValue(CoordinatorStateAccessor.TABLE);
     assertThat(delete.getPartitionKey().getColumnName(0)).isEqualTo(Attribute.ID);
     assertThat(delete.getPartitionKey().getTextValue(0)).isEqualTo(ANY_ID_1);
     assertThat(delete.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
@@ -1121,7 +1125,7 @@ public class CoordinatorTest {
       throws ExecutionException, CoordinatorException {
     // Arrange
     when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
-    coordinator = new Coordinator(storage, config);
+    coordinator = new CoordinatorStateAccessor(storage, config);
     doNothing().when(storage).delete(any(Delete.class));
 
     // Act
@@ -1131,7 +1135,7 @@ public class CoordinatorTest {
     ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
     verify(storage).delete(captor.capture());
     assertThat(captor.getValue().forNamespace()).hasValue("changed_coordinator");
-    assertThat(captor.getValue().forTable()).hasValue(Coordinator.TABLE);
+    assertThat(captor.getValue().forTable()).hasValue(CoordinatorStateAccessor.TABLE);
   }
 
   @Test
@@ -1261,7 +1265,8 @@ public class CoordinatorTest {
 
     // Act + Assert — getState skips the parent marker (childId not listed) and resolves to the full
     // key, so the delete must target the full key, not the parent marker.
-    assertThat(coordinator.getState(fullId).map(Coordinator.State::getId)).hasValue(fullId);
+    assertThat(coordinator.getState(fullId).map(CoordinatorStateAccessor.State::getId))
+        .hasValue(fullId);
     coordinator.deleteState(fullId);
 
     ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
@@ -1295,9 +1300,9 @@ public class CoordinatorTest {
   }
 
   /**
-   * Mockito matcher that compares Coordinator.State by id and TransactionState only — ignoring
-   * createdAt. Used to verify putState calls without relying on the production code's wall-clock
-   * timestamp.
+   * Mockito matcher that compares CoordinatorStateAccessor.State by id and TransactionState only —
+   * ignoring createdAt. Used to verify putState calls without relying on the production code's
+   * wall-clock timestamp.
    */
   private static org.mockito.ArgumentMatcher<State> stateMatcher(
       String id, TransactionState state) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -127,7 +127,7 @@ public class RecoveryExecutorTest {
               .build());
 
   @Mock private DistributedStorage storage;
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
   @Mock private RecoveryHandler recovery;
   @Mock private TransactionTableMetadataManager tableMetadataManager;
   @Mock private Snapshot.Key snapshotKey;
@@ -443,8 +443,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange: writing the ABORTED state conflicts because the transaction committed concurrently
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State committedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State committedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(committedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
@@ -476,8 +477,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange: writing the ABORTED state conflicts because another actor aborted the transaction
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty(), Optional.of(abortedState));
     when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
     when(storage.get(any(Get.class))).thenReturn(Optional.of(transactionResult));
@@ -664,8 +666,9 @@ public class RecoveryExecutorTest {
     // new writer's coordinator state is ABORTED, so the record is resolved (rolled back) for it.
     TransactionResult original = prepareResult(TransactionState.PREPARED);
     TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
     when(recovery.isTransactionExpired(original)).thenReturn(true);
@@ -733,8 +736,9 @@ public class RecoveryExecutorTest {
     // transaction, whose coordinator state is ABORTED, so the record is rolled back for it.
     TransactionResult original = prepareResult(TransactionState.PREPARED);
     TransactionResult rePrepared = prepareResult(TransactionState.PREPARED, ANY_ID_1);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.of(abortedState));
     when(recovery.isTransactionExpired(original)).thenReturn(true);
@@ -905,8 +909,9 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -935,8 +940,9 @@ public class RecoveryExecutorTest {
     // Arrange
     TransactionResult transactionResult =
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -964,8 +970,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State commitState =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State commitState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     executor = spy(executor);
@@ -995,8 +1002,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
-    Coordinator.State commitState =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State commitState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     // Act
@@ -1136,8 +1144,9 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -1166,8 +1175,9 @@ public class RecoveryExecutorTest {
     // Arrange
     TransactionResult transactionResult =
         prepareResultWithoutBeforeImage(TransactionState.PREPARED);
-    Coordinator.State abortedState =
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State abortedState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
 
     // Act
@@ -1195,8 +1205,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State commitState =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State commitState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     executor = spy(executor);
@@ -1226,8 +1237,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
-    Coordinator.State commitState =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State commitState =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
 
     // Act
@@ -1336,9 +1348,9 @@ public class RecoveryExecutorTest {
           throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis()));
     when(recovery.recover(selection, transactionResult, state)).thenReturn(true);
 
@@ -1371,8 +1383,9 @@ public class RecoveryExecutorTest {
       throws Exception {
     // Arrange
     TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
-    Coordinator.State state =
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis());
 
     // Act — the present-state overload is used by finishTransaction and returns nothing.
     executor.executeSynchronously(selection, transactionResult, state);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -57,7 +57,7 @@ public class RecoveryHandlerTest {
               .build());
 
   @Mock private DistributedStorage storage;
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
   @Mock private TransactionTableMetadataManager transactionTableMetadataManager;
   @Mock private TransactionTableMetadata transactionTableMetadata;
   @Mock private Selection selection;
@@ -112,9 +112,9 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     doNothing()
         .when(handler)
@@ -140,8 +140,9 @@ public class RecoveryHandlerTest {
     // Arrange
     long committedAt = 1234567890123L;
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
-        Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, committedAt));
+    Optional<CoordinatorStateAccessor.State> state =
+        Optional.of(
+            new CoordinatorStateAccessor.State(ANY_ID_1, TransactionState.COMMITTED, committedAt));
     CommitMutationComposer composer = mock(CommitMutationComposer.class);
     doReturn(Collections.emptyList()).when(composer).get();
     doReturn(composer)
@@ -162,9 +163,9 @@ public class RecoveryHandlerTest {
           throws ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     CommitMutationComposer composer = mock(CommitMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
@@ -188,9 +189,9 @@ public class RecoveryHandlerTest {
           throws ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     CommitMutationComposer composer = mock(CommitMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
@@ -214,9 +215,10 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
+            new CoordinatorStateAccessor.State(
+                ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -233,9 +235,10 @@ public class RecoveryHandlerTest {
           throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
+            new CoordinatorStateAccessor.State(
+                ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     RollbackMutationComposer composer = mock(RollbackMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -257,9 +260,10 @@ public class RecoveryHandlerTest {
           throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
+            new CoordinatorStateAccessor.State(
+                ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     RollbackMutationComposer composer = mock(RollbackMutationComposer.class);
     List<Mutation> mutations = Collections.singletonList(mock(Mutation.class));
     doReturn(mutations).when(composer).get();
@@ -282,7 +286,7 @@ public class RecoveryHandlerTest {
           throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(System.currentTimeMillis());
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -302,8 +306,8 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
+    doNothing().when(coordinator).putState(any(CoordinatorStateAccessor.State.class));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -323,13 +327,13 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     // A concurrent actor already aborted the writer; the re-read returns that ABORTED state.
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis())));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
@@ -351,14 +355,14 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     // A concurrent commit won the race; the re-read sees COMMITTED, which must be reported
     // instead of a false ABORTED.
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(
             Optional.of(
-                new Coordinator.State(
+                new CoordinatorStateAccessor.State(
                     ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis())));
     doNothing()
         .when(handler)
@@ -386,7 +390,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
 
@@ -408,7 +412,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doThrow(CoordinatorException.class).when(coordinator).forceAbort(anyString());
 
     // Act
@@ -430,7 +434,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class)))
         .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.COMMITTED, ANY_ID_1)));
 
@@ -453,7 +457,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class))).thenReturn(Optional.empty());
 
     // Act
@@ -476,7 +480,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class)))
         .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.PREPARED, ANY_ID_2)));
 
@@ -499,7 +503,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class)))
         .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.COMMITTED, ANY_ID_1)));
 
@@ -521,7 +525,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class))).thenReturn(Optional.empty());
 
     // Act
@@ -543,7 +547,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class)))
         .thenReturn(Optional.of(prepareResult(ANY_TIME_1, TransactionState.PREPARED, ANY_ID_2)));
 
@@ -565,7 +569,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class))).thenThrow(ExecutionException.class);
 
     // Act Assert
@@ -584,7 +588,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     when(storage.get(any(Get.class))).thenThrow(ExecutionException.class);
 
     // Act Assert
@@ -638,8 +642,9 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Coordinator.State state =
-        new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis());
     doNothing()
         .when(handler)
         .rollforwardRecord(any(Selection.class), any(TransactionResult.class), anyLong());
@@ -658,8 +663,9 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Coordinator.State state =
-        new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(
+            ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis());
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -680,9 +686,9 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 ANY_ID_1, TransactionState.COMMITTED, System.currentTimeMillis()));
     doNothing()
         .when(handler)
@@ -700,9 +706,10 @@ public class RecoveryHandlerTest {
       throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result = preparePreparedResult(ANY_TIME_1);
-    Optional<Coordinator.State> state =
+    Optional<CoordinatorStateAccessor.State> state =
         Optional.of(
-            new Coordinator.State(ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
+            new CoordinatorStateAccessor.State(
+                ANY_ID_1, TransactionState.ABORTED, System.currentTimeMillis()));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
@@ -722,7 +729,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doThrow(CoordinatorConflictException.class).when(coordinator).forceAbort(anyString());
 
     // Act
@@ -741,7 +748,7 @@ public class RecoveryHandlerTest {
     // Arrange — the writer has no coordinator state and has not expired, so it may still be in
     // flight; best-effort recovery must leave it untouched.
     TransactionResult result = preparePreparedResult(System.currentTimeMillis());
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
 
     // Act
     handler.tryRecover(selection, result, state);
@@ -760,7 +767,7 @@ public class RecoveryHandlerTest {
     TransactionResult result =
         preparePreparedResult(
             System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
-    Optional<Coordinator.State> state = Optional.empty();
+    Optional<CoordinatorStateAccessor.State> state = Optional.empty();
     doNothing().when(coordinator).forceAbort(anyString());
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -44,7 +44,7 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -62,7 +62,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   @Mock private DistributedStorageAdmin admin;
   @Mock private ConsensusCommitConfig config;
   @Mock private DatabaseConfig databaseConfig;
-  @Mock private Coordinator coordinator;
+  @Mock private CoordinatorStateAccessor coordinator;
   @Mock private ParallelExecutor parallelExecutor;
   @Mock private RecoveryExecutor recoveryExecutor;
   @Mock private CrudHandler crud;

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -11,7 +11,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -921,13 +921,13 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
 
   protected void extraCheckOnCoordinatorTable() throws ExecutionException {
     TableMetadata expectedMetadata =
-        Coordinator.buildTableMetadata(isGroupCommitEnabled(getTestName()), false);
+        CoordinatorStateAccessor.buildTableMetadata(isGroupCommitEnabled(getTestName()), false);
 
     try (DistributedStorageAdmin storageAdmin =
         StorageFactory.create(getProperties(getTestName())).getStorageAdmin()) {
       assertThat(
               storageAdmin.getTableMetadata(
-                  getCoordinatorNamespaceName(getTestName()), Coordinator.TABLE))
+                  getCoordinatorNamespaceName(getTestName()), CoordinatorStateAccessor.TABLE))
           .isEqualTo(expectedMetadata);
     }
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
@@ -61,11 +61,11 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
       String coordinatorNamespace =
           new ConsensusCommitConfig(new DatabaseConfig(propertiesWithGroupCommitEnabled))
               .getCoordinatorNamespace()
-              .orElse(Coordinator.NAMESPACE);
+              .orElse(CoordinatorStateAccessor.NAMESPACE);
       try (DistributedStorageAdmin storageAdmin =
           StorageFactory.create(propertiesWithGroupCommitEnabled).getStorageAdmin()) {
         TableMetadata metadata =
-            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+            storageAdmin.getTableMetadata(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
         assertThat(metadata).isNotNull();
         assertThat(metadata.getColumnNames()).contains(Attribute.CHILD_IDS);
       }
@@ -110,11 +110,11 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
       String coordinatorNamespace =
           new ConsensusCommitConfig(new DatabaseConfig(propertiesWithGroupCommitDisabled))
               .getCoordinatorNamespace()
-              .orElse(Coordinator.NAMESPACE);
+              .orElse(CoordinatorStateAccessor.NAMESPACE);
       try (DistributedStorageAdmin storageAdmin =
           StorageFactory.create(propertiesWithGroupCommitDisabled).getStorageAdmin()) {
         TableMetadata metadata =
-            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+            storageAdmin.getTableMetadata(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
         assertThat(metadata).isNotNull();
         assertThat(metadata.getColumnNames()).contains(Attribute.CHILD_IDS);
       }
@@ -158,11 +158,11 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
       String coordinatorNamespace =
           new ConsensusCommitConfig(new DatabaseConfig(propertiesWithWriteSetLoggingEnabled))
               .getCoordinatorNamespace()
-              .orElse(Coordinator.NAMESPACE);
+              .orElse(CoordinatorStateAccessor.NAMESPACE);
       try (DistributedStorageAdmin storageAdmin =
           StorageFactory.create(propertiesWithWriteSetLoggingEnabled).getStorageAdmin()) {
         TableMetadata metadata =
-            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+            storageAdmin.getTableMetadata(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
         assertThat(metadata).isNotNull();
         assertThat(metadata.getColumnNames()).contains(Attribute.WRITE_SET);
       }
@@ -207,11 +207,11 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
       String coordinatorNamespace =
           new ConsensusCommitConfig(new DatabaseConfig(propertiesWithWriteSetLoggingDisabled))
               .getCoordinatorNamespace()
-              .orElse(Coordinator.NAMESPACE);
+              .orElse(CoordinatorStateAccessor.NAMESPACE);
       try (DistributedStorageAdmin storageAdmin =
           StorageFactory.create(propertiesWithWriteSetLoggingDisabled).getStorageAdmin()) {
         TableMetadata metadata =
-            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+            storageAdmin.getTableMetadata(coordinatorNamespace, CoordinatorStateAccessor.TABLE);
         assertThat(metadata).isNotNull();
         assertThat(metadata.getColumnNames()).contains(Attribute.WRITE_SET);
       }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitImportTableIntegrationTestBase.java
@@ -75,7 +75,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
 
   private ConsensusCommitManager manager;
   private DistributedStorage storage;
-  private Coordinator coordinator;
+  private CoordinatorStateAccessor coordinator;
   private RecoveryHandler recovery;
   private RecoveryExecutor recoveryExecutor;
   @Nullable private CoordinatorGroupCommitter groupCommitter;
@@ -124,7 +124,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
   public void setUp() throws Exception {
     dropTables();
     storage = spy(originalStorage);
-    coordinator = spy(new Coordinator(storage, consensusCommitConfig));
+    coordinator = spy(new CoordinatorStateAccessor(storage, consensusCommitConfig));
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
@@ -279,8 +279,8 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     if (coordinatorState == null) {
       return;
     }
-    Coordinator.State state =
-        new Coordinator.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
     coordinator.putState(state);
   }
 
@@ -593,7 +593,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // Assert
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @Test
@@ -786,7 +786,7 @@ public abstract class ConsensusCommitImportTableIntegrationTestBase {
     // Assert
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -74,7 +74,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
 
   private ConsensusCommitManager manager;
   private DistributedStorage storage;
-  private Coordinator coordinator;
+  private CoordinatorStateAccessor coordinator;
   private RecoveryHandler recovery;
   private RecoveryExecutor recoveryExecutor;
   @Nullable private CoordinatorGroupCommitter groupCommitter;
@@ -136,7 +136,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   public void setUp() throws Exception {
     truncateTables();
     storage = spy(originalStorage);
-    coordinator = spy(new Coordinator(storage, consensusCommitConfig));
+    coordinator = spy(new CoordinatorStateAccessor(storage, consensusCommitConfig));
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
@@ -279,8 +279,8 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     if (coordinatorState == null) {
       return;
     }
-    Coordinator.State state =
-        new Coordinator.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
+    CoordinatorStateAccessor.State state =
+        new CoordinatorStateAccessor.State(ANY_ID_1, coordinatorState, System.currentTimeMillis());
     coordinator.putState(state);
   }
 
@@ -661,7 +661,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // Assert
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @Test
@@ -892,7 +892,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     // Assert
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -128,7 +128,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   private ParallelExecutor parallelExecutor;
 
   private DistributedStorage storage;
-  private Coordinator coordinator;
+  private CoordinatorStateAccessor coordinator;
   private RecoveryHandler recovery;
   private RecoveryExecutor recoveryExecutor;
   private CommitHandler commit;
@@ -287,7 +287,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .isEqualTo(TransactionState.COMMITTED);
 
     // commit-state should not occur for read-only transactions
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @ParameterizedTest
@@ -333,7 +333,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .isEqualTo(TransactionState.COMMITTED);
 
     // commit-state should not occur for read-only transactions
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @ParameterizedTest
@@ -388,7 +388,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     // commit-state should not occur for read-only transactions
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @ParameterizedTest
@@ -1622,7 +1622,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // In all cases, recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -1755,7 +1755,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       // In READ_COMMITTED isolation and read-only mode, recovery should not occur
       verify(recovery, never())
           .tryRecover(any(Selection.class), any(TransactionResult.class), any());
-      verify(coordinator, never()).putState(any(Coordinator.State.class));
+      verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
       verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     } else if (isolation == Isolation.READ_COMMITTED) {
       // In READ_COMMITTED isolation and read-write mode, the record is recovered in the background
@@ -2223,7 +2223,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // In all cases, recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2598,7 +2598,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -2751,7 +2751,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         ANY_ID_2,
         current);
     coordinator.putState(
-        new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis()));
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.COMMITTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -2825,7 +2826,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         ANY_ID_2,
         current);
     coordinator.putState(
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -2878,7 +2880,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         ANY_ID_2,
         current);
     coordinator.putState(
-        new Coordinator.State(ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
+        new CoordinatorStateAccessor.State(
+            ANY_ID_2, TransactionState.ABORTED, System.currentTimeMillis()));
 
     DistributedTransaction transaction = manager.begin();
 
@@ -3095,7 +3098,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     storage.put(put);
 
     coordinator.putState(
-        new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
+        new CoordinatorStateAccessor.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
   }
 
   private void
@@ -3407,7 +3410,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
@@ -3681,7 +3684,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     }
 
     coordinator.putState(
-        new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
+        new CoordinatorStateAccessor.State(ANY_ID_2, coordinatorState, System.currentTimeMillis()));
     return ANY_ID_2;
   }
 
@@ -3720,7 +3723,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     doAnswer(
             invocation -> {
               coordinator.putState(
-                  new Coordinator.State(
+                  new CoordinatorStateAccessor.State(
                       ongoingTxId, TransactionState.COMMITTED, System.currentTimeMillis()));
               return Optional.empty();
             })
@@ -4226,7 +4229,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                   "simulated conflict: group-commit parent row was committed");
             })
         .when(coordinator)
-        .putState(any(Coordinator.State.class));
+        .putState(any(CoordinatorStateAccessor.State.class));
 
     // The coordinator cleanup process removed the parent row in the window between the conflict
     // and the re-read -- return empty to model the cleaned-up state. The fall-through then writes
@@ -4378,7 +4381,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // The re-preparing transaction is aborted, so resolving it rolls the record back to its
     // before-image, restoring the intervening committed value as the record's committed image.
     coordinator.putState(
-        new Coordinator.State(
+        new CoordinatorStateAccessor.State(
             REPREPARING_TX_ID, TransactionState.ABORTED, System.currentTimeMillis()));
     doAnswer(
             invocation -> {
@@ -4899,7 +4902,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // In all isolations, recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @ParameterizedTest
@@ -5153,7 +5156,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // In all isolations, recovery should not occur
     verify(recovery, never()).tryRecover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator, never()).putState(any(Coordinator.State.class));
+    verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
   }
 
   @ParameterizedTest
@@ -9618,10 +9621,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           return;
         }
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         break;
       case PARTITION:
       case TABLE:
@@ -9632,16 +9635,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           verify(storage).mutate(anyList());
 
           // no commit-state should occur
-          verify(coordinator, never()).putState(any(Coordinator.State.class));
+          verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
         } else {
           // one for prepare, one for commit
           verify(storage, times(2)).mutate(anyList());
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
         }
         break;
@@ -9720,9 +9723,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         } else {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         }
         break;
       case TABLE:
@@ -9733,16 +9736,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           verify(storage).mutate(anyList());
 
           // no commit-state should occur
-          verify(coordinator, never()).putState(any(Coordinator.State.class));
+          verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
         } else {
           // one for prepare, one for commit
           verify(storage, times(2)).mutate(anyList());
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
         }
         break;
@@ -9822,9 +9825,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
       } else {
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
       }
     } else {
       // same storage
@@ -9838,9 +9841,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
           break;
         case STORAGE:
@@ -9849,16 +9852,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             verify(storage).mutate(anyList());
 
             // no commit-state should occur
-            verify(coordinator, never()).putState(any(Coordinator.State.class));
+            verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
           } else {
             // one for prepare, one for commit
             verify(storage, times(2)).mutate(anyList());
 
             // commit-state should occur
             if (isGroupCommitEnabled()) {
-              verify(coordinator).putState(any(Coordinator.State.class));
+              verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
             } else {
-              verify(coordinator).putState(any(Coordinator.State.class));
+              verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
             }
           }
           break;
@@ -9959,10 +9962,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           return;
         }
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         break;
       case PARTITION:
       case TABLE:
@@ -9973,16 +9976,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           verify(storage).mutate(anyList());
 
           // no commit-state should occur
-          verify(coordinator, never()).putState(any(Coordinator.State.class));
+          verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
         } else {
           // one for prepare, one for commit
           verify(storage, times(2)).mutate(anyList());
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
         }
         break;
@@ -10083,9 +10086,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
         // commit-state should occur
         if (isGroupCommitEnabled()) {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         } else {
-          verify(coordinator).putState(any(Coordinator.State.class));
+          verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         }
         break;
       case TABLE:
@@ -10096,16 +10099,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
           verify(storage).mutate(anyList());
 
           // no commit-state should occur
-          verify(coordinator, never()).putState(any(Coordinator.State.class));
+          verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
         } else {
           // one for prepare, one for commit
           verify(storage, times(2)).mutate(anyList());
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
         }
         break;
@@ -10207,9 +10210,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
       } else {
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
       }
     } else {
       // same storage
@@ -10223,9 +10226,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
           // commit-state should occur
           if (isGroupCommitEnabled()) {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           } else {
-            verify(coordinator).putState(any(Coordinator.State.class));
+            verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
           }
           break;
         case STORAGE:
@@ -10234,16 +10237,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             verify(storage).mutate(anyList());
 
             // no commit-state should occur
-            verify(coordinator, never()).putState(any(Coordinator.State.class));
+            verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
           } else {
             // one for prepare, one for commit
             verify(storage, times(2)).mutate(anyList());
 
             // commit-state should occur
             if (isGroupCommitEnabled()) {
-              verify(coordinator).putState(any(Coordinator.State.class));
+              verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
             } else {
-              verify(coordinator).putState(any(Coordinator.State.class));
+              verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
             }
           }
           break;
@@ -10339,10 +10342,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
       // commit-state should occur
       if (isGroupCommitEnabled()) {
-        verify(coordinator).putState(any(Coordinator.State.class));
+        verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
         return;
       }
-      verify(coordinator).putState(any(Coordinator.State.class));
+      verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
     } else if (onePhaseCommitEnabled) {
       // only one transaction read, no validation read
       verify(storage).get(any(Get.class));
@@ -10351,7 +10354,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       verify(storage).mutate(anyList());
 
       // no commit-state should occur
-      verify(coordinator, never()).putState(any(Coordinator.State.class));
+      verify(coordinator, never()).putState(any(CoordinatorStateAccessor.State.class));
     } else {
       // only one transaction read, no validation read
       verify(storage).get(any(Get.class));
@@ -10360,7 +10363,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       verify(storage, times(2)).mutate(anyList());
 
       // commit-state should occur
-      verify(coordinator).putState(any(Coordinator.State.class));
+      verify(coordinator).putState(any(CoordinatorStateAccessor.State.class));
     }
 
     Optional<Result> result1 =
@@ -10761,7 +10764,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Assert — the persisted tx_write_set BLOB can be read back and parsed as a valid WriteSet
     // carrying both writes (the exact EntryGroup partitioning depends on group commit; we only
     // assert the total entry count).
-    Optional<Coordinator.State> state = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(txId);
     assertThat(state).isPresent();
     assertThat(state.get().getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(state.get().getWriteSet()).isPresent();
@@ -10939,7 +10942,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     pushRecordBackToPrepared(0, 1, txId);
 
     // Sanity check
-    Optional<Coordinator.State> stateBefore = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> stateBefore = coordinator.getState(txId);
     assertThat(stateBefore).isPresent();
     assertThat(stateBefore.get().getState()).isEqualTo(TransactionState.COMMITTED);
     Optional<Result> raw00Before = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11007,7 +11010,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
                     .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 1)))
             .build();
     coordinator.putState(
-        new Coordinator.State(
+        new CoordinatorStateAccessor.State(
             txId, writeSet, TransactionState.ABORTED, System.currentTimeMillis()));
 
     // Sanity check
@@ -11020,8 +11023,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     boolean finished = manager.finishTransaction(txId);
 
     // Assert — record (0, 0) is restored to the before-image (tx_id=ANY_ID_1, tx_state=COMMITTED,
-    // balance=INITIAL_BALANCE), record (0, 1) remains absent at storage, and the Coordinator
-    // state row is gone.
+    // balance=INITIAL_BALANCE), record (0, 1) remains absent at storage, and the
+    // Coordinator state row is gone.
     assertThat(finished).isTrue();
     assertThat(coordinator.getState(txId)).isEmpty();
     Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11104,10 +11107,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         Arrays.asList(
             km.keysFromFullKey(fullTxId1).childKey, km.keysFromFullKey(fullTxId2).childKey);
     coordinator.putState(
-        new Coordinator.State(parentId, childIds, writeSet, TransactionState.COMMITTED, now));
+        new CoordinatorStateAccessor.State(
+            parentId, childIds, writeSet, TransactionState.COMMITTED, now));
 
     // Sanity check
-    Optional<Coordinator.State> stateBefore = coordinator.getState(fullTxId1);
+    Optional<CoordinatorStateAccessor.State> stateBefore = coordinator.getState(fullTxId1);
     assertThat(stateBefore).isPresent();
     assertThat(stateBefore.get().getState()).isEqualTo(TransactionState.COMMITTED);
     Optional<Result> raw00Before = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11145,10 +11149,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   void finishTransaction_TransactionTerminatedWithoutWriteSet_ShouldReturnFalseAndLeaveState()
       throws Exception {
     // Scenario 4: a transaction that did not go through DistributedTransaction#commit() — here it
-    // was terminated via DistributedTransactionManager#rollback() — leaves a Coordinator ABORTED
-    // state row that carries no write set. finishTransaction is not applicable to such a
-    // transaction: it must report that by returning false without doing any work and leave the
-    // state row in place for lazy recovery to handle.
+    // was terminated via DistributedTransactionManager#rollback() — leaves a
+    // Coordinator ABORTED state row that carries no write set. finishTransaction is not
+    // applicable to such a transaction: it must report that by returning false without doing any
+    // work and leave the state row in place for lazy recovery to handle.
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
 
     String txId = UUID.randomUUID().toString();
@@ -11156,7 +11160,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     manager.rollback(txId);
 
     // Sanity check — the state row is present, ABORTED, and carries no write set.
-    Optional<Coordinator.State> stateBefore = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> stateBefore = coordinator.getState(txId);
     assertThat(stateBefore).isPresent();
     assertThat(stateBefore.get().getState()).isEqualTo(TransactionState.ABORTED);
     assertThat(stateBefore.get().getWriteSet()).isNotPresent();
@@ -11166,7 +11170,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert — not applicable (no write set), so it returns false and leaves the state row intact.
     assertThat(finished).isFalse();
-    Optional<Coordinator.State> stateAfter = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> stateAfter = coordinator.getState(txId);
     assertThat(stateAfter).isPresent();
     assertThat(stateAfter.get().getState()).isEqualTo(TransactionState.ABORTED);
     assertThat(stateAfter.get().getWriteSet()).isNotPresent();
@@ -11319,7 +11323,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert — the writer is aborted and the record rolled back to the before-image.
     assertThat(recovered).isTrue();
-    Optional<Coordinator.State> state = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(txId);
     assertThat(state).isPresent();
     assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
     Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11404,10 +11408,10 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange — record (0,0) is PREPARED by a group-commit transaction (its tx_id is a full
     // group-commit key) with no Coordinator state and an expired prepared-at. This is an abandoned
     // group-commit writer (the group never reached commit). recoverRecord must abort it through the
-    // group-commit-aware path (Coordinator.forceAbortForGroupCommit), which writes both the
-    // lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same rows that
-    // conflict-protect against a racing real group commit. This is the expired counterpart of the
-    // not-expired test above and confirms recoverRecord drives the no-state group-commit branch
+    // group-commit-aware path (CoordinatorStateAccessor.forceAbortForGroupCommit), which writes
+    // both the lazy-recovery-abort-with-parent-id row and the full-id ABORTED row — the same rows
+    // that conflict-protect against a racing real group commit. This is the expired counterpart of
+    // the not-expired test above and confirms recoverRecord drives the no-state group-commit branch
     // identically to lazy recovery.
     ConsensusCommitManager manager = createConsensusCommitManager(Isolation.SNAPSHOT);
     String txId =
@@ -11429,7 +11433,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // before-image. getState on the full key resolves to ABORTED (it falls through to the full-id
     // ABORTED row written by the group-commit abort path).
     assertThat(recovered).isTrue();
-    Optional<Coordinator.State> state = coordinator.getState(txId);
+    Optional<CoordinatorStateAccessor.State> state = coordinator.getState(txId);
     assertThat(state).isPresent();
     assertThat(state.get().getState()).isEqualTo(TransactionState.ABORTED);
     Optional<Result> raw = originalStorage.get(prepareGet(0, 0, namespace1, TABLE_1));
@@ -11631,14 +11635,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     switch (commitType) {
       case NORMAL_COMMIT:
-        Coordinator.State state =
-            new Coordinator.State(ANY_ID_2, coordinatorState, System.currentTimeMillis());
+        CoordinatorStateAccessor.State state =
+            new CoordinatorStateAccessor.State(
+                ANY_ID_2, coordinatorState, System.currentTimeMillis());
         coordinator.putState(state);
         break;
       case GROUP_COMMIT:
         Keys<String, String, String> keys = keyManipulator.keysFromFullKey(ongoingTxId);
         coordinator.putState(
-            new Coordinator.State(
+            new CoordinatorStateAccessor.State(
                 keys.parentKey,
                 Collections.singletonList(keys.childKey),
                 null,
@@ -11647,7 +11652,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         break;
       case DELAYED_GROUP_COMMIT:
         coordinator.putState(
-            new Coordinator.State(ongoingTxId, coordinatorState, System.currentTimeMillis()));
+            new CoordinatorStateAccessor.State(
+                ongoingTxId, coordinatorState, System.currentTimeMillis()));
         break;
     }
 
@@ -11803,7 +11809,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   private ConsensusCommitManager createConsensusCommitManager(
       Isolation isolation, boolean onePhaseCommitEnabled) {
     storage = spy(originalStorage);
-    coordinator = spy(new Coordinator(storage, consensusCommitConfig));
+    coordinator = spy(new CoordinatorStateAccessor(storage, consensusCommitConfig));
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
@@ -74,7 +74,8 @@ public final class ConsensusCommitTestUtils {
 
   public static void addSuffixToCoordinatorNamespace(Properties properties, String suffix) {
     String coordinatorNamespace =
-        properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+        properties.getProperty(
+            ConsensusCommitConfig.COORDINATOR_NAMESPACE, CoordinatorStateAccessor.NAMESPACE);
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + suffix);
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -25,7 +25,7 @@ import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator.State;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +61,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   private DistributedStorage storage2;
   private ConsensusCommitAdmin consensusCommitAdmin1;
   private ConsensusCommitAdmin consensusCommitAdmin2;
-  private Coordinator coordinatorForStorage1;
+  private CoordinatorStateAccessor coordinatorForStorage1;
   private String namespace1;
   private String namespace2;
 
@@ -88,7 +88,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     storage2 = factory2.getStorage();
     manager1 = new TwoPhaseConsensusCommitManager(storage1, admin1, databaseConfig1);
     manager2 = new TwoPhaseConsensusCommitManager(storage2, admin2, databaseConfig2);
-    coordinatorForStorage1 = new Coordinator(storage1, consensusCommitConfig1);
+    coordinatorForStorage1 = new CoordinatorStateAccessor(storage1, consensusCommitConfig1);
   }
 
   protected void initialize() throws Exception {}

--- a/integration-test/src/main/java/com/scalar/db/util/AdminTestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/util/AdminTestUtils.java
@@ -5,7 +5,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 
@@ -60,8 +60,9 @@ public abstract class AdminTestUtils {
   public boolean areTableMetadataForCoordinatorTablesPresent() throws Exception {
     ConsensusCommitConfig config =
         new ConsensusCommitConfig(new DatabaseConfig(coordinatorStorageProperties));
-    String coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
-    String coordinatorTable = Coordinator.TABLE;
+    String coordinatorNamespace =
+        config.getCoordinatorNamespace().orElse(CoordinatorStateAccessor.NAMESPACE);
+    String coordinatorTable = CoordinatorStateAccessor.TABLE;
     // Use the DistributedStorageAdmin instead of the DistributedTransactionAdmin because the latter
     // expects the table to hold transaction table metadata columns which is not the case for the
     // coordinator table
@@ -75,7 +76,7 @@ public abstract class AdminTestUtils {
       return false;
     }
     TableMetadata expectedMetadata =
-        Coordinator.buildTableMetadata(
+        CoordinatorStateAccessor.buildTableMetadata(
             config.isCoordinatorGroupCommitEnabled(), config.isCoordinatorWriteSetLoggingEnabled());
     return tableMetadata.equals(expectedMetadata);
   }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
@@ -5,7 +5,7 @@ import com.scalar.db.schemaloader.SchemaLoaderException;
 import com.scalar.db.storage.cosmos.CosmosAdmin;
 import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -108,7 +108,7 @@ public class CosmosCommand extends StorageSpecificCommand implements Callable<In
     if (coordinatorNamespacePrefix != null) {
       props.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE,
-          coordinatorNamespacePrefix + Coordinator.NAMESPACE);
+          coordinatorNamespacePrefix + CoordinatorStateAccessor.NAMESPACE);
     }
 
     Map<String, String> options = new HashMap<>();

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithServer.java
@@ -2,7 +2,7 @@ package com.scalar.db.server;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminRepairTableIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.db.util.AdminTestUtils;
 import java.io.IOException;
 import java.util.Properties;
@@ -23,7 +23,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithServer
       // Add testName as a coordinator namespace suffix
       String coordinatorNamespace =
           properties.getProperty(
-              ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+              ConsensusCommitConfig.COORDINATOR_NAMESPACE, CoordinatorStateAccessor.NAMESPACE);
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
@@ -43,7 +43,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithServer
 
     // Add testName as a coordinator namespace suffix
     String coordinatorNamespace =
-        properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+        properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, CoordinatorStateAccessor.NAMESPACE);
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3661
- **Commit to backport:** a849c01c40e7df872ef89f171bdc5367bf6bfb7f

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3661 &&
git cherry-pick --no-rerere-autoupdate -m1 a849c01c40e7df872ef89f171bdc5367bf6bfb7f
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!