### PR TITLE
Backport to branch(3) : Cap active transactions and refresh the idle timer on each operation

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -31,7 +31,9 @@ public abstract class AbstractDistributedTransactionProvider
       // active transaction registry) carry the behavior of every inner decorator.
       transactionManager =
           new ActiveTransactionManagedDistributedTransactionManager(
-              transactionManager, config.getActiveTransactionManagementExpirationTimeMillis());
+              transactionManager,
+              config.getActiveTransactionManagementExpirationTimeMillis(),
+              config.getActiveTransactionManagementMaxActiveTransactions());
     }
 
     return transactionManager;
@@ -58,7 +60,9 @@ public abstract class AbstractDistributedTransactionProvider
       // Wrap the transaction manager for active transaction management
       transactionManager =
           new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
-              transactionManager, config.getActiveTransactionManagementExpirationTimeMillis());
+              transactionManager,
+              config.getActiveTransactionManagementExpirationTimeMillis(),
+              config.getActiveTransactionManagementMaxActiveTransactions());
     }
 
     return transactionManager;
@@ -77,7 +81,9 @@ public abstract class AbstractDistributedTransactionProvider
       // so that the idle-expiry reap traverses every inner decorator via releaseContext.
       coordinator =
           new ActiveTransactionManagedTwoPhaseCommitCoordinator(
-              coordinator, config.getActiveTransactionManagementExpirationTimeMillis());
+              coordinator,
+              config.getActiveTransactionManagementExpirationTimeMillis(),
+              config.getActiveTransactionManagementMaxActiveTransactions());
     }
 
     return coordinator;
@@ -100,7 +106,9 @@ public abstract class AbstractDistributedTransactionProvider
       // so that the idle-expiry reap traverses every inner decorator via releaseContext.
       participant =
           new ActiveTransactionManagedTwoPhaseCommitParticipant(
-              participant, config.getActiveTransactionManagementExpirationTimeMillis());
+              participant,
+              config.getActiveTransactionManagementExpirationTimeMillis(),
+              config.getActiveTransactionManagementMaxActiveTransactions());
     }
 
     return participant;

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -37,18 +37,32 @@ public class ActiveTransactionManagedDistributedTransactionManager
   private final ActiveTransactionRegistry<DistributedTransaction> registry;
 
   public ActiveTransactionManagedDistributedTransactionManager(
-      DistributedTransactionManager transactionManager, long expirationTimeMillis) {
+      DistributedTransactionManager transactionManager,
+      long expirationTimeMillis,
+      int maxActiveTransactions) {
     super(transactionManager);
     registry =
-        new ActiveTransactionRegistry<>(expirationTimeMillis, DistributedTransaction::rollback);
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, maxActiveTransactions, DistributedTransaction::rollback);
   }
 
   public ActiveTransactionManagedDistributedTransactionManager(
       DistributedTransactionManager transactionManager,
       long expirationTimeMillis,
-      ActiveTransactionRegistry.ExpirationHandler<DistributedTransaction> expirationHandler) {
+      int maxActiveTransactions,
+      ActiveTransactionRegistry.DisposalHandler<DistributedTransaction> disposalHandler) {
     super(transactionManager);
-    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, expirationHandler);
+    registry =
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, maxActiveTransactions, disposalHandler);
+  }
+
+  @VisibleForTesting
+  ActiveTransactionManagedDistributedTransactionManager(
+      DistributedTransactionManager transactionManager,
+      ActiveTransactionRegistry<DistributedTransaction> registry) {
+    super(transactionManager);
+    this.registry = registry;
   }
 
   @Override
@@ -99,23 +113,30 @@ public class ActiveTransactionManagedDistributedTransactionManager
 
     @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
+      registry.touch(getId());
       return super.get(get);
     }
 
     @Override
     public synchronized List<Result> scan(Scan scan) throws CrudException {
+      registry.touch(getId());
       return super.scan(scan);
     }
 
     @Override
     public synchronized Scanner getScanner(Scan scan) throws CrudException {
-      return new SynchronizedScanner(this, super.getScanner(scan));
+      registry.touch(getId());
+      // Refresh the idle timer on each read so a slowly-consumed scan is not reaped mid-iteration,
+      // then synchronize the read against a concurrent reaper rollback (SynchronizedScanner).
+      return new ActiveTransactionRefreshingScanner(
+          registry, getId(), new SynchronizedScanner(this, super.getScanner(scan)));
     }
 
     /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
+      registry.touch(getId());
       super.put(put);
     }
 
@@ -123,11 +144,13 @@ public class ActiveTransactionManagedDistributedTransactionManager
     @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
+      registry.touch(getId());
       super.put(puts);
     }
 
     @Override
     public synchronized void delete(Delete delete) throws CrudException {
+      registry.touch(getId());
       super.delete(delete);
     }
 
@@ -135,32 +158,38 @@ public class ActiveTransactionManagedDistributedTransactionManager
     @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
+      registry.touch(getId());
       super.delete(deletes);
     }
 
     @Override
     public synchronized void insert(Insert insert) throws CrudException {
+      registry.touch(getId());
       super.insert(insert);
     }
 
     @Override
     public synchronized void upsert(Upsert upsert) throws CrudException {
+      registry.touch(getId());
       super.upsert(upsert);
     }
 
     @Override
     public synchronized void update(Update update) throws CrudException {
+      registry.touch(getId());
       super.update(update);
     }
 
     @Override
     public synchronized void mutate(List<? extends Mutation> mutations) throws CrudException {
+      registry.touch(getId());
       super.mutate(mutations);
     }
 
     @Override
     public synchronized List<BatchResult> batch(List<? extends Operation> operations)
         throws CrudException {
+      registry.touch(getId());
       return super.batch(operations);
     }
 

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -51,12 +51,15 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ActiveTransactionManagedTwoPhaseCommitCoordinator(
-      TwoPhaseCommit.Coordinator coordinator, long expirationTimeMillis) {
+      TwoPhaseCommit.Coordinator coordinator,
+      long expirationTimeMillis,
+      int maxActiveTransactions) {
     super(coordinator);
-    // The registry stores the transaction ID itself; on expiry it is handed back so we can release
-    // the corresponding context on the wrapped coordinator.
+    // The registry stores the transaction ID itself; on expiry or eviction it is handed back so we
+    // can release the corresponding context on the wrapped coordinator.
     this.registry =
-        new ActiveTransactionRegistry<>(expirationTimeMillis, coordinator::releaseContext);
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, maxActiveTransactions, coordinator::releaseContext);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -70,14 +70,18 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ActiveTransactionManagedTwoPhaseCommitParticipant(
-      TwoPhaseCommit.Participant participant, long expirationTimeMillis) {
+      TwoPhaseCommit.Participant participant,
+      long expirationTimeMillis,
+      int maxActiveTransactions) {
     super(participant);
     // The registry stores a small per-transaction entry carrying the transaction ID and the
-    // terminal-at-validate flag; on expiry it is handed back so we can release the corresponding
-    // context on the wrapped participant.
+    // terminal-at-validate flag; on expiry or eviction it is handed back so we can release the
+    // corresponding context on the wrapped participant.
     this.registry =
         new ActiveTransactionRegistry<>(
-            expirationTimeMillis, tracked -> participant.releaseContext(tracked.transactionId));
+            expirationTimeMillis,
+            maxActiveTransactions,
+            tracked -> participant.releaseContext(tracked.transactionId));
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -117,7 +121,10 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
   public TransactionCrudOperable.Scanner getScanner(String transactionId, Scan scan)
       throws CrudException, TransactionNotFoundException {
     registry.touch(transactionId);
-    return super.getScanner(transactionId, scan);
+    // The scanner outlives this call: wrap it so each one()/all()/iteration also refreshes the idle
+    // timer, otherwise a transaction streaming a large result slowly could be reaped mid-scan.
+    return new ActiveTransactionRefreshingScanner(
+        registry, transactionId, super.getScanner(transactionId, scan));
   }
 
   /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -39,18 +39,32 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   private final ActiveTransactionRegistry<TwoPhaseCommitTransaction> registry;
 
   public ActiveTransactionManagedTwoPhaseCommitTransactionManager(
-      TwoPhaseCommitTransactionManager transactionManager, long expirationTimeMillis) {
+      TwoPhaseCommitTransactionManager transactionManager,
+      long expirationTimeMillis,
+      int maxActiveTransactions) {
     super(transactionManager);
     registry =
-        new ActiveTransactionRegistry<>(expirationTimeMillis, TwoPhaseCommitTransaction::rollback);
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, maxActiveTransactions, TwoPhaseCommitTransaction::rollback);
   }
 
   public ActiveTransactionManagedTwoPhaseCommitTransactionManager(
       TwoPhaseCommitTransactionManager transactionManager,
       long expirationTimeMillis,
-      ActiveTransactionRegistry.ExpirationHandler<TwoPhaseCommitTransaction> expirationHandler) {
+      int maxActiveTransactions,
+      ActiveTransactionRegistry.DisposalHandler<TwoPhaseCommitTransaction> disposalHandler) {
     super(transactionManager);
-    registry = new ActiveTransactionRegistry<>(expirationTimeMillis, expirationHandler);
+    registry =
+        new ActiveTransactionRegistry<>(
+            expirationTimeMillis, maxActiveTransactions, disposalHandler);
+  }
+
+  @VisibleForTesting
+  ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+      TwoPhaseCommitTransactionManager transactionManager,
+      ActiveTransactionRegistry<TwoPhaseCommitTransaction> registry) {
+    super(transactionManager);
+    this.registry = registry;
   }
 
   @Override
@@ -105,23 +119,30 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
 
     @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
+      registry.touch(getId());
       return super.get(get);
     }
 
     @Override
     public synchronized List<Result> scan(Scan scan) throws CrudException {
+      registry.touch(getId());
       return super.scan(scan);
     }
 
     @Override
     public synchronized Scanner getScanner(Scan scan) throws CrudException {
-      return new SynchronizedScanner(this, super.getScanner(scan));
+      registry.touch(getId());
+      // Refresh the idle timer on each read so a slowly-consumed scan is not reaped mid-iteration,
+      // then synchronize the read against a concurrent reaper rollback (SynchronizedScanner).
+      return new ActiveTransactionRefreshingScanner(
+          registry, getId(), new SynchronizedScanner(this, super.getScanner(scan)));
     }
 
     /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
     @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
+      registry.touch(getId());
       super.put(put);
     }
 
@@ -129,11 +150,13 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
+      registry.touch(getId());
       super.put(puts);
     }
 
     @Override
     public synchronized void delete(Delete delete) throws CrudException {
+      registry.touch(getId());
       super.delete(delete);
     }
 
@@ -141,42 +164,50 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
+      registry.touch(getId());
       super.delete(deletes);
     }
 
     @Override
     public synchronized void insert(Insert insert) throws CrudException {
+      registry.touch(getId());
       super.insert(insert);
     }
 
     @Override
     public synchronized void upsert(Upsert upsert) throws CrudException {
+      registry.touch(getId());
       super.upsert(upsert);
     }
 
     @Override
     public synchronized void update(Update update) throws CrudException {
+      registry.touch(getId());
       super.update(update);
     }
 
     @Override
     public synchronized void mutate(List<? extends Mutation> mutations) throws CrudException {
+      registry.touch(getId());
       super.mutate(mutations);
     }
 
     @Override
     public synchronized List<BatchResult> batch(List<? extends Operation> operations)
         throws CrudException {
+      registry.touch(getId());
       return super.batch(operations);
     }
 
     @Override
     public synchronized void prepare() throws PreparationException {
+      registry.touch(getId());
       super.prepare();
     }
 
     @Override
     public synchronized void validate() throws ValidationException {
+      registry.touch(getId());
       super.validate();
     }
 

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionRefreshingScanner.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionRefreshingScanner.java
@@ -1,0 +1,69 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import com.scalar.db.exception.transaction.CrudException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link Scanner} decorator that refreshes a transaction's idle timer in its {@link
+ * ActiveTransactionRegistry} on every read, so that consuming a long-lived scanner counts as
+ * activity.
+ *
+ * <p>Active-transaction tracking refreshes a transaction's idle timer on each CRUD/record call, but
+ * a scanner outlives the {@code getScanner} call: its {@code one()} / {@code all()} run afterwards
+ * (for a remote participant, across separate pull RPCs). Without this wrapper those reads would not
+ * refresh the timer, so a transaction streaming a large result slowly could be reaped mid-scan.
+ *
+ * <p>{@code iterator()} drives iteration through this decorator's {@code one()}, so each advance
+ * refreshes the timer (and, via the delegate's {@code one()}, inherits whatever the delegate does —
+ * e.g. synchronization in {@link SynchronizedScanner}). {@code close()} is not treated as activity
+ * and does not refresh the timer.
+ *
+ * <p>Only actual reads refresh the timer: merely holding the returned scanner without calling
+ * {@code one()} / {@code all()} (or iterating) does not count as activity, so an unread, idle
+ * scanner can still be reaped once its transaction's idle window elapses.
+ */
+class ActiveTransactionRefreshingScanner implements Scanner {
+
+  private final ActiveTransactionRegistry<?> registry;
+  private final String transactionId;
+  private final Scanner delegate;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  ActiveTransactionRefreshingScanner(
+      ActiveTransactionRegistry<?> registry, String transactionId, Scanner delegate) {
+    this.registry = registry;
+    this.transactionId = transactionId;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Optional<Result> one() throws CrudException {
+    registry.touch(transactionId);
+    return delegate.one();
+  }
+
+  @Override
+  public List<Result> all() throws CrudException {
+    registry.touch(transactionId);
+    return delegate.all();
+  }
+
+  @Override
+  public void close() throws CrudException {
+    delegate.close();
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<Result> iterator() {
+    // Drive iteration through this decorator's one(), which refreshes the idle timer (and, via the
+    // delegate's one(), inherits whatever the delegate does, e.g. synchronization).
+    return new ScannerIterator<>(this);
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionRegistry.java
@@ -14,8 +14,6 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class ActiveTransactionRegistry<T> {
 
-  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
-
   private static final Logger logger = LoggerFactory.getLogger(ActiveTransactionRegistry.class);
 
   private final ActiveExpiringMap<String, T> activeTransactions;
@@ -24,26 +22,46 @@ public class ActiveTransactionRegistry<T> {
    * Constructs an ActiveTransactionRegistry.
    *
    * @param expirationTimeMillis the expiration time in milliseconds
-   * @param expirationHandler the handler invoked when a transaction expires
+   * @param maxActiveTransactions the maximum number of active transactions to keep; when exceeded,
+   *     a transaction is evicted (disposed via {@code disposalHandler}) per the cache's recency-
+   *     and frequency-aware policy to make room. Non-positive means unbounded.
+   * @param disposalHandler the handler invoked to dispose a transaction when it expires or is
+   *     evicted
    */
   public ActiveTransactionRegistry(
-      long expirationTimeMillis, ExpirationHandler<T> expirationHandler) {
+      long expirationTimeMillis, int maxActiveTransactions, DisposalHandler<T> disposalHandler) {
     this.activeTransactions =
         new ActiveExpiringMap<>(
             expirationTimeMillis,
-            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
+            maxActiveTransactions,
             (id, t) -> {
               logger.warn("The transaction is expired. Transaction ID: {}", id);
-              try {
-                expirationHandler.onExpired(t);
-              } catch (Exception e) {
-                logger.warn("Failed to handle the expired transaction. Transaction ID: {}", id, e);
-              }
+              dispose(id, t, disposalHandler, "expired");
+            },
+            (id, t) -> {
+              logger.warn(
+                  "The transaction is evicted because the maximum number of active transactions "
+                      + "({}) was exceeded. Transaction ID: {}",
+                  maxActiveTransactions,
+                  id);
+              dispose(id, t, disposalHandler, "evicted");
             });
+  }
+
+  private void dispose(String id, T transaction, DisposalHandler<T> disposalHandler, String cause) {
+    try {
+      disposalHandler.onDisposed(transaction);
+    } catch (Exception e) {
+      logger.warn("Failed to handle the {} transaction. Transaction ID: {}", cause, id, e);
+    }
   }
 
   /**
    * Adds a transaction to the registry.
+   *
+   * <p>A {@code true} return means the transaction was inserted, not that it will remain
+   * registered: at the cap, a just-added transaction can be evicted (and disposed) moments later.
+   * Callers must not assume a successful add keeps the transaction alive.
    *
    * @param id the transaction ID
    * @param transaction the transaction to add
@@ -84,13 +102,14 @@ public class ActiveTransactionRegistry<T> {
   }
 
   /**
-   * Functional interface invoked when a transaction expires, to dispose of its resources (e.g.,
-   * roll it back, or release its context without a storage rollback).
+   * Functional interface invoked to dispose of a transaction's resources (e.g., roll it back, or
+   * release its context without a storage rollback) when the transaction either expires (idle
+   * timeout) or is evicted because the maximum number of active transactions was exceeded.
    *
    * @param <T> the type of transaction
    */
   @FunctionalInterface
-  public interface ExpirationHandler<T> {
-    void onExpired(T transaction) throws Exception;
+  public interface DisposalHandler<T> {
+    void onDisposed(T transaction) throws Exception;
   }
 }

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -34,6 +34,7 @@ public class DatabaseConfig {
   private long metadataCacheExpirationTimeSecs;
   private boolean activeTransactionManagementEnabled;
   private long activeTransactionManagementExpirationTimeMillis;
+  private int activeTransactionManagementMaxActiveTransactions;
   private boolean attributePropagationEnabled;
   @Nullable private String defaultNamespaceName;
   private boolean crossPartitionScanEnabled;
@@ -54,6 +55,8 @@ public class DatabaseConfig {
       PREFIX + "active_transaction_management.enabled";
   public static final String ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS =
       PREFIX + "active_transaction_management.expiration_time_millis";
+  public static final String ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS =
+      PREFIX + "active_transaction_management.max_active_transactions";
   public static final String ATTRIBUTE_PROPAGATION_ENABLED =
       PREFIX + "attribute_propagation.enabled";
   public static final String DEFAULT_NAMESPACE_NAME = PREFIX + "default_namespace_name";
@@ -64,6 +67,7 @@ public class DatabaseConfig {
   public static final String SCAN_FETCH_SIZE = PREFIX + "scan_fetch_size";
 
   public static final int DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS = 60;
+  public static final int DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS = 10000;
   public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
   public static final int DEFAULT_SCAN_FETCH_SIZE = 10;
 
@@ -111,6 +115,8 @@ public class DatabaseConfig {
         getBoolean(getProperties(), ACTIVE_TRANSACTION_MANAGEMENT_ENABLED, true);
     activeTransactionManagementExpirationTimeMillis =
         getActiveTransactionManagementExpirationTimeMillis(getProperties());
+    activeTransactionManagementMaxActiveTransactions =
+        getActiveTransactionManagementMaxActiveTransactions(getProperties());
     attributePropagationEnabled = getBoolean(getProperties(), ATTRIBUTE_PROPAGATION_ENABLED, true);
     defaultNamespaceName = getString(getProperties(), DEFAULT_NAMESPACE_NAME, null);
     crossPartitionScanEnabled = getBoolean(getProperties(), CROSS_PARTITION_SCAN, true);
@@ -166,6 +172,10 @@ public class DatabaseConfig {
     return activeTransactionManagementExpirationTimeMillis;
   }
 
+  public int getActiveTransactionManagementMaxActiveTransactions() {
+    return activeTransactionManagementMaxActiveTransactions;
+  }
+
   public boolean isAttributePropagationEnabled() {
     return attributePropagationEnabled;
   }
@@ -203,5 +213,12 @@ public class DatabaseConfig {
 
   public static long getActiveTransactionManagementExpirationTimeMillis(Properties properties) {
     return getLong(properties, ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS, -1);
+  }
+
+  public static int getActiveTransactionManagementMaxActiveTransactions(Properties properties) {
+    return getInt(
+        properties,
+        ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS,
+        DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS);
   }
 }

--- a/core/src/main/java/com/scalar/db/util/ActiveExpiringMap.java
+++ b/core/src/main/java/com/scalar/db/util/ActiveExpiringMap.java
@@ -1,234 +1,201 @@
 package com.scalar.db.util;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.Uninterruptibles;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.AbstractCollection;
-import java.util.AbstractMap;
-import java.util.AbstractSet;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * A thread-safe map whose entries are kept alive only while they stay "active" and are removed
+ * automatically when they go stale or when the map grows too large. It is a thin adapter over a <a
+ * href="https://github.com/ben-manes/caffeine">Caffeine</a> cache.
+ *
+ * <p>Entries are reclaimed by two independent mechanisms:
+ *
+ * <ul>
+ *   <li><b>Time-based (idle) expiration.</b> When {@code valueLifetimeMillis} is positive, an entry
+ *       that is not accessed (via {@link #get(Object)}, {@link #updateExpirationTime(Object)}, or a
+ *       write) for that long is removed and the expiration handler is invoked. Expiration is
+ *       proactive: a scheduler removes idle entries promptly even when the map is otherwise
+ *       untouched, so an abandoned entry does not linger until the next access. A non-positive
+ *       {@code valueLifetimeMillis} disables idle expiration.
+ *   <li><b>Size-based eviction.</b> When {@code maxSize} is positive and an insertion pushes the
+ *       map beyond it, Caffeine evicts an entry (recency- and frequency-aware, Window-TinyLFU) and
+ *       invokes the eviction handler. A frequently-touched entry is preferentially retained over a
+ *       cold/abandoned one. A non-positive {@code maxSize} leaves the map unbounded.
+ * </ul>
+ *
+ * <p><b>A successful insert is not a retention guarantee.</b> Inserts report success synchronously,
+ * but size-based eviction is decided asynchronously afterward, so under sustained pressure at
+ * {@code maxSize} a freshly-inserted entry can be evicted moments later. Callers must not assume an
+ * inserted entry is, or will remain, present.
+ *
+ * <p>Reclamation handlers run on a dedicated fixed-size daemon executor, outside any internal lock,
+ * so a slow or blocking handler does not block concurrent admissions. Explicit {@link
+ * #remove(Object)} calls and replacements do not invoke either handler.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ */
 @ThreadSafe
 public class ActiveExpiringMap<K, V> {
-  private final ConcurrentMap<K, ValueHolder> map;
-  private final long valueLifetimeMillis;
-  private final long valueExpirationThreadIntervalMillis;
-  private final BiConsumer<K, V> valueExpirationHandler;
+  // Lets Caffeine proactively expire idle entries even when the cache is not being accessed. On
+  // Java 8, Scheduler.systemScheduler() is unavailable, so we back the scheduler with our own
+  // daemon executor. A single shared thread suffices because it only triggers short maintenance
+  // tasks; the actual removal/handler work runs on the cache's removal executor.
+  private static final Scheduler PROACTIVE_SCHEDULER =
+      Scheduler.forScheduledExecutorService(newDaemonScheduler());
 
-  public ActiveExpiringMap(
-      long valueLifetimeMillis,
-      long valueExpirationThreadIntervalMillis,
-      BiConsumer<K, V> valueExpirationHandler) {
-    map = new ConcurrentHashMap<>();
-    this.valueLifetimeMillis = valueLifetimeMillis;
-    this.valueExpirationThreadIntervalMillis = valueExpirationThreadIntervalMillis;
-    this.valueExpirationHandler = valueExpirationHandler;
-    if (valueLifetimeMillis > 0) {
-      startValueExpirationThread();
-    }
+  // Runs the reclamation handlers (idle-expiry and size-eviction). Disposal work can block on
+  // network/storage I/O (e.g. rolling a transaction back or releasing its context), so it must not
+  // run on ForkJoinPool.commonPool() — Caffeine's default removal executor — where a burst of
+  // blocking disposals could starve unrelated common-pool work. Threads are daemon. The fixed
+  // thread
+  // count bounds how many disposals run concurrently, throttling a mass reclamation to at most that
+  // many concurrent backend calls rather than flooding the backend; any excess queues (the queue is
+  // unbounded, so no disposal is dropped) and drains as threads free up.
+  private static final Executor DISPOSAL_EXECUTOR = newDaemonDisposalExecutor();
+
+  private final Cache<K, V> cache;
+
+  private static ScheduledExecutorService newDaemonScheduler() {
+    ThreadFactory threadFactory =
+        r -> {
+          Thread thread = new Thread(r, "active-expiring-map-scheduler");
+          thread.setDaemon(true);
+          return thread;
+        };
+    return Executors.newSingleThreadScheduledExecutor(threadFactory);
   }
 
-  private void startValueExpirationThread() {
-    Thread expirationThread =
-        new Thread(
-            () -> {
-              while (true) {
-                map.entrySet().stream()
-                    .filter(e -> e.getValue().isExpired())
-                    .map(Entry::getKey)
-                    .forEach(
-                        key -> {
-                          ValueHolder value = map.remove(key);
-                          if (value != null) {
-                            valueExpirationHandler.accept(key, value.get());
-                          }
-                        });
-                Uninterruptibles.sleepUninterruptibly(
-                    valueExpirationThreadIntervalMillis, TimeUnit.MILLISECONDS);
-              }
-            });
-    expirationThread.setDaemon(true);
-    expirationThread.setName("value expiration thread");
-    expirationThread.start();
+  private static ExecutorService newDaemonDisposalExecutor() {
+    ThreadFactory threadFactory =
+        r -> {
+          Thread thread = new Thread(r, "active-expiring-map-disposal");
+          thread.setDaemon(true);
+          return thread;
+        };
+    int poolSize = Math.max(1, Runtime.getRuntime().availableProcessors());
+    return Executors.newFixedThreadPool(poolSize, threadFactory);
+  }
+
+  /**
+   * Creates a time-expiring map with no size bound.
+   *
+   * @param valueLifetimeMillis the idle time-to-live; an entry not accessed for this long is
+   *     removed. Non-positive disables idle expiration.
+   * @param valueExpirationHandler invoked for each entry removed by idle expiration
+   */
+  public ActiveExpiringMap(long valueLifetimeMillis, BiConsumer<K, V> valueExpirationHandler) {
+    this(valueLifetimeMillis, 0, valueExpirationHandler, (k, v) -> {});
+  }
+
+  /**
+   * Creates a time-expiring map.
+   *
+   * @param valueLifetimeMillis the idle time-to-live; an entry not accessed for this long is
+   *     removed. Non-positive disables idle expiration.
+   * @param maxSize the maximum number of entries; when exceeded on insertion an entry is evicted to
+   *     make room. Non-positive means unbounded.
+   * @param valueExpirationHandler invoked for each entry removed by idle expiration
+   * @param valueEvictionHandler invoked for each entry evicted due to {@code maxSize}
+   */
+  public ActiveExpiringMap(
+      long valueLifetimeMillis,
+      int maxSize,
+      BiConsumer<K, V> valueExpirationHandler,
+      BiConsumer<K, V> valueEvictionHandler) {
+    this(valueLifetimeMillis, maxSize, valueExpirationHandler, valueEvictionHandler, null, null);
+  }
+
+  @VisibleForTesting
+  ActiveExpiringMap(
+      long valueLifetimeMillis,
+      int maxSize,
+      BiConsumer<K, V> valueExpirationHandler,
+      BiConsumer<K, V> valueEvictionHandler,
+      @Nullable Ticker ticker,
+      @Nullable Executor executor) {
+    Caffeine<Object, Object> builder = Caffeine.newBuilder();
+    // Run reclamation handlers off the dedicated disposal pool by default; tests inject a
+    // same-thread executor so removals (and their handlers) settle synchronously.
+    builder = builder.executor(executor != null ? executor : DISPOSAL_EXECUTOR);
+    if (ticker != null) {
+      builder = builder.ticker(ticker);
+    }
+    if (valueLifetimeMillis > 0) {
+      builder = builder.expireAfterAccess(valueLifetimeMillis, TimeUnit.MILLISECONDS);
+      // The proactive scheduler reaps idle entries against the real clock. An injected (fake)
+      // ticker drives time manually, so attaching the scheduler would only add nondeterministic
+      // interference; attach it only under the real clock.
+      if (ticker == null) {
+        builder = builder.scheduler(PROACTIVE_SCHEDULER);
+      }
+    }
+    if (maxSize > 0) {
+      builder = builder.maximumSize(maxSize);
+    }
+    this.cache =
+        builder
+            .<K, V>removalListener(
+                (key, value, cause) -> {
+                  if (key == null || value == null) {
+                    return;
+                  }
+                  if (cause == RemovalCause.EXPIRED) {
+                    valueExpirationHandler.accept(key, value);
+                  } else if (cause == RemovalCause.SIZE) {
+                    valueEvictionHandler.accept(key, value);
+                  }
+                  // EXPLICIT (remove) and REPLACED (overwrite) are not reclamation events, so no
+                  // handler runs for them.
+                })
+            .build();
   }
 
   public Optional<V> get(K key) {
-    ValueHolder value = map.get(key);
-    if (value == null) {
-      return Optional.empty();
-    }
-    value.updateExpirationTime();
-    return Optional.of(value.get());
-  }
-
-  public Optional<V> putIfAbsent(K key, V value) {
-    ValueHolder prev = map.putIfAbsent(key, new ValueHolder(value));
-    return prev == null ? Optional.empty() : Optional.of(prev.get());
+    // A read counts as access under expireAfterAccess, so it refreshes the idle timer (and marks
+    // the entry as recently used, making it less likely to be size-evicted).
+    return Optional.ofNullable(cache.getIfPresent(key));
   }
 
   public Optional<V> put(K key, V value) {
-    ValueHolder prev = map.put(key, new ValueHolder(value));
-    return prev == null ? Optional.empty() : Optional.of(prev.get());
+    return Optional.ofNullable(cache.asMap().put(key, value));
   }
 
-  public Optional<V> computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
-    ValueHolder prev = map.computeIfAbsent(key, mappingFunction.andThen(ValueHolder::new));
-    return prev == null ? Optional.empty() : Optional.of(prev.get());
-  }
-
-  public Optional<V> computeIfPresent(
-      K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-    ValueHolder prev =
-        map.computeIfPresent(
-            key,
-            (k, oldValue) -> {
-              V newValue = remappingFunction.apply(k, oldValue.get());
-              return new ValueHolder(newValue);
-            });
-    return prev == null ? Optional.empty() : Optional.of(prev.get());
-  }
-
-  public boolean containsKey(K key) {
-    return map.containsKey(key);
-  }
-
-  public boolean containsValue(V value) {
-    return map.values().stream().map(ValueHolder::get).anyMatch(value::equals);
+  public Optional<V> putIfAbsent(K key, V value) {
+    return Optional.ofNullable(cache.asMap().putIfAbsent(key, value));
   }
 
   public Optional<V> remove(K key) {
-    ValueHolder prev = map.remove(key);
-    return prev == null ? Optional.empty() : Optional.of(prev.get());
+    return Optional.ofNullable(cache.asMap().remove(key));
   }
 
-  public Set<K> keySet() {
-    return map.keySet();
-  }
-
-  public Collection<V> values() {
-    Collection<ValueHolder> values = map.values();
-    return new AbstractCollection<V>() {
-      @Override
-      public Iterator<V> iterator() {
-        return new Iterator<V>() {
-          private final Iterator<ValueHolder> valueIterator = values.iterator();
-
-          @Override
-          public boolean hasNext() {
-            return valueIterator.hasNext();
-          }
-
-          @Override
-          public V next() {
-            ValueHolder next = valueIterator.next();
-            return next.get();
-          }
-
-          @Override
-          public void remove() {
-            valueIterator.remove();
-          }
-        };
-      }
-
-      @Override
-      public int size() {
-        return values.size();
-      }
-    };
-  }
-
-  public Set<Map.Entry<K, V>> entrySet() {
-    return new AbstractSet<Entry<K, V>>() {
-      private final Set<Entry<K, ValueHolder>> entries = map.entrySet();
-
-      @Override
-      public Iterator<Entry<K, V>> iterator() {
-        return new Iterator<Entry<K, V>>() {
-          private final Iterator<Entry<K, ValueHolder>> entryIterator = entries.iterator();
-
-          @Override
-          public boolean hasNext() {
-            return entryIterator.hasNext();
-          }
-
-          @SuppressFBWarnings("SE_BAD_FIELD")
-          @Override
-          public Entry<K, V> next() {
-            Entry<K, ValueHolder> next = entryIterator.next();
-            return new AbstractMap.SimpleEntry<K, V>(next.getKey(), next.getValue().get()) {
-              @Override
-              public V setValue(V value) {
-                throw new UnsupportedOperationException();
-              }
-            };
-          }
-
-          @Override
-          public void remove() {
-            entryIterator.remove();
-          }
-        };
-      }
-
-      @Override
-      public int size() {
-        return entries.size();
-      }
-    };
-  }
-
+  /**
+   * Refreshes the idle timer of an entry, treating it as recently used. Does nothing if no entry
+   * with the given key is present.
+   *
+   * @param key the key
+   */
   public void updateExpirationTime(K key) {
-    ValueHolder value = map.get(key);
-    if (value != null) {
-      value.updateExpirationTime();
-    }
+    cache.getIfPresent(key);
   }
 
+  /** Performs any pending maintenance (expiration/eviction) synchronously. For tests only. */
   @VisibleForTesting
-  @Nullable
-  ValueHolder getValueHolder(K key) {
-    return map.get(key);
-  }
-
-  @VisibleForTesting
-  class ValueHolder {
-    private final V value;
-    private final AtomicLong lastUpdateTime = new AtomicLong();
-
-    public ValueHolder(V value) {
-      this.value = value;
-      updateExpirationTime();
-    }
-
-    public void updateExpirationTime() {
-      lastUpdateTime.set(System.currentTimeMillis());
-    }
-
-    public boolean isExpired() {
-      return System.currentTimeMillis() - lastUpdateTime.get() >= valueLifetimeMillis;
-    }
-
-    public V get() {
-      return value;
-    }
-
-    public long getLastUpdateTime() {
-      return lastUpdateTime.get();
-    }
+  void cleanUp() {
+    cache.cleanUp();
   }
 }

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManagerTest.java
@@ -6,16 +6,30 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Isolation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.SerializableStrategy;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -33,7 +47,8 @@ public class ActiveTransactionManagedDistributedTransactionManagerTest {
 
     // Arrange
     transactionManager =
-        new ActiveTransactionManagedDistributedTransactionManager(wrappedTransactionManager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(
+            wrappedTransactionManager, -1, -1);
   }
 
   @Test
@@ -56,6 +71,66 @@ public class ActiveTransactionManagedDistributedTransactionManagerTest {
     assertThat(transaction2)
         .isInstanceOf(
             ActiveTransactionManagedDistributedTransactionManager.ActiveTransaction.class);
+  }
+
+  @Test
+  public void getScanner_ReturnedScanner_ShouldDriveUnderlyingOneWhenIterated() throws Exception {
+    // Arrange
+    DistributedTransaction wrappedTransaction = mock(DistributedTransaction.class);
+    when(wrappedTransaction.getId()).thenReturn("txId1");
+    when(wrappedTransactionManager.begin()).thenReturn(wrappedTransaction);
+    TransactionCrudOperable.Scanner rawScanner = mock(TransactionCrudOperable.Scanner.class);
+    Result result = mock(Result.class);
+    when(rawScanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    Scan scan = Scan.newBuilder().namespace("ns").table("tbl").all().build();
+    when(wrappedTransaction.getScanner(scan)).thenReturn(rawScanner);
+
+    // Act
+    DistributedTransaction transaction = transactionManager.begin();
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    List<Result> results = new ArrayList<>();
+    scanner.iterator().forEachRemaining(results::add);
+
+    // Assert — iterating drives the underlying scanner's one() per element, so iteration flows
+    // through the idle-timer-refreshing (and synchronizing) wrapper rather than bypassing it via
+    // the
+    // raw scanner's own iterator.
+    assertThat(results).containsExactly(result);
+    verify(rawScanner, times(2)).one();
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "deprecation"})
+  public void crudOperations_OnHeldTransaction_ShouldRefreshIdleTimerViaRegistryTouch()
+      throws Exception {
+    // Arrange — inject a mock registry so we can observe the idle-timer refresh directly.
+    ActiveTransactionRegistry<DistributedTransaction> registry =
+        mock(ActiveTransactionRegistry.class);
+    when(registry.add(anyString(), any())).thenReturn(true);
+    DistributedTransaction wrappedTransaction = mock(DistributedTransaction.class);
+    when(wrappedTransaction.getId()).thenReturn("txId1");
+    when(wrappedTransactionManager.begin()).thenReturn(wrappedTransaction);
+    ActiveTransactionManagedDistributedTransactionManager manager =
+        new ActiveTransactionManagedDistributedTransactionManager(
+            wrappedTransactionManager, registry);
+
+    // Act: every CRUD op on a held transaction reference must refresh the idle timer, so a
+    // long-running begin-and-hold transaction is neither idle-reaped nor LRU-evicted mid-work.
+    DistributedTransaction transaction = manager.begin();
+    transaction.get(mock(Get.class));
+    transaction.scan(mock(Scan.class));
+    transaction.put(mock(Put.class));
+    transaction.put(Collections.singletonList(mock(Put.class)));
+    transaction.delete(mock(Delete.class));
+    transaction.delete(Collections.singletonList(mock(Delete.class)));
+    transaction.insert(mock(Insert.class));
+    transaction.upsert(mock(Upsert.class));
+    transaction.update(mock(Update.class));
+    transaction.mutate(Collections.singletonList(mock(Put.class)));
+    transaction.batch(Collections.singletonList(mock(Get.class)));
+
+    // Assert — one refresh per CRUD operation (begin() registers but does not touch).
+    verify(registry, times(11)).touch("txId1");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -39,7 +39,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     MockitoAnnotations.openMocks(this).close();
     when(delegate.begin(any(), eq(false), any(), any())).thenReturn(TX);
     coordinator =
-        new ActiveTransactionManagedTwoPhaseCommitCoordinator(delegate, EXPIRATION_MILLIS);
+        new ActiveTransactionManagedTwoPhaseCommitCoordinator(
+            delegate, EXPIRATION_MILLIS, /* maxActiveTransactions= */ -1);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -16,6 +16,7 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Insert;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
@@ -51,7 +52,8 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
   void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     participant =
-        new ActiveTransactionManagedTwoPhaseCommitParticipant(delegate, EXPIRATION_MILLIS);
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(
+            delegate, EXPIRATION_MILLIS, /* maxActiveTransactions= */ -1);
   }
 
   private static Get get() {
@@ -94,6 +96,27 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     participant.insert(TX, insert);
 
     verify(delegate).insert(TX, insert);
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void getScanner_ReturnedScanner_ShouldRefreshIdleTimerOnEachRead() throws Exception {
+    ActiveTransactionRegistry registry = mock(ActiveTransactionRegistry.class);
+    ActiveTransactionManagedTwoPhaseCommitParticipant p =
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(delegate, registry);
+    Scan scan = Scan.newBuilder().namespace(NS).table(TBL).all().build();
+    TransactionCrudOperable.Scanner rawScanner = mock(TransactionCrudOperable.Scanner.class);
+    when(rawScanner.one()).thenReturn(Optional.empty());
+    when(rawScanner.all()).thenReturn(Collections.emptyList());
+    when(delegate.getScanner(TX, scan)).thenReturn(rawScanner);
+
+    TransactionCrudOperable.Scanner scanner = p.getScanner(TX, scan);
+    scanner.one();
+    scanner.all();
+
+    // getScanner refreshes once; then each one()/all() on the returned scanner refreshes too, so a
+    // slowly-consumed scan is not reaped mid-iteration.
+    verify(registry, times(3)).touch(TX);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest.java
@@ -2,17 +2,27 @@ package com.scalar.db.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,7 +40,8 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest {
 
     // Arrange
     transactionManager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(wrappedTransactionManager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+            wrappedTransactionManager, -1, -1);
   }
 
   @Test
@@ -53,6 +64,68 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManagerTest {
     assertThat(transaction2)
         .isInstanceOf(
             ActiveTransactionManagedTwoPhaseCommitTransactionManager.ActiveTransaction.class);
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "deprecation"})
+  public void crudOperations_OnHeldTransaction_ShouldRefreshIdleTimerViaRegistryTouch()
+      throws Exception {
+    // Arrange — inject a mock registry so we can observe the idle-timer refresh directly.
+    ActiveTransactionRegistry<TwoPhaseCommitTransaction> registry =
+        mock(ActiveTransactionRegistry.class);
+    when(registry.add(anyString(), any())).thenReturn(true);
+    TwoPhaseCommitTransaction wrappedTransaction = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction.getId()).thenReturn("txId1");
+    when(wrappedTransactionManager.begin()).thenReturn(wrappedTransaction);
+    ActiveTransactionManagedTwoPhaseCommitTransactionManager manager =
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+            wrappedTransactionManager, registry);
+
+    // Act: every CRUD op on a held transaction reference must refresh the idle timer, so a
+    // long-running begin-and-hold transaction is neither idle-reaped nor LRU-evicted mid-work.
+    TwoPhaseCommitTransaction transaction = manager.begin();
+    transaction.get(mock(Get.class));
+    transaction.scan(mock(Scan.class));
+    transaction.put(mock(Put.class));
+    transaction.put(Collections.singletonList(mock(Put.class)));
+    transaction.delete(mock(Delete.class));
+    transaction.delete(Collections.singletonList(mock(Delete.class)));
+    transaction.insert(mock(Insert.class));
+    transaction.upsert(mock(Upsert.class));
+    transaction.update(mock(Update.class));
+    transaction.mutate(Collections.singletonList(mock(Put.class)));
+    transaction.batch(Collections.singletonList(mock(Get.class)));
+
+    // Assert — one refresh per CRUD operation (begin() registers but does not touch).
+    verify(registry, times(11)).touch("txId1");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void prepareAndValidate_OnHeldTransaction_ShouldRefreshIdleTimerButTerminalOpsShouldNot()
+      throws Exception {
+    // Arrange — inject a mock registry so we can observe the idle-timer refresh directly.
+    ActiveTransactionRegistry<TwoPhaseCommitTransaction> registry =
+        mock(ActiveTransactionRegistry.class);
+    when(registry.add(anyString(), any())).thenReturn(true);
+    TwoPhaseCommitTransaction wrappedTransaction = mock(TwoPhaseCommitTransaction.class);
+    when(wrappedTransaction.getId()).thenReturn("txId1");
+    when(wrappedTransactionManager.begin()).thenReturn(wrappedTransaction);
+    ActiveTransactionManagedTwoPhaseCommitTransactionManager manager =
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(
+            wrappedTransactionManager, registry);
+
+    // Act: prepare()/validate() are non-terminal operations on a held transaction, so they must
+    // refresh the idle timer; commit() is terminal and removes the entry, so it must not touch.
+    TwoPhaseCommitTransaction transaction = manager.begin();
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert — one refresh each for prepare()/validate() only; commit() removes instead of
+    // touching.
+    verify(registry, times(2)).touch("txId1");
+    verify(registry).remove("txId1");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionRefreshingScannerTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionRefreshingScannerTest.java
@@ -1,0 +1,85 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TransactionCrudOperable.Scanner;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ActiveTransactionRefreshingScannerTest {
+
+  private static final String TX = "tx-1";
+
+  @Test
+  void one_ShouldRefreshIdleTimerThenDelegate() throws Exception {
+    ActiveTransactionRegistry<?> registry = mock(ActiveTransactionRegistry.class);
+    Scanner delegate = mock(Scanner.class);
+    when(delegate.one()).thenReturn(Optional.empty());
+    ActiveTransactionRefreshingScanner scanner =
+        new ActiveTransactionRefreshingScanner(registry, TX, delegate);
+
+    scanner.one();
+
+    verify(registry).touch(TX);
+    verify(delegate).one();
+  }
+
+  @Test
+  void all_ShouldRefreshIdleTimerThenDelegate() throws Exception {
+    ActiveTransactionRegistry<?> registry = mock(ActiveTransactionRegistry.class);
+    Scanner delegate = mock(Scanner.class);
+    when(delegate.all()).thenReturn(Collections.emptyList());
+    ActiveTransactionRefreshingScanner scanner =
+        new ActiveTransactionRefreshingScanner(registry, TX, delegate);
+
+    scanner.all();
+
+    verify(registry).touch(TX);
+    verify(delegate).all();
+  }
+
+  @Test
+  void close_ShouldDelegateWithoutRefreshing() throws Exception {
+    ActiveTransactionRegistry<?> registry = mock(ActiveTransactionRegistry.class);
+    Scanner delegate = mock(Scanner.class);
+    ActiveTransactionRefreshingScanner scanner =
+        new ActiveTransactionRefreshingScanner(registry, TX, delegate);
+
+    scanner.close();
+
+    verify(registry, never()).touch(TX);
+    verify(delegate).close();
+  }
+
+  @Test
+  void iterator_ShouldRefreshIdleTimerAsItAdvances() throws Exception {
+    ActiveTransactionRegistry<?> registry = mock(ActiveTransactionRegistry.class);
+    Scanner delegate = mock(Scanner.class);
+    Result r1 = mock(Result.class);
+    Result r2 = mock(Result.class);
+    // Iteration is driven through this decorator's one(), so the timer is refreshed on each
+    // advance.
+    when(delegate.one())
+        .thenReturn(Optional.of(r1))
+        .thenReturn(Optional.of(r2))
+        .thenReturn(Optional.empty());
+    ActiveTransactionRefreshingScanner scanner =
+        new ActiveTransactionRefreshingScanner(registry, TX, delegate);
+
+    List<Result> results = new ArrayList<>();
+    scanner.iterator().forEachRemaining(results::add);
+
+    assertThat(results).containsExactly(r1, r2);
+    // Refreshed once per one() call: two elements plus the terminating empty read = exactly three.
+    verify(registry, times(3)).touch(TX);
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionRegistryTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionRegistryTest.java
@@ -1,0 +1,59 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+
+class ActiveTransactionRegistryTest {
+
+  // Size-based eviction and its disposal handler run asynchronously, so assertions poll up to a
+  // generous timeout rather than reading immediately.
+  private static void awaitUntil(BooleanSupplier condition) {
+    long deadline = System.currentTimeMillis() + 5000;
+    while (!condition.getAsBoolean()) {
+      if (System.currentTimeMillis() >= deadline) {
+        throw new AssertionError("Condition was not met within the timeout");
+      }
+      Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Test
+  void add_WhenEvictionDisposalHandlerThrows_ShouldSwallowExceptionAndStillEvict() {
+    // Arrange: cap of 1 and a disposal handler that always throws. Non-positive expiration time
+    // keeps time-based expiration off so only size-based eviction can fire.
+    AtomicInteger disposed = new AtomicInteger();
+    ActiveTransactionRegistry<String> registry =
+        new ActiveTransactionRegistry<>(
+            -1,
+            1,
+            t -> {
+              disposed.incrementAndGet();
+              throw new RuntimeException("boom");
+            });
+
+    assertThat(registry.add("a", "a")).isTrue();
+
+    // Act: inserting past the cap evicts an entry to make room. Its disposal handler throws, but
+    // the
+    // registry must swallow it so the admitting caller is unaffected.
+    assertThatCode(() -> assertThat(registry.add("b", "b")).isTrue()).doesNotThrowAnyException();
+
+    // Assert: the throwing handler ran for the evicted entry and the registry is back within the
+    // cap (exactly one of the two entries remains).
+    awaitUntil(() -> disposed.get() == 1);
+    long present = 0;
+    if (registry.get("a").isPresent()) {
+      present++;
+    }
+    if (registry.get("b").isPresent()) {
+      present++;
+    }
+    assertThat(present).isEqualTo(1);
+  }
+}

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -39,6 +39,8 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.getActiveTransactionManagementMaxActiveTransactions())
+        .isEqualTo(DatabaseConfig.DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS);
     assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -69,6 +71,8 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.getActiveTransactionManagementMaxActiveTransactions())
+        .isEqualTo(DatabaseConfig.DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS);
     assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
@@ -100,6 +104,8 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.getActiveTransactionManagementMaxActiveTransactions())
+        .isEqualTo(DatabaseConfig.DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS);
     assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
@@ -133,6 +139,8 @@ public class DatabaseConfigTest {
         .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.isActiveTransactionManagementEnabled()).isTrue();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
+    assertThat(config.getActiveTransactionManagementMaxActiveTransactions())
+        .isEqualTo(DatabaseConfig.DEFAULT_ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS);
     assertThat(config.isAttributePropagationEnabled()).isTrue();
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
@@ -337,6 +345,7 @@ public class DatabaseConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.ACTIVE_TRANSACTION_MANAGEMENT_ENABLED, "false");
     props.setProperty(DatabaseConfig.ACTIVE_TRANSACTION_MANAGEMENT_EXPIRATION_TIME_MILLIS, "3600");
+    props.setProperty(DatabaseConfig.ACTIVE_TRANSACTION_MANAGEMENT_MAX_ACTIVE_TRANSACTIONS, "5000");
 
     // Act
     DatabaseConfig config = new DatabaseConfig(props);
@@ -350,6 +359,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.isActiveTransactionManagementEnabled()).isFalse();
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(3600);
+    assertThat(config.getActiveTransactionManagementMaxActiveTransactions()).isEqualTo(5000);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -273,7 +273,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.begin(ANY_TX_ID);
@@ -458,7 +458,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.start(ANY_TX_ID);
@@ -500,7 +500,7 @@ public class ConsensusCommitManagerTest {
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
 
@@ -515,7 +515,7 @@ public class ConsensusCommitManagerTest {
   public void resume_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
@@ -527,7 +527,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.commit();
@@ -542,7 +542,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(CommitException.class).when(commit).commit(any(TransactionContext.class));
 
@@ -565,7 +565,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.rollback();
@@ -579,7 +579,7 @@ public class ConsensusCommitManagerTest {
   public void join_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
 
@@ -594,7 +594,7 @@ public class ConsensusCommitManagerTest {
   public void join_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     assertThatThrownBy(() -> manager.join(ANY_TX_ID))
@@ -606,7 +606,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.commit();
@@ -621,7 +621,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(CommitException.class).when(commit).commit(any(TransactionContext.class));
 
@@ -644,7 +644,7 @@ public class ConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.rollback();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -141,7 +141,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.begin(ANY_TX_ID);
@@ -220,7 +220,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.start(ANY_TX_ID);
@@ -250,7 +250,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     // Act
     TwoPhaseConsensusCommit transaction =
@@ -270,7 +270,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     TwoPhaseCommitTransaction transaction1 = manager.join(ANY_TX_ID);
 
@@ -285,7 +285,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   public void join_TxIdGiven_WithGroupCommitEnabled_ShouldThrowException() {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
 
@@ -297,7 +297,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     TwoPhaseCommitTransaction transaction1 = manager.begin(ANY_TX_ID);
 
@@ -312,7 +312,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   public void resume_CalledWithJoin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     TwoPhaseCommitTransaction transaction1 = manager.join(ANY_TX_ID);
 
@@ -327,7 +327,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   public void resume_CalledWithoutBeginOrJoin_ThrowTransactionNotFoundException() {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
@@ -339,7 +339,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     TwoPhaseCommitTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.prepare();
@@ -355,7 +355,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     doThrow(CommitConflictException.class).when(commit).commitStateWithoutWriteSet(any());
 
@@ -379,7 +379,7 @@ public class TwoPhaseConsensusCommitManagerTest {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     TwoPhaseCommitTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.prepare();
@@ -396,7 +396,7 @@ public class TwoPhaseConsensusCommitManagerTest {
           throws TransactionException {
     // Arrange
     TwoPhaseCommitTransactionManager manager =
-        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedTwoPhaseCommitTransactionManager(this.manager, -1, -1);
 
     doThrow(UnknownTransactionStatusException.class)
         .when(commit)

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -937,7 +937,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.begin(ANY_ID);
@@ -949,7 +949,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     manager.start(ANY_ID);
@@ -960,7 +960,7 @@ public class JdbcTransactionManagerTest {
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction1 = manager.begin(ANY_ID);
 
@@ -975,7 +975,7 @@ public class JdbcTransactionManagerTest {
   public void resume_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_ID))
@@ -987,7 +987,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.commit();
@@ -1002,7 +1002,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException, SQLException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(SQLException.class).when(connection).commit();
 
@@ -1025,7 +1025,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.rollback();
@@ -1041,7 +1041,7 @@ public class JdbcTransactionManagerTest {
           throws TransactionException, SQLException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(SQLException.class).when(connection).rollback();
 
@@ -1061,7 +1061,7 @@ public class JdbcTransactionManagerTest {
   public void join_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction1 = manager.begin(ANY_ID);
 
@@ -1076,7 +1076,7 @@ public class JdbcTransactionManagerTest {
   public void join_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     // Act Assert
     assertThatThrownBy(() -> manager.join(ANY_ID)).isInstanceOf(TransactionNotFoundException.class);
@@ -1087,7 +1087,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.commit();
@@ -1101,7 +1101,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException, SQLException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(SQLException.class).when(connection).commit();
 
@@ -1124,7 +1124,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.rollback();
@@ -1139,7 +1139,7 @@ public class JdbcTransactionManagerTest {
           throws TransactionException, SQLException {
     // Arrange
     DistributedTransactionManager manager =
-        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1);
+        new ActiveTransactionManagedDistributedTransactionManager(this.manager, -1, -1);
 
     doThrow(SQLException.class).when(connection).rollback();
 

--- a/core/src/test/java/com/scalar/db/util/ActiveExpiringMapTest.java
+++ b/core/src/test/java/com/scalar/db/util/ActiveExpiringMapTest.java
@@ -2,23 +2,40 @@ package com.scalar.db.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.util.concurrent.Uninterruptibles;
-import java.util.AbstractMap;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
 
 public class ActiveExpiringMapTest {
 
+  // A same-thread executor so Caffeine runs maintenance and removal handlers synchronously within
+  // the calling operation (e.g. cleanUp()); combined with a fake ticker this makes
+  // expiration/eviction assertions deterministic instead of racing an async removal executor.
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  // Handlers run asynchronously on the cache's removal executor, so assertions on them poll up to a
+  // generous timeout rather than reading immediately.
+  private static void awaitUntil(BooleanSupplier condition) {
+    long deadline = System.currentTimeMillis() + 5000;
+    while (!condition.getAsBoolean()) {
+      if (System.currentTimeMillis() >= deadline) {
+        throw new AssertionError("Condition was not met within the timeout");
+      }
+      Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+    }
+  }
+
   @Test
   public void getAndPut_ShouldBehaveCorrectly() {
     // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
+    ActiveExpiringMap<String, String> activeExpiringMap = new ActiveExpiringMap<>(0, (k, v) -> {});
 
     // Act Assert
     activeExpiringMap.put("k1", "v1");
@@ -32,11 +49,23 @@ public class ActiveExpiringMapTest {
   }
 
   @Test
+  public void put_WhenReplacingExistingKey_ShouldReturnPreviousValue() {
+    // Arrange
+    ActiveExpiringMap<String, String> activeExpiringMap = new ActiveExpiringMap<>(0, (k, v) -> {});
+    activeExpiringMap.put("k1", "v1");
+
+    // Act
+    Optional<String> previous = activeExpiringMap.put("k1", "v1-new");
+
+    // Assert
+    assertThat(previous).hasValue("v1");
+    assertThat(activeExpiringMap.get("k1")).hasValue("v1-new");
+  }
+
+  @Test
   public void putIfAbsent_ShouldBehaveCorrectly() {
     // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
+    ActiveExpiringMap<String, String> activeExpiringMap = new ActiveExpiringMap<>(0, (k, v) -> {});
     activeExpiringMap.put("k1", "v1");
 
     // Act
@@ -51,44 +80,12 @@ public class ActiveExpiringMapTest {
   }
 
   @Test
-  public void containsKey_ShouldBehaveCorrectly() {
-    // Arrange
+  public void remove_ShouldBehaveCorrectlyAndNotFireHandlers() {
+    // Arrange: remove() is an explicit removal (e.g. commit/rollback deregistering), so it must not
+    // fire either the expiration or the eviction handler.
+    Set<String> disposed = ConcurrentHashMap.newKeySet();
     ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
-    activeExpiringMap.put("k2", "v2");
-    activeExpiringMap.put("k3", "v3");
-
-    // Act Assert
-    assertThat(activeExpiringMap.containsKey("k1")).isTrue();
-    assertThat(activeExpiringMap.containsKey("k2")).isTrue();
-    assertThat(activeExpiringMap.containsKey("k3")).isTrue();
-    assertThat(activeExpiringMap.containsKey("k4")).isFalse();
-  }
-
-  @Test
-  public void containsValue_ShouldBehaveCorrectly() {
-    // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
-    activeExpiringMap.put("k2", "v2");
-    activeExpiringMap.put("k3", "v2");
-
-    // Act Assert
-    assertThat(activeExpiringMap.containsValue("v1")).isTrue();
-    assertThat(activeExpiringMap.containsValue("v2")).isTrue();
-    assertThat(activeExpiringMap.containsValue("v3")).isFalse();
-  }
-
-  @Test
-  public void remove_ShouldBehaveCorrectly() {
-    // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
+        new ActiveExpiringMap<>(0, 0, (k, v) -> disposed.add(k), (k, v) -> disposed.add(k));
     activeExpiringMap.put("k1", "v1");
     activeExpiringMap.put("k2", "v2");
     activeExpiringMap.put("k3", "v3");
@@ -103,169 +100,141 @@ public class ActiveExpiringMapTest {
     assertThat(activeExpiringMap.get("k1")).hasValue("v1");
     assertThat(activeExpiringMap.get("k2")).isEmpty();
     assertThat(activeExpiringMap.get("k3")).hasValue("v3");
-    assertThat(activeExpiringMap.get("k4")).isEmpty();
+    // An explicit remove is not a reclamation event.
+    assertThat(disposed).isEmpty();
   }
 
   @Test
-  public void keySet_ShouldBehaveCorrectly() {
-    // Arrange
+  public void put_WhenReplacingExistingKey_ShouldNotFireHandlers() {
+    // Arrange: a replacement is not a reclamation event, so neither handler runs.
+    Set<String> disposed = ConcurrentHashMap.newKeySet();
     ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
+        new ActiveExpiringMap<>(0, 2, (k, v) -> disposed.add(k), (k, v) -> disposed.add(k));
     activeExpiringMap.put("k1", "v1");
     activeExpiringMap.put("k2", "v2");
-    activeExpiringMap.put("k3", "v3");
-
-    // Act Assert
-    Set<String> keySet = activeExpiringMap.keySet();
-    assertThat(keySet).contains("k1", "k2", "k3");
-
-    keySet.remove("k2");
-    assertThat(keySet).contains("k1", "k3");
-    assertThat(activeExpiringMap.keySet()).contains("k1", "k3");
-  }
-
-  @Test
-  public void values_ShouldBehaveCorrectly() {
-    // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
-    activeExpiringMap.put("k2", "v2");
-    activeExpiringMap.put("k3", "v3");
-    activeExpiringMap.put("k4", "v4");
-
-    // Act Assert
-    Collection<String> values = activeExpiringMap.values();
-    assertThat(values).containsExactly("v1", "v2", "v3", "v4");
-
-    values.remove("v3");
-    assertThat(values).containsExactly("v1", "v2", "v4");
-    assertThat(activeExpiringMap.values()).containsExactly("v1", "v2", "v4");
-    assertThat(activeExpiringMap.get("k1")).isEqualTo(Optional.of("v1"));
-    assertThat(activeExpiringMap.get("k2")).isEqualTo(Optional.of("v2"));
-    assertThat(activeExpiringMap.get("k3")).isEqualTo(Optional.empty());
-    assertThat(activeExpiringMap.get("k4")).isEqualTo(Optional.of("v4"));
-  }
-
-  @Test
-  public void entrySet_ShouldBehaveCorrectly() {
-    // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
-    activeExpiringMap.put("k2", "v2");
-    activeExpiringMap.put("k3", "v3");
-    activeExpiringMap.put("k4", "v4");
-
-    // Act Assert
-    Set<Map.Entry<String, String>> entries = activeExpiringMap.entrySet();
-    assertThat(entries)
-        .containsOnly(
-            new AbstractMap.SimpleEntry<>("k1", "v1"),
-            new AbstractMap.SimpleEntry<>("k2", "v2"),
-            new AbstractMap.SimpleEntry<>("k3", "v3"),
-            new AbstractMap.SimpleEntry<>("k4", "v4"));
-
-    entries.remove(new AbstractMap.SimpleEntry<>("k3", "v3"));
-    assertThat(entries)
-        .containsOnly(
-            new AbstractMap.SimpleEntry<>("k1", "v1"),
-            new AbstractMap.SimpleEntry<>("k2", "v2"),
-            new AbstractMap.SimpleEntry<>("k4", "v4"));
-    assertThat(activeExpiringMap.entrySet())
-        .containsOnly(
-            new AbstractMap.SimpleEntry<>("k1", "v1"),
-            new AbstractMap.SimpleEntry<>("k2", "v2"),
-            new AbstractMap.SimpleEntry<>("k4", "v4"));
-  }
-
-  @Test
-  public void updateExpirationTime_ShouldBehaveCorrectly() {
-    // Arrange
-    ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
 
     // Act
-    ActiveExpiringMap<String, String>.ValueHolder valueBeforeUpdate =
-        activeExpiringMap.getValueHolder("k1");
-    assertThat(valueBeforeUpdate).isNotNull();
-    long lastUpdateTimeBeforeUpdate = valueBeforeUpdate.getLastUpdateTime();
-
-    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-
-    activeExpiringMap.updateExpirationTime("k1");
-
-    ActiveExpiringMap<String, String>.ValueHolder valueAfterUpdate =
-        activeExpiringMap.getValueHolder("k1");
-    assertThat(valueAfterUpdate).isNotNull();
-    long lastUpdateTimeAfterUpdate = valueAfterUpdate.getLastUpdateTime();
+    activeExpiringMap.put("k1", "v1-new");
+    activeExpiringMap.cleanUp();
 
     // Assert
-    assertThat(lastUpdateTimeAfterUpdate).isGreaterThan(lastUpdateTimeBeforeUpdate);
+    assertThat(disposed).isEmpty();
+    assertThat(activeExpiringMap.get("k1")).hasValue("v1-new");
+    assertThat(activeExpiringMap.get("k2")).hasValue("v2");
   }
 
   @Test
-  public void valueExpirationThread_ShouldNotEvictRecentlyUpdatedValue_ButEvictsIdleValue() {
-    // Arrange: a 300ms lifetime with a 25ms sweep interval. This asserts the contract the higher
-    // layers rely on — refreshing the expiration time (via touch/updateExpirationTime) actually
-    // prevents the background reaper from evicting an entry — not merely that the timestamp field
-    // moves (covered by updateExpirationTime_ShouldBehaveCorrectly).
+  public void idleEntry_ShouldBeProactivelyExpired_WithoutAnyAccess() {
+    // Arrange: a 200ms idle lifetime. This asserts the reason ActiveExpiringMap exists over a plain
+    // lazy cache: an idle entry is reaped (and its expiration handler fired) proactively, without
+    // any subsequent access to trigger maintenance.
     Set<String> expired = ConcurrentHashMap.newKeySet();
     ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(300, 25, (k, v) -> expired.add(k));
+        new ActiveExpiringMap<>(200, (k, v) -> expired.add(k));
+    activeExpiringMap.put("idle", "v");
+
+    // Act: do not touch or access the entry at all.
+
+    // Assert: it is expired proactively.
+    awaitUntil(() -> expired.contains("idle"));
+    assertThat(activeExpiringMap.get("idle")).isEmpty();
+  }
+
+  @Test
+  public void updateExpirationTime_ShouldPreventIdleExpiration_ButIdleEntryStillExpires() {
+    // Arrange: a 300ms idle lifetime driven by a fake ticker, so the expiration decision is
+    // deterministic and does not depend on wall-clock sleeps. Refreshing an entry within the
+    // lifetime keeps it alive; an untouched entry expires.
+    FakeTicker ticker = new FakeTicker();
+    Set<String> expired = ConcurrentHashMap.newKeySet();
+    // A fake ticker plus a same-thread executor makes this fully deterministic: cleanUp() below
+    // both decides expiration (fake clock) and runs the handler inline (direct executor), so no
+    // wall-clock polling is needed.
+    ActiveExpiringMap<String, String> activeExpiringMap =
+        new ActiveExpiringMap<>(
+            300, 0, (k, v) -> expired.add(k), (k, v) -> {}, ticker, DIRECT_EXECUTOR);
     activeExpiringMap.put("touched", "v");
     activeExpiringMap.put("idle", "v");
 
-    // Act: keep refreshing "touched" across more than one lifetime window; never touch "idle".
-    for (int i = 0; i < 6; i++) {
-      Uninterruptibles.sleepUninterruptibly(80, TimeUnit.MILLISECONDS);
-      activeExpiringMap.updateExpirationTime("touched");
-    }
+    // Act: advance within the lifetime and refresh "touched"; never touch "idle". After a second
+    // advance, "idle" has been idle 400ms (> 300, expired) while "touched" has been idle 200ms
+    // (< 300, alive).
+    ticker.advance(200, TimeUnit.MILLISECONDS);
+    activeExpiringMap.updateExpirationTime("touched");
+    ticker.advance(200, TimeUnit.MILLISECONDS);
+    activeExpiringMap.cleanUp();
 
-    // Assert: the reaper evicted the idle value and fired its handler, but honored the refreshed
-    // timer of the touched value, which is still present.
-    assertThat(expired).contains("idle");
-    assertThat(expired).doesNotContain("touched");
+    // Assert: the idle value expired and fired its handler; the refreshed value survives.
+    assertThat(expired).containsExactly("idle");
     assertThat(activeExpiringMap.get("touched")).hasValue("v");
   }
 
   @Test
-  public void computeIfAbsent_ShouldBehaveCorrectly() {
-    // Arrange
+  public void put_WhenOverMaxSize_ShouldEvictViaEvictionHandler_NotExpirationHandler() {
+    // Arrange: capacity 2, no idle expiration (lifetime 0). Eviction and expiration use distinct
+    // handlers so the test can tell a cap-eviction apart from a timeout.
+    Set<String> expired = ConcurrentHashMap.newKeySet();
+    Set<String> evicted = ConcurrentHashMap.newKeySet();
+    // A same-thread executor runs the eviction inline during cleanUp(), so the assertion is
+    // deterministic rather than polling an async removal executor.
     ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
+        new ActiveExpiringMap<>(
+            0, 2, (k, v) -> expired.add(k), (k, v) -> evicted.add(k), null, DIRECT_EXECUTOR);
 
-    // Act
-    Optional<String> actual1 = activeExpiringMap.computeIfAbsent("k1", k -> "v1");
-    Optional<String> actual2 = activeExpiringMap.computeIfAbsent("k1", k -> "v2");
+    // Act: insert three distinct keys, exceeding the cap.
+    activeExpiringMap.put("k1", "v1");
+    activeExpiringMap.put("k2", "v2");
+    activeExpiringMap.put("k3", "v3");
+    activeExpiringMap.cleanUp();
 
-    // Assert
-    assertThat(actual1).hasValue("v1");
-    assertThat(actual2).hasValue("v1");
-    assertThat(activeExpiringMap.get("k1")).hasValue("v1");
+    // Assert: exactly one entry was evicted via the eviction handler (not the expiration handler),
+    // and the map settled back to its cap of two.
+    assertThat(evicted).hasSize(1);
+    assertThat(expired).isEmpty();
+    long present = 0;
+    if (activeExpiringMap.get("k1").isPresent()) {
+      present++;
+    }
+    if (activeExpiringMap.get("k2").isPresent()) {
+      present++;
+    }
+    if (activeExpiringMap.get("k3").isPresent()) {
+      present++;
+    }
+    assertThat(present).isEqualTo(2);
   }
 
   @Test
-  public void computeIfPresent_ShouldBehaveCorrectly() {
-    // Arrange
+  public void put_WhenMaxSizeNonPositive_ShouldNotEvict() {
+    // Arrange: a non-positive maxSize means unbounded.
+    Set<String> evicted = ConcurrentHashMap.newKeySet();
     ActiveExpiringMap<String, String> activeExpiringMap =
-        new ActiveExpiringMap<>(0, 0, (k, v) -> {});
-
-    activeExpiringMap.put("k1", "v1");
+        new ActiveExpiringMap<>(0, 0, (k, v) -> {}, (k, v) -> evicted.add(k));
 
     // Act
-    Optional<String> actual1 = activeExpiringMap.computeIfPresent("k1", (k, v) -> "v2");
-    Optional<String> actual2 = activeExpiringMap.computeIfPresent("k2", (k, v) -> "v3");
+    for (int i = 0; i < 1000; i++) {
+      activeExpiringMap.put("k" + i, "v" + i);
+    }
+    activeExpiringMap.cleanUp();
 
-    // Assert
-    assertThat(actual1).hasValue("v2");
-    assertThat(actual2).isEmpty();
-    assertThat(activeExpiringMap.get("k1")).hasValue("v2");
-    assertThat(activeExpiringMap.get("k2")).isEmpty();
+    // Assert: nothing evicted; every entry is still present.
+    assertThat(evicted).isEmpty();
+    for (int i = 0; i < 1000; i++) {
+      assertThat(activeExpiringMap.get("k" + i)).hasValue("v" + i);
+    }
+  }
+
+  /** A manually-advanced time source so time-based expiration can be tested deterministically. */
+  private static final class FakeTicker implements Ticker {
+    private final AtomicLong nanos = new AtomicLong();
+
+    @Override
+    public long read() {
+      return nanos.get();
+    }
+
+    void advance(long duration, TimeUnit unit) {
+      nanos.addAndGet(unit.toNanos(duration));
+    }
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3673
- **Commit to backport:** fd96bbf3a512258a7ce86c7d01bfcb8ad99d0e25

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3673 &&
git cherry-pick --no-rerere-autoupdate -m1 fd96bbf3a512258a7ce86c7d01bfcb8ad99d0e25
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!