### PR TITLE
Add repairTable missing-index unit test to branch 3.17 (omitted from the #3597 backport)

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -1484,6 +1484,36 @@ public class JdbcAdminTest {
     verify(adminSpy).addTableMetadata(connection, namespace, table, metadata, true, true);
   }
 
+  @ParameterizedTest
+  @EnumSource(RdbEngine.class)
+  public void repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex(RdbEngine rdbEngine)
+      throws ExecutionException, SQLException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addClusteringKey("c2")
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BOOLEAN)
+            .addColumn("c4", DataType.DATE)
+            .addSecondaryIndex("c3")
+            .addSecondaryIndex("c4")
+            .build();
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(rdbEngine));
+
+    // Act
+    adminSpy.repairTable(namespace, table, metadata, Collections.emptyMap());
+
+    // Assert
+    verify(adminSpy).createIndex(connection, namespace, table, "c3", true);
+    verify(adminSpy).createIndex(connection, namespace, table, "c4", true);
+  }
+
   @Test
   public void
       createMetadataTableIfNotExists_WithInternalDbError_forMysql_shouldThrowInternalDbError()


### PR DESCRIPTION
## Description

Adds the unit test `repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex` to `JdbcAdminTest` on branch `3.17`.

This test was introduced on `master` by #3596 but omitted when its backport (#3597) landed on `3.17`. The behavior it covers — `repairTable` creating a missing secondary index on an existing table — already works on `3.17` (the `repairTable` alignment merged via #3719), so this only restores the missing coverage, matching branches `3` and `3.18`.

The test is ported verbatim from branch `3` and passes for all JDBC engines.

Please merge this PR after all checks have passed.