### PR TITLE
Fix fat jar build failures by enabling zip64 and stop publishing the Data Loader Core fat jar

### DIFF
--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -35,6 +35,8 @@ shadowJar {
         attributes 'Main-Class': 'com.scalar.db.dataloader.cli.DataLoaderCli'
     }
     mergeServiceFiles()
+    // The fat jar contains more than 65535 entries, which requires the zip64 extension
+    zip64 = true
 }
 
 spotless {

--- a/data-loader/core/build.gradle
+++ b/data-loader/core/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'net.ltgt.errorprone' version "${errorpronePluginVersion}"
-    id 'com.github.johnrengelman.shadow' version "${shadowPluginVersion}"
     id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
     id 'maven-publish'
     id 'base'

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -64,6 +64,8 @@ shadowJar {
         attributes 'Main-Class': 'com.scalar.db.schemaloader.SchemaLoader'
     }
     mergeServiceFiles()
+    // The fat jar contains more than 65535 entries, which requires the zip64 extension
+    zip64 = true
 }
 
 spotless {


### PR DESCRIPTION
## Description

The `Release SNAPSHOT` workflow on the `master` branch is failing ([failed run](https://github.com/scalar-labs/scalardb/actions/runs/29238012632)) with the following error:

```
Execution failed for task ':data-loader:data-loader-core:shadowJar'.
> org.apache.tools.zip.Zip64RequiredException: archive contains more than 65535 entries.
```

The dependency updates in #3694 (mainly the AWS SDK BOM and `google-cloud-*` bumps) pushed the fat jars over the 65,535-entry limit of the standard ZIP format. Building archives beyond this limit requires the zip64 extension.

While investigating, we also found that the fat jar of Data Loader Core has been unintentionally published to Maven Central (as `scalardb-data-loader-core-*-all.jar`) since 3.16.0. #2736 originally added a guard to avoid publishing it, but #2742 accidentally removed the guard. Since the Shadow plugin automatically registers the `shadowRuntimeElements` variant on `components.java`, applying the plugin was enough to make `./gradlew publish` build and publish the fat jar, which is why the release workflow hit this error. The fat jar of Data Loader Core is not needed in the first place, so this PR stops building and publishing it altogether.

Note that the fat jars of Schema Loader and Data Loader CLI also exceed the 65,535-entry limit now. Their `shadowJar` tasks are skipped during `publish`, so the release workflow didn't hit them, but Docker image builds and release artifact uploads would fail with the same error.

## Related issues and/or PRs

- Related to #3694 (the dependency updates that pushed the fat jars over the limit)
- Related to #2736 (originally avoided publishing the Data Loader Core fat jar)
- Related to #2742 (accidentally removed the guard above)

## Changes made

- Removed the Shadow plugin from `data-loader/core/build.gradle` so that the unneeded fat jar of Data Loader Core is no longer built or published.
- Enabled the zip64 extension for the `shadowJar` tasks of Data Loader CLI and Schema Loader, whose fat jars now contain more than 65,535 entries (69,784 and 69,315 entries, respectively).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Verified locally:

- `./gradlew publish` (the command that failed in the release workflow) succeeds, and the Data Loader Core publication no longer contains the `-all.jar` file or the `shadowRuntimeElements` variant in the Gradle module metadata.
- `./gradlew :data-loader:cli:shadowJar :schema-loader:shadowJar` succeeds with zip64 enabled.
- A zip64 fat jar runs fine on JDK 8 (`java -jar scalardb-schema-loader-*.jar`).

Starting with the next release, `scalardb-data-loader-core-*-all.jar` will no longer be published to Maven Central. Please keep this in mind when backporting this change.

## Release notes

N/A
