### PR TITLE
Persist the write set on validate-phase aborts in the coordinator

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -211,7 +211,8 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // transaction write-less. The prepare phase is internal to commit(), so the failure is
           // reported as a commit-level exception: a conflict as CommitConflictException so the
           // caller's retry logic still sees it as retriable, anything else as CommitException.
-          abortAndRollbackRecords(transactionId, context.readOnly, participants);
+          abortAndRollbackRecords(
+              transactionId, context.readOnly, /* writeSetsByParticipant= */ null, participants);
           if (e instanceof PreparationConflictException) {
             throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
           }
@@ -222,7 +223,8 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // records already PREPARED on the other participants, then surface the
           // TransactionNotFoundException as-is (the facade maps it to a retriable conflict). As
           // above, hasWrites is not trustworthy mid-prepare, so only readOnly counts.
-          abortAndRollbackRecords(transactionId, context.readOnly, participants);
+          abortAndRollbackRecords(
+              transactionId, context.readOnly, /* writeSetsByParticipant= */ null, participants);
           throw e;
         }
 
@@ -237,7 +239,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // abort on the snapshot it owns). The failure is reported as a commit-level exception,
           // mirroring the prepare phase: a conflict as CommitConflictException, anything else as
           // CommitException.
-          abortAndRollbackRecords(transactionId, !hasWrites, participants);
+          abortAndRollbackRecords(transactionId, !hasWrites, writeSetsByParticipant, participants);
           if (e instanceof ValidationConflictException) {
             throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
           }
@@ -245,7 +247,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
         } catch (TransactionNotFoundException e) {
           // A participant no longer knows this transaction while validating. As above, hasWrites
           // is authoritative at this point.
-          abortAndRollbackRecords(transactionId, !hasWrites, participants);
+          abortAndRollbackRecords(transactionId, !hasWrites, writeSetsByParticipant, participants);
           throw e;
         }
 
@@ -361,12 +363,23 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   // For a transaction NOT known write-less, the ABORTED row is written unconditionally: records
   // may be left PREPARED, and writing ABORTED lets lazy recovery abort them on the next read
   // instead of leaving them locked until the transaction lifetime expires.
+  //
+  // writeSetsByParticipant is the aggregated per-participant write set (keys only) to persist on
+  // the ABORTED row, or null to persist none. Only the validate-phase abort paths supply it: by
+  // then every prepareRecords has returned, so the aggregate is complete (the same map the commit
+  // path persists). The prepare-phase paths pass null because a participant may have thrown before
+  // returning its entries, leaving the aggregate incomplete — a partial write set would be worse
+  // than none. This mirrors CommitHandler, which persists the keys-only write set on its own
+  // abort path.
   private void abortAndRollbackRecords(
-      String transactionId, boolean knownWriteLess, List<Participant> participants)
+      String transactionId,
+      boolean knownWriteLess,
+      @Nullable Map<String, List<WriteSetEntry>> writeSetsByParticipant,
+      List<Participant> participants)
       throws UnknownTransactionStatusException {
     if (isCoordinatorStateWriteRequired(!knownWriteLess)) {
       try {
-        abortState(transactionId);
+        abortState(transactionId, writeSetsByParticipant);
       } catch (UnknownTransactionStatusException e) {
         // The ABORTED-state write's outcome is unknown: the records stay PREPARED for lazy
         // recovery (mirroring CommitHandler, records are not rolled back on an unknown abort). The
@@ -461,13 +474,27 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   private long commitState(
       String transactionId, Map<String, List<WriteSetEntry>> writeSetsByParticipant)
       throws CommitConflictException, UnknownTransactionStatusException {
-    WriteSet writeSet = WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant, false);
-    return coordinatorCommitHandler.commitState(transactionId, writeSet);
+    return coordinatorCommitHandler.commitState(
+        transactionId, encodeKeysOnlyWriteSet(writeSetsByParticipant));
   }
 
-  // Writes the ABORTED state row via the Coordinator-side handler. ABORTED rows carry no write set.
-  private void abortState(String transactionId) throws UnknownTransactionStatusException {
-    coordinatorCommitHandler.abortState(transactionId, null);
+  // Writes the ABORTED state row via the Coordinator-side handler, persisting the write set encoded
+  // from writeSetsByParticipant (keys only), or none when null. Mirrors commitState, which likewise
+  // takes the aggregated map and encodes it here. See abortAndRollbackRecords for when a
+  // write set is supplied.
+  private void abortState(
+      String transactionId, @Nullable Map<String, List<WriteSetEntry>> writeSetsByParticipant)
+      throws UnknownTransactionStatusException {
+    WriteSet writeSet =
+        writeSetsByParticipant == null ? null : encodeKeysOnlyWriteSet(writeSetsByParticipant);
+    coordinatorCommitHandler.abortState(transactionId, writeSet);
+  }
+
+  // Keys only (includeColumns=false), matching the KEYS_ONLY detail requested at prepareRecords:
+  // the Coordinator persists which records the transaction touched, not their column values.
+  private static WriteSet encodeKeysOnlyWriteSet(
+      Map<String, List<WriteSetEntry>> writeSetsByParticipant) {
+    return WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant, false);
   }
 
   private void releaseResources(String transactionId) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -474,14 +474,16 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
     return context;
   }
 
-  // Encodes the per-participant write sets and writes the COMMITTED state row via the
-  // Coordinator-side handler, which generates the committedAt and returns it so the records are
-  // committed with the same timestamp.
+  // Writes the COMMITTED state row via the Coordinator-side handler, persisting the write set
+  // encoded from writeSetsByParticipant (keys only), or none when null — the same null tolerance
+  // as abortState, matching the handler's @Nullable contract. The handler generates the
+  // committedAt and returns it so the records are committed with the same timestamp.
   private long commitState(
-      String transactionId, Map<String, List<WriteSetEntry>> writeSetsByParticipant)
+      String transactionId, @Nullable Map<String, List<WriteSetEntry>> writeSetsByParticipant)
       throws CommitConflictException, UnknownTransactionStatusException {
-    return coordinatorCommitHandler.commitState(
-        transactionId, encodeKeysOnlyWriteSet(writeSetsByParticipant));
+    WriteSet writeSet =
+        writeSetsByParticipant == null ? null : encodeKeysOnlyWriteSet(writeSetsByParticipant);
+    return coordinatorCommitHandler.commitState(transactionId, writeSet);
   }
 
   // Writes the ABORTED state row via the Coordinator-side handler, persisting the write set encoded

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -211,8 +211,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // transaction write-less. The prepare phase is internal to commit(), so the failure is
           // reported as a commit-level exception: a conflict as CommitConflictException so the
           // caller's retry logic still sees it as retriable, anything else as CommitException.
-          abortAndRollbackRecords(
-              transactionId, context.readOnly, /* writeSetsByParticipant= */ null, participants);
+          abortAndRollbackRecords(transactionId, context.readOnly, participants);
           if (e instanceof PreparationConflictException) {
             throw new CommitConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
           }
@@ -223,8 +222,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
           // records already PREPARED on the other participants, then surface the
           // TransactionNotFoundException as-is (the facade maps it to a retriable conflict). As
           // above, hasWrites is not trustworthy mid-prepare, so only readOnly counts.
-          abortAndRollbackRecords(
-              transactionId, context.readOnly, /* writeSetsByParticipant= */ null, participants);
+          abortAndRollbackRecords(transactionId, context.readOnly, participants);
           throw e;
         }
 
@@ -365,12 +363,10 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
   // instead of leaving them locked until the transaction lifetime expires.
   //
   // writeSetsByParticipant is the aggregated per-participant write set (keys only) to persist on
-  // the ABORTED row, or null to persist none. Only the validate-phase abort paths supply it: by
-  // then every prepareRecords has returned, so the aggregate is complete (the same map the commit
-  // path persists). The prepare-phase paths pass null because a participant may have thrown before
-  // returning its entries, leaving the aggregate incomplete — a partial write set would be worse
-  // than none. This mirrors CommitHandler, which persists the keys-only write set on its own
-  // abort path.
+  // the ABORTED row, or null to persist none. The validate-phase abort paths call this form with
+  // the complete aggregate — by then every prepareRecords has returned, so it is the same map the
+  // commit path persists — mirroring CommitHandler, which persists the keys-only write set on its
+  // own abort path. The prepare-phase paths use the overload below, which persists none.
   private void abortAndRollbackRecords(
       String transactionId,
       boolean knownWriteLess,
@@ -394,6 +390,16 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommit.Coordinator {
     for (Participant participant : participants) {
       bestEffortRollbackRecords(participant, transactionId);
     }
+  }
+
+  // Prepare-phase form: persists no write set on the ABORTED row. A participant may have thrown
+  // before returning its entries from prepareRecords, leaving the aggregate incomplete, and a
+  // partial write set would be worse than none.
+  private void abortAndRollbackRecords(
+      String transactionId, boolean knownWriteLess, List<Participant> participants)
+      throws UnknownTransactionStatusException {
+    abortAndRollbackRecords(
+        transactionId, knownWriteLess, /* writeSetsByParticipant= */ null, participants);
   }
 
   // The single policy behind both Coordinator state gates: the row (COMMITTED on the

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -327,7 +326,14 @@ class ConsensusCommitCoordinatorTest {
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class)
         .hasCauseInstanceOf(ValidationConflictException.class);
-    verify(coordinatorCommitHandler).abortState(eq("tx-1"), notNull());
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
+    WriteSet writeSet = captor.getValue();
+    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
+    EntryGroup group = writeSet.getEntryGroups(0);
+    assertThat(group.getEntriesList()).hasSize(1);
+    assertThat(group.getEntries(0).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     verify(participant).rollbackRecords("tx-1");
   }
 
@@ -378,7 +384,14 @@ class ConsensusCommitCoordinatorTest {
     // aggregate); the records are rolled back.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(TransactionNotFoundException.class);
-    verify(coordinatorCommitHandler).abortState(eq("tx-1"), notNull());
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
+    WriteSet writeSet = captor.getValue();
+    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
+    EntryGroup group = writeSet.getEntryGroups(0);
+    assertThat(group.getEntriesList()).hasSize(1);
+    assertThat(group.getEntries(0).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     verify(participant).rollbackRecords("tx-1");
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -261,8 +262,7 @@ class ConsensusCommitCoordinatorTest {
   @Test
   void commit_NoWrites_WithWriteOmission_ShouldSkipCommitStateValidateAndCommitRecords()
       throws Exception {
-    // Arrange — coordinator-write omission on read-only is enabled (the production default), and
-    // the
+    // Arrange — coordinator-write omission on read-only is enabled (production default). The
     // participant has no writes and requires no validation (prepareRecords returns an empty write
     // set with isValidationRequired() == false).
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
@@ -322,11 +322,12 @@ class ConsensusCommitCoordinatorTest {
         .validateRecords("tx-1");
 
     // Act Assert — PREPARED records exist (hasWrites is true), so the ABORTED state row is written
-    // for lazy recovery even though the omission is enabled, and the records are rolled back.
+    // for lazy recovery even though the omission is enabled, now carrying the keys-only write set
+    // (validate-phase aborts have the complete aggregate), and the records are rolled back.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class)
         .hasCauseInstanceOf(ValidationConflictException.class);
-    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), notNull());
     verify(participant).rollbackRecords("tx-1");
   }
 
@@ -373,10 +374,11 @@ class ConsensusCommitCoordinatorTest {
 
     // Act Assert — the exception is rethrown as-is, and PREPARED records exist (hasWrites is
     // true), so the ABORTED state row is written for lazy recovery even though the omission is
-    // enabled; the records are rolled back.
+    // enabled, now carrying the keys-only write set (validate-phase aborts have the complete
+    // aggregate); the records are rolled back.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(TransactionNotFoundException.class);
-    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), notNull());
     verify(participant).rollbackRecords("tx-1");
   }
 
@@ -735,11 +737,17 @@ class ConsensusCommitCoordinatorTest {
         .when(p1)
         .validateRecords("tx-1");
 
-    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException.
+    // Act Assert — the validate conflict surfaces as a retriable CommitConflictException. The
+    // ABORTED row is written (omission disabled) and now carries the keys-only write set (empty
+    // here, since the transaction is write-less), mirroring the commit path.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class)
         .hasCauseInstanceOf(ValidationConflictException.class);
-    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
+    // A non-null but empty write set (no entry groups), not null — the write-less validate-phase
+    // abort proves the transaction touched no records, mirroring the write-less commit path.
+    assertThat(captor.getValue().getEntryGroupsList()).isEmpty();
     verify(p1).rollbackRecords("tx-1");
   }
 
@@ -778,12 +786,17 @@ class ConsensusCommitCoordinatorTest {
     doThrow(new ValidationException("validation failed", "tx-1")).when(p1).validateRecords("tx-1");
 
     // Act Assert — a non-conflict validate failure surfaces as a non-retriable CommitException, and
-    // the abort path still runs.
+    // the abort path still runs, writing the ABORTED row with the keys-only write set (empty here,
+    // since the transaction is write-less).
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitException.class)
         .isNotInstanceOf(CommitConflictException.class)
         .hasCauseInstanceOf(ValidationException.class);
-    verify(coordinatorCommitHandler).abortState("tx-1", null);
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
+    // A non-null but empty write set (no entry groups), not null — the write-less validate-phase
+    // abort proves the transaction touched no records, mirroring the write-less commit path.
+    assertThat(captor.getValue().getEntryGroupsList()).isEmpty();
     verify(p1).rollbackRecords("tx-1");
   }
 
@@ -821,8 +834,8 @@ class ConsensusCommitCoordinatorTest {
   void commit_TwoParticipants_WhenCommitRecordsThrowsOnFirst_ShouldStillCommitSecond()
       throws Exception {
     // Arrange — both participants write (so commitRecords is driven on each) and commit
-    // successfully
-    // through prepare/commitState; the first participant's best-effort commitRecords then fails.
+    // successfully through prepare/commitState; the first participant's best-effort commitRecords
+    // then fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
     Participant p1 = registeredWritingParticipant("tx-1", "participant-1");
     Participant p2 = registeredWritingParticipant("tx-1", "participant-2");
@@ -1081,9 +1094,8 @@ class ConsensusCommitCoordinatorTest {
       commit_TwoParticipantsWithWrites_WithWriteOmission_ShouldEncodeWriteSetGroupedByParticipantId()
           throws Exception {
     // Arrange — coordinator-write omission on read-only is enabled, but both participants return a
-    // non-empty write set (hasWrites=true), so the COMMITTED state IS written and the
-    // per-participant
-    // write sets are aggregated and stamped with the owning participant id.
+    // non-empty write set (hasWrites=true), so the COMMITTED state IS written and the write sets
+    // are aggregated per participant and stamped with the owning participant id.
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
@@ -1119,6 +1131,61 @@ class ConsensusCommitCoordinatorTest {
     assertThat(group2.getEntriesList()).hasSize(1);
     assertThat(group2.getEntries(0).getParticipantId()).isEqualTo("participant-2");
     assertThat(group2.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+  }
+
+  @Test
+  void commit_TwoParticipantsWithWrites_WhenValidateFails_ShouldWriteAbortedWithAggregatedWriteSet()
+      throws Exception {
+    // Arrange — two writing participants that both require validation; the second fails validation,
+    // driving the validate-phase abort. By then every prepareRecords has returned, so the
+    // aggregated write set is complete — the same map the commit path would persist.
+    consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap(), null);
+    Participant p1 =
+        registeredParticipant(
+            "tx-1",
+            "participant-1",
+            preparation(
+                Arrays.asList(
+                    writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 1), Optional.empty()),
+                    writeSetEntry(WriteSetEntry.Type.DELETE, Key.ofInt("pk", 2), Optional.empty())),
+                /* validationRequired= */ true));
+    Participant p2 =
+        registeredParticipant(
+            "tx-1",
+            "participant-2",
+            preparation(
+                Arrays.asList(
+                    writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 3), Optional.empty())),
+                /* validationRequired= */ true));
+    doThrow(new ValidationConflictException("validation conflict", "tx-1"))
+        .when(p2)
+        .validateRecords("tx-1");
+
+    // Act Assert — the ABORTED row carries the same participant-grouped, keys-only write set the
+    // commit path encodes (one EntryGroup per participant in registration order), so active
+    // recovery can find the touched records.
+    assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
+        .isInstanceOf(CommitConflictException.class)
+        .hasCauseInstanceOf(ValidationConflictException.class);
+    ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
+    verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
+    WriteSet writeSet = captor.getValue();
+    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+
+    EntryGroup group1 = writeSet.getEntryGroups(0);
+    assertThat(group1.getEntriesList()).hasSize(2);
+    assertThat(group1.getEntries(0).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group1.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+    assertThat(group1.getEntries(1).getParticipantId()).isEqualTo("participant-1");
+    assertThat(group1.getEntries(1).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
+
+    EntryGroup group2 = writeSet.getEntryGroups(1);
+    assertThat(group2.getEntriesList()).hasSize(1);
+    assertThat(group2.getEntries(0).getParticipantId()).isEqualTo("participant-2");
+    assertThat(group2.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+
+    verify(p1).rollbackRecords("tx-1");
+    verify(p2).rollbackRecords("tx-1");
   }
 
   @Test
@@ -1249,8 +1316,7 @@ class ConsensusCommitCoordinatorTest {
   }
 
   // Registers a participant whose prepareRecords returns the given (non-empty) write set, so
-  // commit()
-  // exercises the hasWrites=true aggregation/encoding path.
+  // commit() exercises the hasWrites=true aggregation/encoding path.
   private Participant registeredParticipantWithWrites(
       String transactionId, String participantId, WriteSetEntry... entries) throws Exception {
     Participant participant = mock(Participant.class);
@@ -1265,8 +1331,7 @@ class ConsensusCommitCoordinatorTest {
   }
 
   // A minimal WriteSetEntry stub sufficient for encoding (includeColumns=false, so getColumns is
-  // not
-  // read). The namespace/table are stubbed non-null because the encoder sets them on the proto.
+  // not read). The namespace/table are stubbed non-null because the encoder sets them on the proto.
   private static WriteSetEntry writeSetEntry(
       WriteSetEntry.Type type, Key partitionKey, Optional<Key> clusteringKey) {
     WriteSetEntry entry = mock(WriteSetEntry.class);


### PR DESCRIPTION
## Description

`ConsensusCommitCoordinator` persists the aggregated write set (keys only) on the COMMITTED Coordinator state row, but always wrote the ABORTED state row with no write set — unlike the 1PC `CommitHandler`, which persists the keys-only write set on its abort path too. The write set records which records a transaction touched, so omitting it on abort leaves an active-recovery / write-set-logging consumer without that information for aborted transactions, and leaves the commit and abort paths asymmetric.

The coordinator can supply a *complete* write set only on the validate-phase abort paths: by then every `prepareRecords` has returned, so the aggregate is the same map the commit path persists. On the prepare-phase abort paths a participant may have thrown before returning its entries, leaving the aggregate incomplete — a partial write set would be worse than none — so those keep writing no write set. This PR persists the write set on the validate-phase aborts only.

## Related issues and/or PRs

- Related to #3689, which introduced `WriteSetDetailLevel` and the keys-only write-set persistence on the commit path that this abort path now mirrors

## Changes made

- `abortAndRollbackRecords` now takes the aggregated `writeSetsByParticipant` map (or `null`), mirroring `commitState`, and `abortState` encodes it here just as `commitState` does. The validate-phase callers pass the complete map; the prepare-phase callers pass `null`.
- Extracted the shared keys-only encoding (`encodeKeysOnlyWriteSet`) used by both `commitState` and `abortState`, so the COMMITTED and ABORTED rows are encoded identically.
- A write-less validate-phase abort persists an empty write set when the row is written at all (coordinator-write omission disabled), symmetric with the write-less commit which likewise persists an empty COMMITTED write set.
- Added a test that a two-writer validate-phase abort persists the same participant-grouped, keys-only write set the commit path encodes; updated the validate-phase abort tests to expect the write set — the write-less ones asserting an empty (but non-null) write set. The prepare-phase abort tests still assert no write set is written.
- Tidied a few pre-existing oddly-wrapped comments in the same test file (words stranded on their own line).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Prepare-phase aborts intentionally persist no write set: the aggregate is incomplete there (a participant may have thrown mid-`prepareRecords`), the same reason the existing `hasWrites` value is documented as not trustworthy on those paths.
- The write-less validate-phase abort writing an empty write set is a deliberate symmetry with the write-less commit path (which also encodes an empty write set when the row is written) and with the 1PC `CommitHandler`. If persisting nothing (rather than an empty write set) for write-less aborts is preferred, that is a one-line change (`hasWrites ? map : null`).

## Release notes

N/A
