### PR TITLE
Backport to branch(3.16) : Avoid unnecessary writes when repairing a table

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -45,9 +45,13 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ThreadSafe
 public class CosmosAdmin implements DistributedStorageAdmin {
+  private static final Logger logger = LoggerFactory.getLogger(CosmosAdmin.class);
+
   public static final String REQUEST_UNIT = "ru";
   public static final String DEFAULT_REQUEST_UNIT = "400";
   public static final String NO_SCALING = "no-scaling";
@@ -92,7 +96,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     try {
-      createTableInternal(namespace, table, metadata, false);
+      createTableInternal(namespace, table, metadata);
     } catch (IllegalArgumentException e) {
       throw e;
     } catch (RuntimeException e) {
@@ -100,11 +104,10 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void createTableInternal(
-      String namespace, String table, TableMetadata metadata, boolean ifNotExists)
+  private void createTableInternal(String namespace, String table, TableMetadata metadata)
       throws ExecutionException {
     checkMetadata(metadata);
-    createContainer(namespace, table, metadata, ifNotExists);
+    createContainer(namespace, table, metadata, false);
     putTableMetadata(namespace, table, metadata, true);
   }
 
@@ -402,6 +405,22 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   private void updateIndexingPolicy(
       String databaseName, String containerName, TableMetadata newTableMetadata)
       throws ExecutionException {
+    updateIndexingPolicy(databaseName, containerName, newTableMetadata, false);
+  }
+
+  /**
+   * Updates the container's indexing policy to match the given metadata. When {@code
+   * skipWhenAlreadyUpToDate} is true (the repair path), the container's actual indexing policy is
+   * compared against the desired one first and the (RU-consuming) container replace is skipped when
+   * it already matches. The comparison is against the actual physical state -- not the ScalarDB
+   * metadata -- because repair must fix the indexing policy even when the metadata already matches.
+   */
+  private void updateIndexingPolicy(
+      String databaseName,
+      String containerName,
+      TableMetadata newTableMetadata,
+      boolean skipWhenAlreadyUpToDate)
+      throws ExecutionException {
     CosmosDatabase database = client.getDatabase(databaseName);
     try {
       // get the existing container properties
@@ -409,14 +428,52 @@ public class CosmosAdmin implements DistributedStorageAdmin {
           database.createContainerIfNotExists(containerName, PARTITION_KEY_PATH);
       CosmosContainerProperties properties = response.getProperties();
 
+      IndexingPolicy newIndexingPolicy = computeIndexingPolicy(newTableMetadata);
+      if (skipWhenAlreadyUpToDate
+          && indexingPolicyUpToDate(properties.getIndexingPolicy(), newIndexingPolicy)) {
+        logger.debug(
+            "The indexing policy for the {} container is already up to date; skipping the indexing policy update",
+            getFullTableName(databaseName, containerName));
+        return;
+      }
+
       // set the new index policy to the container properties
-      properties.setIndexingPolicy(computeIndexingPolicy(newTableMetadata));
+      properties.setIndexingPolicy(newIndexingPolicy);
 
       // update the container properties
       database.getContainer(containerName).replace(properties);
     } catch (RuntimeException e) {
       throw new ExecutionException("Updating the indexing policy failed", e);
     }
+  }
+
+  /**
+   * Returns whether the container's current indexing policy already matches the desired one on the
+   * attributes ScalarDB controls: the set of included paths and the composite indexes. The included
+   * paths cover the secondary indexes, plus the partition-key path when the table has no clustering
+   * keys; the composite indexes cover the partition key and clustering keys when the table has
+   * clustering keys. The excluded paths are not compared because Cosmos adds its own (e.g. for the
+   * etag), which would cause spurious mismatches.
+   */
+  private static boolean indexingPolicyUpToDate(IndexingPolicy current, IndexingPolicy desired) {
+    return includedPaths(current).equals(includedPaths(desired))
+        && compositeIndexes(current).equals(compositeIndexes(desired));
+  }
+
+  private static Set<String> includedPaths(IndexingPolicy policy) {
+    return policy.getIncludedPaths().stream()
+        .map(IncludedPath::getPath)
+        .collect(Collectors.toSet());
+  }
+
+  private static List<List<String>> compositeIndexes(IndexingPolicy policy) {
+    return policy.getCompositeIndexes().stream()
+        .map(
+            paths ->
+                paths.stream()
+                    .map(path -> path.getPath() + " " + path.getOrder())
+                    .collect(Collectors.toList()))
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -520,8 +577,20 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     try {
-      createTableInternal(namespace, table, metadata, true);
-      updateIndexingPolicy(namespace, table, metadata);
+      checkMetadata(metadata);
+      // Always run the physical container repair. The metadata write is guarded by comparing the
+      // stored ScalarDB metadata, while the indexing-policy update is guarded by comparing the
+      // container's actual indexing policy (inside updateIndexingPolicy) -- repair must fix the
+      // physical indexing policy even when the ScalarDB metadata already matches.
+      createContainer(namespace, table, metadata, true);
+      if (tableMetadataAlreadyUpToDate(namespace, table, metadata)) {
+        logger.debug(
+            "The metadata for the {} container is already up to date; skipping the metadata update",
+            getFullTableName(namespace, table));
+      } else {
+        putTableMetadata(namespace, table, metadata, true);
+      }
+      updateIndexingPolicy(namespace, table, metadata, true);
     } catch (IllegalArgumentException e) {
       throw e;
     } catch (Exception e) {
@@ -542,6 +611,24 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       throw new ExecutionException(String.format("Reading the database %s failed", id), e);
     }
     return true;
+  }
+
+  /**
+   * Returns whether the stored table metadata already equals the desired metadata. Fails open: if
+   * reading the current metadata throws (e.g. the metadata is corrupt and cannot be parsed), this
+   * returns {@code false} so the caller rewrites the metadata rather than skipping the repair.
+   */
+  private boolean tableMetadataAlreadyUpToDate(
+      String namespace, String table, TableMetadata metadata) {
+    try {
+      return metadata.equals(getTableMetadata(namespace, table));
+    } catch (Exception e) {
+      logger.debug(
+          "Failed to read the stored metadata for the {} container; proceeding with the metadata update",
+          getFullTableName(namespace, table),
+          e);
+      return false;
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -90,6 +92,8 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateTableRequest;
  */
 @ThreadSafe
 public class DynamoAdmin implements DistributedStorageAdmin {
+  private static final Logger logger = LoggerFactory.getLogger(DynamoAdmin.class);
+
   public static final String NO_SCALING = "no-scaling";
   public static final String NO_BACKUP = "no-backup";
   public static final String REQUEST_UNIT = "ru";
@@ -238,7 +242,16 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       TableMetadata metadata,
       Map<String, String> options)
       throws ExecutionException {
-    createTableInternal(nonPrefixedNamespace, table, metadata, false, options);
+    createTableInternal(nonPrefixedNamespace, table, metadata, options);
+  }
+
+  private void createTableInternal(
+      String nonPrefixedNamespace,
+      String table,
+      TableMetadata metadata,
+      Map<String, String> options)
+      throws ExecutionException {
+    createTableInternal(nonPrefixedNamespace, table, metadata, false, options, false);
   }
 
   private void createTableInternal(
@@ -246,7 +259,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       String table,
       TableMetadata metadata,
       boolean ifNotExists,
-      Map<String, String> options)
+      Map<String, String> options,
+      boolean skipMetadataWriteWhenAlreadyUpToDate)
       throws ExecutionException {
     Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     checkMetadata(metadata);
@@ -290,7 +304,32 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
 
     createMetadataTableIfNotExists(noBackup);
-    upsertTableMetadata(namespace, table, metadata);
+    if (skipMetadataWriteWhenAlreadyUpToDate
+        && tableMetadataAlreadyUpToDate(nonPrefixedNamespace, table, metadata)) {
+      logger.debug(
+          "The metadata for the {} table is already up to date; skipping the metadata update",
+          getFullTableName(namespace, table));
+    } else {
+      upsertTableMetadata(namespace, table, metadata);
+    }
+  }
+
+  /**
+   * Returns whether the stored table metadata already equals the desired metadata. Fails open: if
+   * reading the current metadata throws (e.g. the metadata is corrupt and cannot be parsed), this
+   * returns {@code false} so the caller rewrites the metadata rather than skipping the repair.
+   */
+  private boolean tableMetadataAlreadyUpToDate(
+      String nonPrefixedNamespace, String table, TableMetadata metadata) {
+    try {
+      return metadata.equals(getTableMetadata(nonPrefixedNamespace, table));
+    } catch (Exception e) {
+      logger.debug(
+          "Failed to read the stored metadata for the {} table; proceeding with the metadata update",
+          getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table),
+          e);
+      return false;
+    }
   }
 
   private boolean internalTableExists(Namespace namespace, String table) throws ExecutionException {
@@ -1277,7 +1316,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       Map<String, String> options)
       throws ExecutionException {
     try {
-      createTableInternal(nonPrefixedNamespace, table, metadata, true, options);
+      createTableInternal(nonPrefixedNamespace, table, metadata, true, options, true);
       for (String indexColumnName : metadata.getSecondaryIndexNames()) {
         if (!rawIndexExists(nonPrefixedNamespace, table, indexColumnName)) {
           createIndex(nonPrefixedNamespace, table, indexColumnName, options);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -778,7 +778,11 @@ public class JdbcAdmin implements DistributedStorageAdmin {
         createIndex(connection, namespace, table, indexedColumn, true);
       }
 
-      if (tableExistsInternal(connection, metadataSchema, METADATA_TABLE)) {
+      if (tableMetadataAlreadyUpToDate(namespace, table, metadata)) {
+        logger.debug(
+            "The metadata for the {} table is already up to date; skipping the metadata update",
+            getFullTableName(namespace, table));
+      } else if (tableExistsInternal(connection, metadataSchema, METADATA_TABLE)) {
         // Delete then add the metadata for the table
         execute(connection, getDeleteTableMetadataStatement(namespace, table));
         addTableMetadata(connection, namespace, table, metadata, false);
@@ -789,6 +793,24 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     } catch (ExecutionException | SQLException e) {
       throw new ExecutionException(
           String.format("Repairing the table %s.%s failed", namespace, table), e);
+    }
+  }
+
+  /**
+   * Returns whether the stored table metadata already equals the desired metadata. Fails open: if
+   * reading the current metadata throws (e.g. the metadata is corrupt and cannot be parsed), this
+   * returns {@code false} so the caller rewrites the metadata rather than skipping the repair.
+   */
+  private boolean tableMetadataAlreadyUpToDate(
+      String namespace, String table, TableMetadata metadata) {
+    try {
+      return metadata.equals(getTableMetadata(namespace, table));
+    } catch (Exception e) {
+      logger.debug(
+          "Failed to read the stored metadata for the {} table; proceeding with the metadata update",
+          getFullTableName(namespace, table),
+          e);
+      return false;
     }
   }
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -31,10 +31,10 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.cassandra.CassandraAdmin.CompactionStrategy;
 import com.scalar.db.storage.cassandra.CassandraAdmin.ReplicationStrategy;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -583,15 +583,18 @@ public class CassandraAdminTest {
     verify(cassandraSession, times(3)).execute(captor.capture());
     Assertions.assertThat(captor.getAllValues().get(0))
         .isEqualTo(createTableStatement.getQueryString());
-    // Assert index creation
-    Iterator<String> indexIterator = tableMetadata.getSecondaryIndexNames().iterator();
-    for (int i = 1; indexIterator.hasNext(); i++) {
-      String index = indexIterator.next();
-      assertThat(captor.getAllValues().get(i).trim())
-          .isEqualTo(
-              String.format(
-                  "CREATE INDEX IF NOT EXISTS tbl_index_%1$s ON sample_ns.tbl(%1$s)", index));
+    // Assert index creation. Secondary index names are an unordered set, so verify the index DDL
+    // statements without depending on iteration order.
+    List<String> expectedIndexStatements = new ArrayList<>();
+    for (String index : tableMetadata.getSecondaryIndexNames()) {
+      expectedIndexStatements.add(
+          String.format("CREATE INDEX IF NOT EXISTS tbl_index_%1$s ON sample_ns.tbl(%1$s)", index));
     }
+    List<String> actualIndexStatements = new ArrayList<>();
+    for (int i = 1; i < captor.getAllValues().size(); i++) {
+      actualIndexStatements.add(captor.getAllValues().get(i).trim());
+    }
+    assertThat(actualIndexStatements).containsExactlyInAnyOrderElementsOf(expectedIndexStatements);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.CosmosScripts;
 import com.azure.cosmos.CosmosStoredProcedure;
+import com.azure.cosmos.models.CompositePath;
 import com.azure.cosmos.models.CompositePathSortOrder;
 import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosContainerResponse;
@@ -29,6 +31,7 @@ import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.CosmosStoredProcedureProperties;
+import com.azure.cosmos.models.IncludedPath;
 import com.azure.cosmos.models.IndexingPolicy;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.ThroughputProperties;
@@ -39,6 +42,7 @@ import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -67,6 +71,9 @@ public abstract class CosmosAdminTestBase {
   @Mock private CosmosContainer container;
   private CosmosAdmin admin;
   private String metadataDatabaseName;
+  // The container properties mock returned by setUpRepairTableMocks, for stubbing the current
+  // indexing policy in indexing-policy repair tests.
+  private CosmosContainerProperties repairContainerProperties;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -800,6 +807,7 @@ public abstract class CosmosAdminTestBase {
         .thenReturn(response);
     CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
     when(response.getProperties()).thenReturn(properties);
+    when(properties.getIndexingPolicy()).thenReturn(new IndexingPolicy());
 
     // Act Assert
     admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
@@ -810,6 +818,8 @@ public abstract class CosmosAdminTestBase {
     verify(metadataDatabase).createContainerIfNotExists(any());
     verify(metadataContainer).upsertItem(cosmosTableMetadata);
     verify(storedProcedure).read();
+    // The stored procedure already exists, so it must not be created again
+    verify(scripts, never()).createStoredProcedure(any());
   }
 
   @Test
@@ -857,6 +867,7 @@ public abstract class CosmosAdminTestBase {
         .thenReturn(response);
     CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
     when(response.getProperties()).thenReturn(properties);
+    when(properties.getIndexingPolicy()).thenReturn(new IndexingPolicy());
 
     // Act
     admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
@@ -868,6 +879,497 @@ public abstract class CosmosAdminTestBase {
     verify(metadataContainer).upsertItem(cosmosTableMetadata);
     verify(storedProcedure).read();
     verify(scripts).createStoredProcedure(any());
+  }
+
+  @Test
+  public void repairTable_ShouldCreateTableIfNotExistsAndUpsertMetadata()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .secondaryIndexNames(ImmutableSet.of("c3"))
+            .build();
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
+
+    // Metadata container
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+
+    // Missing stored procedure
+    CosmosScripts scripts = mock(CosmosScripts.class);
+    when(container.getScripts()).thenReturn(scripts);
+    CosmosStoredProcedure storedProcedure = mock(CosmosStoredProcedure.class);
+    CosmosException cosmosException = mock(CosmosException.class);
+    when(scripts.getStoredProcedure(CosmosAdmin.STORED_PROCEDURE_FILE_NAME))
+        .thenReturn(storedProcedure);
+    when(cosmosException.getStatusCode()).thenReturn(404);
+    when(storedProcedure.read()).thenThrow(cosmosException);
+
+    // Existing container properties
+    CosmosContainerResponse response = mock(CosmosContainerResponse.class);
+    when(database.createContainerIfNotExists(table, "/concatenatedPartitionKey"))
+        .thenReturn(response);
+    CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
+    when(response.getProperties()).thenReturn(properties);
+    when(properties.getIndexingPolicy()).thenReturn(new IndexingPolicy());
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert
+    ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
+        ArgumentCaptor.forClass(CosmosContainerProperties.class);
+
+    verify(database).createContainerIfNotExists(containerPropertiesCaptor.capture());
+    assertThat(containerPropertiesCaptor.getValue().getId()).isEqualTo(table);
+
+    // check index related info
+    IndexingPolicy indexingPolicy = containerPropertiesCaptor.getValue().getIndexingPolicy();
+    assertThat(indexingPolicy.getIncludedPaths().size()).isEqualTo(2);
+    assertThat(indexingPolicy.getIncludedPaths().get(0).getPath())
+        .isEqualTo("/concatenatedPartitionKey/?");
+    assertThat(indexingPolicy.getIncludedPaths().get(1).getPath()).isEqualTo("/values/c3/?");
+    assertThat(indexingPolicy.getExcludedPaths().size()).isEqualTo(1);
+    assertThat(indexingPolicy.getExcludedPaths().get(0).getPath()).isEqualTo("/*");
+    assertThat(indexingPolicy.getCompositeIndexes().size()).isEqualTo(0);
+
+    verify(client).createDatabaseIfNotExists(eq(metadataDatabaseName), any());
+
+    verify(metadataDatabase).createContainerIfNotExists(any());
+    verify(metadataContainer).upsertItem(cosmosTableMetadata);
+    verify(storedProcedure).read();
+    verify(scripts).createStoredProcedure(any());
+  }
+
+  private CosmosContainer setUpRepairTableMocks(String namespace, String table) {
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
+
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+
+    // Missing stored procedure so the physical container repair path runs fully
+    CosmosScripts scripts = mock(CosmosScripts.class);
+    when(container.getScripts()).thenReturn(scripts);
+    CosmosStoredProcedure storedProcedure = mock(CosmosStoredProcedure.class);
+    CosmosException cosmosException = mock(CosmosException.class);
+    when(scripts.getStoredProcedure(CosmosAdmin.STORED_PROCEDURE_FILE_NAME))
+        .thenReturn(storedProcedure);
+    when(cosmosException.getStatusCode()).thenReturn(404);
+    when(storedProcedure.read()).thenThrow(cosmosException);
+
+    CosmosContainerResponse response = mock(CosmosContainerResponse.class);
+    when(database.createContainerIfNotExists(table, "/concatenatedPartitionKey"))
+        .thenReturn(response);
+    CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
+    when(response.getProperties()).thenReturn(properties);
+    // A real container always has an indexing policy; default to an empty one so it does not match
+    // the desired policy (tests that exercise the up-to-date path override this).
+    when(properties.getIndexingPolicy()).thenReturn(new IndexingPolicy());
+    repairContainerProperties = properties;
+
+    return metadataContainer;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubStoredTableMetadata(
+      CosmosContainer metadataContainer, CosmosTableMetadata stored) {
+    CosmosItemResponse<CosmosTableMetadata> metadataResponse = mock(CosmosItemResponse.class);
+    when(metadataContainer.readItem(
+            anyString(),
+            any(PartitionKey.class),
+            ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
+        .thenReturn(metadataResponse);
+    when(metadataResponse.getItem()).thenReturn(stored);
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataEqualsDesired_ShouldNotUpsertMetadata()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .secondaryIndexNames(ImmutableSet.of("c3"))
+            .build());
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: physical container repair still runs, but the metadata upsert is skipped
+    verify(database).createContainerIfNotExists(any(CosmosContainerProperties.class));
+    verify(metadataContainer, never()).upsertItem(any());
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataDiffersFromDesired_ShouldUpsertMetadata()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    // Stored metadata is missing the secondary index, so it differs from the desired metadata
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build());
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert
+    verify(metadataContainer).upsertItem(any(CosmosTableMetadata.class));
+  }
+
+  @Test
+  public void repairTable_WhenIndexingPolicyAlreadyUpToDate_ShouldNotReplaceContainer()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .secondaryIndexNames(ImmutableSet.of("c3"))
+            .build());
+    // The container's actual indexing policy already matches the desired one
+    IndexingPolicy currentPolicy = new IndexingPolicy();
+    currentPolicy.setIncludedPaths(
+        Arrays.asList(
+            new IncludedPath("/concatenatedPartitionKey/?"), new IncludedPath("/values/c3/?")));
+    when(repairContainerProperties.getIndexingPolicy()).thenReturn(currentPolicy);
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: the indexing policy is already correct, so the container is not replaced
+    verify(container, never()).replace(any(CosmosContainerProperties.class));
+  }
+
+  @Test
+  public void repairTable_WhenIndexingPolicyDiffers_ShouldReplaceContainer()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .secondaryIndexNames(ImmutableSet.of("c3"))
+            .build());
+    // The container's actual indexing policy is missing the c3 secondary index path
+    IndexingPolicy currentPolicy = new IndexingPolicy();
+    currentPolicy.setIncludedPaths(
+        Collections.singletonList(new IncludedPath("/concatenatedPartitionKey/?")));
+    when(repairContainerProperties.getIndexingPolicy()).thenReturn(currentPolicy);
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: the indexing policy is stale, so the container is replaced to fix it
+    verify(container).replace(any(CosmosContainerProperties.class));
+  }
+
+  @Test
+  public void repairTable_WhenReadingStoredMetadataThrows_ShouldFailOpenAndUpsertMetadata()
+      throws ExecutionException {
+    // Arrange: reading the current metadata throws (e.g. a corrupt record); the guard must fail
+    // open and write rather than skip the metadata update
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    when(metadataContainer.readItem(
+            anyString(),
+            any(PartitionKey.class),
+            ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
+        .thenThrow(new RuntimeException("corrupted"));
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: no exception propagates and the metadata is rewritten
+    verify(metadataContainer).upsertItem(any(CosmosTableMetadata.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void repairTable_WhenStoredMetadataAbsent_ShouldUpsertMetadata()
+      throws ExecutionException {
+    // Arrange: no stored metadata (read returns null); the guard must write
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    CosmosItemResponse<CosmosTableMetadata> metadataResponse = mock(CosmosItemResponse.class);
+    when(metadataContainer.readItem(
+            anyString(),
+            any(PartitionKey.class),
+            ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
+        .thenReturn(metadataResponse);
+    when(metadataResponse.getItem()).thenReturn(null);
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert
+    verify(metadataContainer).upsertItem(any(CosmosTableMetadata.class));
+  }
+
+  @Test
+  public void repairTable_WhenCompositeIndexUpToDate_ShouldNotReplaceContainer()
+      throws ExecutionException {
+    // Arrange: a table with a clustering key, so the desired indexing policy has a composite index
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addColumn("c4", DataType.INT)
+            .addPartitionKey("c1")
+            .addClusteringKey("c2", Order.ASC)
+            .addSecondaryIndex("c4")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .clusteringKeyNames(Sets.newLinkedHashSet("c2"))
+            .clusteringOrders(ImmutableMap.of("c2", "ASC"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint", "c4", "int"))
+            .secondaryIndexNames(ImmutableSet.of("c4"))
+            .build());
+    // The container's actual indexing policy already matches the desired one, including the
+    // composite index derived from the clustering key
+    IndexingPolicy currentPolicy = new IndexingPolicy();
+    currentPolicy.setIncludedPaths(Collections.singletonList(new IncludedPath("/values/c4/?")));
+    currentPolicy.setCompositeIndexes(
+        Collections.singletonList(
+            Arrays.asList(
+                compositePath("/concatenatedPartitionKey", CompositePathSortOrder.ASCENDING),
+                compositePath("/clusteringKey/c2", CompositePathSortOrder.ASCENDING))));
+    when(repairContainerProperties.getIndexingPolicy()).thenReturn(currentPolicy);
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: the composite index already matches, so the container is not replaced
+    verify(container, never()).replace(any(CosmosContainerProperties.class));
+  }
+
+  @Test
+  public void repairTable_WhenCompositeIndexDiffers_ShouldReplaceContainer()
+      throws ExecutionException {
+    // Arrange: a table with a clustering key, so the desired indexing policy has a composite index
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addColumn("c4", DataType.INT)
+            .addPartitionKey("c1")
+            .addClusteringKey("c2", Order.ASC)
+            .addSecondaryIndex("c4")
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .clusteringKeyNames(Sets.newLinkedHashSet("c2"))
+            .clusteringOrders(ImmutableMap.of("c2", "ASC"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint", "c4", "int"))
+            .secondaryIndexNames(ImmutableSet.of("c4"))
+            .build());
+    // The included paths match, but the composite index is missing the clustering-key path, so the
+    // policy differs only on the composite-index dimension
+    IndexingPolicy currentPolicy = new IndexingPolicy();
+    currentPolicy.setIncludedPaths(Collections.singletonList(new IncludedPath("/values/c4/?")));
+    currentPolicy.setCompositeIndexes(
+        Collections.singletonList(
+            Collections.singletonList(
+                compositePath("/concatenatedPartitionKey", CompositePathSortOrder.ASCENDING))));
+    when(repairContainerProperties.getIndexingPolicy()).thenReturn(currentPolicy);
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert: the composite index is stale, so the container is replaced to fix it
+    verify(container).replace(any(CosmosContainerProperties.class));
+  }
+
+  @Test
+  public void repairTable_WhenClusteringKeyButNoSecondaryIndex_ShouldNotThrow()
+      throws ExecutionException {
+    // Arrange: a table with a clustering key and no secondary index. computeIndexingPolicy then
+    // sets compositeIndexes but never calls setIncludedPaths, so the desired policy's included
+    // paths come straight from the SDK getter. This verifies that comparison does not throw (the
+    // SDK lazily initializes getIncludedPaths()/getCompositeIndexes() to empty lists, never null).
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addClusteringKey("c2", Order.ASC)
+            .build();
+    CosmosContainer metadataContainer = setUpRepairTableMocks(namespace, table);
+    stubStoredTableMetadata(
+        metadataContainer,
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .clusteringKeyNames(Sets.newLinkedHashSet("c2"))
+            .clusteringOrders(ImmutableMap.of("c2", "ASC"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build());
+
+    // Act Assert
+    assertThatCode(() -> admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap()))
+        .doesNotThrowAnyException();
+  }
+
+  private static CompositePath compositePath(String path, CompositePathSortOrder order) {
+    CompositePath compositePath = new CompositePath();
+    compositePath.setPath(path);
+    compositePath.setOrder(order);
+    return compositePath;
+  }
+
+  @Test
+  public void repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn("c1", DataType.INT)
+            .addColumn("c2", DataType.TEXT)
+            .addColumn("c3", DataType.BIGINT)
+            .addPartitionKey("c1")
+            .addSecondaryIndex("c3")
+            .build();
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
+    // Metadata container
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+    // Stored procedure exists
+    CosmosScripts scripts = mock(CosmosScripts.class);
+    when(container.getScripts()).thenReturn(scripts);
+    CosmosStoredProcedure storedProcedure = mock(CosmosStoredProcedure.class);
+    when(scripts.getStoredProcedure(CosmosAdmin.STORED_PROCEDURE_FILE_NAME))
+        .thenReturn(storedProcedure);
+    // Existing container properties
+    CosmosContainerResponse response = mock(CosmosContainerResponse.class);
+    when(database.createContainerIfNotExists(table, "/concatenatedPartitionKey"))
+        .thenReturn(response);
+    CosmosContainerProperties properties = mock(CosmosContainerProperties.class);
+    when(response.getProperties()).thenReturn(properties);
+    when(properties.getIndexingPolicy()).thenReturn(new IndexingPolicy());
+
+    // Act
+    admin.repairTable(namespace, table, tableMetadata, Collections.emptyMap());
+
+    // Assert
+    verify(container, times(1)).replace(properties);
+    verify(properties, times(1)).setIndexingPolicy(any(IndexingPolicy.class));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1120,6 +1120,107 @@ public abstract class DynamoAdminTestBase {
                 .build());
   }
 
+  private void stubExistingTableAndMetadataTableForRepair() {
+    when(client.describeTable(DescribeTableRequest.builder().tableName(getFullTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
+    when(client.describeTable(
+            DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
+    when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
+        .thenReturn(backupIsEnabledResponse);
+  }
+
+  private GetItemResponse storedTableMetadataItem(Map<String, AttributeValue> columns) {
+    GetItemResponse response = mock(GetItemResponse.class);
+    when(response.item())
+        .thenReturn(
+            ImmutableMap.<String, AttributeValue>builder()
+                .put(
+                    DynamoAdmin.METADATA_ATTR_TABLE,
+                    AttributeValue.builder().s(getFullTableName()).build())
+                .put(DynamoAdmin.METADATA_ATTR_COLUMNS, AttributeValue.builder().m(columns).build())
+                .put(
+                    DynamoAdmin.METADATA_ATTR_PARTITION_KEY,
+                    AttributeValue.builder().l(AttributeValue.builder().s("c1").build()).build())
+                .build());
+    return response;
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataEqualsDesired_ShouldNotUpsertMetadata()
+      throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    stubExistingTableAndMetadataTableForRepair();
+    GetItemResponse stored =
+        storedTableMetadataItem(ImmutableMap.of("c1", AttributeValue.builder().s("text").build()));
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(stored);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert: physical repair still runs, but the metadata write is skipped
+    verify(client, never()).putItem(any(PutItemRequest.class));
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataDiffersFromDesired_ShouldUpsertMetadata()
+      throws ExecutionException {
+    // Arrange: desired has an extra column, so the stored metadata differs
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.INT)
+            .build();
+    stubExistingTableAndMetadataTableForRepair();
+    GetItemResponse stored =
+        storedTableMetadataItem(ImmutableMap.of("c1", AttributeValue.builder().s("text").build()));
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(stored);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert
+    verify(client).putItem(any(PutItemRequest.class));
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataAbsent_ShouldUpsertMetadata()
+      throws ExecutionException {
+    // Arrange: no stored metadata (getItem returns an empty item, so getTableMetadata returns
+    // null); the guard must fall through to the write rather than skip
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    stubExistingTableAndMetadataTableForRepair();
+    GetItemResponse absent = mock(GetItemResponse.class);
+    when(absent.item()).thenReturn(ImmutableMap.of());
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(absent);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert
+    verify(client).putItem(any(PutItemRequest.class));
+  }
+
+  @Test
+  public void repairTable_WhenReadingStoredMetadataThrows_ShouldFailOpenAndUpsertMetadata()
+      throws ExecutionException {
+    // Arrange: reading the current metadata throws; the guard must fail open and write
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    stubExistingTableAndMetadataTableForRepair();
+    when(client.getItem(any(GetItemRequest.class))).thenThrow(new RuntimeException("corrupted"));
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert
+    verify(client).putItem(any(PutItemRequest.class));
+  }
+
   @Test
   public void repairTable_WhenMetadataIsInvalid_ShouldThrowIllegalArgumentException() {
     // Arrange: a BOOLEAN secondary index is rejected by checkMetadata with an

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -19,6 +19,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.description;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -2780,6 +2782,96 @@ public abstract class JdbcAdminTestBase {
     verify(adminSpy, never()).createTableInternal(connection, namespace, table, metadata);
     verify(adminSpy).createIndex(connection, namespace, table, "c3", true);
     verify(adminSpy).createIndex(connection, namespace, table, "c4", true);
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataEqualsDesired_ShouldNotAddTableMetadata()
+      throws SQLException, ExecutionException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(RdbEngine.MYSQL));
+    // The stored metadata already matches the desired metadata
+    doReturn(metadata).when(adminSpy).getTableMetadata(namespace, table);
+
+    // Act
+    adminSpy.repairTable(namespace, table, metadata, Collections.emptyMap());
+
+    // Assert: the metadata write is skipped
+    verify(adminSpy, never()).addTableMetadata(any(), any(), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataDiffersFromDesired_ShouldAddTableMetadata()
+      throws SQLException, ExecutionException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata desired =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    TableMetadata stored =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.INT).build();
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(RdbEngine.MYSQL));
+    doReturn(stored).when(adminSpy).getTableMetadata(namespace, table);
+
+    // Act
+    adminSpy.repairTable(namespace, table, desired, Collections.emptyMap());
+
+    // Assert
+    verify(adminSpy)
+        .addTableMetadata(eq(connection), eq(namespace), eq(table), eq(desired), anyBoolean());
+  }
+
+  @Test
+  public void repairTable_WhenStoredMetadataAbsent_ShouldAddTableMetadata()
+      throws SQLException, ExecutionException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(RdbEngine.MYSQL));
+    // No stored metadata
+    doReturn(null).when(adminSpy).getTableMetadata(namespace, table);
+
+    // Act
+    adminSpy.repairTable(namespace, table, metadata, Collections.emptyMap());
+
+    // Assert
+    verify(adminSpy)
+        .addTableMetadata(eq(connection), eq(namespace), eq(table), eq(metadata), anyBoolean());
+  }
+
+  @Test
+  public void repairTable_WhenReadingStoredMetadataThrowsRuntimeException_ShouldFailOpenAndWrite()
+      throws SQLException, ExecutionException {
+    // Arrange: reading the stored metadata throws (e.g. a corrupted value); the guard must fail
+    // open and rewrite the metadata rather than propagating the error.
+    String namespace = "my_ns";
+    String table = "foo_table";
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+    when(connection.createStatement()).thenReturn(mock(Statement.class));
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin adminSpy = spy(createJdbcAdminFor(RdbEngine.MYSQL));
+    doThrow(new IllegalArgumentException("corrupted"))
+        .when(adminSpy)
+        .getTableMetadata(namespace, table);
+
+    // Act
+    adminSpy.repairTable(namespace, table, metadata, Collections.emptyMap());
+
+    // Assert: no exception propagates and the metadata is rewritten
+    verify(adminSpy)
+        .addTableMetadata(eq(connection), eq(namespace), eq(table), eq(metadata), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
This is a backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3613
- **Backported commit:** 6fe6eaf99fbfd4097070b13ce901cde6dfab81c9

Cherry-picked from the branch `3.18` backport (#3623), on top of the branch `3.16` backport of #3612 (#3724, already merged). `repairTable` now skips rewriting the table metadata when the stored metadata already matches the desired metadata (failing open on read errors), avoiding unnecessary writes across the JDBC, DynamoDB, and Cosmos DB adapters.

Because branch `3.16` differs from `3.18`, the following manual adaptations were made:

- **`JdbcAdmin.repairTable`**: the "skip when already up to date" guard was applied to branch `3.16`'s repairTable structure (which was itself adapted for missing-index repair in #3720). The `tableMetadataAlreadyUpToDate` helper reads the stored metadata via `getTableMetadata(namespace, table)` since branch `3.16` has no `TableMetadataService`. The import/logger/`BasicDataSource` conflicts were resolved keeping the branch `3.16` types.
- **`JdbcAdminTestBase`**: the original PR's `repairTable_WhenStoredMetadata*` tests were added to `JdbcAdminTest` (which does not exist on this branch); they were ported to `JdbcAdminTestBase` and adapted to branch `3.16`'s signatures (5-arg `addTableMetadata`, `createJdbcAdminFor`, stubbing the public `getTableMetadata`).
- **Object Storage** adapter files were dropped since the adapter does not exist on branch `3.16`.

Please merge this PR after all checks have passed.