### PR TITLE
Release participant contexts when the commit outcome is unknown

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
@@ -78,10 +78,11 @@ public interface TwoPhaseCommit {
    *
    * <p><b>Concurrency.</b> Implementations must serialize per-transaction work: for one transaction
    * ID the methods here must be mutually exclusive, so concurrent calls cannot corrupt that
-   * transaction's state. This explicitly covers {@link #releaseContext}, which a context-reaper
-   * drives from its own thread and may therefore invoke concurrently with any other method for the
-   * same transaction ID. Calls for different transaction IDs may proceed concurrently. Decorators
-   * that add a background reaper rely on this contract for their own thread-safety.
+   * transaction's state. This explicitly covers {@link #releaseTransactionContext}, which a
+   * context-reaper drives from its own thread and may therefore invoke concurrently with any other
+   * method for the same transaction ID. Calls for different transaction IDs may proceed
+   * concurrently. Decorators that add a background reaper rely on this contract for their own
+   * thread-safety.
    */
   interface Coordinator extends AutoCloseable {
 
@@ -234,7 +235,7 @@ public interface TwoPhaseCommit {
      *     faults. The context may still be held; reap-style callers treat the failure as
      *     best-effort, since the context is reclaimed by other means (e.g. a later reap or close)
      */
-    void releaseContext(String transactionId)
+    void releaseTransactionContext(String transactionId)
         throws TransactionNotFoundException, TransactionException;
 
     /**
@@ -274,10 +275,10 @@ public interface TwoPhaseCommit {
    *   <li>Lifecycle and record-level two-phase commit methods ({@link #join}, {@link
    *       #prepareRecords}, {@link #validateRecords}, {@link #commitRecords}, {@link
    *       #rollbackRecords}) are invoked by {@link Coordinator}.
-   *   <li>{@link #releaseContext} and {@link #hasTransactionContext} are invoked by neither — they
-   *       are driven by a context-reaper/decorator: the former a reap-only terminal that reclaims
-   *       an abandoned or idle-reaped context without touching storage, the latter a liveness probe
-   *       consulted before such a reap.
+   *   <li>{@link #releaseTransactionContext} and {@link #hasTransactionContext} are invoked by
+   *       neither — they are driven by a context-reaper/decorator: the former a reap-only terminal
+   *       that reclaims an abandoned or idle-reaped context without touching storage, the latter a
+   *       liveness probe consulted before such a reap.
    * </ul>
    *
    * <p>Operations must follow the transaction's lifecycle: CRUD while the transaction is open, then
@@ -290,11 +291,11 @@ public interface TwoPhaseCommit {
    *
    * <p><b>Concurrency.</b> Implementations must serialize per-transaction work: for one transaction
    * ID the methods here must be mutually exclusive, so concurrent calls cannot corrupt that
-   * transaction's context. Because a context-reaper drives {@link #releaseContext} and {@link
-   * #hasTransactionContext} from its own thread (see above), either may be invoked concurrently
-   * with an in-flight CRUD or record-level call for the same transaction ID. Calls for different
-   * transaction IDs may proceed concurrently. Decorators that add a background reaper rely on this
-   * contract for their own thread-safety.
+   * transaction's context. Because a context-reaper drives {@link #releaseTransactionContext} and
+   * {@link #hasTransactionContext} from its own thread (see above), either may be invoked
+   * concurrently with an in-flight CRUD or record-level call for the same transaction ID. Calls for
+   * different transaction IDs may proceed concurrently. Decorators that add a background reaper
+   * rely on this contract for their own thread-safety.
    */
   interface Participant extends AutoCloseable {
 
@@ -679,7 +680,7 @@ public interface TwoPhaseCommit {
      *     faults. The context may still be held; reap-style callers treat the failure as
      *     best-effort, since the context is reclaimed by other means (e.g. a later reap or close)
      */
-    void releaseContext(String transactionId)
+    void releaseTransactionContext(String transactionId)
         throws TransactionNotFoundException, TransactionException;
 
     /**

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommit.java
@@ -226,8 +226,16 @@ public interface TwoPhaseCommit {
      * treat this as a terminal step, releasing any per-transaction resources it holds.
      *
      * @param transactionId the canonical transaction ID returned by {@link #begin}
+     * @throws TransactionNotFoundException if the implementation reports the unknown-transaction
+     *     no-op on its conventional not-found channel instead of returning silently (typical across
+     *     a transport boundary). An alternative carrier of the no-op outcome — there was no context
+     *     to release — so callers must treat it like a normal return
+     * @throws TransactionException if releasing the context fails due to transient or nontransient
+     *     faults. The context may still be held; reap-style callers treat the failure as
+     *     best-effort, since the context is reclaimed by other means (e.g. a later reap or close)
      */
-    void releaseContext(String transactionId);
+    void releaseContext(String transactionId)
+        throws TransactionNotFoundException, TransactionException;
 
     /**
      * Closes the Coordinator and releases any resources it holds.
@@ -589,15 +597,22 @@ public interface TwoPhaseCommit {
      *
      * <p>Unlike the other record-level steps, an unknown transaction — one this participant never
      * joined, or whose context it has already released (for example, a write-less participant that
-     * released early when its later steps were skipped, or a prior rollback) — is a no-op rather
-     * than an error: there is nothing left to undo.
+     * released early when its later steps were skipped, or a prior rollback) — is not an error:
+     * there is nothing left for this participant to undo. Implementations report it as a silent
+     * no-op or as a {@link TransactionNotFoundException}, never as a {@link RollbackException}.
      *
      * @param transactionId the canonical transaction ID
+     * @throws TransactionNotFoundException if the implementation reports the unknown-transaction
+     *     no-op on its conventional not-found channel instead of returning silently (typical across
+     *     a transport boundary). An alternative carrier of the no-op outcome — there was nothing
+     *     left for this participant to undo — so callers must treat it like a normal return.
+     *     Routine on abort paths: the Coordinator rolls back every participant uniformly, including
+     *     ones that already self-released
      * @throws RollbackException if rolling back the records of a known transaction fails due to
-     *     transient or nontransient faults; never thrown for an unknown transaction, which is a
-     *     no-op
+     *     transient or nontransient faults; never thrown for an unknown transaction
      */
-    void rollbackRecords(String transactionId) throws RollbackException;
+    void rollbackRecords(String transactionId)
+        throws RollbackException, TransactionNotFoundException;
 
     /**
      * Returns whether this participant still holds a local context for the transaction.
@@ -651,9 +666,21 @@ public interface TwoPhaseCommit {
      * A decorator may treat this as a terminal step, releasing any per-transaction resources it
      * holds.
      *
+     * <p>Callers invoke this from housekeeping paths (e.g. an idle reaper), or best-effort while a
+     * client awaits a terminal outcome; an implementation that crosses a network must bound the
+     * call with its own deadline rather than block indefinitely.
+     *
      * @param transactionId the canonical transaction ID
+     * @throws TransactionNotFoundException if the implementation reports the unknown-transaction
+     *     no-op on its conventional not-found channel instead of returning silently (typical across
+     *     a transport boundary). An alternative carrier of the no-op outcome — there was no context
+     *     to release — so callers must treat it like a normal return
+     * @throws TransactionException if releasing the context fails due to transient or nontransient
+     *     faults. The context may still be held; reap-style callers treat the failure as
+     *     best-effort, since the context is reclaimed by other means (e.g. a later reap or close)
      */
-    void releaseContext(String transactionId);
+    void releaseContext(String transactionId)
+        throws TransactionNotFoundException, TransactionException;
 
     /**
      * Closes the Participant and releases any resources it holds.

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -78,7 +78,7 @@ public abstract class AbstractDistributedTransactionProvider
 
     if (config.isActiveTransactionManagementEnabled()) {
       // Wrap the coordinator for active transaction management. This must be the outermost wrapping
-      // so that the idle-expiry reap traverses every inner decorator via releaseContext.
+      // so that the idle-expiry reap traverses every inner decorator via releaseTransactionContext.
       coordinator =
           new ActiveTransactionManagedTwoPhaseCommitCoordinator(
               coordinator,
@@ -103,7 +103,7 @@ public abstract class AbstractDistributedTransactionProvider
 
     if (config.isActiveTransactionManagementEnabled()) {
       // Wrap the participant for active transaction management. This must be the outermost wrapping
-      // so that the idle-expiry reap traverses every inner decorator via releaseContext.
+      // so that the idle-expiry reap traverses every inner decorator via releaseTransactionContext.
       participant =
           new ActiveTransactionManagedTwoPhaseCommitParticipant(
               participant,

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -198,7 +198,14 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     return new ActiveTransactionRegistry<>(
         /* expirationTimeMillis= */ -1,
         maxActiveTransactions,
-        tracked -> coordinator.releaseContext(tracked.transactionId));
+        tracked -> {
+          try {
+            coordinator.releaseContext(tracked.transactionId);
+          } catch (TransactionNotFoundException e) {
+            // The context is already gone — the outcome this release wanted; not-found is its
+            // alternative carrier (see the interface Javadoc).
+          }
+        });
   }
 
   private static ScheduledExecutorService newSweeperExecutor() {
@@ -293,7 +300,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseContext(String transactionId) throws TransactionException {
     try {
       super.releaseContext(transactionId);
     } finally {
@@ -444,9 +451,14 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   private void releaseOnWrapped(String transactionId) {
     try {
       super.releaseContext(transactionId);
+    } catch (TransactionNotFoundException e) {
+      // The context is already gone — the outcome this release wanted; not-found is its
+      // alternative carrier (see the interface Javadoc).
     } catch (Exception e) {
-      // A failed release must not abort the rest of the sweep pass. (The wrapped releaseContext
-      // is not expected to throw at all — this is a guard, not a path.)
+      // A failed release must not abort the rest of the sweep pass. For the in-process wrapped
+      // coordinator this is a guard, not a path (it never throws); a remote implementation may
+      // legitimately fail here per the interface contract — still best-effort, the context is
+      // reclaimed by other means (see the interface Javadoc).
       logger.warn(
           "Failed to release the context of the expired transaction. Transaction ID: {}",
           transactionId,

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -26,13 +26,13 @@ import org.slf4j.LoggerFactory;
  * participants no longer hold them.
  *
  * <p>Each transaction is tracked from {@link #begin} until its terminal step ({@link #commit} /
- * {@link #rollback} / {@link #releaseContext}), with a per-transaction expiration time that {@code
- * begin} and {@link #registerParticipant} push {@code expirationTimeMillis} out. The coordinator
- * observes only those two calls — the CRUD a transaction issues goes directly to its participants —
- * so an elapsed expiration time alone cannot tell an abandoned transaction from a healthy
- * long-running one. A background sweep therefore probes the registered participants of every
- * expired transaction ({@link TwoPhaseCommit.Participant#hasTransactionContext}) — in place, while
- * the transaction stays tracked:
+ * {@link #rollback} / {@link #releaseTransactionContext}), with a per-transaction expiration time
+ * that {@code begin} and {@link #registerParticipant} push {@code expirationTimeMillis} out. The
+ * coordinator observes only those two calls — the CRUD a transaction issues goes directly to its
+ * participants — so an elapsed expiration time alone cannot tell an abandoned transaction from a
+ * healthy long-running one. A background sweep therefore probes the registered participants of
+ * every expired transaction ({@link TwoPhaseCommit.Participant#hasTransactionContext}) — in place,
+ * while the transaction stays tracked:
  *
  * <ul>
  *   <li>If any participant still holds the transaction — or cannot be probed — the expiration time
@@ -41,8 +41,8 @@ import org.slf4j.LoggerFactory;
  *       errs on the side of retention.
  *   <li>If no participant holds it, the transaction can no longer commit (the participants' own
  *       idle reaping has already released their contexts), so the sweep calls {@link
- *       TwoPhaseCommit.Coordinator#releaseContext} on the wrapped coordinator to free its
- *       role-local resources without any storage rollback. A subsequent {@code commit}/{@code
+ *       TwoPhaseCommit.Coordinator#releaseTransactionContext} on the wrapped coordinator to free
+ *       its role-local resources without any storage rollback. A subsequent {@code commit}/{@code
  *       rollback} for a reaped transaction fails with {@link TransactionNotFoundException}, which
  *       is retriable from the client's perspective; the records left behind are recovered lazily by
  *       the usual recovery path.
@@ -92,22 +92,22 @@ import org.slf4j.LoggerFactory;
  * this small.
  *
  * <p>This decorator is intended to be the outermost coordinator decorator so that the reap
- * traverses the inner decorators via {@code releaseContext}.
+ * traverses the inner decorators via {@code releaseTransactionContext}.
  *
  * <p>Thread safety: the {@link ThreadSafe} guarantee relies on two mechanisms. First, the wrapped
  * coordinator honors the {@link TwoPhaseCommit.Coordinator} concurrency contract — it serializes
- * its own per-transaction work, including {@code releaseContext} concurrently with any other method
- * for the same transaction ID (e.g. {@code ConsensusCommitCoordinator} synchronizes every
- * per-transaction method on a per-context monitor) — which makes the sweep's {@code releaseContext}
- * safe against an in-flight {@code commit}/{@code rollback}. Second, the sweep and {@link
- * #registerParticipant} shake hands on the tracked entry's monitor: a registration pushes the
- * expiration time out under the monitor <em>before</em> delegating to the wrapped coordinator, and
- * the sweep re-checks under the same monitor that the expiration time has not moved before
- * releasing and removing. A reap therefore never overlaps a registration that is about to succeed —
- * either the registration extends the deadline first and the sweep backs off, or the reap completes
- * first and the delegated registration is rejected by the wrapped coordinator, whose context is
- * already released. Probing itself is I/O and runs outside the monitor, so a slow probe never
- * blocks a registration.
+ * its own per-transaction work, including {@code releaseTransactionContext} concurrently with any
+ * other method for the same transaction ID (e.g. {@code ConsensusCommitCoordinator} synchronizes
+ * every per-transaction method on a per-context monitor) — which makes the sweep's {@code
+ * releaseTransactionContext} safe against an in-flight {@code commit}/{@code rollback}. Second, the
+ * sweep and {@link #registerParticipant} shake hands on the tracked entry's monitor: a registration
+ * pushes the expiration time out under the monitor <em>before</em> delegating to the wrapped
+ * coordinator, and the sweep re-checks under the same monitor that the expiration time has not
+ * moved before releasing and removing. A reap therefore never overlaps a registration that is about
+ * to succeed — either the registration extends the deadline first and the sweep backs off, or the
+ * reap completes first and the delegated registration is rejected by the wrapped coordinator, whose
+ * context is already released. Probing itself is I/O and runs outside the monitor, so a slow probe
+ * never blocks a registration.
  *
  * <p>The accepted cost of those two mechanisms combined: a reap whose release lands behind an
  * in-flight terminal step for the same transaction blocks on the wrapped coordinator's
@@ -200,7 +200,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
         maxActiveTransactions,
         tracked -> {
           try {
-            coordinator.releaseContext(tracked.transactionId);
+            coordinator.releaseTransactionContext(tracked.transactionId);
           } catch (TransactionNotFoundException e) {
             // The context is already gone — the outcome this release wanted; not-found is its
             // alternative carrier (see the interface Javadoc).
@@ -285,7 +285,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
       // This intentionally differs from the manager-side decorator, which keeps the entry when
       // commit throws so that idle expiry later rolls it back: the coordinator's durable state
       // record (not this in-memory entry) is the source of truth for recovery, so keeping the
-      // entry would only produce a spurious reap log and a no-op releaseContext.
+      // entry would only produce a spurious reap log and a no-op releaseTransactionContext.
       registry.remove(transactionId);
     }
   }
@@ -300,9 +300,9 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   }
 
   @Override
-  public void releaseContext(String transactionId) throws TransactionException {
+  public void releaseTransactionContext(String transactionId) throws TransactionException {
     try {
-      super.releaseContext(transactionId);
+      super.releaseTransactionContext(transactionId);
     } finally {
       registry.remove(transactionId);
     }
@@ -450,7 +450,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
 
   private void releaseOnWrapped(String transactionId) {
     try {
-      super.releaseContext(transactionId);
+      super.releaseTransactionContext(transactionId);
     } catch (TransactionNotFoundException e) {
       // The context is already gone — the outcome this release wanted; not-found is its
       // alternative carrier (see the interface Javadoc).

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -88,7 +88,14 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
         new ActiveTransactionRegistry<>(
             expirationTimeMillis,
             maxActiveTransactions,
-            tracked -> participant.releaseContext(tracked.transactionId));
+            tracked -> {
+              try {
+                participant.releaseContext(tracked.transactionId);
+              } catch (TransactionNotFoundException e) {
+                // The context is already gone — the outcome this release wanted; not-found is its
+                // alternative carrier (see the interface Javadoc).
+              }
+            });
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -232,7 +239,8 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
   }
 
   @Override
-  public void rollbackRecords(String transactionId) throws RollbackException {
+  public void rollbackRecords(String transactionId)
+      throws RollbackException, TransactionNotFoundException {
     try {
       super.rollbackRecords(transactionId);
     } finally {
@@ -241,7 +249,7 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseContext(String transactionId) throws TransactionException {
     try {
       super.releaseContext(transactionId);
     } finally {

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -31,17 +31,17 @@ import javax.annotation.concurrent.ThreadSafe;
  * A {@link TwoPhaseCommit.Participant} decorator that reaps the contexts of inactive transactions.
  *
  * <p>Each transaction is tracked from {@link #join} until its terminal step ({@link #commitRecords}
- * / {@link #rollbackRecords} / {@link #releaseContext}). Every CRUD operation and record-level step
- * refreshes the transaction's idle timer, so inactivity here is measured as true idle time. When a
- * transaction stays inactive longer than the configured expiration time, this decorator calls
- * {@link TwoPhaseCommit.Participant#releaseContext} on the wrapped participant to free its
- * role-local resources (e.g. open scanners, the snapshot) without performing any storage rollback,
- * even when the records are prepared. The records left behind are recovered lazily by the usual
- * recovery path.
+ * / {@link #rollbackRecords} / {@link #releaseTransactionContext}). Every CRUD operation and
+ * record-level step refreshes the transaction's idle timer, so inactivity here is measured as true
+ * idle time. When a transaction stays inactive longer than the configured expiration time, this
+ * decorator calls {@link TwoPhaseCommit.Participant#releaseTransactionContext} on the wrapped
+ * participant to free its role-local resources (e.g. open scanners, the snapshot) without
+ * performing any storage rollback, even when the records are prepared. The records left behind are
+ * recovered lazily by the usual recovery path.
  *
  * <p>This decorator is intended to be the outermost participant decorator so that the reap
- * traverses the inner decorators via {@code releaseContext}. It is the participant-side counterpart
- * of {@link ActiveTransactionManagedTwoPhaseCommitCoordinator}.
+ * traverses the inner decorators via {@code releaseTransactionContext}. It is the participant-side
+ * counterpart of {@link ActiveTransactionManagedTwoPhaseCommitCoordinator}.
  *
  * <p>A write-less participant does not always reach {@link #commitRecords}: the Coordinator skips
  * the steps a participant no longer needs, so for such a participant the last driven step is {@link
@@ -62,12 +62,12 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Thread safety: the {@link ThreadSafe} guarantee here relies on the wrapped participant
  * honoring the {@link TwoPhaseCommit.Participant} concurrency contract — serializing its own
- * per-transaction work. The reaper thread's {@code releaseContext} call may run concurrently with
- * an in-flight CRUD or record-level call for the same transaction id; the wrapped role is
- * responsible for making those mutually exclusive (e.g. {@code ConsensusCommitParticipant}
- * synchronizes every per-transaction method, including {@code releaseContext}, on a per-context
- * monitor). A wrapped participant that violates that contract would break this guarantee with no
- * signal at this layer.
+ * per-transaction work. The reaper thread's {@code releaseTransactionContext} call may run
+ * concurrently with an in-flight CRUD or record-level call for the same transaction id; the wrapped
+ * role is responsible for making those mutually exclusive (e.g. {@code ConsensusCommitParticipant}
+ * synchronizes every per-transaction method, including {@code releaseTransactionContext}, on a
+ * per-context monitor). A wrapped participant that violates that contract would break this
+ * guarantee with no signal at this layer.
  */
 @ThreadSafe
 public class ActiveTransactionManagedTwoPhaseCommitParticipant
@@ -90,7 +90,7 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
             maxActiveTransactions,
             tracked -> {
               try {
-                participant.releaseContext(tracked.transactionId);
+                participant.releaseTransactionContext(tracked.transactionId);
               } catch (TransactionNotFoundException e) {
                 // The context is already gone — the outcome this release wanted; not-found is its
                 // alternative carrier (see the interface Javadoc).
@@ -249,9 +249,9 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
   }
 
   @Override
-  public void releaseContext(String transactionId) throws TransactionException {
+  public void releaseTransactionContext(String transactionId) throws TransactionException {
     try {
-      super.releaseContext(transactionId);
+      super.releaseTransactionContext(transactionId);
     } finally {
       registry.remove(transactionId);
     }

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -167,7 +167,8 @@ public class AttributePropagatingTwoPhaseCommitParticipant
   }
 
   @Override
-  public void rollbackRecords(String transactionId) throws RollbackException {
+  public void rollbackRecords(String transactionId)
+      throws RollbackException, TransactionNotFoundException {
     try {
       super.rollbackRecords(transactionId);
     } finally {
@@ -176,7 +177,7 @@ public class AttributePropagatingTwoPhaseCommitParticipant
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseContext(String transactionId) throws TransactionException {
     try {
       super.releaseContext(transactionId);
     } finally {

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -45,8 +45,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * Coordinator skips {@code commitRecords} (and possibly {@code validateRecords}) for a write-less
  * participant — including every read-only transaction — so a normally-committed write-less
  * transaction would otherwise never reach a terminal step that clears its entry. The attributes are
- * also dropped on {@code rollbackRecords} and {@code releaseContext} to cover transactions that are
- * rolled back or reaped before ever preparing.
+ * also dropped on {@code rollbackRecords} and {@code releaseTransactionContext} to cover
+ * transactions that are rolled back or reaped before ever preparing.
  *
  * <p>The record-level step {@code validateRecords} and non-CRUD methods are forwarded unchanged;
  * they do not read the transaction-scoped attributes.
@@ -58,10 +58,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * is actually running — which requires both active transaction management to be enabled and a
  * positive {@code scalar.db.active_transaction_management.expiration_time_millis} (a non-positive
  * value, which is the default, disables the reaper). Only then does idle expiry call {@code
- * releaseContext} and clear the entry. The leak is in lockstep with the wrapped participant's own
- * per-transaction context, which active transaction management reaps under the same precondition.
- * Enable active transaction management with a positive expiration time whenever this decorator is
- * used.
+ * releaseTransactionContext} and clear the entry. The leak is in lockstep with the wrapped
+ * participant's own per-transaction context, which active transaction management reaps under the
+ * same precondition. Enable active transaction management with a positive expiration time whenever
+ * this decorator is used.
  */
 @ThreadSafe
 public class AttributePropagatingTwoPhaseCommitParticipant
@@ -177,9 +177,9 @@ public class AttributePropagatingTwoPhaseCommitParticipant
   }
 
   @Override
-  public void releaseContext(String transactionId) throws TransactionException {
+  public void releaseTransactionContext(String transactionId) throws TransactionException {
     try {
-      super.releaseContext(transactionId);
+      super.releaseTransactionContext(transactionId);
     } finally {
       transactionAttributes.remove(transactionId);
     }

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
@@ -54,7 +54,7 @@ public abstract class DecoratedTwoPhaseCommitCoordinator implements TwoPhaseComm
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseContext(String transactionId) throws TransactionException {
     coordinator.releaseContext(transactionId);
   }
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
@@ -54,8 +54,8 @@ public abstract class DecoratedTwoPhaseCommitCoordinator implements TwoPhaseComm
   }
 
   @Override
-  public void releaseContext(String transactionId) throws TransactionException {
-    coordinator.releaseContext(transactionId);
+  public void releaseTransactionContext(String transactionId) throws TransactionException {
+    coordinator.releaseTransactionContext(transactionId);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
@@ -146,8 +146,8 @@ public abstract class DecoratedTwoPhaseCommitParticipant implements TwoPhaseComm
   }
 
   @Override
-  public void releaseContext(String transactionId) throws TransactionException {
-    participant.releaseContext(transactionId);
+  public void releaseTransactionContext(String transactionId) throws TransactionException {
+    participant.releaseTransactionContext(transactionId);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipant.java
@@ -140,12 +140,13 @@ public abstract class DecoratedTwoPhaseCommitParticipant implements TwoPhaseComm
   }
 
   @Override
-  public void rollbackRecords(String transactionId) throws RollbackException {
+  public void rollbackRecords(String transactionId)
+      throws RollbackException, TransactionNotFoundException {
     participant.rollbackRecords(transactionId);
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseContext(String transactionId) throws TransactionException {
     participant.releaseContext(transactionId);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -261,6 +261,18 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
               bestEffortRollbackRecords(participant, transactionId);
             }
             throw e;
+          } catch (UnknownTransactionStatusException e) {
+            // The COMMITTED-state write's outcome is unknown: the records must stay PREPARED for
+            // lazy recovery to resolve against the Coordinator state row, so neither commitRecords
+            // nor rollbackRecords may run. The participants' in-memory contexts are useless either
+            // way — commit is terminal on every outcome (the finally below releases this
+            // Coordinator's context), so nothing can ever drive them again. Release them promptly
+            // instead of leaving them to each participant's own idle reaping
+            // (releaseContext touches no storage).
+            for (Participant participant : toCommit) {
+              bestEffortReleaseContext(participant, transactionId);
+            }
+            throw e;
           }
         } else {
           // Write-less transaction with the Coordinator write omitted: no participant has writes,
@@ -353,7 +365,18 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
       String transactionId, boolean knownWriteLess, List<Participant> participants)
       throws UnknownTransactionStatusException {
     if (isCoordinatorStateWriteRequired(!knownWriteLess)) {
-      abortState(transactionId);
+      try {
+        abortState(transactionId);
+      } catch (UnknownTransactionStatusException e) {
+        // The ABORTED-state write's outcome is unknown: the records stay PREPARED for lazy
+        // recovery (mirroring CommitHandler, records are not rolled back on an unknown abort). The
+        // participants' in-memory contexts are just as unreachable as on the commit-state path —
+        // commit is terminal on every outcome — so release them promptly without touching storage.
+        for (Participant participant : participants) {
+          bestEffortReleaseContext(participant, transactionId);
+        }
+        throw e;
+      }
     }
     for (Participant participant : participants) {
       bestEffortRollbackRecords(participant, transactionId);
@@ -386,6 +409,11 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   private void bestEffortRollbackRecords(Participant participant, String txId) {
     try {
       participant.rollbackRecords(txId);
+    } catch (TransactionNotFoundException e) {
+      // The participant no longer knows the transaction (it self-released early, or already
+      // rolled back) — the documented no-op outcome arriving on its conventional not-found
+      // carrier. Any records it might still leave PREPARED are lazy recovery's to reconcile,
+      // exactly as on a silent no-op return; nothing to report.
     } catch (Exception e) {
       // Best-effort step: the records are left PREPARED and lazy recovery rolls them back on a
       // subsequent read of the record (no background sweep). Logged at WARN since the records hold
@@ -393,6 +421,24 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
       logger.warn(
           "rollbackRecords failed; the records are left PREPARED and will be rolled back by lazy "
               + "recovery on a subsequent read. Transaction ID: {}",
+          txId,
+          e);
+    }
+  }
+
+  private void bestEffortReleaseContext(Participant participant, String txId) {
+    try {
+      participant.releaseContext(txId);
+    } catch (TransactionNotFoundException e) {
+      // The context is already gone (self-released, or reaped by the participant's own idle
+      // reaping) — the outcome this release wanted; not-found is its alternative carrier.
+    } catch (Exception e) {
+      // Best-effort step. Unlike the record-level best-effort steps, this failure leaves nothing
+      // locked — only an in-memory context that the participant reclaims by other means (e.g. a
+      // later reap or close) — so it logs at DEBUG.
+      logger.debug(
+          "releaseContext failed; the participant's context is left to be reclaimed "
+              + "by other means (e.g. a later reap or close). Transaction ID: {}",
           txId,
           e);
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -268,9 +268,9 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
             // way — commit is terminal on every outcome (the finally below releases this
             // Coordinator's context), so nothing can ever drive them again. Release them promptly
             // instead of leaving them to each participant's own idle reaping
-            // (releaseContext touches no storage).
+            // (releaseTransactionContext touches no storage).
             for (Participant participant : toCommit) {
-              bestEffortReleaseContext(participant, transactionId);
+              bestEffortReleaseTransactionContext(participant, transactionId);
             }
             throw e;
           }
@@ -319,7 +319,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseTransactionContext(String transactionId) {
     CoordinatorContext context = contexts.get(transactionId);
     if (context == null) {
       // Unknown or already-released transaction: nothing to release.
@@ -373,7 +373,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
         // participants' in-memory contexts are just as unreachable as on the commit-state path —
         // commit is terminal on every outcome — so release them promptly without touching storage.
         for (Participant participant : participants) {
-          bestEffortReleaseContext(participant, transactionId);
+          bestEffortReleaseTransactionContext(participant, transactionId);
         }
         throw e;
       }
@@ -426,9 +426,9 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
     }
   }
 
-  private void bestEffortReleaseContext(Participant participant, String txId) {
+  private void bestEffortReleaseTransactionContext(Participant participant, String txId) {
     try {
-      participant.releaseContext(txId);
+      participant.releaseTransactionContext(txId);
     } catch (TransactionNotFoundException e) {
       // The context is already gone (self-released, or reaped by the participant's own idle
       // reaping) — the outcome this release wanted; not-found is its alternative carrier.
@@ -437,7 +437,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
       // locked — only an in-memory context that the participant reclaims by other means (e.g. a
       // later reap or close) — so it logs at DEBUG.
       logger.debug(
-          "releaseContext failed; the participant's context is left to be reclaimed "
+          "releaseTransactionContext failed; the participant's context is left to be reclaimed "
               + "by other means (e.g. a later reap or close). Transaction ID: {}",
           txId,
           e);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -507,7 +507,7 @@ public class ConsensusCommitParticipant implements TwoPhaseCommit.Participant {
   }
 
   @Override
-  public void releaseContext(String transactionId) {
+  public void releaseTransactionContext(String transactionId) {
     ParticipantContext pc = contexts.get(transactionId);
     if (pc == null) {
       // Unknown or already-released transaction: nothing to release.

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -294,6 +294,44 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
+  void sweep_WhenReleaseThrowsNotFound_ShouldTreatAsAlreadyGoneAndFinishThePass() throws Exception {
+    // TransactionNotFoundException from the wrapped release is the contract's alternative carrier
+    // of "there was no context to release" - the outcome the reap wanted. The entry must still be
+    // removed, and the pass must go on to reap the other expired transaction.
+    doThrow(new TransactionNotFoundException("already gone", TX)).when(delegate).releaseContext(TX);
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+    when(delegate.begin(eq("tx-2"), eq(false), any(), any())).thenReturn("tx-2");
+    coordinator.begin("tx-2", false, Collections.emptyMap(), null);
+    forceExpire(TX);
+    forceExpire("tx-2");
+
+    coordinator.sweep();
+
+    assertThat(registry.get(TX)).isEmpty();
+    verify(delegate).releaseContext("tx-2");
+    assertThat(registry.get("tx-2")).isEmpty();
+  }
+
+  @Test
+  void sweep_WhenReleaseThrowsException_ShouldFinishThePass() throws Exception {
+    // A failed release must not abort the rest of the pass: the guard logs and moves on, the
+    // entry is still removed (the release is best-effort), and the other expired transaction is
+    // still reaped.
+    doThrow(new TransactionException("boom", TX)).when(delegate).releaseContext(TX);
+    coordinator.begin(null, false, Collections.emptyMap(), null);
+    when(delegate.begin(eq("tx-2"), eq(false), any(), any())).thenReturn("tx-2");
+    coordinator.begin("tx-2", false, Collections.emptyMap(), null);
+    forceExpire(TX);
+    forceExpire("tx-2");
+
+    coordinator.sweep();
+
+    assertThat(registry.get(TX)).isEmpty();
+    verify(delegate).releaseContext("tx-2");
+    assertThat(registry.get("tx-2")).isEmpty();
+  }
+
+  @Test
   void sweep_WhenRegistrationLandsDuringProbe_ShouldNotReap() throws Exception {
     // The reap-vs-registration race: a registration lands while the probe is in flight. It pushes
     // the expiration time out under the entry monitor before delegating, so the reap re-check

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -75,7 +75,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     coordinator.sweep();
 
     verify(participant, never()).hasTransactionContext(any());
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -88,7 +88,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
   }
 
@@ -103,7 +103,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     forceExpire(TX);
     coordinator.sweep();
     verify(participant).hasTransactionContext(TX);
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
 
     // The alive verdict pushed the expiration time out, so another pass must not probe again.
@@ -115,7 +115,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     stubHeld(participant, false);
     forceExpire(TX);
     coordinator.sweep();
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
   }
 
@@ -154,7 +154,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -170,7 +170,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -190,9 +190,9 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isPresent();
-    verify(delegate).releaseContext("tx-2");
+    verify(delegate).releaseTransactionContext("tx-2");
     assertThat(registry.get("tx-2")).isEmpty();
   }
 
@@ -203,7 +203,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // retrying a release that keeps throwing would re-attempt (and WARN) every pass forever, so
     // a leaked wrapped context is left as the wrapped coordinator's responsibility - and other
     // expired transactions in the same pass are still reaped.
-    doThrow(new RuntimeException("boom")).when(delegate).releaseContext(TX);
+    doThrow(new RuntimeException("boom")).when(delegate).releaseTransactionContext(TX);
     stubHeld(participant, false);
     coordinator.begin(null, false, Collections.emptyMap(), participant);
     TwoPhaseCommit.Participant otherParticipant = mock(TwoPhaseCommit.Participant.class);
@@ -215,9 +215,9 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     assertThatCode(coordinator::sweep).doesNotThrowAnyException();
 
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
-    verify(delegate).releaseContext("tx-2");
+    verify(delegate).releaseTransactionContext("tx-2");
     assertThat(registry.get("tx-2")).isEmpty();
   }
 
@@ -232,7 +232,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     assertThatThrownBy(coordinator::sweep).isInstanceOf(LinkageError.class);
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -247,14 +247,14 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     forceExpire(TX);
 
     assertThatCode(coordinator::sweepSafely).doesNotThrowAnyException();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
 
     // The entry is still expired (the aborted pass extended nothing), so the next pass retries
     // the probe; the participant now answers definitively and the transaction is reaped.
     doReturn(false).when(participant).hasTransactionContext(TX);
     coordinator.sweepSafely();
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
   }
 
@@ -270,7 +270,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
   }
 
@@ -289,7 +289,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -298,7 +298,9 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // TransactionNotFoundException from the wrapped release is the contract's alternative carrier
     // of "there was no context to release" - the outcome the reap wanted. The entry must still be
     // removed, and the pass must go on to reap the other expired transaction.
-    doThrow(new TransactionNotFoundException("already gone", TX)).when(delegate).releaseContext(TX);
+    doThrow(new TransactionNotFoundException("already gone", TX))
+        .when(delegate)
+        .releaseTransactionContext(TX);
     coordinator.begin(null, false, Collections.emptyMap(), null);
     when(delegate.begin(eq("tx-2"), eq(false), any(), any())).thenReturn("tx-2");
     coordinator.begin("tx-2", false, Collections.emptyMap(), null);
@@ -308,7 +310,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     coordinator.sweep();
 
     assertThat(registry.get(TX)).isEmpty();
-    verify(delegate).releaseContext("tx-2");
+    verify(delegate).releaseTransactionContext("tx-2");
     assertThat(registry.get("tx-2")).isEmpty();
   }
 
@@ -317,7 +319,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // A failed release must not abort the rest of the pass: the guard logs and moves on, the
     // entry is still removed (the release is best-effort), and the other expired transaction is
     // still reaped.
-    doThrow(new TransactionException("boom", TX)).when(delegate).releaseContext(TX);
+    doThrow(new TransactionException("boom", TX)).when(delegate).releaseTransactionContext(TX);
     coordinator.begin(null, false, Collections.emptyMap(), null);
     when(delegate.begin(eq("tx-2"), eq(false), any(), any())).thenReturn("tx-2");
     coordinator.begin("tx-2", false, Collections.emptyMap(), null);
@@ -327,7 +329,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     coordinator.sweep();
 
     assertThat(registry.get(TX)).isEmpty();
-    verify(delegate).releaseContext("tx-2");
+    verify(delegate).releaseTransactionContext("tx-2");
     assertThat(registry.get("tx-2")).isEmpty();
   }
 
@@ -349,7 +351,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
     assertThat(registry.get(TX).get().hasParticipant("participant-2")).isTrue();
   }
@@ -400,7 +402,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     // The sweep probed the live participant and kept the transaction; it did not reap.
     verify(participant).hasTransactionContext(TX);
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -425,7 +427,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     coordinator.sweep();
 
     verify(participant, never()).hasTransactionContext(any());
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     assertThat(registry.get(TX)).isPresent();
   }
 
@@ -475,7 +477,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     stubHeld(participant, false);
     forceExpire(TX);
     coordinator.sweep();
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
     assertThat(registry.get(TX)).isEmpty();
   }
 
@@ -507,7 +509,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // The transaction is no longer tracked, so the sweep must not release its context.
     assertThat(registry.get(TX)).isEmpty();
     coordinator.sweep();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
@@ -519,7 +521,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     verify(delegate).rollback(TX);
     assertThat(registry.get(TX)).isEmpty();
     coordinator.sweep();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
@@ -537,7 +539,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // not subsequently release its context (no double reap).
     assertThat(registry.get(TX)).isEmpty();
     coordinator.sweep();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
@@ -553,19 +555,19 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     assertThat(registry.get(TX)).isEmpty();
     coordinator.sweep();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
-  void releaseContext_ShouldDelegateOnceAndStopTracking() throws Exception {
+  void releaseTransactionContext_ShouldDelegateOnceAndStopTracking() throws Exception {
     coordinator.begin(null, false, Collections.emptyMap(), null);
 
-    coordinator.releaseContext(TX);
+    coordinator.releaseTransactionContext(TX);
 
-    // The sweep must not call releaseContext again after the client already released it.
+    // The sweep must not call releaseTransactionContext again after the client already released it.
     assertThat(registry.get(TX)).isEmpty();
     coordinator.sweep();
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
   }
 
   @Test
@@ -582,7 +584,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     // A failed begin tracked nothing, so the sweep must not release any context.
     coordinator.sweep();
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
@@ -598,7 +600,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // A pass overlapping the shutdown must not probe or release on behalf of a closed
     // coordinator: the wrapped close discards the contexts.
     verify(participant, never()).hasTransactionContext(any());
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   @Test
@@ -617,7 +619,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
     coordinator.sweep();
 
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
     verify(delegate).close();
   }
 
@@ -631,7 +633,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
             delegate, /* expirationTimeMillis= */ 100, /* maxActiveTransactions= */ -1);
     try {
       scheduled.begin(null, false, Collections.emptyMap(), participant);
-      verify(delegate, timeout(10000)).releaseContext(TX);
+      verify(delegate, timeout(10000)).releaseTransactionContext(TX);
     } finally {
       scheduled.close();
     }
@@ -651,7 +653,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
               return null;
             })
         .when(localDelegate)
-        .releaseContext(any());
+        .releaseTransactionContext(any());
     ActiveTransactionManagedTwoPhaseCommitCoordinator capped =
         new ActiveTransactionManagedTwoPhaseCommitCoordinator(
             localDelegate, /* expirationTimeMillis= */ -1, /* maxActiveTransactions= */ 1);
@@ -671,7 +673,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
         TimeUnit.MILLISECONDS.sleep(50);
       }
 
-      verify(localDelegate, atLeastOnce()).releaseContext(any());
+      verify(localDelegate, atLeastOnce()).releaseTransactionContext(any());
       verify(participant, never()).hasTransactionContext(any());
     } finally {
       capped.close();

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -78,7 +78,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
 
     verify(delegate).join(TX, false, Collections.emptyMap());
     // After the idle expiration, the reaper releases the context on the wrapped participant.
-    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext(TX);
   }
 
   @Test
@@ -87,12 +87,14 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     // not-found channel (the contract's alternative carrier of "there was no context to
     // release"); the disposal path tolerates it, and the reaper keeps collecting other
     // transactions.
-    doThrow(new TransactionNotFoundException("already gone", TX)).when(delegate).releaseContext(TX);
+    doThrow(new TransactionNotFoundException("already gone", TX))
+        .when(delegate)
+        .releaseTransactionContext(TX);
     participant.join(TX, false, Collections.emptyMap());
     participant.join("tx-2", false, Collections.emptyMap());
 
-    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
-    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext("tx-2");
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext(TX);
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext("tx-2");
   }
 
   @Test
@@ -205,7 +207,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     // prepareRecords is this participant's terminal step, so the entry is removed now: the reaper
     // never releases the context (and logs no spurious expiry warning).
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -218,7 +220,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     participant.validateRecords(TX); // terminal step for a write-less, validating participant
 
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -231,7 +233,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     participant.commitRecords(TX, 1L); // terminal step
 
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -244,7 +246,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     participant.rollbackRecords(TX);
 
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -264,9 +266,10 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     // rollbackRecords owns cleanup). With no rollback driven here, the entry survives, so the
     // reaper
     // still releases the context. This distinguishes "not removed on failure" from "removed": had
-    // the failure wrongly removed the entry, releaseContext would never fire and this would time
+    // the failure wrongly removed the entry, releaseTransactionContext would never fire and this
+    // would time
     // out.
-    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext(TX);
   }
 
   @Test
@@ -286,7 +289,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     // rollbackRecords is driven, which removes the entry. The reaper must then not release it.
     participant.rollbackRecords(TX);
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -298,7 +301,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     verify(delegate).commitRecords(TX, 1L);
     // The transaction is no longer tracked, so the reaper must not release its context.
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -309,7 +312,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
 
     verify(delegate).rollbackRecords(TX);
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -326,7 +329,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     // The finally block deregistered the transaction even though commitRecords threw, so the
     // reaper must not subsequently release its context (no double reap).
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
@@ -341,18 +344,19 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     }
 
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(TX);
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test
-  void releaseContext_ShouldDelegateOnceAndStopReaping() throws Exception {
+  void releaseTransactionContext_ShouldDelegateOnceAndStopReaping() throws Exception {
     participant.join(TX, false, Collections.emptyMap());
 
-    participant.releaseContext(TX);
+    participant.releaseTransactionContext(TX);
 
-    // The reaper must not call releaseContext again after the client already released it.
+    // The reaper must not call releaseTransactionContext again after the client already released
+    // it.
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate).releaseContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
   }
 
   @Test
@@ -367,7 +371,7 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
 
     // A failed join registered nothing, so the reaper must not release any context.
     Thread.sleep(PAST_SWEEP_MILLIS);
-    verify(delegate, never()).releaseContext(any());
+    verify(delegate, never()).releaseTransactionContext(any());
   }
 
   // Deterministic wiring check (no Thread.sleep): every CRUD and record-level override must refresh

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -25,6 +25,7 @@ import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.Key;
 import java.util.Collections;
@@ -78,6 +79,20 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
     verify(delegate).join(TX, false, Collections.emptyMap());
     // After the idle expiration, the reaper releases the context on the wrapped participant.
     verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+  }
+
+  @Test
+  void join_WhenReleaseThrowsNotFound_ShouldTreatItAsAlreadyGoneAndKeepReaping() throws Exception {
+    // A remote wrapped participant may report the reap's no-op outcome on its conventional
+    // not-found channel (the contract's alternative carrier of "there was no context to
+    // release"); the disposal path tolerates it, and the reaper keeps collecting other
+    // transactions.
+    doThrow(new TransactionNotFoundException("already gone", TX)).when(delegate).releaseContext(TX);
+    participant.join(TX, false, Collections.emptyMap());
+    participant.join("tx-2", false, Collections.emptyMap());
+
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext(TX);
+    verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseContext("tx-2");
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
@@ -18,6 +18,7 @@ import com.scalar.db.api.TwoPhaseCommit;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.io.Key;
 import java.util.Arrays;
 import java.util.Collections;
@@ -312,6 +313,24 @@ class AttributePropagatingTwoPhaseCommitParticipantTest {
     participant.join(TX, false, attrs("k", "v"));
 
     participant.rollbackRecords(TX);
+
+    participant.get(TX, get());
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(delegate).get(eq(TX), captor.capture());
+    assertThat(captor.getValue().getAttributes()).isEmpty();
+  }
+
+  @Test
+  void rollbackRecords_WhenDelegateThrowsNotFound_ShouldPropagateAndStillDropAttributes()
+      throws Exception {
+    // The wrapped participant may report the unknown-transaction no-op on its conventional
+    // not-found channel; this decorator must pass it through untouched (the callers decide what it
+    // means per path) while the finally block still drops the captured attributes.
+    participant.join(TX, false, attrs("k", "v"));
+    doThrow(new TransactionNotFoundException("gone", TX)).when(delegate).rollbackRecords(TX);
+
+    assertThatThrownBy(() -> participant.rollbackRecords(TX))
+        .isInstanceOf(TransactionNotFoundException.class);
 
     participant.get(TX, get());
     ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);

--- a/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipantTest.java
@@ -339,10 +339,10 @@ class AttributePropagatingTwoPhaseCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_ShouldDropTheCapturedAttributes() throws Exception {
+  void releaseTransactionContext_ShouldDropTheCapturedAttributes() throws Exception {
     participant.join(TX, false, attrs("k", "v"));
 
-    participant.releaseContext(TX);
+    participant.releaseTransactionContext(TX);
 
     participant.get(TX, get());
     ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
@@ -54,7 +54,7 @@ class DecoratedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void releaseContext_ShouldDelegate() {
+  void releaseContext_ShouldDelegate() throws Exception {
     coordinator.releaseContext(TX);
     verify(delegate).releaseContext(TX);
   }

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
@@ -54,9 +54,9 @@ class DecoratedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void releaseContext_ShouldDelegate() throws Exception {
-    coordinator.releaseContext(TX);
-    verify(delegate).releaseContext(TX);
+  void releaseTransactionContext_ShouldDelegate() throws Exception {
+    coordinator.releaseTransactionContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
@@ -107,7 +107,7 @@ class DecoratedTwoPhaseCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_ShouldDelegate() {
+  void releaseContext_ShouldDelegate() throws Exception {
     participant.releaseContext(TX);
     verify(delegate).releaseContext(TX);
   }

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitParticipantTest.java
@@ -107,9 +107,9 @@ class DecoratedTwoPhaseCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_ShouldDelegate() throws Exception {
-    participant.releaseContext(TX);
-    verify(delegate).releaseContext(TX);
+  void releaseTransactionContext_ShouldDelegate() throws Exception {
+    participant.releaseTransactionContext(TX);
+    verify(delegate).releaseTransactionContext(TX);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -505,14 +505,14 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void releaseContext_ShouldReleaseContextWithoutDrivingParticipantsOrWritingState()
+  void releaseTransactionContext_ShouldReleaseContextWithoutDrivingParticipantsOrWritingState()
       throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     Participant participant = registeredWritingParticipant("tx-1", "participant-1");
 
     // Act
-    consensusCommitCoordinator.releaseContext("tx-1");
+    consensusCommitCoordinator.releaseTransactionContext("tx-1");
 
     // Assert — reap-only terminal: the participant is NOT contacted (role-local), no Coordinator
     // state row is written, and the context is released so a subsequent commit no longer knows the
@@ -526,9 +526,9 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void releaseContext_UnknownTransaction_ShouldBeNoOp() throws Exception {
+  void releaseTransactionContext_UnknownTransaction_ShouldBeNoOp() throws Exception {
     // Releasing a transaction never begun (or already finished) is a lenient no-op.
-    consensusCommitCoordinator.releaseContext("unknown");
+    consensusCommitCoordinator.releaseTransactionContext("unknown");
     verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
     verify(coordinatorCommitHandler, never()).commitState(anyString(), any());
   }
@@ -565,14 +565,14 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void releaseContext_AfterCommit_ShouldBeNoOp() throws Exception {
+  void releaseTransactionContext_AfterCommit_ShouldBeNoOp() throws Exception {
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     consensusCommitCoordinator.commit("tx-1");
 
     // Releasing the context of an already-committed (released) transaction is a lenient no-op: the
     // context was already discarded by commit, so there is nothing to release and no abort is
     // written.
-    consensusCommitCoordinator.releaseContext("tx-1");
+    consensusCommitCoordinator.releaseTransactionContext("tx-1");
     verify(coordinatorCommitHandler, never()).abortState(anyString(), any());
   }
 
@@ -900,7 +900,7 @@ class ConsensusCommitCoordinatorTest {
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
     verify(p1, never()).rollbackRecords(anyString());
-    verify(p1).releaseContext("tx-1");
+    verify(p1).releaseTransactionContext("tx-1");
   }
 
   @Test
@@ -927,8 +927,8 @@ class ConsensusCommitCoordinatorTest {
         .isInstanceOf(UnknownTransactionStatusException.class);
     verify(p1, never()).rollbackRecords(anyString());
     verify(p2, never()).rollbackRecords(anyString());
-    verify(p1).releaseContext("tx-1");
-    verify(p2).releaseContext("tx-1");
+    verify(p1).releaseTransactionContext("tx-1");
+    verify(p2).releaseTransactionContext("tx-1");
   }
 
   @Test
@@ -946,14 +946,16 @@ class ConsensusCommitCoordinatorTest {
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .abortState(anyString(), any());
-    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+    doThrow(new TransactionException("unreachable", "tx-1"))
+        .when(p1)
+        .releaseTransactionContext("tx-1");
 
     // Act Assert — the release is best-effort per participant on this path too: the first failure
     // neither masks the unknown status nor stops the second participant's release, and the records
     // are still not rolled back on either participant.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
-    verify(p2).releaseContext("tx-1");
+    verify(p2).releaseTransactionContext("tx-1");
     verify(p1, never()).rollbackRecords(anyString());
     verify(p2, never()).rollbackRecords(anyString());
   }
@@ -972,12 +974,13 @@ class ConsensusCommitCoordinatorTest {
     // back: they stay PREPARED for lazy recovery to resolve against the Coordinator state row
     // (COMMITTED row -> roll-forward; no row -> abort after the transaction lifetime). The
     // participant's in-memory context is released promptly: commit is terminal on every outcome,
-    // so nothing can ever drive the participant again, and releaseContext touches no storage.
+    // so nothing can ever drive the participant again, and releaseTransactionContext touches no
+    // storage.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
     verify(p1, never()).commitRecords(anyString(), anyLong());
     verify(p1, never()).rollbackRecords(anyString());
-    verify(p1).releaseContext("tx-1");
+    verify(p1).releaseTransactionContext("tx-1");
 
     // The Coordinator context is released too (commit is terminal): a retried commit is rejected
     // as unknown.
@@ -986,17 +989,20 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void commit_WhenCommitStateWriteFailsUnknownAndReleaseContextFails_ShouldStillPropagateUnknown()
-      throws Exception {
-    // Arrange — the participant's releaseContext itself fails (e.g. an unreachable remote
-    // participant, which is likely correlated with the coordinator-table trouble that caused the
-    // unknown status in the first place).
+  void
+      commit_WhenCommitStateWriteFailsUnknownAndReleaseTransactionContextFails_ShouldStillPropagateUnknown()
+          throws Exception {
+    // Arrange — the participant's releaseTransactionContext itself fails (e.g. an unreachable
+    // remote participant, which is likely correlated with the coordinator-table trouble that
+    // caused the unknown status in the first place).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
-    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+    doThrow(new TransactionException("unreachable", "tx-1"))
+        .when(p1)
+        .releaseTransactionContext("tx-1");
 
     // Act Assert — the release is best-effort: its failure must not mask the unknown status (the
     // participant's context is then reclaimed by its own idle reaping).
@@ -1022,8 +1028,8 @@ class ConsensusCommitCoordinatorTest {
     // scoping).
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
-    verify(writer).releaseContext("tx-1");
-    verify(writeLess, never()).releaseContext(anyString());
+    verify(writer).releaseTransactionContext("tx-1");
+    verify(writeLess, never()).releaseTransactionContext(anyString());
   }
 
   @Test
@@ -1038,13 +1044,15 @@ class ConsensusCommitCoordinatorTest {
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
-    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+    doThrow(new TransactionException("unreachable", "tx-1"))
+        .when(p1)
+        .releaseTransactionContext("tx-1");
 
     // Act Assert — the release is best-effort per participant: the first failure neither masks the
     // unknown status nor stops the second participant's release.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
-    verify(p2).releaseContext("tx-1");
+    verify(p2).releaseTransactionContext("tx-1");
     verify(p1, never()).commitRecords(anyString(), anyLong());
     verify(p2, never()).commitRecords(anyString(), anyLong());
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -859,6 +859,25 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
+  void rollback_WhenParticipantReportsNotFound_ShouldTreatAsBenignNoOpAndRollBackOthers()
+      throws Exception {
+    // Arrange — the first participant reports the unknown transaction on its conventional
+    // not-found channel (typical for a remote participant that already self-released or was
+    // idle-reaped), which the contract defines as an alternative carrier of the no-op outcome.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new TransactionNotFoundException("gone", "tx-1")).when(p1).rollbackRecords("tx-1");
+
+    // Act — the rollback completes normally; the not-found is treated exactly like a no-op return.
+    consensusCommitCoordinator.rollback("tx-1");
+
+    // Assert — every participant is still driven.
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
+  }
+
+  @Test
   void commit_WhenAbortStateWriteFailsUnknown_ShouldPropagateUnknownStatusAndNotRollBack()
       throws Exception {
     // Arrange — prepare fails, and writing the ABORTED state genuinely fails with unknown status
@@ -876,9 +895,158 @@ class ConsensusCommitCoordinatorTest {
     // Act Assert — the ABORTED write's unknown status surfaces (not the retryable prepare
     // conflict), and records are NOT rolled back: the Coordinator state is the source of truth, so
     // lazy recovery reconciles later. Mirrors CommitHandler#abortStateAndRollbackRecordsIfNeeded.
+    // The participant's in-memory context, however, is released: commit is terminal on every
+    // outcome, so nothing can ever drive the participant again.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(UnknownTransactionStatusException.class);
     verify(p1, never()).rollbackRecords(anyString());
+    verify(p1).releaseContext("tx-1");
+  }
+
+  @Test
+  void commit_TwoParticipants_WhenAbortStateWriteFailsUnknown_ShouldReleaseBothContexts()
+      throws Exception {
+    // Arrange — the first participant's prepare fails, driving the internal abort path, and the
+    // ABORTED-state write fails with unknown status. Both participants are registered, so the
+    // abort path holds a context for each.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new PreparationConflictException("conflict", "tx-1"))
+        .when(p1)
+        .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .abortState(anyString(), any());
+
+    // Act Assert — the unknown status surfaces, records are not rolled back on either participant,
+    // and the abort path releases every registered participant's context (unlike the commit-state
+    // path's toCommit scoping, a participant that never prepared still holds an ACTIVE context
+    // here).
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(p1, never()).rollbackRecords(anyString());
+    verify(p2, never()).rollbackRecords(anyString());
+    verify(p1).releaseContext("tx-1");
+    verify(p2).releaseContext("tx-1");
+  }
+
+  @Test
+  void
+      commit_TwoParticipants_WhenAbortStateWriteFailsUnknownAndFirstReleaseFails_ShouldStillReleaseSecond()
+          throws Exception {
+    // Arrange — the internal abort path with an unknown-status ABORTED write, and the first
+    // participant's release itself fails.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredParticipant("tx-1", "participant-1");
+    Participant p2 = registeredParticipant("tx-1", "participant-2");
+    doThrow(new PreparationConflictException("conflict", "tx-1"))
+        .when(p1)
+        .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .abortState(anyString(), any());
+    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+
+    // Act Assert — the release is best-effort per participant on this path too: the first failure
+    // neither masks the unknown status nor stops the second participant's release, and the records
+    // are still not rolled back on either participant.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(p2).releaseContext("tx-1");
+    verify(p1, never()).rollbackRecords(anyString());
+    verify(p2, never()).rollbackRecords(anyString());
+  }
+
+  @Test
+  void commit_WhenCommitStateWriteFailsUnknown_ShouldPropagateUnknownStatusAndReleaseContexts()
+      throws Exception {
+    // Arrange — a writing participant, and the COMMITTED state write fails with unknown status.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+
+    // Act Assert — the unknown status surfaces, and the records are neither committed nor rolled
+    // back: they stay PREPARED for lazy recovery to resolve against the Coordinator state row
+    // (COMMITTED row -> roll-forward; no row -> abort after the transaction lifetime). The
+    // participant's in-memory context is released promptly: commit is terminal on every outcome,
+    // so nothing can ever drive the participant again, and releaseContext touches no storage.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(p1, never()).commitRecords(anyString(), anyLong());
+    verify(p1, never()).rollbackRecords(anyString());
+    verify(p1).releaseContext("tx-1");
+
+    // The Coordinator context is released too (commit is terminal): a retried commit is rejected
+    // as unknown.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  void commit_WhenCommitStateWriteFailsUnknownAndReleaseContextFails_ShouldStillPropagateUnknown()
+      throws Exception {
+    // Arrange — the participant's releaseContext itself fails (e.g. an unreachable remote
+    // participant, which is likely correlated with the coordinator-table trouble that caused the
+    // unknown status in the first place).
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+
+    // Act Assert — the release is best-effort: its failure must not mask the unknown status (the
+    // participant's context is then reclaimed by its own idle reaping).
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+  }
+
+  @Test
+  void commit_WhenCommitStateWriteFailsUnknown_ShouldReleaseOnlyWritingParticipants()
+      throws Exception {
+    // Arrange — a writer and a write-less participant; the COMMITTED-state write fails with
+    // unknown status. The write-less participant already self-released at prepareRecords, so only
+    // toCommit (the writer) still holds a context.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant writer = registeredWritingParticipant("tx-1", "participant-1");
+    Participant writeLess = registeredParticipant("tx-1", "participant-2");
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+
+    // Act Assert — the unknown status surfaces, and only the writing participant is released; the
+    // self-released one is left untouched (mirroring the CommitConflictException path's rollback
+    // scoping).
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(writer).releaseContext("tx-1");
+    verify(writeLess, never()).releaseContext(anyString());
+  }
+
+  @Test
+  void
+      commit_TwoParticipants_WhenCommitStateWriteFailsUnknownAndFirstReleaseFails_ShouldStillReleaseSecond()
+          throws Exception {
+    // Arrange — two writing participants; the COMMITTED-state write fails with unknown status and
+    // the first participant's release itself fails.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
+    Participant p2 = registeredWritingParticipant("tx-1", "participant-2");
+    doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
+        .when(coordinatorCommitHandler)
+        .commitState(anyString(), any());
+    doThrow(new TransactionException("unreachable", "tx-1")).when(p1).releaseContext("tx-1");
+
+    // Act Assert — the release is best-effort per participant: the first failure neither masks the
+    // unknown status nor stops the second participant's release.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(UnknownTransactionStatusException.class);
+    verify(p2).releaseContext("tx-1");
+    verify(p1, never()).commitRecords(anyString(), anyLong());
+    verify(p2, never()).commitRecords(anyString(), anyLong());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
@@ -100,7 +100,7 @@ class ConsensusCommitParticipantTest {
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
     assertThat(participant.hasTransactionContext(ANY_TX_ID)).isTrue();
 
-    participant.releaseContext(ANY_TX_ID);
+    participant.releaseTransactionContext(ANY_TX_ID);
     assertThat(participant.hasTransactionContext(ANY_TX_ID)).isFalse();
   }
 
@@ -890,11 +890,12 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_WhenPrepared_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+  void releaseTransactionContext_WhenPrepared_ShouldReleaseContextWithoutStorageRollback()
+      throws Exception {
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
     prepare(ANY_TX_ID);
 
-    participant.releaseContext(ANY_TX_ID);
+    participant.releaseTransactionContext(ANY_TX_ID);
 
     // Reap-only terminal: even though the transaction is PREPARED, the records are NOT rolled back
     // in storage (lazy recovery reconciles them); only the in-memory context is released.
@@ -905,13 +906,14 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_WhenValidated_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+  void releaseTransactionContext_WhenValidated_ShouldReleaseContextWithoutStorageRollback()
+      throws Exception {
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
     prepare(ANY_TX_ID);
     doNothing().when(commit).validateRecords(any(TransactionContext.class));
     participant.validateRecords(ANY_TX_ID);
 
-    participant.releaseContext(ANY_TX_ID);
+    participant.releaseTransactionContext(ANY_TX_ID);
 
     // Reap-only terminal: even a VALIDATED (write-bearing, commitRecords not yet driven) context is
     // NOT rolled back in storage — lazy recovery reconciles its PREPARED records; only the
@@ -923,10 +925,11 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_WhenActive_ShouldReleaseContextWithoutStorageRollback() throws Exception {
+  void releaseTransactionContext_WhenActive_ShouldReleaseContextWithoutStorageRollback()
+      throws Exception {
     participant.join(ANY_TX_ID, false, Collections.emptyMap());
 
-    participant.releaseContext(ANY_TX_ID);
+    participant.releaseTransactionContext(ANY_TX_ID);
 
     // Reap-only terminal on an ACTIVE (never prepared) context: only an in-memory snapshot exists,
     // so there is nothing to roll back in storage — the context is simply released.
@@ -937,9 +940,9 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void releaseContext_UnknownTransactionId_ShouldBeNoOp() {
+  void releaseTransactionContext_UnknownTransactionId_ShouldBeNoOp() {
     // An absent context (never joined, or already released) leaves nothing to release: a no-op.
-    participant.releaseContext("unknown-tx");
+    participant.releaseTransactionContext("unknown-tx");
     verify(commit, never()).rollbackRecords(any(TransactionContext.class));
   }
 


### PR DESCRIPTION
## Description

When `ConsensusCommitCoordinator#commit` surfaces an `UnknownTransactionStatusException` — the COMMITTED-state write failed with an unknown outcome (or its conflict-resolution read-back did), or the ABORTED-state write did on an internal abort path — the records must stay PREPARED for lazy recovery to resolve against the Coordinator state row, so neither `commitRecords` nor `rollbackRecords` may run. The participants' in-memory contexts, however, are already unreachable at that point: commit is terminal on every outcome, so nothing can ever drive those participants again. They previously just sat there until each participant's own idle reaping collected them. This PR releases them promptly instead, and completes the exception vocabulary of the context-releasing paths (including the `releaseContext` → `releaseTransactionContext` rename deferred from #3708).

## Related issues and/or PRs

- #3664 (where `rollbackRecords`' `TransactionNotFoundException` declaration was removed; this PR restores it under redefined semantics — see below)

## Changes made

- Both unknown-status paths in `ConsensusCommitCoordinator#commit` now drive a best-effort `Participant#releaseTransactionContext` — the reap-only terminal that touches no storage — before rethrowing: the commit-state path releases the participants that still hold a context (`toCommit`; write-less participants already self-released), and the abort path releases every registered participant (a participant that never prepared still holds an ACTIVE context there). The durable story is unchanged: PREPARED records are still reconciled by lazy recovery, and a failed release just falls back to the participant's own idle reaping (logged at DEBUG — unlike the record-level best-effort steps, nothing is left locked).
- Declare `throws TransactionNotFoundException, TransactionException` on both `TwoPhaseCommit` `releaseTransactionContext` methods, in line with the rest of the interface: a remote implementation surfaces transport faults through the declared exception and may surface the unknown-transaction no-op through its conventional not-found error mapping — `TransactionNotFoundException` as an alternative carrier of "there was no context to release", which callers treat exactly like a normal return. A time-bounded requirement is documented on the participant side (the release can now run while a client awaits commit's terminal outcome). The in-process implementations remain lenient no-ops.
- Restore `throws TransactionNotFoundException` on `Participant#rollbackRecords`. It was removed in #3664 because the abort path rolls back every participant uniformly, and a self-released participant reporting not-found *as an error* would have produced a spurious records-left-PREPARED WARN on every such abort. That argument was against not-found as an error; redefining it as the documented no-op's alternative carrier — with the best-effort caller explicitly quiet about it — restores the declaration without the spurious logs, and lets a remote participant's conventional error mapping work unmodified instead of requiring a swallow-not-found special case.
- Every reap-style caller treats `TransactionNotFoundException` as the benign outcome it wanted: the coordinator-side sweep's release, both `ActiveTransactionRegistry` disposal paths (participant idle-reap and coordinator cap-eviction), and the new unknown-status release.
- Rename `releaseContext` → `releaseTransactionContext` on both roles (interface, implementations, decorators, callers, tests, Javadoc), aligning the context-releasing terminal with `hasTransactionContext`. Kept as a separate, purely mechanical commit for reviewability.
- Tests: the commit-state and abort-path unknown-status scenarios (release scoping per path, no commit/rollback of records, retried commit rejected as unknown, a failing release neither masking the unknown status nor stopping other releases), not-found tolerance on every reap path, and `rollbackRecords` treating not-found as a benign no-op while still rolling back the other participants.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This PR is two commits by design: the behavior/contract change, then the mechanical rename. Reviewing them separately is recommended.
- The interface-wide rule after this PR: "definitely no context" may always arrive as `TransactionNotFoundException`, and each caller interprets it per path — the probe reads it as *absent*, `releaseTransactionContext` / `rollbackRecords` read it as a *benign no-op*, prepare/validate read it as an *abort trigger*, and `commitRecords` absorbs it best-effort. A remote implementation can therefore use one conventional not-found mapping for every method.
- A remote implementation of these interfaces (out of scope for this PR) can adopt the renamed methods and signatures as-is, should apply the same not-found tolerance in its own reap-style callers, and must bound the remote release with a deadline per the new Javadoc contract.

## Release notes

N/A
