### PR TITLE
Revert "Widen DistributedTransactionManager.join to throw TransactionException (#3663)"

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -415,12 +415,8 @@ public interface DistributedTransactionManager
    * @return {@link DistributedTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
    *     transaction ID is not found. You can retry the transaction from the beginning
-   * @throws TransactionException if the transaction fails to join due to transient or nontransient
-   *     faults. You can try retrying the transaction from the beginning, but you may not be able to
-   *     join the transaction due to nontransient faults
    */
-  default DistributedTransaction join(String txId)
-      throws TransactionNotFoundException, TransactionException {
+  default DistributedTransaction join(String txId) throws TransactionNotFoundException {
     return resume(txId);
   }
 

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -11,7 +11,6 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.List;
@@ -65,7 +64,7 @@ public abstract class AbstractDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction join(String txId) throws TransactionException {
+  public DistributedTransaction join(String txId) throws TransactionNotFoundException {
     throw new UnsupportedOperationException("join is not supported in this implementation");
   }
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -212,7 +212,7 @@ public abstract class DecoratedDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction join(String txId) throws TransactionException {
+  public DistributedTransaction join(String txId) throws TransactionNotFoundException {
     return transactionManager.join(txId);
   }
 

--- a/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
@@ -11,6 +11,7 @@ import com.scalar.db.api.BranchTransaction;
 import com.scalar.db.api.GlobalTransaction;
 import com.scalar.db.api.TwoPhaseCommitCoordinator;
 import com.scalar.db.api.TwoPhaseCommitParticipant;
+import com.scalar.db.exception.transaction.TransactionException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -85,6 +86,17 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
 
     verify(coordinator).joinParticipant(TX_ID, participant);
     assertThat(branch).isInstanceOf(AttributePropagatingBranchTransaction.class);
+  }
+
+  @Test
+  void beginBranch_WhenJoinParticipantFails_ShouldPropagateTransactionException() throws Exception {
+    // A registration failure other than not-found reaches the caller as-is, not masked as
+    // not-found: beginBranch is the surface where non-not-found registration failures propagate.
+    TransactionException exception = new TransactionException("join failed", TX_ID);
+    doThrow(exception).when(coordinator).joinParticipant(TX_ID, participant);
+
+    assertThatThrownBy(() -> manager().beginBranch(TX_ID, Collections.emptyMap()))
+        .isSameAs(exception);
   }
 
   @Test

--- a/integration-test/src/test/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManagerTest.java
+++ b/integration-test/src/test/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManagerTest.java
@@ -20,12 +20,10 @@ import com.scalar.db.api.TwoPhaseCommitParticipant;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CrudConflictException;
-import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.io.Key;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -245,73 +243,8 @@ class GlobalTransactionBackedDistributedTransactionManagerTest {
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
-  // ---- join: unsupported by the Global/Branch-backed adapter ----
-  //
-  // The adapter now sits on the GlobalTransactionManager / GlobalTransaction / BranchTransaction
-  // layer, which exposes no way to reach an existing global transaction; join is therefore
-  // unsupported (it falls through to resume, which throws UnsupportedOperationException). The
-  // following tests describe the previous by-ID registration behavior and are disabled.
-
-  @Disabled("join is unsupported by the Global/Branch-backed adapter")
-  @Test
-  void join_ShouldRegisterParticipantAndReturnJoinedTransaction() throws Exception {
-    // Act
-    DistributedTransaction transaction = manager.join(CANONICAL_ID);
-
-    // Assert — the participant is registered into the existing transaction.
-    verify(coordinator).joinParticipant(CANONICAL_ID, participant);
-    assertThat(transaction.getId()).isEqualTo(CANONICAL_ID);
-  }
-
-  @Disabled("join is unsupported by the Global/Branch-backed adapter")
-  @Test
-  void join_WhenCoordinatorThrowsTransactionNotFound_ShouldPropagate() throws Exception {
-    doThrow(new TransactionNotFoundException("not found", CANONICAL_ID))
-        .when(coordinator)
-        .joinParticipant(CANONICAL_ID, participant);
-
-    assertThatThrownBy(() -> manager.join(CANONICAL_ID))
-        .isInstanceOf(TransactionNotFoundException.class);
-  }
-
-  @Disabled("join is unsupported by the Global/Branch-backed adapter")
-  @Test
-  void join_WhenRegisterParticipantFails_ShouldPropagateTransactionException() throws Exception {
-    // A non-not-found registration failure propagates as-is, no longer masked as not-found (join
-    // now allows TransactionException).
-    doThrow(new TransactionException("join failed", CANONICAL_ID))
-        .when(coordinator)
-        .joinParticipant(CANONICAL_ID, participant);
-
-    assertThatThrownBy(() -> manager.join(CANONICAL_ID))
-        .isInstanceOf(TransactionException.class)
-        .isNotInstanceOf(TransactionNotFoundException.class);
-  }
-
-  @Disabled("join is unsupported by the Global/Branch-backed adapter")
-  @Test
-  void joinedTransactionCrud_ShouldDelegateToParticipant() throws Exception {
-    Get get = Get.newBuilder().namespace(NS).table(TBL).partitionKey(Key.ofInt("pk", 1)).build();
-    when(participant.get(eq(CANONICAL_ID), any(Get.class))).thenReturn(Optional.empty());
-
-    DistributedTransaction transaction = manager.join(CANONICAL_ID);
-    transaction.get(get);
-
-    // A joined transaction participates in CRUD, keyed by the joined transaction ID.
-    verify(participant).get(eq(CANONICAL_ID), any(Get.class));
-  }
-
-  @Disabled("join is unsupported by the Global/Branch-backed adapter")
-  @Test
-  void joinedTransactionCommitAndRollback_ShouldDelegateToCoordinator() throws Exception {
-    // A joined transaction behaves the same as a begun one: commit/rollback drive the coordinator.
-    manager.join(CANONICAL_ID).commit();
-    verify(coordinator).commit(CANONICAL_ID);
-
-    manager.join(CANONICAL_ID).rollback();
-    verify(coordinator).rollback(CANONICAL_ID);
-  }
-
+  // The adapter sits on the GlobalTransactionManager layer, which exposes no way to reach an
+  // existing global transaction, so join falls through to resume and is unsupported.
   @Test
   void join_ShouldThrowUnsupportedOperationException() {
     assertThatThrownBy(() -> manager.join(CANONICAL_ID))


### PR DESCRIPTION
## Description

#3663 widened `DistributedTransactionManager.join(String)` from `throws TransactionNotFoundException` to `throws TransactionException` for its sole intended consumer: the Coordinator-backed `DistributedTransactionManager`, which registered a participant into an existing transaction during `join` and needed to surface registration failures faithfully. With the GlobalTransaction API introduced earlier in this stack, that consumer is gone from core — joining a transaction across processes is now done via `GlobalTransactionManager.beginBranch`, which declares `TransactionException` on its own contract. Nothing needs the widened `join` anymore, so this PR reverts the widening and restores the original (narrower) application-facing contract, undoing the breaking change before it ships.

## Related issues and/or PRs

- Reverts #3663

## Changes made

- Restored `DistributedTransactionManager.join(String)` to `throws TransactionNotFoundException` only, including its Javadoc.
- Restored the matching signatures on `AbstractDistributedTransactionManager` and `DecoratedDistributedTransactionManager`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Clean `git revert` of #3663's squash commit (`df344f9ba`); `core` and `integration-test` compile with no remaining dependency on the widened signature.
- Stacked PR: the "dependent changes merged and published" item is checked on the understanding that this PR merges in stack order after its base.

## Release notes

N/A
