### PR TITLE
Deprecate the external API for Consensus Commit implicit pre-read and insert mode

### DIFF
--- a/core/src/main/java/com/scalar/db/api/CrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/CrudOperable.java
@@ -77,7 +77,8 @@ public interface CrudOperable<E extends TransactionException> {
    *
    * @param put a {@code Put} command
    * @throws E if the transaction CRUD operation fails
-   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use the insert, upsert, or
+   *     update operations instead.
    */
   @Deprecated
   void put(Put put) throws E;
@@ -91,7 +92,7 @@ public interface CrudOperable<E extends TransactionException> {
    * @param puts a list of {@code Put} commands
    * @throws E if the transaction CRUD operation fails
    * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
-   *     instead.
+   *     instead, or the insert, upsert, or update operations for individual writes.
    */
   @Deprecated
   void put(List<Put> puts) throws E;

--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -326,13 +326,23 @@ public class OperationBuilder {
     T clearValue(String columnName);
   }
 
+  /**
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
+   */
+  @Deprecated
   public interface ImplicitPreReadEnabled<T> {
     /**
      * Disables implicit pre-read for this put operation. This is a utility method for Consensus
      * Commit.
      *
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T disableImplicitPreRead();
 
     /**
@@ -340,7 +350,11 @@ public class OperationBuilder {
      * Commit.
      *
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T enableImplicitPreRead();
 
     /**
@@ -349,17 +363,31 @@ public class OperationBuilder {
      *
      * @param implicitPreReadEnabled whether implicit pre-read is enabled or not
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T implicitPreReadEnabled(boolean implicitPreReadEnabled);
   }
 
+  /**
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
+   */
+  @Deprecated
   public interface InsertModeEnabled<T> {
     /**
      * Disables the insert mode for this put operation. This is a utility method for Consensus
      * Commit.
      *
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T disableInsertMode();
 
     /**
@@ -367,7 +395,11 @@ public class OperationBuilder {
      * Commit.
      *
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T enableInsertMode();
 
     /**
@@ -376,7 +408,11 @@ public class OperationBuilder {
      *
      * @param insertModeEnabled whether the insert mode is enabled or not
      * @return the operation builder
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
      */
+    @Deprecated
     T insertModeEnabled(boolean insertModeEnabled);
   }
 

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -830,8 +830,8 @@ public class Put extends Mutation {
    * Consensus Commit.
    *
    * @return whether implicit pre-read is enabled for this Put
-   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Use {@link
-   *     ConsensusCommitOperationAttributes#isImplicitPreReadEnabled(Put)} instead
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to introspect them.
    */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
@@ -844,8 +844,8 @@ public class Put extends Mutation {
    * Commit.
    *
    * @return whether the insert mode is enabled for this Put
-   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Use {@link
-   *     ConsensusCommitOperationAttributes#isInsertModeEnabled(Put)} instead
+   * @deprecated As of release 3.15.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to introspect them.
    */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated

--- a/core/src/main/java/com/scalar/db/api/PutBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/PutBuilder.java
@@ -264,18 +264,24 @@ public class PutBuilder {
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable disableImplicitPreRead() {
       ConsensusCommitOperationAttributes.disableImplicitPreRead(attributes);
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable enableImplicitPreRead() {
       ConsensusCommitOperationAttributes.enableImplicitPreRead(attributes);
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable implicitPreReadEnabled(boolean implicitPreReadEnabled) {
       if (implicitPreReadEnabled) {
@@ -286,18 +292,24 @@ public class PutBuilder {
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable disableInsertMode() {
       ConsensusCommitOperationAttributes.disableInsertMode(attributes);
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable enableInsertMode() {
       ConsensusCommitOperationAttributes.enableInsertMode(attributes);
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public Buildable insertModeEnabled(boolean insertModeEnabled) {
       if (insertModeEnabled) {
@@ -542,36 +554,48 @@ public class PutBuilder {
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting disableImplicitPreRead() {
       super.disableImplicitPreRead();
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting enableImplicitPreRead() {
       super.enableImplicitPreRead();
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting implicitPreReadEnabled(boolean implicitPreReadEnabled) {
       super.implicitPreReadEnabled(implicitPreReadEnabled);
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting disableInsertMode() {
       super.disableInsertMode();
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting enableInsertMode() {
       super.enableInsertMode();
       return this;
     }
 
+    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    @Deprecated
     @Override
     public BuildableFromExisting insertModeEnabled(boolean insertModeEnabled) {
       super.insertModeEnabled(insertModeEnabled);

--- a/core/src/main/java/com/scalar/db/api/PutBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/PutBuilder.java
@@ -264,7 +264,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable disableImplicitPreRead() {
@@ -272,7 +276,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable enableImplicitPreRead() {
@@ -280,7 +288,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable implicitPreReadEnabled(boolean implicitPreReadEnabled) {
@@ -292,7 +304,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable disableInsertMode() {
@@ -300,7 +316,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable enableInsertMode() {
@@ -308,7 +328,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public Buildable insertModeEnabled(boolean insertModeEnabled) {
@@ -554,7 +578,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting disableImplicitPreRead() {
@@ -562,7 +590,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting enableImplicitPreRead() {
@@ -570,7 +602,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting implicitPreReadEnabled(boolean implicitPreReadEnabled) {
@@ -578,7 +614,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting disableInsertMode() {
@@ -586,7 +626,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting enableInsertMode() {
@@ -594,7 +638,11 @@ public class PutBuilder {
       return this;
     }
 
-    /** @deprecated As of release 3.19.0. Will be removed in release 4.0.0. */
+    /**
+     * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+     *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+     *     operations instead.
+     */
     @Deprecated
     @Override
     public BuildableFromExisting insertModeEnabled(boolean insertModeEnabled) {

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -55,7 +55,8 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    *     still fail if the cause is nontransient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
-   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use the insert, upsert, or
+   *     update operations instead.
    */
   @Deprecated
   @Override
@@ -72,7 +73,7 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
-   *     instead.
+   *     instead, or the insert, upsert, or update operations for individual writes.
    */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
@@ -74,7 +74,8 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
-   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0.
+   * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use the insert, upsert, or
+   *     update operations instead.
    */
   @Deprecated
   @Override
@@ -97,7 +98,7 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
    * @deprecated As of release 3.13.0. Will be removed in release 4.0.0. Use {@link #mutate(List)}
-   *     instead.
+   *     instead, or the insert, upsert, or update operations for individual writes.
    */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributes.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitOperationAttributes.java
@@ -10,11 +10,25 @@ public final class ConsensusCommitOperationAttributes {
 
   private static final String OPERATION_ATTRIBUTE_PREFIX = "cc-";
 
-  /** The operation attribute key for whether implicit pre-read is enabled. */
+  /**
+   * The operation attribute key for whether implicit pre-read is enabled.
+   *
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to set or
+   *     introspect them.
+   */
+  @Deprecated
   public static final String IMPLICIT_PRE_READ_ENABLED =
       OPERATION_ATTRIBUTE_PREFIX + "implicit-pre-read-enabled";
 
-  /** The operation attribute key for whether insert mode is enabled. */
+  /**
+   * The operation attribute key for whether insert mode is enabled.
+   *
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to set or
+   *     introspect them.
+   */
+  @Deprecated
   public static final String INSERT_MODE_ENABLED =
       OPERATION_ATTRIBUTE_PREFIX + "insert-mode-enabled";
 
@@ -29,7 +43,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the original {@code Put} operation
    * @return a new {@code Put} with implicit pre-read enabled
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static Put enableImplicitPreRead(Put put) {
     return Put.newBuilder(put).attribute(IMPLICIT_PRE_READ_ENABLED, "true").build();
   }
@@ -38,7 +56,11 @@ public final class ConsensusCommitOperationAttributes {
    * Enables implicit pre-read in the operation attributes.
    *
    * @param attributes the operation attributes
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static void enableImplicitPreRead(Map<String, String> attributes) {
     attributes.put(IMPLICIT_PRE_READ_ENABLED, "true");
   }
@@ -48,7 +70,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the original {@code Put} operation
    * @return a new {@code Put} with implicit pre-read disabled
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static Put disableImplicitPreRead(Put put) {
     return Put.newBuilder(put).clearAttribute(IMPLICIT_PRE_READ_ENABLED).build();
   }
@@ -57,7 +83,11 @@ public final class ConsensusCommitOperationAttributes {
    * Disables implicit pre-read in the operation attributes.
    *
    * @param attributes the operation attributes
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static void disableImplicitPreRead(Map<String, String> attributes) {
     attributes.remove(IMPLICIT_PRE_READ_ENABLED);
   }
@@ -67,7 +97,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the original {@code Put} operation
    * @return a new {@code Put} with insert mode enabled
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static Put enableInsertMode(Put put) {
     return Put.newBuilder(put).attribute(INSERT_MODE_ENABLED, "true").build();
   }
@@ -76,7 +110,11 @@ public final class ConsensusCommitOperationAttributes {
    * Enables insert mode in the operation attributes.
    *
    * @param attributes the operation attributes
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static void enableInsertMode(Map<String, String> attributes) {
     attributes.put(INSERT_MODE_ENABLED, "true");
   }
@@ -86,7 +124,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the original {@code Put} operation
    * @return a new {@code Put} with insert mode disabled
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static Put disableInsertMode(Put put) {
     return Put.newBuilder(put).clearAttribute(INSERT_MODE_ENABLED).build();
   }
@@ -95,7 +137,11 @@ public final class ConsensusCommitOperationAttributes {
    * Disables insert mode in the operation attributes.
    *
    * @param attributes the operation attributes
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details; use the insert, upsert, or update
+   *     operations instead.
    */
+  @Deprecated
   public static void disableInsertMode(Map<String, String> attributes) {
     attributes.remove(INSERT_MODE_ENABLED);
   }
@@ -105,7 +151,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the {@code Put} operation
    * @return {@code true} if implicit pre-read is enabled, {@code false} otherwise
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to set or
+   *     introspect them.
    */
+  @Deprecated
   public static boolean isImplicitPreReadEnabled(Put put) {
     Optional<String> attribute = put.getAttribute(IMPLICIT_PRE_READ_ENABLED);
     return attribute.isPresent() && "true".equalsIgnoreCase(attribute.get());
@@ -116,7 +166,11 @@ public final class ConsensusCommitOperationAttributes {
    *
    * @param put the {@code Put} operation
    * @return {@code true} if insert mode is enabled, {@code false} otherwise
+   * @deprecated As of release 3.19.0. Will be removed in release 4.0.0. Implicit pre-read and
+   *     insert mode are Consensus Commit internal details with no external need to set or
+   *     introspect them.
    */
+  @Deprecated
   public static boolean isInsertModeEnabled(Put put) {
     Optional<String> attribute = put.getAttribute(INSERT_MODE_ENABLED);
     return attribute.isPresent() && "true".equalsIgnoreCase(attribute.get());


### PR DESCRIPTION
## Description

"Implicit pre-read" and "insert mode" are Consensus Commit implementation details that leaked onto the public `Put` API — via typed `PutBuilder` methods, the public `ConsensusCommitOperationAttributes` utility (methods and attribute-key constants), and the `OperationBuilder.ImplicitPreReadEnabled` / `InsertModeEnabled` interfaces. The modern `insert()` / `upsert()` / `update()` operations already cover the user-facing use cases, and the only operation that carried these knobs, `put(Put)`, is already deprecated. This PR deprecates the external-facing surface so users are guided to `insert` / `upsert` / `update`, while the mechanism itself stays fully functional for Consensus Commit's internal use. The change is annotation- and Javadoc-only — no runtime behavior, attribute mechanism, or wire-format changes.

## Related issues and/or PRs

N/A

## Changes made

- Deprecated the implicit-pre-read / insert-mode methods (`enable*` / `disable*` / `is*Enabled`) and the public attribute-key constants (`IMPLICIT_PRE_READ_ENABLED`, `INSERT_MODE_ENABLED`) in `ConsensusCommitOperationAttributes`. The `transaction-isolation` attribute API in the same class is untouched.
- Deprecated the `OperationBuilder.ImplicitPreReadEnabled<T>` / `InsertModeEnabled<T>` interfaces and their methods, and the corresponding overrides in `PutBuilder` (`Buildable` / `BuildableFromExisting`).
- Refreshed the existing `@deprecated` Javadoc on `Put.isImplicitPreReadEnabled()` / `isInsertModeEnabled()` so it no longer points at the now-also-deprecated `ConsensusCommitOperationAttributes` readers.
- Enriched the `@deprecated` Javadoc of the already-deprecated `put(Put)` / `put(List<Put>)` methods in `CrudOperable`, `TransactionCrudOperable`, and `TransactionManagerCrudOperable` to recommend `insert` / `upsert` / `update`.
- All deprecation messages state "As of release 3.19.0. Will be removed in release 4.0.0."

No logic changes; the operation-attribute mechanism and internal Consensus Commit usage are unchanged.

## Checklist

The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Annotation/Javadoc-only; there is no behavior change, so no new tests were added — the existing unit and integration suites already exercise these methods and the underlying implicit-pre-read / insert-mode behavior, and the full `:core:test` suite passes.
- No `@SuppressWarnings` were added: the build has no `-Werror`/`-Xlint`, and the codebase already tolerates internal deprecation warnings unsuppressed (e.g. `AbstractDistributedTransaction.mutate` calls the deprecated `put(Put)`) and deprecated-type imports (e.g. `Put.java` imports the deprecated `Value`). The internal callers (`CrudHandler`, `Snapshot`, the mutation composers, `ConsensusCommitUtils`) and the tests are intentionally left untouched. Because this deprecates public API that internal/test code still uses, `-Xlint:deprecation` reports warnings by design; the build itself introduces no new failures or Error Prone errors.
- Out of scope and verified untouched: `TwoPhaseCommitParticipant` and its implementers already deprecate `put(String, Put)` as of 3.19.0; the `parallel_implicit_pre_read.enabled` config is a separate performance setting (not the per-operation attribute); `CrudHandler.readIfImplicitPreReadEnabled` is internal orchestration, not a user knob.
- Follow-up (separate repo): confirm `scalardb-cluster` does not escalate deprecation warnings to errors where it references these surfaces; a paired change would only be needed if it does.

## Release notes

Deprecated the external API for Consensus Commit implicit pre-read and insert mode — the `Put` builder methods, the `ConsensusCommitOperationAttributes` methods and attribute-key constants, and the `OperationBuilder.ImplicitPreReadEnabled` / `InsertModeEnabled` interfaces. Use the `insert`, `upsert`, or `update` operations instead.