### PR TITLE
Backport to branch(3.16) : Align repairTable behavior with master

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.scalar.db.api.DistributedStorageAdminRepairTableIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.util.AdminTestUtils;
+import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +24,22 @@ public class CassandraAdminRepairTableIntegrationTest
   @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
+  }
+
+  // Override setUp() to share the ClusterManager between admin and adminTestUtils so that schema
+  // changes made via one are visible to the other. Without sharing, schema metadata propagates
+  // asynchronously across driver sessions and the repair-then-tableExists test sequence becomes
+  // flaky.
+  @Override
+  @BeforeEach
+  protected void setUp() throws Exception {
+    Properties properties = getProperties(TEST_NAME);
+    ClusterManager clusterManager = new ClusterManager(new DatabaseConfig(properties));
+    admin = new CassandraAdmin(clusterManager, new DatabaseConfig(properties));
+    adminTestUtils = new CassandraAdminTestUtils(properties, clusterManager);
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(getNamespace(), options);
+    admin.createTable(getNamespace(), getTable(), getTableMetadata(), options);
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminTestUtils.java
@@ -16,6 +16,11 @@ public class CassandraAdminTestUtils extends AdminTestUtils {
     clusterManager = new ClusterManager(databaseConfig);
   }
 
+  public CassandraAdminTestUtils(Properties properties, ClusterManager clusterManager) {
+    super(properties);
+    this.clusterManager = clusterManager;
+  }
+
   @Override
   public void dropMetadataTable() {
     // Do nothing

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
@@ -34,6 +34,7 @@ public class DynamoSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTe
       Path configFilePath, Path schemaFilePath) {
     return ImmutableList.<String>builder()
         .addAll(super.getCommandArgsForTableReparation(configFilePath, schemaFilePath))
+        .add("--no-scaling")
         .add("--no-backup")
         .build();
   }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -362,13 +362,14 @@ public interface Admin {
   }
 
   /**
-   * Repairs a table which may be in an unknown state.
+   * Repairs a table that may be in an unknown state, such as the table exists in the underlying
+   * storage but not its ScalarDB metadata or vice versa. This will re-create the table, its
+   * secondary indexes, and their metadata if necessary.
    *
-   * @param namespace an existing namespace
-   * @param table an existing table
+   * @param namespace a namespace
+   * @param table a table
    * @param metadata the metadata associated to the table to repair
    * @param options options to repair
-   * @throws IllegalArgumentException if the table does not exist
    * @throws ExecutionException if the operation fails
    */
   void repairTable(

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -8,6 +8,7 @@ import com.datastax.driver.core.ColumnMetadata;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.Create;
+import com.datastax.driver.core.schemabuilder.CreateIndex;
 import com.datastax.driver.core.schemabuilder.CreateKeyspace;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction;
@@ -88,8 +89,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     // Create the system namespace if it does not exist
     createKeyspace(systemNamespace, true, options);
 
-    createTableInternal(namespace, table, metadata, options);
-    createSecondaryIndexes(namespace, table, metadata.getSecondaryIndexNames(), options);
+    createTableInternal(namespace, table, metadata, false, options);
+    createSecondaryIndexes(namespace, table, metadata.getSecondaryIndexNames(), false);
   }
 
   @Override
@@ -166,17 +167,29 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   public void createIndex(
       String namespace, String table, String columnName, Map<String, String> options)
       throws ExecutionException {
+    createIndexInternal(namespace, table, columnName, false);
+  }
+
+  public void createIndexInternal(
+      String namespace, String table, String columnName, boolean ifNotExists)
+      throws ExecutionException {
     String indexName = getIndexName(table, columnName);
-    SchemaStatement createIndex =
-        SchemaBuilder.createIndex(indexName)
+    CreateIndex createIndex = SchemaBuilder.createIndex(indexName);
+    if (ifNotExists) {
+      createIndex = createIndex.ifNotExists();
+    }
+    SchemaStatement createIndexStatement =
+        createIndex
             .onTable(quoteIfNecessary(namespace), quoteIfNecessary(table))
             .andColumn(quoteIfNecessary(columnName));
+
     try {
-      clusterManager.getSession().execute(createIndex.getQueryString());
+      clusterManager.getSession().execute(createIndexStatement.getQueryString());
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Creating the secondary index for %s.%s.%s failed", namespace, table, columnName),
+              "Creating the secondary index on the %s column of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }
@@ -310,12 +323,13 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   public void repairTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
-    // We have this check to stay consistent with the behavior of the other admins classes
-    if (!tableExists(namespace, table)) {
-      throw new IllegalArgumentException(
-          "The table " + getFullTableName(namespace, table) + "  does not exist");
+    try {
+      createTableInternal(namespace, table, metadata, true, options);
+      createSecondaryIndexes(namespace, table, metadata.getSecondaryIndexNames(), true);
+    } catch (ExecutionException e) {
+      throw new ExecutionException(
+          String.format("Repairing the %s table failed", getFullTableName(namespace, table)), e);
     }
-    // The table metadata are not managed by ScalarDB, so we don't need to do anything here
   }
 
   @Override
@@ -363,10 +377,17 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
   @VisibleForTesting
   void createTableInternal(
-      String keyspace, String table, TableMetadata metadata, Map<String, String> options)
+      String keyspace,
+      String table,
+      TableMetadata metadata,
+      boolean ifNotExists,
+      Map<String, String> options)
       throws ExecutionException {
     Create createTable =
         SchemaBuilder.createTable(quoteIfNecessary(keyspace), quoteIfNecessary(table));
+    if (ifNotExists) {
+      createTable = createTable.ifNotExists();
+    }
     // Add columns
     for (String pk : metadata.getPartitionKeyNames()) {
       createTable =
@@ -419,16 +440,16 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       clusterManager.getSession().execute(createTableWithOptions.getQueryString());
     } catch (RuntimeException e) {
       throw new ExecutionException(
-          String.format("Creating the table %s.%s failed", keyspace, table), e);
+          String.format("Creating the %s table failed", getFullTableName(keyspace, table)), e);
     }
   }
 
   @VisibleForTesting
   void createSecondaryIndexes(
-      String keyspace, String table, Set<String> secondaryIndexNames, Map<String, String> options)
+      String keyspace, String table, Set<String> secondaryIndexNames, boolean ifNotExists)
       throws ExecutionException {
     for (String name : secondaryIndexNames) {
-      createIndex(keyspace, table, name, options);
+      createIndexInternal(keyspace, table, name, ifNotExists);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -91,16 +91,21 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   public void createTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
-    checkMetadata(metadata);
     try {
-      // Create the metadata database and container first if they do not exist
-      createMetadataDatabaseAndContainerIfNotExists();
-
-      createContainer(namespace, table, metadata);
-      putTableMetadata(namespace, table, metadata, false);
+      createTableInternal(namespace, table, metadata, false);
+    } catch (IllegalArgumentException e) {
+      throw e;
     } catch (RuntimeException e) {
       throw new ExecutionException("Creating the container failed", e);
     }
+  }
+
+  private void createTableInternal(
+      String namespace, String table, TableMetadata metadata, boolean ifNotExists)
+      throws ExecutionException {
+    checkMetadata(metadata);
+    createContainer(namespace, table, metadata, ifNotExists);
+    putTableMetadata(namespace, table, metadata, true);
   }
 
   private void checkMetadata(TableMetadata metadata) {
@@ -113,19 +118,28 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void createContainer(String database, String table, TableMetadata metadata)
+  private void createContainer(
+      String database, String table, TableMetadata metadata, boolean ifNotExists)
       throws ExecutionException {
     CosmosDatabase cosmosDatabase = client.getDatabase(database);
     CosmosContainerProperties properties = computeContainerProperties(table, metadata);
-    cosmosDatabase.createContainer(properties);
-
-    addStoredProcedure(database, table);
+    if (ifNotExists) {
+      cosmosDatabase.createContainerIfNotExists(properties);
+    } else {
+      cosmosDatabase.createContainer(properties);
+    }
+    addStoredProcedure(database, table, ifNotExists);
   }
 
-  private void addStoredProcedure(String namespace, String table) throws ExecutionException {
+  private void addStoredProcedure(String namespace, String table, boolean ifNotExists)
+      throws ExecutionException {
     CosmosDatabase cosmosDatabase = client.getDatabase(namespace);
     CosmosStoredProcedureProperties storedProcedureProperties =
         computeContainerStoredProcedureProperties();
+
+    if (ifNotExists && storedProcedureExists(namespace, table)) {
+      return;
+    }
     cosmosDatabase
         .getContainer(table)
         .getScripts()
@@ -506,24 +520,14 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     try {
-      try {
-        // Since the metadata table may be missing, we cannot use CosmosAdmin.tableExists() as it
-        // queries the metadata table to verify if the given table exists
-        client.getDatabase(namespace).getContainer(table).read();
-      } catch (CosmosException e) {
-        if (e.getStatusCode() == 404) {
-          throw new IllegalArgumentException(
-              "The table " + getFullTableName(namespace, table) + "  does not exist");
-        }
-      }
-      createMetadataDatabaseAndContainerIfNotExists();
-      putTableMetadata(namespace, table, metadata, true);
-      if (!storedProcedureExists(namespace, table)) {
-        addStoredProcedure(namespace, table);
-      }
-    } catch (ExecutionException | CosmosException e) {
+      createTableInternal(namespace, table, metadata, true);
+      updateIndexingPolicy(namespace, table, metadata);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
       throw new ExecutionException(
-          String.format("Repairing the table %s.%s failed", namespace, table), e);
+          String.format("Repairing the %s container failed", getFullTableName(namespace, table)),
+          e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -238,13 +238,18 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       TableMetadata metadata,
       Map<String, String> options)
       throws ExecutionException {
+    createTableInternal(nonPrefixedNamespace, table, metadata, false, options);
+  }
+
+  private void createTableInternal(
+      String nonPrefixedNamespace,
+      String table,
+      TableMetadata metadata,
+      boolean ifNotExists,
+      Map<String, String> options)
+      throws ExecutionException {
     Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     checkMetadata(metadata);
-
-    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
-
-    // Create the metadata table first if it does not exist
-    createMetadataTableIfNotExists(noBackup);
 
     long ru = Long.parseLong(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
 
@@ -257,22 +262,40 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     requestBuilder.tableName(getFullTableName(namespace, table));
 
     try {
-      client.createTable(requestBuilder.build());
+      if (!(ifNotExists && internalTableExists(namespace, table))) {
+        client.createTable(requestBuilder.build());
+        waitForTableCreation(namespace, table);
+      }
     } catch (Exception e) {
-      throw new ExecutionException("Creating the table failed", e);
+      throw new ExecutionException(
+          "Creating the " + getFullTableName(namespace, table) + " table failed", e);
     }
-    waitForTableCreation(namespace, table);
 
     boolean noScaling = Boolean.parseBoolean(options.getOrDefault(NO_SCALING, DEFAULT_NO_SCALING));
     if (!noScaling) {
       enableAutoScaling(namespace, table, metadata.getSecondaryIndexNames(), ru);
     }
 
+    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
     if (!noBackup) {
       enableContinuousBackup(namespace, table);
     }
 
-    putTableMetadata(namespace, table, metadata);
+    createMetadataTableIfNotExists(noBackup);
+    upsertTableMetadata(namespace, table, metadata);
+  }
+
+  private boolean internalTableExists(Namespace namespace, String table) throws ExecutionException {
+    try {
+      client.describeTable(
+          DescribeTableRequest.builder().tableName(getFullTableName(namespace, table)).build());
+      return true;
+    } catch (ResourceNotFoundException e) {
+      return false;
+    } catch (Exception e) {
+      throw new ExecutionException(
+          "Checking the " + getFullTableName(namespace, table) + " table existence failed", e);
+    }
   }
 
   private void checkMetadata(TableMetadata metadata) {
@@ -381,7 +404,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     return getFullTableName(namespace, tableName) + "." + GLOBAL_INDEX_NAME_PREFIX + "." + keyName;
   }
 
-  private void putTableMetadata(Namespace namespace, String table, TableMetadata metadata)
+  private void upsertTableMetadata(Namespace namespace, String table, TableMetadata metadata)
       throws ExecutionException {
     // Add metadata
     Map<String, AttributeValue> itemValues = new HashMap<>();
@@ -885,10 +908,51 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
     // update metadata
     TableMetadata tableMetadata = getTableMetadata(nonPrefixedNamespace, table);
-    putTableMetadata(
+    upsertTableMetadata(
         namespace,
         table,
         TableMetadata.newBuilder(tableMetadata).addSecondaryIndex(columnName).build());
+  }
+
+  private boolean rawIndexExists(String nonPrefixedNamespace, String table, String indexName)
+      throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+    String globalIndexName =
+        String.join(
+            ".",
+            getFullTableName(namespace, table),
+            DynamoAdmin.GLOBAL_INDEX_NAME_PREFIX,
+            indexName);
+    int retryCount = 0;
+    try {
+      while (true) {
+        DescribeTableResponse response =
+            client.describeTable(
+                DescribeTableRequest.builder()
+                    .tableName(getFullTableName(namespace, table))
+                    .build());
+        GlobalSecondaryIndexDescription description =
+            response.table().globalSecondaryIndexes().stream()
+                .filter(d -> d.indexName().equals(globalIndexName))
+                .findFirst()
+                .orElse(null);
+        if (description == null) {
+          return false;
+        }
+        if (description.indexStatus() == IndexStatus.ACTIVE) {
+          return true;
+        }
+        if (retryCount++ >= MAX_RETRY_COUNT) {
+          throw new ExecutionException(
+              String.format(
+                  "Waiting for the secondary index %s on the %s table to be active failed",
+                  indexName, getFullTableName(namespace, table)));
+        }
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
+      }
+    } catch (ResourceNotFoundException e) {
+      return false;
+    }
   }
 
   private void waitForIndexCreation(Namespace namespace, String table, String columnName)
@@ -983,7 +1047,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
     // update metadata
     TableMetadata tableMetadata = getTableMetadata(nonPrefixedNamespace, table);
-    putTableMetadata(
+    upsertTableMetadata(
         namespace,
         table,
         TableMetadata.newBuilder(tableMetadata).removeSecondaryIndex(columnName).build());
@@ -1204,20 +1268,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       TableMetadata metadata,
       Map<String, String> options)
       throws ExecutionException {
-    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
-      if (!tableExists(nonPrefixedNamespace, table)) {
-        throw new IllegalArgumentException(
-            "The table " + getFullTableName(namespace, table) + "  does not exist");
+      createTableInternal(nonPrefixedNamespace, table, metadata, true, options);
+      for (String indexColumnName : metadata.getSecondaryIndexNames()) {
+        if (!rawIndexExists(nonPrefixedNamespace, table, indexColumnName)) {
+          createIndex(nonPrefixedNamespace, table, indexColumnName, options);
+        }
       }
-      boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
-      createMetadataTableIfNotExists(noBackup);
-      putTableMetadata(namespace, table, metadata);
-    } catch (IllegalArgumentException e) {
-      throw e;
     } catch (RuntimeException e) {
       throw new ExecutionException(
-          String.format("Repairing the table %s.%s failed", namespace, table), e);
+          String.format(
+              "Repairing the %s table failed",
+              getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table)),
+          e);
     }
   }
 
@@ -1230,7 +1293,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       TableMetadata updatedTableMetadata =
           TableMetadata.newBuilder(currentTableMetadata).addColumn(columnName, columnType).build();
       Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
-      putTableMetadata(namespace, table, updatedTableMetadata);
+      upsertTableMetadata(namespace, table, updatedTableMetadata);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           String.format(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -119,7 +119,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void createTableInternal(
+  @VisibleForTesting
+  void createTableInternal(
       Connection connection, String schema, String table, TableMetadata metadata)
       throws SQLException {
     String createTableStatement = "CREATE TABLE " + encloseFullTableName(schema, table) + "(";
@@ -150,15 +151,16 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     execute(connection, sqls);
   }
 
-  private void createIndex(
-      Connection connection, String schema, String table, TableMetadata metadata)
+  @VisibleForTesting
+  void createIndex(Connection connection, String schema, String table, TableMetadata metadata)
       throws SQLException {
     for (String indexedColumn : metadata.getSecondaryIndexNames()) {
       createIndex(connection, schema, table, indexedColumn);
     }
   }
 
-  private void addTableMetadata(
+  @VisibleForTesting
+  void addTableMetadata(
       Connection connection,
       String namespace,
       String table,
@@ -766,8 +768,9 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     try (Connection connection = dataSource.getConnection()) {
       if (!tableExistsInternal(connection, namespace, table)) {
-        throw new IllegalArgumentException(
-            CoreError.TABLE_NOT_FOUND.buildMessage(getFullTableName(namespace, table)));
+        // Create the table if it does not exist
+        createTableInternal(connection, namespace, table, metadata);
+        createIndex(connection, namespace, table, metadata);
       }
 
       if (tableExistsInternal(connection, metadataSchema, METADATA_TABLE)) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -151,8 +151,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     execute(connection, sqls);
   }
 
-  @VisibleForTesting
-  void createIndex(Connection connection, String schema, String table, TableMetadata metadata)
+  private void createIndex(
+      Connection connection, String schema, String table, TableMetadata metadata)
       throws SQLException {
     for (String indexedColumn : metadata.getSecondaryIndexNames()) {
       createIndex(connection, schema, table, indexedColumn);
@@ -770,7 +770,12 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       if (!tableExistsInternal(connection, namespace, table)) {
         // Create the table if it does not exist
         createTableInternal(connection, namespace, table, metadata);
-        createIndex(connection, namespace, table, metadata);
+      }
+
+      // Create any secondary indexes that do not exist yet. This covers both a newly created table
+      // and an existing table that is missing some of its secondary indexes.
+      for (String indexedColumn : metadata.getSecondaryIndexNames()) {
+        createIndex(connection, namespace, table, indexedColumn, true);
       }
 
       if (tableExistsInternal(connection, metadataSchema, METADATA_TABLE)) {
@@ -876,9 +881,26 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   private void createIndex(Connection connection, String schema, String table, String indexedColumn)
       throws SQLException {
+    createIndex(connection, schema, table, indexedColumn, false);
+  }
+
+  @VisibleForTesting
+  void createIndex(
+      Connection connection, String schema, String table, String indexedColumn, boolean ifNotExists)
+      throws SQLException {
     String indexName = getIndexName(schema, table, indexedColumn);
     String createIndexStatement = rdbEngine.createIndexSql(schema, table, indexName, indexedColumn);
-    execute(connection, createIndexStatement);
+    if (ifNotExists) {
+      createIndexStatement = rdbEngine.tryAddIfNotExistsToCreateIndexSql(createIndexStatement);
+    }
+    try {
+      execute(connection, createIndexStatement);
+    } catch (SQLException e) {
+      // Suppress the exception thrown when the index already exists
+      if (!(ifNotExists && rdbEngine.isDuplicateIndexError(e))) {
+        throw e;
+      }
+    }
   }
 
   private void dropIndex(Connection connection, String schema, String table, String indexedColumn)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineDb2.java
@@ -287,6 +287,19 @@ class RdbEngineDb2 extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // Even though the "create index if exists ..." syntax does not exist,
+    // only a warning is raised when the index already exists but no error is thrown
+    // so we return false in any case
+    return false;
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
+    return createIndexSql;
+  }
+
+  @Override
   public SelectQuery buildSelectQuery(SelectQuery.Builder builder, int limit) {
     return new SelectWithLimitQuery(builder, limit);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -209,6 +209,19 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+    // Error number: 1061; Symbol: ER_DUP_KEYNAME; SQLSTATE: 42000
+    // Message: Duplicate key name '%s'
+    return e.getErrorCode() == 1061;
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
+    return createIndexSql;
+  }
+
+  @Override
   public String getDataTypeForEngine(DataType scalarDbDataType) {
     switch (scalarDbDataType) {
       case BIGINT:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -221,6 +221,19 @@ public class RdbEngineOracle extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // https://docs.oracle.com/en/error-help/db/ora-00955/
+    // code : 955
+    // message : name is already used by an existing object
+    return e.getErrorCode() == 955;
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
+    return createIndexSql;
+  }
+
+  @Override
   public String getDataTypeForEngine(DataType scalarDbDataType) {
     switch (scalarDbDataType) {
       case BIGINT:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -188,6 +188,17 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // Since the "IF NOT EXISTS" syntax is used to create an index, we always return false
+    return false;
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
+    return createIndexSql.replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS");
+  }
+
+  @Override
   public String enclose(String name) {
     return "\"" + name + "\"";
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -170,6 +170,15 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-1000-to-1999?view=sql-server-ver16
+    // Error code: 1913
+    // Message: The operation failed because an index or statistics with name '%.*ls' already exists
+    // on %S_MSG '%.*ls'.
+    return e.getErrorCode() == 1913;
+  }
+
+  @Override
   public String enclose(String name) {
     return "[" + name + "]";
   }
@@ -383,6 +392,7 @@ class RdbEngineSqlServer extends AbstractRdbEngine {
     return escape.isEmpty() ? "\\" : escape;
   }
 
+  @Override
   public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
     return createIndexSql;
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -95,6 +95,17 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
+  public boolean isDuplicateIndexError(SQLException e) {
+    // Since the "IF NOT EXISTS" syntax is used to create an index, we always return false
+    return false;
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
+    return createIndexSql.replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS");
+  }
+
+  @Override
   public String getDataTypeForEngine(DataType scalarDbDataType) {
     switch (scalarDbDataType) {
       case BOOLEAN:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -117,6 +117,8 @@ public interface RdbEngineStrategy {
 
   String dropIndexSql(String schema, String table, String indexName);
 
+  String tryAddIfNotExistsToCreateIndexSql(String createIndexSql);
+
   /**
    * Enclose the target (schema, table or column) to use reserved words and special characters.
    *
@@ -161,6 +163,8 @@ public interface RdbEngineStrategy {
   }
 
   boolean isUndefinedIndexError(SQLException e);
+
+  boolean isDuplicateIndexError(SQLException e);
 
   default @Nullable String getCatalogName(String namespace) {
     return null;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -244,8 +245,77 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
 
   @Override
   public void repairCoordinatorTables(Map<String, String> options) throws ExecutionException {
-    admin.repairTable(
-        coordinatorNamespace, Coordinator.TABLE, getCoordinatorTableMetadata(), options);
+    admin.createNamespace(coordinatorNamespace, true, options);
+
+    // Snapshot the current Coordinator table metadata before repairTable upserts the desired one.
+    TableMetadata currentMetadata = admin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+
+    // Pick the desired schema:
+    // - If the existing Coordinator already has the CHILD_IDS column (i.e., it was previously
+    //   created with group commit enabled), preserve the WITH_GROUP_COMMIT_ENABLED schema
+    //   regardless of the current config value. The ScalarDB-side metadata must reflect the
+    //   physical column set; the runtime config independently decides whether to USE the column.
+    //   Without this, toggling group commit from true to false and then running repair would
+    //   upsert no-child_ids metadata against a with-child_ids physical table, leaving them out
+    //   of sync (and breaking subsequent toggles back to enabled, where ALTER TABLE ADD COLUMN
+    //   would fail because the column already exists physically).
+    // - Otherwise (no existing Coordinator, or existing Coordinator without CHILD_IDS), use the
+    //   config-dependent schema, which lets a user upgrade a pre-group-commit Coordinator to
+    //   WITH_GROUP_COMMIT_ENABLED by toggling the config and calling repairCoordinatorTables.
+    TableMetadata coordinatorTableMetadata;
+    if (currentMetadata != null && currentMetadata.getColumnNames().contains(Attribute.CHILD_IDS)) {
+      coordinatorTableMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED;
+    } else {
+      coordinatorTableMetadata = getCoordinatorTableMetadata();
+    }
+
+    // Upgrade the schema (ALTER TABLE ADD COLUMN for any non-key columns the desired schema
+    // requires that the existing Coordinator is missing) BEFORE repairTable. addNewColumnToTable
+    // checks the existing metadata via getTableMetadata, so it must run while the metadata still
+    // reflects the pre-upgrade column set. If repairTable runs first, it upserts the metadata to
+    // the desired schema (which already includes the column), and the subsequent
+    // addNewColumnToTable call would be rejected with "column already exists" against the
+    // ScalarDB-side metadata even though the physical column does not yet exist.
+    upgradeCoordinatorTableSchema(currentMetadata, coordinatorTableMetadata);
+
+    admin.repairTable(coordinatorNamespace, Coordinator.TABLE, coordinatorTableMetadata, options);
+  }
+
+  // Adds any non-key columns the desired Coordinator table schema requires that the existing
+  // Coordinator table is still missing. Specifically handles the case where group commit is being
+  // turned on against a Coordinator table that was previously created with group commit disabled
+  // (i.e., without the {@code child_ids} column). Mirrors the column-migration logic that master
+  // implements in upgradeCoordinatorTable() under the (master-only) {@code upgrade()} API.
+  private void upgradeCoordinatorTableSchema(
+      @Nullable TableMetadata currentMetadata, TableMetadata coordinatorTableMetadata)
+      throws ExecutionException {
+    if (currentMetadata == null) {
+      return;
+    }
+    for (String columnName : coordinatorTableMetadata.getColumnNames()) {
+      if (currentMetadata.getColumnNames().contains(columnName)) {
+        continue;
+      }
+      if (coordinatorTableMetadata.getPartitionKeyNames().contains(columnName)
+          || coordinatorTableMetadata.getClusteringKeyNames().contains(columnName)
+          || coordinatorTableMetadata.getSecondaryIndexNames().contains(columnName)) {
+        // In practice, this currently doesn't happen. Special handling would be needed if a key
+        // column were ever added to the Coordinator table metadata in the future.
+        throw new IllegalStateException(
+            String.format(
+                "Failed to upgrade the Coordinator table schema. Key columns can't be migrated. Column: %s",
+                columnName));
+      }
+    }
+
+    for (String columnName : coordinatorTableMetadata.getColumnNames()) {
+      if (currentMetadata.getColumnNames().contains(columnName)) {
+        continue;
+      }
+      DataType columnDataType = coordinatorTableMetadata.getColumnDataType(columnName);
+      admin.addNewColumnToTable(
+          coordinatorNamespace, Coordinator.TABLE, columnName, columnDataType);
+    }
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -2,11 +2,11 @@ package com.scalar.db.storage.cassandra;
 
 import static com.datastax.driver.core.Metadata.quote;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +34,7 @@ import com.scalar.db.storage.cassandra.CassandraAdmin.ReplicationStrategy;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -201,7 +202,7 @@ public class CassandraAdminTest {
             .addSecondaryIndex("c4")
             .build();
     // Act
-    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, new HashMap<>());
+    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, false, new HashMap<>());
 
     // Assert
     TableOptions<Options> createTableStatement =
@@ -253,7 +254,7 @@ public class CassandraAdminTest {
     options.put(CassandraAdmin.COMPACTION_STRATEGY, CompactionStrategy.LCS.toString());
 
     // Act
-    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, options);
+    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, false, options);
 
     // Assert
     TableOptions<Options> createTableStatement =
@@ -302,7 +303,7 @@ public class CassandraAdminTest {
     options.put(CassandraAdmin.COMPACTION_STRATEGY, CompactionStrategy.LCS.toString());
 
     // Act
-    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, options);
+    cassandraAdmin.createTableInternal(namespace, table, tableMetadata, false, options);
 
     // Assert
     TableOptions<Options> createTableStatement =
@@ -332,7 +333,7 @@ public class CassandraAdminTest {
     indexes.add("c5");
 
     // Act
-    cassandraAdmin.createSecondaryIndexes(namespace, table, indexes, Collections.emptyMap());
+    cassandraAdmin.createSecondaryIndexes(namespace, table, indexes, false);
 
     // Assert
     SchemaStatement c1IndexStatement =
@@ -358,7 +359,7 @@ public class CassandraAdminTest {
     indexes.add("to");
 
     // Act
-    cassandraAdmin.createSecondaryIndexes(namespace, table, indexes, Collections.emptyMap());
+    cassandraAdmin.createSecondaryIndexes(namespace, table, indexes, false);
 
     // Assert
     SchemaStatement c1IndexStatement =
@@ -547,51 +548,87 @@ public class CassandraAdminTest {
   }
 
   @Test
-  public void repairTable_WithExistingTable_ShouldDoNothing() {
+  public void repairTable_ShouldCreateTableAndIndexesIfTheyDoNotExists() throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";
     String table = "tbl";
-    com.datastax.driver.core.TableMetadata tableMetadata1 =
-        mock(com.datastax.driver.core.TableMetadata.class);
-    when(tableMetadata1.getName()).thenReturn(table);
-    List<com.datastax.driver.core.TableMetadata> tableMetadataList =
-        ImmutableList.of(tableMetadata1);
-
-    when(cassandraSession.getCluster()).thenReturn(cluster);
-    when(cluster.getMetadata()).thenReturn(metadata);
-    when(metadata.getKeyspace(any())).thenReturn(keyspaceMetadata);
-    when(keyspaceMetadata.getTables()).thenReturn(tableMetadataList);
-
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addClusteringKey("c4")
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BLOB)
+            .addColumn("c4", DataType.INT)
+            .addColumn("c5", DataType.BOOLEAN)
+            .addSecondaryIndex("c2")
+            .addSecondaryIndex("c4")
+            .build();
     // Act
-    assertThatCode(
-            () ->
-                cassandraAdmin.repairTable(
-                    namespace, table, mock(TableMetadata.class), Collections.emptyMap()))
-        .doesNotThrowAnyException();
+    cassandraAdmin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
 
-    // Assert
-    verify(metadata).getKeyspace(namespace);
+    // Assert table creation
+    TableOptions<Options> createTableStatement =
+        SchemaBuilder.createTable(namespace, table)
+            .ifNotExists()
+            .addPartitionKey("c1", com.datastax.driver.core.DataType.cint())
+            .addClusteringColumn("c4", com.datastax.driver.core.DataType.cint())
+            .addColumn("c2", com.datastax.driver.core.DataType.text())
+            .addColumn("c3", com.datastax.driver.core.DataType.blob())
+            .addColumn("c5", com.datastax.driver.core.DataType.cboolean())
+            .withOptions()
+            .clusteringOrder("c4", Direction.ASC)
+            .compactionOptions(SchemaBuilder.sizedTieredStategy());
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(cassandraSession, times(3)).execute(captor.capture());
+    Assertions.assertThat(captor.getAllValues().get(0))
+        .isEqualTo(createTableStatement.getQueryString());
+    // Assert index creation
+    Iterator<String> indexIterator = tableMetadata.getSecondaryIndexNames().iterator();
+    for (int i = 1; indexIterator.hasNext(); i++) {
+      String index = indexIterator.next();
+      assertThat(captor.getAllValues().get(i).trim())
+          .isEqualTo(
+              String.format(
+                  "CREATE INDEX IF NOT EXISTS tbl_index_%1$s ON sample_ns.tbl(%1$s)", index));
+    }
   }
 
   @Test
-  public void repairTable_WithNonExistingTable_ShouldThrowIllegalArgumentException() {
+  public void repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex()
+      throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";
     String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addClusteringKey("c4")
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BLOB)
+            .addColumn("c4", DataType.INT)
+            .addColumn("c5", DataType.BOOLEAN)
+            .addSecondaryIndex("c2")
+            .addSecondaryIndex("c4")
+            .build();
+    // The table already exists
+    when(clusterManager.getMetadata(namespace, table))
+        .thenReturn(mock(com.datastax.driver.core.TableMetadata.class));
     when(cassandraSession.getCluster()).thenReturn(cluster);
     when(cluster.getMetadata()).thenReturn(metadata);
     when(metadata.getKeyspace(any())).thenReturn(keyspaceMetadata);
-    when(keyspaceMetadata.getTables()).thenReturn(ImmutableList.of());
+    when(keyspaceMetadata.getTable(table))
+        .thenReturn(mock(com.datastax.driver.core.TableMetadata.class));
+
+    CassandraAdmin adminSpy = spy(cassandraAdmin);
 
     // Act
-    assertThatThrownBy(
-            () ->
-                cassandraAdmin.repairTable(
-                    namespace, table, mock(TableMetadata.class), Collections.emptyMap()))
-        .isInstanceOf(IllegalArgumentException.class);
+    adminSpy.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
 
     // Assert
-    verify(metadata).getKeyspace(namespace);
+    verify(adminSpy)
+        .createSecondaryIndexes(namespace, table, tableMetadata.getSecondaryIndexNames(), true);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -761,70 +760,7 @@ public abstract class CosmosAdminTestBase {
   }
 
   @Test
-  public void repairTable_withMissingTableToRepair_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    String namespace = "ns";
-    String table = "tbl";
-    TableMetadata metadata = Mockito.mock(TableMetadata.class);
-    when(client.getDatabase(namespace)).thenReturn(database);
-    when(database.getContainer(table)).thenReturn(container);
-    CosmosException cosmosException = mock(CosmosException.class);
-    when(cosmosException.getStatusCode()).thenReturn(404);
-    when(container.read()).thenThrow(cosmosException);
-
-    // Act Assert
-    assertThatThrownBy(() -> admin.repairTable(namespace, table, metadata, Collections.emptyMap()))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void repairTable_withStoredProcedure_ShouldUpsertMetadata() throws ExecutionException {
-    // Arrange
-    String namespace = "ns";
-    String table = "tbl";
-    TableMetadata tableMetadata =
-        TableMetadata.newBuilder()
-            .addColumn("c1", DataType.INT)
-            .addColumn("c2", DataType.TEXT)
-            .addColumn("c3", DataType.BIGINT)
-            .addPartitionKey("c1")
-            .build();
-    CosmosTableMetadata cosmosTableMetadata =
-        CosmosTableMetadata.newBuilder()
-            .id(getFullTableName(namespace, table))
-            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
-            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
-            .build();
-
-    when(client.getDatabase(namespace)).thenReturn(database);
-    when(database.getContainer(table)).thenReturn(container);
-
-    CosmosContainer metadataContainer = mock(CosmosContainer.class);
-    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
-    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
-        .thenReturn(metadataContainer);
-
-    CosmosScripts scripts = mock(CosmosScripts.class);
-    when(container.getScripts()).thenReturn(scripts);
-    CosmosStoredProcedure storedProcedure = mock(CosmosStoredProcedure.class);
-    when(scripts.getStoredProcedure(CosmosAdmin.STORED_PROCEDURE_FILE_NAME))
-        .thenReturn(storedProcedure);
-
-    // Act Assert
-    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
-
-    // Assert
-    verify(container).read();
-    verify(client, times(2)).createDatabaseIfNotExists(eq(metadataDatabaseName), any());
-
-    verify(metadataDatabase, times(2)).createContainerIfNotExists(any());
-    verify(metadataContainer).upsertItem(cosmosTableMetadata);
-    verify(storedProcedure).read();
-  }
-
-  @Test
-  public void repairTable_withoutStoredProcedure_ShouldUpsertMetadataAndCreateProcedure()
+  public void repairTable_withStoredProcedure_ShouldNotAddStoredProcedure()
       throws ExecutionException {
     // Arrange
     String namespace = "ns";
@@ -846,6 +782,58 @@ public abstract class CosmosAdminTestBase {
     when(client.getDatabase(namespace)).thenReturn(database);
     when(database.getContainer(table)).thenReturn(container);
 
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+
+    CosmosScripts scripts = mock(CosmosScripts.class);
+    when(container.getScripts()).thenReturn(scripts);
+    CosmosStoredProcedure storedProcedure = mock(CosmosStoredProcedure.class);
+    when(scripts.getStoredProcedure(CosmosAdmin.STORED_PROCEDURE_FILE_NAME))
+        .thenReturn(storedProcedure);
+
+    // Existing container properties (for updateIndexingPolicy)
+    CosmosContainerResponse response = mock(CosmosContainerResponse.class);
+    when(database.createContainerIfNotExists(table, "/concatenatedPartitionKey"))
+        .thenReturn(response);
+    CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
+    when(response.getProperties()).thenReturn(properties);
+
+    // Act Assert
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert
+    verify(client).createDatabaseIfNotExists(eq(metadataDatabaseName), any());
+
+    verify(metadataDatabase).createContainerIfNotExists(any());
+    verify(metadataContainer).upsertItem(cosmosTableMetadata);
+    verify(storedProcedure).read();
+  }
+
+  @Test
+  public void repairTable_withoutStoredProcedure_ShouldCreateStoredProcedure()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .build();
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
+
     // Metadata container
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
@@ -863,14 +851,20 @@ public abstract class CosmosAdminTestBase {
     when(cosmosException.getStatusCode()).thenReturn(404);
     when(storedProcedure.read()).thenThrow(cosmosException);
 
+    // Existing container properties (for updateIndexingPolicy)
+    CosmosContainerResponse response = mock(CosmosContainerResponse.class);
+    when(database.createContainerIfNotExists(table, "/concatenatedPartitionKey"))
+        .thenReturn(response);
+    CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
+    when(response.getProperties()).thenReturn(properties);
+
     // Act
     admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
 
     // Assert
-    verify(container).read();
-    verify(client, times(2)).createDatabaseIfNotExists(eq(metadataDatabaseName), any());
+    verify(client).createDatabaseIfNotExists(eq(metadataDatabaseName), any());
 
-    verify(metadataDatabase, times(2)).createContainerIfNotExists(any());
+    verify(metadataDatabase).createContainerIfNotExists(any());
     verify(metadataContainer).upsertItem(cosmosTableMetadata);
     verify(storedProcedure).read();
     verify(scripts).createStoredProcedure(any());

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -290,7 +290,7 @@ public abstract class DynamoAdminTestBase {
     List<CreateTableRequest> actualCreateTableRequests = createTableRequestCaptor.getAllValues();
 
     List<AttributeDefinition> attributeDefinitions =
-        actualCreateTableRequests.get(1).attributeDefinitions();
+        actualCreateTableRequests.get(0).attributeDefinitions();
     assertThat(attributeDefinitions.size()).isEqualTo(3);
     assertThat(attributeDefinitions.get(0).attributeName()).isEqualTo(DynamoAdmin.PARTITION_KEY);
     assertThat(attributeDefinitions.get(0).attributeType()).isEqualTo(ScalarAttributeType.B);
@@ -299,24 +299,24 @@ public abstract class DynamoAdminTestBase {
     assertThat(attributeDefinitions.get(2).attributeName()).isEqualTo("c4");
     assertThat(attributeDefinitions.get(2).attributeType()).isEqualTo(ScalarAttributeType.B);
 
-    assertThat(actualCreateTableRequests.get(1).keySchema().size()).isEqualTo(2);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).attributeName())
+    assertThat(actualCreateTableRequests.get(0).keySchema().size()).isEqualTo(2);
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).attributeName())
         .isEqualTo(DynamoAdmin.PARTITION_KEY);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).keyType())
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).keyType())
         .isEqualTo(KeyType.HASH);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(1).attributeName())
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(1).attributeName())
         .isEqualTo(DynamoAdmin.CLUSTERING_KEY);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(1).keyType())
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(1).keyType())
         .isEqualTo(KeyType.RANGE);
 
-    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().size()).isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().get(0).indexName())
+    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().size()).isEqualTo(1);
+    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().get(0).indexName())
         .isEqualTo(getFullTableName() + ".global_index.c4");
-    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().get(0).keySchema().size())
+    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().get(0).keySchema().size())
         .isEqualTo(1);
     assertThat(
             actualCreateTableRequests
-                .get(1)
+                .get(0)
                 .globalSecondaryIndexes()
                 .get(0)
                 .keySchema()
@@ -325,7 +325,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo("c4");
     assertThat(
             actualCreateTableRequests
-                .get(1)
+                .get(0)
                 .globalSecondaryIndexes()
                 .get(0)
                 .keySchema()
@@ -334,7 +334,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(KeyType.HASH);
     assertThat(
             actualCreateTableRequests
-                .get(1)
+                .get(0)
                 .globalSecondaryIndexes()
                 .get(0)
                 .projection()
@@ -342,7 +342,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(ProjectionType.ALL);
     assertThat(
             actualCreateTableRequests
-                .get(1)
+                .get(0)
                 .globalSecondaryIndexes()
                 .get(0)
                 .provisionedThroughput()
@@ -350,39 +350,39 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(10);
     assertThat(
             actualCreateTableRequests
-                .get(1)
+                .get(0)
                 .globalSecondaryIndexes()
                 .get(0)
                 .provisionedThroughput()
                 .writeCapacityUnits())
         .isEqualTo(10);
 
-    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().writeCapacityUnits())
+    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().writeCapacityUnits())
         .isEqualTo(10);
-    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().readCapacityUnits())
+    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().readCapacityUnits())
         .isEqualTo(10);
 
-    assertThat(actualCreateTableRequests.get(1).tableName()).isEqualTo(getFullTableName());
+    assertThat(actualCreateTableRequests.get(0).tableName()).isEqualTo(getFullTableName());
 
     // for the table metadata table
-    attributeDefinitions = actualCreateTableRequests.get(0).attributeDefinitions();
+    attributeDefinitions = actualCreateTableRequests.get(1).attributeDefinitions();
     assertThat(attributeDefinitions.size()).isEqualTo(1);
     assertThat(attributeDefinitions.get(0).attributeName())
         .isEqualTo(DynamoAdmin.METADATA_ATTR_TABLE);
     assertThat(attributeDefinitions.get(0).attributeType()).isEqualTo(ScalarAttributeType.S);
 
-    assertThat(actualCreateTableRequests.get(0).keySchema().size()).isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).attributeName())
+    assertThat(actualCreateTableRequests.get(1).keySchema().size()).isEqualTo(1);
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).attributeName())
         .isEqualTo(DynamoAdmin.METADATA_ATTR_TABLE);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).keyType())
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).keyType())
         .isEqualTo(KeyType.HASH);
 
-    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().writeCapacityUnits())
+    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().writeCapacityUnits())
         .isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().readCapacityUnits())
+    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().readCapacityUnits())
         .isEqualTo(1);
 
-    assertThat(actualCreateTableRequests.get(0).tableName()).isEqualTo(getFullMetadataTableName());
+    assertThat(actualCreateTableRequests.get(1).tableName()).isEqualTo(getFullMetadataTableName());
 
     ArgumentCaptor<PutItemRequest> putItemRequestCaptor =
         ArgumentCaptor.forClass(PutItemRequest.class);
@@ -436,8 +436,8 @@ public abstract class DynamoAdminTestBase {
     List<UpdateContinuousBackupsRequest> updateContinuousBackupsRequests =
         updateContinuousBackupsRequestCaptor.getAllValues();
     assertThat(updateContinuousBackupsRequests.size()).isEqualTo(2);
-    assertThat(updateContinuousBackupsRequests.get(1).tableName()).isEqualTo(getFullTableName());
-    assertThat(updateContinuousBackupsRequests.get(0).tableName())
+    assertThat(updateContinuousBackupsRequests.get(0).tableName()).isEqualTo(getFullTableName());
+    assertThat(updateContinuousBackupsRequests.get(1).tableName())
         .isEqualTo(getFullMetadataTableName());
   }
 
@@ -1091,54 +1091,32 @@ public abstract class DynamoAdminTestBase {
   }
 
   @Test
-  public void repairTable_WithNonExistingTableToRepair_shouldThrowIllegalArgumentException() {
-    // Arrange
-    TableMetadata metadata =
-        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
-    ListTablesResponse listTablesResponse = mock(ListTablesResponse.class);
-    when(client.listTables(any(ListTablesRequest.class))).thenReturn(listTablesResponse);
-    when(listTablesResponse.lastEvaluatedTableName()).thenReturn(null);
-    when(listTablesResponse.tableNames()).thenReturn(ImmutableList.of());
-
-    // Act Assert
-    assertThatThrownBy(() -> admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of()))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void repairTable_WithNonExistingMetadataForTable_shouldAddMetadataForTable()
+  public void repairTable_WithExistingTableToRepairAndMetadataTables_shouldNotCreateTables()
       throws ExecutionException {
     // Arrange
     TableMetadata metadata =
         TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
 
-    // The table to repair exists
-    ListTablesResponse listTablesResponse = mock(ListTablesResponse.class);
-    when(client.listTables(any(ListTablesRequest.class))).thenReturn(listTablesResponse);
-    when(listTablesResponse.lastEvaluatedTableName()).thenReturn(null);
-    when(listTablesResponse.tableNames()).thenReturn(ImmutableList.of(getFullTableName()));
+    // Prepare tableIsActiveResponse
+    TableDescription tableDescription = mock(TableDescription.class);
+    when(tableIsActiveResponse.table()).thenReturn(tableDescription);
+    when(tableDescription.tableStatus()).thenReturn(TableStatus.ACTIVE);
 
-    // Wait for metadata table creation
-    DescribeTableResponse describeTableResponseMetadataTableCreation =
-        mock(DescribeTableResponse.class);
-    TableDescription tableDescriptionMetadataTableCreation = mock(TableDescription.class);
-    when(describeTableResponseMetadataTableCreation.table())
-        .thenReturn(tableDescriptionMetadataTableCreation);
-    when(tableDescriptionMetadataTableCreation.tableStatus()).thenReturn(TableStatus.ACTIVE);
-
+    // The table to repair and the metadata table both exist
+    when(client.describeTable(DescribeTableRequest.builder().tableName(getFullTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
     when(client.describeTable(
             DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build()))
-        .thenThrow(ResourceNotFoundException.class)
-        .thenReturn(describeTableResponseMetadataTableCreation);
+        .thenReturn(tableIsActiveResponse);
 
-    // Continuous backup check
-    DescribeContinuousBackupsResponse describeContinuousBackupsResponse =
+    // Continuous backup check (already enabled, so update is a no-op semantically)
+    DescribeContinuousBackupsResponse backupIsEnabledResponse =
         mock(DescribeContinuousBackupsResponse.class);
     when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
-        .thenReturn(describeContinuousBackupsResponse);
+        .thenReturn(backupIsEnabledResponse);
     ContinuousBackupsDescription continuousBackupsDescription =
         mock(ContinuousBackupsDescription.class);
-    when(describeContinuousBackupsResponse.continuousBackupsDescription())
+    when(backupIsEnabledResponse.continuousBackupsDescription())
         .thenReturn(continuousBackupsDescription);
     when(continuousBackupsDescription.continuousBackupsStatus())
         .thenReturn(ContinuousBackupsStatus.ENABLED);
@@ -1147,20 +1125,7 @@ public abstract class DynamoAdminTestBase {
     admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
 
     // Assert
-    // Check metadata table creation
-    ArgumentCaptor<CreateTableRequest> createTableRequestArgumentCaptor =
-        ArgumentCaptor.forClass(CreateTableRequest.class);
-    verify(client).createTable(createTableRequestArgumentCaptor.capture());
-    CreateTableRequest actualCreateTableRequest = createTableRequestArgumentCaptor.getValue();
-    assertThat(actualCreateTableRequest.tableName()).isEqualTo(getFullMetadataTableName());
-
-    // Check continuous backup
-    ArgumentCaptor<UpdateContinuousBackupsRequest> updateContinuousBackupsRequestCaptor =
-        ArgumentCaptor.forClass(UpdateContinuousBackupsRequest.class);
-    verify(client).updateContinuousBackups(updateContinuousBackupsRequestCaptor.capture());
-    UpdateContinuousBackupsRequest updateContinuousBackupsRequest =
-        updateContinuousBackupsRequestCaptor.getValue();
-    assertThat(updateContinuousBackupsRequest.tableName()).isEqualTo(getFullMetadataTableName());
+    verify(client, never()).createTable(any(CreateTableRequest.class));
 
     // Check added metadata
     Map<String, AttributeValue> itemValues = new HashMap<>();
@@ -1180,6 +1145,56 @@ public abstract class DynamoAdminTestBase {
                 .tableName(getFullMetadataTableName())
                 .item(itemValues)
                 .build());
+  }
+
+  @Test
+  public void repairTable_WithNonExistingTableAndMetadataTables_shouldCreateBothTables()
+      throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+
+    // Prepare tableIsActiveResponse
+    TableDescription tableDescription = mock(TableDescription.class);
+    when(tableIsActiveResponse.table()).thenReturn(tableDescription);
+    when(tableDescription.tableStatus()).thenReturn(TableStatus.ACTIVE);
+
+    // The table to repair does not exist initially, then becomes active after creation
+    when(client.describeTable(DescribeTableRequest.builder().tableName(getFullTableName()).build()))
+        .thenThrow(ResourceNotFoundException.class)
+        .thenReturn(tableIsActiveResponse);
+
+    // The metadata table does not exist initially, then becomes active after creation
+    when(client.describeTable(
+            DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build()))
+        .thenThrow(ResourceNotFoundException.class)
+        .thenReturn(tableIsActiveResponse);
+
+    // Continuous backup check
+    DescribeContinuousBackupsResponse backupIsEnabledResponse =
+        mock(DescribeContinuousBackupsResponse.class);
+    when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
+        .thenReturn(backupIsEnabledResponse);
+    ContinuousBackupsDescription continuousBackupsDescription =
+        mock(ContinuousBackupsDescription.class);
+    when(backupIsEnabledResponse.continuousBackupsDescription())
+        .thenReturn(continuousBackupsDescription);
+    when(continuousBackupsDescription.continuousBackupsStatus())
+        .thenReturn(ContinuousBackupsStatus.ENABLED);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert: both the user table and the metadata table are created
+    ArgumentCaptor<CreateTableRequest> createTableRequestArgumentCaptor =
+        ArgumentCaptor.forClass(CreateTableRequest.class);
+    verify(client, times(2)).createTable(createTableRequestArgumentCaptor.capture());
+    CreateTableRequest actualCreateUserTableRequest =
+        createTableRequestArgumentCaptor.getAllValues().get(0);
+    assertThat(actualCreateUserTableRequest.tableName()).isEqualTo(getFullTableName());
+    CreateTableRequest actualCreateMetadataTableRequest =
+        createTableRequestArgumentCaptor.getAllValues().get(1);
+    assertThat(actualCreateMetadataTableRequest.tableName()).isEqualTo(getFullMetadataTableName());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -2738,7 +2738,6 @@ public abstract class JdbcAdminTestBase {
 
     JdbcAdmin adminSpy = spy(createJdbcAdminFor(rdbEngine));
     doNothing().when(adminSpy).createTableInternal(connection, namespace, table, metadata);
-    doNothing().when(adminSpy).createIndex(connection, namespace, table, metadata);
     doNothing().when(adminSpy).addTableMetadata(connection, namespace, table, metadata, true);
 
     // Act
@@ -2747,8 +2746,40 @@ public abstract class JdbcAdminTestBase {
     // Assert
     verify(checkTableExistStatement).execute(expectedCheckTableExistStatement);
     verify(adminSpy).createTableInternal(connection, namespace, table, metadata);
-    verify(adminSpy).createIndex(connection, namespace, table, metadata);
     verify(adminSpy).addTableMetadata(connection, namespace, table, metadata, true);
+  }
+
+  @ParameterizedTest
+  @EnumSource(RdbEngine.class)
+  public void repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex(RdbEngine rdbEngine)
+      throws ExecutionException, SQLException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addClusteringKey("c2")
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BOOLEAN)
+            .addColumn("c4", DataType.DATE)
+            .addSecondaryIndex("c3")
+            .addSecondaryIndex("c4")
+            .build();
+    // The table and the metadata table already exist (every execution succeeds)
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(rdbEngine));
+
+    // Act
+    adminSpy.repairTable(namespace, table, metadata, Collections.emptyMap());
+
+    // Assert
+    // The existing table is not recreated, but the missing secondary indexes are created
+    verify(adminSpy, never()).createTableInternal(connection, namespace, table, metadata);
+    verify(adminSpy).createIndex(connection, namespace, table, "c3", true);
+    verify(adminSpy).createIndex(connection, namespace, table, "c4", true);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -2676,53 +2676,51 @@ public abstract class JdbcAdminTestBase {
   }
 
   @Test
-  public void repairTable_WithNonExistingTableToRepairForMysql_shouldThrowIllegalArgumentException()
-      throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+  public void repairTable_WithNonExistingTableToRepairForMysql_shouldCreateTableAndAddMetadata()
+      throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.MYSQL, "SELECT 1 FROM `my_ns`.`foo_table` LIMIT 1");
   }
 
   @Test
-  public void
-      repairTable_WithNonExistingTableToRepairForOracle_shouldThrowIllegalArgumentException()
-          throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+  public void repairTable_WithNonExistingTableToRepairForOracle_shouldCreateTableAndAddMetadata()
+      throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.ORACLE, "SELECT 1 FROM \"my_ns\".\"foo_table\" FETCH FIRST 1 ROWS ONLY");
   }
 
   @Test
   public void
-      repairTable_WithNonExistingTableToRepairForPostgresql_shouldThrowIllegalArgumentException()
-          throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+      repairTable_WithNonExistingTableToRepairForPostgresql_shouldCreateTableAndAddMetadata()
+          throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.POSTGRESQL, "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1");
   }
 
   @Test
-  public void
-      repairTable_WithNonExistingTableToRepairForSqlServer_shouldThrowIllegalArgumentException()
-          throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+  public void repairTable_WithNonExistingTableToRepairForSqlServer_shouldCreateTableAndAddMetadata()
+      throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.SQL_SERVER, "SELECT TOP 1 1 FROM [my_ns].[foo_table]");
   }
 
   @Test
-  public void
-      repairTable_WithNonExistingTableToRepairForSqlite_shouldThrowIllegalArgumentException()
-          throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+  public void repairTable_WithNonExistingTableToRepairForSqlite_shouldCreateTableAndAddMetadata()
+      throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.SQLITE, "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1");
   }
 
   @Test
-  public void repairTable_WithNonExistingTableToRepairForDb2_shouldThrowIllegalArgumentException()
-      throws SQLException {
-    repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
+  public void repairTable_WithNonExistingTableToRepairForDb2_shouldCreateTableAndAddMetadata()
+      throws SQLException, ExecutionException {
+    repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
         RdbEngine.DB2, "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1");
   }
 
-  private void repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-      RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
+  private void repairTable_WithNonExistingTableToRepairForX_shouldCreateTableAndAddMetadata(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement)
+      throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
@@ -2733,17 +2731,24 @@ public abstract class JdbcAdminTestBase {
     when(connection.createStatement()).thenReturn(checkTableExistStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
-    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    // Mock that the table and the metadata table do not exist
     SQLException sqlException = mock(SQLException.class);
     mockUndefinedTableError(rdbEngine, sqlException);
     when(checkTableExistStatement.execute(any())).thenThrow(sqlException);
 
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(rdbEngine));
+    doNothing().when(adminSpy).createTableInternal(connection, namespace, table, metadata);
+    doNothing().when(adminSpy).createIndex(connection, namespace, table, metadata);
+    doNothing().when(adminSpy).addTableMetadata(connection, namespace, table, metadata, true);
+
     // Act
-    assertThatThrownBy(() -> admin.repairTable(namespace, table, metadata, new HashMap<>()))
-        .isInstanceOf(IllegalArgumentException.class);
+    adminSpy.repairTable(namespace, table, metadata, new HashMap<>());
 
     // Assert
     verify(checkTableExistStatement).execute(expectedCheckTableExistStatement);
+    verify(adminSpy).createTableInternal(connection, namespace, table, metadata);
+    verify(adminSpy).createIndex(connection, namespace, table, metadata);
+    verify(adminSpy).addTableMetadata(connection, namespace, table, metadata, true);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -805,6 +805,7 @@ public abstract class ConsensusCommitAdminTestBase {
     admin.repairCoordinatorTables(options);
 
     // Assert
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
@@ -827,12 +828,75 @@ public abstract class ConsensusCommitAdminTestBase {
     adminWithGroupCommit.repairCoordinatorTables(options);
 
     // Assert
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
     verify(distributedStorageAdmin)
         .repairTable(
             coordinatorNamespaceName,
             Coordinator.TABLE,
             Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
             options);
+  }
+
+  @Test
+  public void
+      repairCoordinatorTables_WithGroupCommitEnabledAndExistingTableMissingChildIdsColumn_ShouldAddChildIdsColumn()
+          throws ExecutionException {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithGroupCommit =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    // The existing Coordinator table was created with group commit disabled, so it does not have
+    // the CHILD_IDS column.
+    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
+        .thenReturn(Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED);
+
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    adminWithGroupCommit.repairCoordinatorTables(options);
+
+    // Assert
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
+    verify(distributedStorageAdmin)
+        .repairTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
+            options);
+    verify(distributedStorageAdmin)
+        .addNewColumnToTable(
+            coordinatorNamespaceName, Coordinator.TABLE, Attribute.CHILD_IDS, DataType.TEXT);
+  }
+
+  @Test
+  public void
+      repairCoordinatorTables_WithGroupCommitDisabledAndExistingTableHavingChildIdsColumn_ShouldPreserveWithChildIdsSchemaAndNotAlterTable()
+          throws ExecutionException {
+    // Arrange
+    // The existing Coordinator table was created with group commit enabled, so it already has the
+    // CHILD_IDS column. We are now repairing with group commit disabled. The ScalarDB-side
+    // metadata must stay aligned with the physical column set (still WITH child_ids); the runtime
+    // group commit config independently decides whether to use that column. So repair should
+    // upsert the WITH_GROUP_COMMIT_ENABLED metadata, NOT the disabled variant, and should not
+    // attempt any column ALTER.
+    when(distributedStorageAdmin.getTableMetadata(coordinatorNamespaceName, Coordinator.TABLE))
+        .thenReturn(Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED);
+
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    admin.repairCoordinatorTables(options);
+
+    // Assert
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
+    verify(distributedStorageAdmin)
+        .repairTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
+            options);
+    verify(distributedStorageAdmin, never()).addNewColumnToTable(any(), any(), any(), any());
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
@@ -1,7 +1,6 @@
 package com.scalar.db.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -24,7 +23,7 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
   private static final Logger logger =
       LoggerFactory.getLogger(DistributedStorageAdminRepairTableIntegrationTestBase.class);
 
-  private static final String TEST_NAME = "storage_admin_repair_table";
+  protected static final String TEST_NAME = "storage_admin_repair_table";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
   private static final String TABLE = "tbl";
   private static final String COL_NAME1 = "c1";
@@ -183,15 +182,29 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
   }
 
   @Test
-  public void repairTable_ForNonExistingTable_ShouldThrowIllegalArgument() {
-    // Arrange
+  public void repairTable_ForExistingTableAndMetadata_ShouldDoNothing() throws Exception {
+    // Act
+    admin.repairTable(getNamespace(), getTable(), getTableMetadata(), getCreationOptions());
 
-    // Act Assert
-    assertThatThrownBy(
-            () ->
-                admin.repairTable(
-                    getNamespace(), "non-existing-table", getTableMetadata(), getCreationOptions()))
-        .isInstanceOf(IllegalArgumentException.class);
+    // Assert
+    assertThat(adminTestUtils.tableExists(getNamespace(), getTable())).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(getTableMetadata());
+  }
+
+  @Test
+  public void repairTable_ForNonExistingTableButExistingMetadata_ShouldCreateTable()
+      throws Exception {
+    // Arrange
+    adminTestUtils.dropTable(getNamespace(), getTable());
+
+    // Act
+    waitForDifferentSessionDdl();
+    admin.repairTable(getNamespace(), getTable(), getTableMetadata(), getCreationOptions());
+
+    // Assert
+    waitForDifferentSessionDdl();
+    assertThat(adminTestUtils.tableExists(getNamespace(), getTable())).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(getTableMetadata());
   }
 
   protected boolean isTimestampTypeSupported() {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -1,7 +1,6 @@
 package com.scalar.db.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -171,9 +170,8 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
   }
 
   @Test
-  public void
-      repairTableAndCoordinatorTable_CoordinatorTablesDoNotExist_ShouldThrowIllegalArgumentException()
-          throws ExecutionException {
+  public void repairCoordinatorTables_CoordinatorTablesDoNotExist_ShouldCreateCoordinatorTables()
+      throws ExecutionException {
     if (!hasCoordinatorTables()) {
       return;
     }
@@ -181,10 +179,26 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
     // Arrange
     admin.dropCoordinatorTables(true);
 
-    // Act Assert
+    // Act
     waitForDifferentSessionDdl();
-    assertThatThrownBy(() -> admin.repairCoordinatorTables(getCreationOptions()))
-        .isInstanceOf(IllegalArgumentException.class);
+    admin.repairCoordinatorTables(getCreationOptions());
+
+    // Assert
+    waitForDifferentSessionDdl();
+    assertThat(admin.coordinatorTablesExist()).isTrue();
+  }
+
+  @Test
+  public void repairCoordinatorTables_CoordinatorTablesExist_ShouldDoNothing() throws Exception {
+    if (!hasCoordinatorTables()) {
+      return;
+    }
+
+    // Act
+    admin.repairCoordinatorTables(getCreationOptions());
+
+    // Assert
+    assertThat(admin.coordinatorTablesExist()).isTrue();
   }
 
   @Test
@@ -204,15 +218,19 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
   }
 
   @Test
-  public void repairTable_ForNonExistingTable_ShouldThrowIllegalArgument() {
+  public void repairTable_ForNonExistingTableButExistingMetadata_ShouldCreateTable()
+      throws Exception {
     // Arrange
+    adminTestUtils.dropTable(getNamespace(), getTable());
 
-    // Act Assert
-    assertThatThrownBy(
-            () ->
-                admin.repairTable(
-                    getNamespace(), "non-existing-table", getTableMetadata(), getCreationOptions()))
-        .isInstanceOf(IllegalArgumentException.class);
+    // Act
+    waitForDifferentSessionDdl();
+    admin.repairTable(getNamespace(), getTable(), getTableMetadata(), getCreationOptions());
+
+    // Assert
+    waitForDifferentSessionDdl();
+    assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(getTableMetadata());
   }
 
   protected boolean hasCoordinatorTables() {

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
@@ -1,7 +1,16 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionAdminRepairTableIntegrationTestBase;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
     extends DistributedTransactionAdminRepairTableIntegrationTestBase {
@@ -14,4 +23,101 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
   }
 
   protected abstract Properties getProps(String testName);
+
+  @Test
+  public void
+      repairCoordinatorTables_WithExistingCoordinatorMissingChildIdsColumn_ShouldAddChildIdsColumn()
+          throws Exception {
+    // Arrange: drop the Coordinator created in setUp and recreate it via a separate admin
+    // instance that has group commit explicitly disabled, so the Coordinator table has no
+    // CHILD_IDS column.
+    admin.dropCoordinatorTables();
+
+    Properties propertiesWithGroupCommitDisabled = new Properties();
+    propertiesWithGroupCommitDisabled.putAll(getProperties(TEST_NAME));
+    propertiesWithGroupCommitDisabled.setProperty(
+        ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "false");
+    try (DistributedTransactionAdmin adminWithGroupCommitDisabled =
+        TransactionFactory.create(propertiesWithGroupCommitDisabled).getTransactionAdmin()) {
+      waitForDifferentSessionDdl();
+      adminWithGroupCommitDisabled.createCoordinatorTables(getCreationOptions());
+    }
+
+    // Act: repair with group commit enabled. The existing Coordinator has no CHILD_IDS column,
+    // so this should add the column via ALTER TABLE ADD COLUMN.
+    Properties propertiesWithGroupCommitEnabled = new Properties();
+    propertiesWithGroupCommitEnabled.putAll(getProperties(TEST_NAME));
+    propertiesWithGroupCommitEnabled.setProperty(
+        ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "true");
+    try (DistributedTransactionAdmin adminWithGroupCommitEnabled =
+        TransactionFactory.create(propertiesWithGroupCommitEnabled).getTransactionAdmin()) {
+      waitForDifferentSessionDdl();
+      adminWithGroupCommitEnabled.repairCoordinatorTables(getCreationOptions());
+
+      // Assert: the column now exists in the post-repair Coordinator metadata. We have to read the
+      // metadata via DistributedStorageAdmin (not via the transaction admin) because
+      // ConsensusCommitAdmin#getTableMetadata returns null for the coordinator namespace by design.
+      waitForDifferentSessionDdl();
+      String coordinatorNamespace =
+          new ConsensusCommitConfig(new DatabaseConfig(propertiesWithGroupCommitEnabled))
+              .getCoordinatorNamespace()
+              .orElse(Coordinator.NAMESPACE);
+      try (DistributedStorageAdmin storageAdmin =
+          StorageFactory.create(propertiesWithGroupCommitEnabled).getStorageAdmin()) {
+        TableMetadata metadata =
+            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getColumnNames()).contains(Attribute.CHILD_IDS);
+      }
+    }
+  }
+
+  @Test
+  public void
+      repairCoordinatorTables_WithExistingCoordinatorHavingChildIdsColumnAndGroupCommitDisabled_ShouldPreserveChildIdsColumn()
+          throws Exception {
+    // Arrange: drop the Coordinator created in setUp and recreate it via a separate admin
+    // instance that has group commit explicitly enabled, so the Coordinator table has the
+    // CHILD_IDS column.
+    admin.dropCoordinatorTables();
+
+    Properties propertiesWithGroupCommitEnabled = new Properties();
+    propertiesWithGroupCommitEnabled.putAll(getProperties(TEST_NAME));
+    propertiesWithGroupCommitEnabled.setProperty(
+        ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "true");
+    try (DistributedTransactionAdmin adminWithGroupCommitEnabled =
+        TransactionFactory.create(propertiesWithGroupCommitEnabled).getTransactionAdmin()) {
+      waitForDifferentSessionDdl();
+      adminWithGroupCommitEnabled.createCoordinatorTables(getCreationOptions());
+    }
+
+    // Act: repair with group commit disabled. The existing Coordinator has the CHILD_IDS column,
+    // so the repair should preserve it (keep the WITH-CHILD_IDS schema) rather than dropping it,
+    // so that ScalarDB metadata stays aligned with the physical column set.
+    Properties propertiesWithGroupCommitDisabled = new Properties();
+    propertiesWithGroupCommitDisabled.putAll(getProperties(TEST_NAME));
+    propertiesWithGroupCommitDisabled.setProperty(
+        ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "false");
+    try (DistributedTransactionAdmin adminWithGroupCommitDisabled =
+        TransactionFactory.create(propertiesWithGroupCommitDisabled).getTransactionAdmin()) {
+      waitForDifferentSessionDdl();
+      adminWithGroupCommitDisabled.repairCoordinatorTables(getCreationOptions());
+
+      // Assert: the column is still present in the post-repair Coordinator metadata. We have to
+      // read the metadata via DistributedStorageAdmin (not via the transaction admin) because
+      // ConsensusCommitAdmin#getTableMetadata returns null for the coordinator namespace by design.
+      waitForDifferentSessionDdl();
+      String coordinatorNamespace =
+          new ConsensusCommitConfig(new DatabaseConfig(propertiesWithGroupCommitDisabled))
+              .getCoordinatorNamespace()
+              .orElse(Coordinator.NAMESPACE);
+      try (DistributedStorageAdmin storageAdmin =
+          StorageFactory.create(propertiesWithGroupCommitDisabled).getStorageAdmin()) {
+        TableMetadata metadata =
+            storageAdmin.getTableMetadata(coordinatorNamespace, Coordinator.TABLE);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getColumnNames()).contains(Attribute.CHILD_IDS);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is a backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3561
- **Backported commit:** 1c4219ef5e271abc0ff8a1f2f4c1b07714e61fdf

Since branch `3.16` predates the `JdbcAdmin` refactoring and some related features, the following manual adaptations were made:

- **`JdbcAdmin#repairTable`**: adapted to the pre-refactoring code shape. Instead of `createTableInternal(..., ifNotExists=true)`, it checks the table existence with `tableExistsInternal()` and creates the table (and its indexes) only when it does not exist. The metadata handling (delete-then-add, or create-then-add) is unchanged, which is equivalent to the overwrite semantics of the original change. Note that, unlike branch `3`, missing secondary indexes on an *existing* table are not repaired, since the `CREATE INDEX IF NOT EXISTS` support was introduced by the later refactoring and is out of scope here.
- **`JdbcAdminTestBase`**: the original PR's test changes were made to `JdbcAdminTest`, which does not exist on this branch. The `repairTable_WithNonExistingTableToRepair...` tests were updated in `JdbcAdminTestBase` instead to verify the new behavior (create the table instead of throwing `IllegalArgumentException`), using the same mock-verification style as the original PR. `createTableInternal`, `createIndex`, and `addTableMetadata` were relaxed to package-private with `@VisibleForTesting` for this (matching what the later refactoring did on newer branches).
- **Object Storage integration test files** were dropped since the Object Storage adapter does not exist on this branch.

Please merge this PR after all checks have passed.