### PR TITLE
Share ConsensusCommitManager's storage and table metadata manager with subclasses and narrow the commit-handler surface

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -71,7 +71,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   private final ParallelExecutor parallelExecutor;
   private final RecoveryExecutor recoveryExecutor;
   private final CrudHandler crud;
-  protected final CommitHandler commit;
+  private final CommitHandler commit;
   private final Isolation isolation;
   private final ConsensusCommitOperationChecker operationChecker;
   @Nullable private final CoordinatorGroupCommitter groupCommitter;
@@ -830,6 +830,21 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
    */
   protected TransactionTableMetadataManager getTableMetadataManager() {
     return tableMetadataManager;
+  }
+
+  /**
+   * Sets a {@link BeforePreparationHook} that runs before the preparation phase of a two-phase
+   * commit. The hook is not invoked when the one-phase commit optimization is taken; see {@link
+   * BeforePreparationHook} for details.
+   *
+   * <p>Subclasses must call this during construction, before any transaction begins. The hook is
+   * not set atomically with respect to in-flight commits, so setting it later races with them.
+   *
+   * @param beforePreparationHook a {@link BeforePreparationHook} to run before the preparation
+   *     phase of a two-phase commit
+   */
+  protected void setBeforePreparationHook(BeforePreparationHook beforePreparationHook) {
+    commit.setBeforePreparationHook(beforePreparationHook);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -807,6 +807,31 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     return groupCommitter != null;
   }
 
+  /**
+   * Returns the {@link DistributedStorage} instance this manager uses.
+   *
+   * <p>This instance is owned by this manager and is closed by {@link #close()}. Subclasses that
+   * reuse it must not close it themselves.
+   *
+   * @return the {@link DistributedStorage} instance this manager uses
+   */
+  protected DistributedStorage getStorage() {
+    return storage;
+  }
+
+  /**
+   * Returns the {@link TransactionTableMetadataManager} instance this manager uses.
+   *
+   * <p>This instance is owned by this manager. It holds no closeable resource, but it caches table
+   * metadata read through the {@link DistributedStorageAdmin} that {@link #close()} closes, so
+   * subclasses must not use it after this manager is closed.
+   *
+   * @return the {@link TransactionTableMetadataManager} instance this manager uses
+   */
+  protected TransactionTableMetadataManager getTableMetadataManager() {
+    return tableMetadataManager;
+  }
+
   @Override
   public void close() {
     storage.close();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -2544,4 +2544,16 @@ public class ConsensusCommitManagerTest {
     // recoverRecord must never perform Coordinator state cleanup, even on failure.
     verify(coordinator, never()).deleteState(anyString());
   }
+
+  @Test
+  public void setBeforePreparationHook_HookGiven_ShouldSetItToCommitHandler() {
+    // Arrange
+    BeforePreparationHook beforePreparationHook = mock(BeforePreparationHook.class);
+
+    // Act
+    manager.setBeforePreparationHook(beforePreparationHook);
+
+    // Assert
+    verify(commit).setBeforePreparationHook(beforePreparationHook);
+  }
 }


### PR DESCRIPTION
## Description

`ConsensusCommitManager` keeps its `storage`, `admin`, and `tableMetadataManager` fields `private` with no accessor, so a subclass that needs the same resources has no way to reuse them and is forced to build its own duplicate set from the same configuration. Separately, the `commit` field is `protected` solely so a subclass can call `commit.setBeforePreparationHook(...)`, which exposes the entire `CommitHandler` just to reach one setter.

This PR reshapes what `ConsensusCommitManager` offers to subclasses in both directions: it exposes the storage and table metadata manager for reuse, and it narrows the commit-handler surface to the single operation a subclass actually needs. This lets a subclass stop duplicating a `DistributedStorage`, a `DistributedStorageAdmin`, and a table-metadata cache built from the same configuration.

## Related issues and/or PRs

- A paired downstream change consumes this new API and will be opened/merged after this PR.

## Changes made

- Added `protected DistributedStorage getStorage()` and `protected TransactionTableMetadataManager getTableMetadataManager()` so subclasses can reuse the manager's instances instead of constructing duplicates. Their Javadoc records the ownership contract: both instances are owned by the manager and closed by `close()`, so a borrower must not close them. No `getAdmin()` accessor was added because the only use of the admin was to build a `TransactionTableMetadataManager`, which is now borrowed directly.
- Changed the `commit` field from `protected final` to `private final` and added `protected void setBeforePreparationHook(BeforePreparationHook)` that delegates to it. This is a breaking change to `protected` API and thus targets 4.0.0. `createCommitHandler` is `private`, so the field was the only commit-handler-related subclass surface; `CommitHandler.setBeforePreparationHook` remains `public` and unchanged.
- Added a unit test verifying `setBeforePreparationHook` delegates to the `CommitHandler`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `commit` field visibility change is a breaking change to `protected` API. Its only known subclass is updated in the paired change, so no in-tree or known out-of-tree consumer is left stranded.

The new accessors return interface-typed fields, which SpotBugs does not flag (`EI_EXPOSE_REP` was verified not to fire on them), so no suppression annotation is needed.

## Release notes

N/A
