### PR TITLE
Extract the two-phase-commit primitive getters into TwoPhaseCommitFactory

### DIFF
--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -2,8 +2,6 @@ package com.scalar.db.service;
 
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.TwoPhaseCommitCoordinator;
-import com.scalar.db.api.TwoPhaseCommitParticipant;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import java.io.File;
@@ -18,7 +16,7 @@ import javax.annotation.Nullable;
  * A factory class to instantiate {@link DistributedTransactionManager} and {@link
  * DistributedTransactionAdmin} and {@link TwoPhaseCommitTransactionManager}
  */
-public class TransactionFactory {
+public final class TransactionFactory {
   private final DatabaseConfig config;
 
   /**
@@ -59,30 +57,6 @@ public class TransactionFactory {
   @Nullable
   public TwoPhaseCommitTransactionManager getTwoPhaseCommitTransactionManager() {
     return ProviderManager.createTwoPhaseCommitTransactionManager(config);
-  }
-
-  /**
-   * Returns a {@link TwoPhaseCommitCoordinator} instance for the new multi-participant two-phase
-   * commit interface.
-   *
-   * @return a {@link TwoPhaseCommitCoordinator} instance
-   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
-   *     commit interface
-   */
-  public TwoPhaseCommitCoordinator getTwoPhaseCommitCoordinator() {
-    return ProviderManager.createTwoPhaseCommitCoordinator(config);
-  }
-
-  /**
-   * Returns a {@link TwoPhaseCommitParticipant} instance for the new multi-participant two-phase
-   * commit interface.
-   *
-   * @return a {@link TwoPhaseCommitParticipant} instance
-   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
-   *     commit interface
-   */
-  public TwoPhaseCommitParticipant getTwoPhaseCommitParticipant() {
-    return ProviderManager.createTwoPhaseCommitParticipant(config);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitFactory.java
@@ -1,0 +1,92 @@
+package com.scalar.db.service;
+
+import com.scalar.db.api.TwoPhaseCommitCoordinator;
+import com.scalar.db.api.TwoPhaseCommitParticipant;
+import com.scalar.db.config.DatabaseConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * A factory to instantiate the internal two-phase commit primitives, {@link
+ * TwoPhaseCommitCoordinator} and {@link TwoPhaseCommitParticipant}.
+ *
+ * <p>These are internal primitives (see their Javadoc); they are not part of the application-facing
+ * transaction API. This factory is kept separate from {@link TransactionFactory} so that {@link
+ * TransactionFactory} stays limited to the application-facing types.
+ */
+public final class TwoPhaseCommitFactory {
+  private final DatabaseConfig config;
+
+  private TwoPhaseCommitFactory(DatabaseConfig config) {
+    this.config = Objects.requireNonNull(config);
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitCoordinator} instance.
+   *
+   * @return a {@link TwoPhaseCommitCoordinator} instance
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public TwoPhaseCommitCoordinator getTwoPhaseCommitCoordinator() {
+    return ProviderManager.createTwoPhaseCommitCoordinator(config);
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitParticipant} instance.
+   *
+   * @return a {@link TwoPhaseCommitParticipant} instance
+   * @throws UnsupportedOperationException if the transaction manager does not support the two-phase
+   *     commit interface
+   */
+  public TwoPhaseCommitParticipant getTwoPhaseCommitParticipant() {
+    return ProviderManager.createTwoPhaseCommitParticipant(config);
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitFactory} instance.
+   *
+   * @param properties properties to use for configuration
+   * @return a {@link TwoPhaseCommitFactory} instance
+   */
+  public static TwoPhaseCommitFactory create(Properties properties) {
+    return new TwoPhaseCommitFactory(new DatabaseConfig(properties));
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitFactory} instance.
+   *
+   * @param propertiesPath a properties path
+   * @return a {@link TwoPhaseCommitFactory} instance
+   * @throws IOException if IO error occurs
+   */
+  public static TwoPhaseCommitFactory create(Path propertiesPath) throws IOException {
+    return new TwoPhaseCommitFactory(new DatabaseConfig(propertiesPath));
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitFactory} instance.
+   *
+   * @param propertiesFile a properties file
+   * @return a {@link TwoPhaseCommitFactory} instance
+   * @throws IOException if IO error occurs
+   */
+  public static TwoPhaseCommitFactory create(File propertiesFile) throws IOException {
+    return new TwoPhaseCommitFactory(new DatabaseConfig(propertiesFile));
+  }
+
+  /**
+   * Returns a {@link TwoPhaseCommitFactory} instance.
+   *
+   * @param propertiesFilePath a properties file path
+   * @return a {@link TwoPhaseCommitFactory} instance
+   * @throws IOException if IO error occurs
+   */
+  public static TwoPhaseCommitFactory create(String propertiesFilePath) throws IOException {
+    return create(Paths.get(propertiesFilePath));
+  }
+}


### PR DESCRIPTION
## Description

`TwoPhaseCommitCoordinator` and `TwoPhaseCommitParticipant` are internal primitives — their Javadoc says users should not depend on them — yet their getters sat on the application-facing `TransactionFactory`. This PR moves them to a separate factory so `TransactionFactory` stays limited to the application-facing types.

## Related issues and/or PRs

N/A

## Changes made

- Removed the `TwoPhaseCommitCoordinator` / `TwoPhaseCommitParticipant` getters from `TransactionFactory`.
- Added `TwoPhaseCommitFactory`, which exposes those getters for the infrastructure code that wires the primitives.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Pure relocation of the getters; the wiring they return is unchanged, so the existing tests cover it.
- Stacked PR: the "dependent changes merged and published" item is checked on the understanding that this PR merges in stack order after its base.

## Release notes

N/A
