### PR TITLE
Add a disposal-handler constructor to the two-phase commit participant reaper

### DIFF
--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -43,6 +43,18 @@ import javax.annotation.concurrent.ThreadSafe;
  * traverses the inner decorators via {@code releaseTransactionContext}. It is the participant-side
  * counterpart of {@link ActiveTransactionManagedTwoPhaseCommitCoordinator}.
  *
+ * <p>By default the reaper releases the context by calling {@link
+ * TwoPhaseCommit.Participant#releaseTransactionContext} directly on the wrapped participant. An
+ * embedder that interposes a cross-cutting decorator between this decorator and the wrapped
+ * participant — for example, an authorization decorator that credential-checks every call — may
+ * need that reap-driven release to run in a different execution context than a normal caller-driven
+ * one, because the reaper runs on an internal timer thread that carries no caller credentials. The
+ * {@linkplain #ActiveTransactionManagedTwoPhaseCommitParticipant(TwoPhaseCommit.Participant, long,
+ * int, ActiveTransactionRegistry.DisposalHandler) disposal-handler constructor} lets such an
+ * embedder substitute the reap-driven release action (e.g. wrap it in a privileged mode) while
+ * leaving every other path untouched. This mirrors the seam {@link
+ * ActiveTransactionManagedDistributedTransactionManager} already exposes for its 1PC reaper.
+ *
  * <p>A write-less participant does not always reach {@link #commitRecords}: the Coordinator skips
  * the steps a participant no longer needs, so for such a participant the last driven step is {@link
  * #prepareRecords} (when no validation is required) or {@link #validateRecords} (when it is). To
@@ -75,27 +87,65 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
 
   private final ActiveTransactionRegistry<TrackedTransaction> registry;
 
+  /**
+   * Creates a decorator whose reaper releases each inactive transaction's context directly on the
+   * wrapped participant, treating a {@link TransactionNotFoundException} from the release as the
+   * already-released no-op it denotes.
+   *
+   * @param participant the wrapped participant
+   * @param expirationTimeMillis the idle expiration time in milliseconds
+   * @param maxActiveTransactions the maximum number of active transactions to track; non-positive
+   *     means unbounded
+   */
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ActiveTransactionManagedTwoPhaseCommitParticipant(
       TwoPhaseCommit.Participant participant,
       long expirationTimeMillis,
       int maxActiveTransactions) {
+    // The default disposal action releases the wrapped participant's context directly.
+    this(
+        participant,
+        expirationTimeMillis,
+        maxActiveTransactions,
+        transactionId -> releaseTransactionContextQuietly(participant, transactionId));
+  }
+
+  /**
+   * Creates a decorator whose reaper disposes of an inactive transaction by invoking {@code
+   * disposalHandler} with the transaction ID, instead of releasing the context directly on the
+   * wrapped participant.
+   *
+   * <p>Use this when the reap-driven release must run in a special execution context — for example,
+   * when a cross-cutting decorator between this decorator and the wrapped participant would reject
+   * a call made from the credential-less reaper thread, so the embedder needs to wrap the release
+   * in a privileged mode (see the class documentation). The handler is invoked for both idle expiry
+   * and cap eviction, and it fully replaces the default action: the embedder performs the actual
+   * release itself (typically {@code participant.releaseTransactionContext(transactionId)}) and, if
+   * its wrapped participant can report an already-released context as a {@link
+   * TransactionNotFoundException}, is responsible for treating that as the benign no-op it denotes.
+   *
+   * @param participant the wrapped participant
+   * @param expirationTimeMillis the idle expiration time in milliseconds
+   * @param maxActiveTransactions the maximum number of active transactions to track; non-positive
+   *     means unbounded
+   * @param disposalHandler invoked with the transaction ID when a tracked transaction is reaped
+   *     (idle expiry or cap eviction), replacing the default release on the wrapped participant
+   */
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ActiveTransactionManagedTwoPhaseCommitParticipant(
+      TwoPhaseCommit.Participant participant,
+      long expirationTimeMillis,
+      int maxActiveTransactions,
+      ActiveTransactionRegistry.DisposalHandler<String> disposalHandler) {
     super(participant);
     // The registry stores a small per-transaction entry carrying the transaction ID and the
-    // terminal-at-validate flag; on expiry or eviction it is handed back so we can release the
-    // corresponding context on the wrapped participant.
+    // terminal-at-validate flag; on expiry or eviction it is handed back so the disposal handler
+    // can release the corresponding context, keyed by transaction ID.
     this.registry =
         new ActiveTransactionRegistry<>(
             expirationTimeMillis,
             maxActiveTransactions,
-            tracked -> {
-              try {
-                participant.releaseTransactionContext(tracked.transactionId);
-              } catch (TransactionNotFoundException e) {
-                // The context is already gone — the outcome this release wanted; not-found is its
-                // alternative carrier (see the interface Javadoc).
-              }
-            });
+            tracked -> disposalHandler.onDisposed(tracked.transactionId));
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -105,6 +155,16 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
       ActiveTransactionRegistry<TrackedTransaction> registry) {
     super(participant);
     this.registry = registry;
+  }
+
+  private static void releaseTransactionContextQuietly(
+      TwoPhaseCommit.Participant participant, String transactionId) throws TransactionException {
+    try {
+      participant.releaseTransactionContext(transactionId);
+    } catch (TransactionNotFoundException e) {
+      // The context is already gone — the outcome this release wanted; not-found is its
+      // alternative carrier (see the interface Javadoc).
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipant.java
@@ -51,9 +51,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * one, because the reaper runs on an internal timer thread that carries no caller credentials. The
  * {@linkplain #ActiveTransactionManagedTwoPhaseCommitParticipant(TwoPhaseCommit.Participant, long,
  * int, ActiveTransactionRegistry.DisposalHandler) disposal-handler constructor} lets such an
- * embedder substitute the reap-driven release action (e.g. wrap it in a privileged mode) while
- * leaving every other path untouched. This mirrors the seam {@link
- * ActiveTransactionManagedDistributedTransactionManager} already exposes for its 1PC reaper.
+ * embedder substitute the reap-driven release action — typically by wrapping {@link
+ * #defaultDisposalHandler} in a privileged mode — while leaving every other path untouched. This
+ * mirrors the seam {@link ActiveTransactionManagedDistributedTransactionManager} already exposes
+ * for its 1PC reaper.
  *
  * <p>A write-less participant does not always reach {@link #commitRecords}: the Coordinator skips
  * the steps a participant no longer needs, so for such a participant the last driven step is {@link
@@ -102,12 +103,11 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
       TwoPhaseCommit.Participant participant,
       long expirationTimeMillis,
       int maxActiveTransactions) {
-    // The default disposal action releases the wrapped participant's context directly.
     this(
         participant,
         expirationTimeMillis,
         maxActiveTransactions,
-        transactionId -> releaseTransactionContextQuietly(participant, transactionId));
+        defaultDisposalHandler(participant));
   }
 
   /**
@@ -119,10 +119,9 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
    * when a cross-cutting decorator between this decorator and the wrapped participant would reject
    * a call made from the credential-less reaper thread, so the embedder needs to wrap the release
    * in a privileged mode (see the class documentation). The handler is invoked for both idle expiry
-   * and cap eviction, and it fully replaces the default action: the embedder performs the actual
-   * release itself (typically {@code participant.releaseTransactionContext(transactionId)}) and, if
-   * its wrapped participant can report an already-released context as a {@link
-   * TransactionNotFoundException}, is responsible for treating that as the benign no-op it denotes.
+   * and cap eviction, and it fully replaces the default action: an embedder that still wants the
+   * default release semantics composes {@link #defaultDisposalHandler} inside its wrapper rather
+   * than re-implementing the release and its not-found handling.
    *
    * @param participant the wrapped participant
    * @param expirationTimeMillis the idle expiration time in milliseconds
@@ -157,14 +156,30 @@ public class ActiveTransactionManagedTwoPhaseCommitParticipant
     this.registry = registry;
   }
 
-  private static void releaseTransactionContextQuietly(
-      TwoPhaseCommit.Participant participant, String transactionId) throws TransactionException {
-    try {
-      participant.releaseTransactionContext(transactionId);
-    } catch (TransactionNotFoundException e) {
-      // The context is already gone — the outcome this release wanted; not-found is its
-      // alternative carrier (see the interface Javadoc).
-    }
+  /**
+   * Returns the disposal handler the default constructor reaps with: it releases the transaction's
+   * context directly on {@code participant}, treating a {@link TransactionNotFoundException} from
+   * the release as the already-released no-op it denotes.
+   *
+   * <p>An embedder supplying its own handler to the {@linkplain
+   * #ActiveTransactionManagedTwoPhaseCommitParticipant(TwoPhaseCommit.Participant, long, int,
+   * ActiveTransactionRegistry.DisposalHandler) disposal-handler constructor} typically composes
+   * this handler inside its wrapper (e.g. invokes it in a privileged mode) rather than
+   * re-implementing the release and its not-found handling.
+   *
+   * @param participant the participant to release contexts on
+   * @return the disposal handler used by the default constructor
+   */
+  public static ActiveTransactionRegistry.DisposalHandler<String> defaultDisposalHandler(
+      TwoPhaseCommit.Participant participant) {
+    return transactionId -> {
+      try {
+        participant.releaseTransactionContext(transactionId);
+      } catch (TransactionNotFoundException e) {
+        // The context is already gone — the outcome this release wanted; not-found is its
+        // alternative carrier (see the interface Javadoc).
+      }
+    };
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -30,6 +30,9 @@ import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.Key;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -95,6 +98,33 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
 
     verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext(TX);
     verify(delegate, timeout(PAST_SWEEP_MILLIS * 4)).releaseTransactionContext("tx-2");
+  }
+
+  @Test
+  void disposalHandler_OnIdleExpiry_ShouldInvokeHandlerWithTransactionId_NotDefaultRelease()
+      throws Exception {
+    // The privileged-reap seam: when a disposal handler is supplied, the reaper invokes it with the
+    // transaction ID instead of releasing the context on the wrapped participant itself, so an
+    // embedder can run the release in its own execution context (e.g. a privileged mode).
+    CountDownLatch disposed = new CountDownLatch(1);
+    AtomicReference<String> disposedId = new AtomicReference<>();
+    ActiveTransactionManagedTwoPhaseCommitParticipant p =
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(
+            delegate,
+            EXPIRATION_MILLIS,
+            /* maxActiveTransactions= */ -1,
+            transactionId -> {
+              disposedId.set(transactionId);
+              disposed.countDown();
+            });
+
+    p.join(TX, false, Collections.emptyMap());
+
+    assertThat(disposed.await(PAST_SWEEP_MILLIS * 4, TimeUnit.MILLISECONDS)).isTrue();
+    assertThat(disposedId.get()).isEqualTo(TX);
+    // The handler replaced the default action: the reaper does not release the context on the
+    // wrapped participant itself.
+    verify(delegate, never()).releaseTransactionContext(TX);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -168,6 +168,24 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
   }
 
   @Test
+  void defaultDisposalHandler_ShouldReleaseOnParticipant_AndTreatNotFoundAsNoOp() throws Exception {
+    // The publicly composable form of the default reap action: it releases the context on the
+    // given participant and swallows the not-found that denotes an already-released context, so
+    // an embedder wrapping it (e.g. in a privileged mode) inherits both behaviors.
+    ActiveTransactionRegistry.DisposalHandler<String> handler =
+        ActiveTransactionManagedTwoPhaseCommitParticipant.defaultDisposalHandler(delegate);
+
+    handler.onDisposed(TX);
+    verify(delegate).releaseTransactionContext(TX);
+
+    doThrow(new TransactionNotFoundException("already gone", "tx-2"))
+        .when(delegate)
+        .releaseTransactionContext("tx-2");
+    handler.onDisposed("tx-2");
+    verify(delegate).releaseTransactionContext("tx-2");
+  }
+
+  @Test
   void hasTransactionContext_ShouldForwardToDelegateUntouched() throws Exception {
     // Deliberately not overridden: the probe passes through to the wrapped participant so it can
     // never refresh this decorator's idle timer - the quiet contract holds by construction. This

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitParticipantTest.java
@@ -128,6 +128,46 @@ class ActiveTransactionManagedTwoPhaseCommitParticipantTest {
   }
 
   @Test
+  void disposalHandler_OnCapEviction_ShouldInvokeHandlerWithTransactionId_NotDefaultRelease()
+      throws Exception {
+    // The disposal-handler constructor promises the handler fires for cap eviction as well as
+    // idle expiry; this pins the eviction path, so a registry change that routed eviction around
+    // the handler would fail here instead of silently breaking an embedder's privileged reap.
+    // Idle expiration is disabled so only the cap can trigger disposal.
+    CountDownLatch disposed = new CountDownLatch(1);
+    AtomicReference<String> disposedId = new AtomicReference<>();
+    ActiveTransactionManagedTwoPhaseCommitParticipant p =
+        new ActiveTransactionManagedTwoPhaseCommitParticipant(
+            delegate,
+            /* expirationTimeMillis= */ -1,
+            /* maxActiveTransactions= */ 1,
+            transactionId -> {
+              disposedId.set(transactionId);
+              disposed.countDown();
+            });
+
+    p.join(TX, false, Collections.emptyMap());
+    p.join("tx-2", false, Collections.emptyMap());
+
+    // Caffeine decides size-based eviction during maintenance, and maintenance is re-triggered by
+    // cache writes; two racing writes can leave the cache over capacity but quiescent. Poke with
+    // further joins - each a real write and itself over-capacity pressure - while polling, so the
+    // eviction decision is reliably driven (mirroring the coordinator-side cap-eviction test).
+    long deadlineMillis = System.currentTimeMillis() + 10000;
+    int poke = 0;
+    while (disposed.getCount() > 0 && System.currentTimeMillis() < deadlineMillis) {
+      p.join("tx-poke-" + poke++, false, Collections.emptyMap());
+      TimeUnit.MILLISECONDS.sleep(50);
+    }
+
+    assertThat(disposed.await(0, TimeUnit.MILLISECONDS)).isTrue();
+    assertThat(disposedId.get()).isNotNull();
+    // The handler replaced the default action: the evicting reaper does not release the context
+    // on the wrapped participant itself.
+    verify(delegate, never()).releaseTransactionContext(any());
+  }
+
+  @Test
   void hasTransactionContext_ShouldForwardToDelegateUntouched() throws Exception {
     // Deliberately not overridden: the probe passes through to the wrapped participant so it can
     // never refresh this decorator's idle timer - the quiet contract holds by construction. This


### PR DESCRIPTION
## Description

`ActiveTransactionManagedTwoPhaseCommitParticipant`'s idle-expiry reaper releases an abandoned transaction's context by calling `releaseTransactionContext` down the wrapped participant chain, on an internal timer thread that carries no caller credentials. When an embedder interposes a cross-cutting decorator that checks credentials on every call — for example, an authorization decorator — between this decorator and the wrapped participant, that check has no token to see on the reaper thread and rejects the release, so the abandoned context (and its locks) is never reclaimed. The node-local safety-net reaper is silently disabled exactly when it is needed.

The 1PC `ActiveTransactionManagedDistributedTransactionManager` already solves the identical problem by exposing a disposal-handler constructor overload, so an embedder can substitute the reap-driven action and run it in a privileged execution context that bypasses the per-call check. The 2PC participant decorator had no equivalent seam; this PR adds the mirrored overload.

## Related issues and/or PRs

- Mirrors the disposal-handler seam already present on the 1PC `ActiveTransactionManagedDistributedTransactionManager`

## Changes made

- Added a public constructor to `ActiveTransactionManagedTwoPhaseCommitParticipant` that takes an `ActiveTransactionRegistry.DisposalHandler<String>` keyed by transaction ID. When supplied, the reaper invokes it with the transaction ID — for both idle expiry and cap eviction — instead of releasing the context on the wrapped participant itself, so an embedder can wrap the release in its own execution context.
- Kept the existing 3-arg constructor behaviorally unchanged; it is now expressed in terms of the new one, with the default action releasing the wrapped participant's context directly and treating a `TransactionNotFoundException` from it as the already-released no-op it denotes. The handler-supplied path fully replaces that default action, so the embedder owns the release and any not-found tolerance (documented on the constructor).
- The registry entry type stays package-private, so the handler payload is the transaction ID (a `String`) rather than the entry — all the reaper has, and all an embedder needs to close over its own wrapped participant for the release.
- Added a unit test that a supplied disposal handler is invoked with the correct transaction ID on idle expiry and that the default release on the wrapped participant is not called. Backward compatibility of the 3-arg constructor (default release on idle expiry) is covered by the existing reaper test.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This mirrors the 1PC seam exactly: the supplied handler replaces the default reap action (as `DistributedTransaction::rollback` is replaced on the 1PC side), so an embedder gets full control over how the reap-driven release runs.
- The default (no-handler) path is unchanged, so deployments that do not interpose a credential-checking decorator between this decorator and the wrapped participant are unaffected.
- The symmetric `Coordinator` decorator (`ActiveTransactionManagedTwoPhaseCommitCoordinator`) is intentionally not given the same overload: its reaper releases the coordinator's own context and, in the deployments this addresses, does not sit behind a credential-checking decorator, so the seam has no consumer there. It can be added later if that changes.

## Release notes

N/A
