### PR TITLE
Deprecate two-phase commit transaction related classes and methods

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
@@ -43,7 +43,9 @@ public interface DistributedTransactionProvider {
    * @return an instance of {@link TwoPhaseCommitTransactionManager} for the transaction manager. If
    *     the transaction manager does not support the two-phase commit interface, returns {@code
    *     null}.
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   @Nullable
   TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(DatabaseConfig config);
 

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
@@ -14,7 +14,10 @@ import java.util.Optional;
 /**
  * A transaction abstraction based on a two-phase commit protocol for interacting with the
  * underlying storage and database implementations.
+ *
+ * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
  */
+@Deprecated
 public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
 
   /**
@@ -29,45 +32,35 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void with(String namespace, String tableName);
 
   /**
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void withNamespace(String namespace);
 
   /**
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   Optional<String> getNamespace();
 
   /**
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void withTable(String tableName);
 
   /**
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   Optional<String> getTable();
 
   /**

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -12,7 +12,10 @@ import java.util.Optional;
  * starts a transaction with {@link #start()} or {@link #start(String)}, and participant processes
  * join the transaction with {@link #join(String)} with the transaction ID. Also, participants can
  * resume the transaction with {@link #resume(String)} with the transaction ID.
+ *
+ * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
  */
+@Deprecated
 public interface TwoPhaseCommitTransactionManager
     extends TransactionManagerCrudOperable, AutoCloseable {
 
@@ -21,45 +24,35 @@ public interface TwoPhaseCommitTransactionManager
    *
    * @param namespace default namespace to operate for
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void with(String namespace, String tableName);
 
   /**
    * Sets the specified namespace as a default value in the instance.
    *
    * @param namespace default namespace to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void withNamespace(String namespace);
 
   /**
    * Returns the namespace.
    *
    * @return an {@code Optional} with the namespace
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   Optional<String> getNamespace();
 
   /**
    * Sets the specified table name as a default value in the instance.
    *
    * @param tableName default table name to operate for
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   void withTable(String tableName);
 
   /**
    * Returns the table name.
    *
    * @return an {@code Optional} with the table name
-   * @deprecated As of release 3.6.0. Will be removed in release 4.0.0
    */
-  @Deprecated
   Optional<String> getTable();
 
   /**

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionProvider.java
@@ -44,6 +44,8 @@ public abstract class AbstractDistributedTransactionProvider
   protected abstract DistributedTransactionManager createRawDistributedTransactionManager(
       DatabaseConfig config);
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Nullable
   @Override
   public final TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
@@ -70,6 +72,8 @@ public abstract class AbstractDistributedTransactionProvider
     return transactionManager;
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Nullable
   protected abstract TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config);

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
 
   private Optional<String> namespace;
@@ -29,37 +31,27 @@ public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommi
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     this.namespace = Optional.ofNullable(namespace);
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getTable() {
     return tableName;

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -16,6 +16,8 @@ import com.scalar.db.util.ScalarDbUtils;
 import java.util.List;
 import java.util.Optional;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 public abstract class AbstractTwoPhaseCommitTransactionManager
     implements TwoPhaseCommitTransactionManager {
 
@@ -27,37 +29,27 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     tableName = Optional.empty();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     this.namespace = Optional.ofNullable(namespace);
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withNamespace(String namespace) {
     this.namespace = Optional.ofNullable(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return namespace;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withTable(String tableName) {
     this.tableName = Optional.ofNullable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getTable() {
     return tableName;

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -29,6 +29,8 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 @ThreadSafe
 public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
@@ -96,7 +98,10 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
    * The methods of this class are synchronized to be thread-safe because the rollback() method may
    * be called from the expiration handler in a different thread while other methods are being
    * executed.
+   *
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   @VisibleForTesting
   class ActiveTransaction extends DecoratedTwoPhaseCommitTransaction {
 
@@ -138,16 +143,12 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
           registry, getId(), new SynchronizedScanner(this, super.getScanner(scan)));
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
       registry.touch(getId());
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
       registry.touch(getId());
@@ -160,8 +161,6 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
       registry.touch(getId());

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -22,6 +22,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Optional;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
 
   private final TwoPhaseCommitTransaction transaction;
@@ -31,36 +33,26 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     this.transaction = transaction;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transaction.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transaction.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transaction.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withTable(String tableName) {
     transaction.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getTable() {
     return transaction.getTable();
@@ -86,15 +78,11 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     return transaction.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     transaction.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     transaction.put(puts);
@@ -105,8 +93,6 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     transaction.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     transaction.delete(deletes);

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -20,6 +20,8 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 public abstract class DecoratedTwoPhaseCommitTransactionManager
     implements TwoPhaseCommitTransactionManager {
 
@@ -30,36 +32,26 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     this.transactionManager = transactionManager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     transactionManager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withNamespace(String namespace) {
     transactionManager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return transactionManager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withTable(String tableName) {
     transactionManager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getTable() {
     return transactionManager.getTable();
@@ -115,15 +107,11 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     return transactionManager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     transactionManager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     transactionManager.put(puts);
@@ -149,8 +137,6 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     transactionManager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     transactionManager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 @ThreadSafe
 public class StateManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
@@ -43,7 +45,10 @@ public class StateManagedTwoPhaseCommitTransactionManager
    * This class is to unify the call sequence of the transaction object. It doesn't care about the
    * potential inconsistency between the status field on JVM memory and the underlying persistent
    * layer.
+   *
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   @VisibleForTesting
   static class StateManagedTransaction extends DecoratedTwoPhaseCommitTransaction {
 
@@ -84,16 +89,12 @@ public class StateManagedTwoPhaseCommitTransactionManager
       return super.getScanner(scan);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public void put(Put put) throws CrudException {
       checkIfActive();
       super.put(put);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public void put(List<Put> puts) throws CrudException {
       checkIfActive();
@@ -106,8 +107,6 @@ public class StateManagedTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
-    /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-    @Deprecated
     @Override
     public void delete(List<Delete> deletes) throws CrudException {
       checkIfActive();

--- a/core/src/main/java/com/scalar/db/service/ProviderManager.java
+++ b/core/src/main/java/com/scalar/db/service/ProviderManager.java
@@ -119,7 +119,9 @@ final class ProviderManager {
    * @param config a database config
    * @return an instance of {@link TwoPhaseCommitTransactionManager}. If the transaction manager
    *     does not support the two-phase commit interface, returns {@code null}.
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   @Nullable
   public static TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -54,7 +54,9 @@ public final class TransactionFactory {
    *
    * @return a {@link TwoPhaseCommitTransactionManager} instance. If the transaction manager does
    *     not support the two-phase commit interface, returns {@code null}.
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   @Nullable
   public TwoPhaseCommitTransactionManager getTwoPhaseCommitTransactionManager() {
     return ProviderManager.createTwoPhaseCommitTransactionManager(config);

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
-/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0 */
+/** @deprecated As of release 3.5.0. Will be removed in release 3.20.0 */
 @Deprecated
 @Immutable
 public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransactionManager {
@@ -35,36 +35,26 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     this.manager = manager;
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void with(String namespace, String tableName) {
     manager.with(namespace, tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withNamespace(String namespace) {
     manager.withNamespace(namespace);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getNamespace() {
     return manager.getNamespace();
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public void withTable(String tableName) {
     manager.withTable(tableName);
   }
 
-  /** @deprecated As of release 3.6.0. Will be removed in release 4.0.0 */
-  @Deprecated
   @Override
   public Optional<String> getTable() {
     return manager.getTable();
@@ -130,15 +120,11 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     return manager.getScanner(scan);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     manager.put(puts);
@@ -164,8 +150,6 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     manager.delete(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     manager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -28,6 +28,8 @@ public class ConsensusCommitProvider extends AbstractDistributedTransactionProvi
     return new ConsensusCommitAdmin(config);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -33,6 +33,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 @NotThreadSafe
 public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
   private static final Logger logger = LoggerFactory.getLogger(TwoPhaseConsensusCommit.class);
@@ -99,15 +101,11 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     return crud.getScanner(scan, context);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     putInternal(put);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     checkArgument(!puts.isEmpty());
@@ -127,8 +125,6 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     deleteInternal(delete);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     checkArgument(!deletes.isEmpty());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -47,6 +47,8 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+@Deprecated
 @ThreadSafe
 public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransactionManager {
 
@@ -343,8 +345,6 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     };
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     executeTransaction(
@@ -355,8 +355,6 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     executeTransaction(
@@ -407,8 +405,6 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         false);
   }
 
-  /** @deprecated As of release 3.13.0. Will be removed in release 4.0.0. */
-  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     executeTransaction(

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -30,6 +30,9 @@ public class JdbcTransactionProvider extends AbstractDistributedTransactionProvi
     return new JdbcTransactionAdmin(config);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Nullable
   @Override
   public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionProvider.java
@@ -28,6 +28,9 @@ public class SingleCrudOperationTransactionProvider implements DistributedTransa
     return new SingleCrudOperationTransactionAdmin(config);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Nullable
   @Override
   public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(

--- a/integration-test/src/main/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManager.java
+++ b/integration-test/src/main/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManager.java
@@ -145,6 +145,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   // which this path does not honor (isolation comes from configuration). Delegate to begin.
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(Isolation isolation) throws TransactionException {
@@ -152,6 +153,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(String txId, Isolation isolation)
@@ -160,6 +162,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
@@ -168,6 +171,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
@@ -175,6 +179,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(String txId, SerializableStrategy strategy)
@@ -183,6 +188,7 @@ public class GlobalTransactionBackedDistributedTransactionManager
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0 */
+  @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
   public DistributedTransaction start(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitProvider.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitProvider.java
@@ -57,6 +57,9 @@ public class TwoPhaseCommitBackedConsensusCommitProvider
     return new ConsensusCommitAdmin(toConsensusCommitConfig(config));
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Nullable
   @Override
   public TwoPhaseCommitTransactionManager createRawTwoPhaseCommitTransactionManager(


### PR DESCRIPTION
## Description

Deprecate the old (pre-GlobalTransaction) two-phase-commit transaction API and its related classes/methods so users are guided to the new GlobalTransaction API, which supersedes it.

## Related issues and/or PRs

N/A

## Changes made

- Deprecate the old public two-phase-commit surface **as of release 3.19.0, for removal in release 3.20.0**:
  - Interfaces: `TwoPhaseCommitTransaction`, `TwoPhaseCommitTransactionManager`.
  - Base/decorator classes: `AbstractTwoPhaseCommitTransaction` / `AbstractTwoPhaseCommitTransactionManager`, `DecoratedTwoPhaseCommitTransaction` / `DecoratedTwoPhaseCommitTransactionManager`, `ActiveTransactionManagedTwoPhaseCommitTransactionManager` / `StateManagedTwoPhaseCommitTransactionManager` (including their nested `ActiveTransaction` / `StateManagedTransaction`).
  - Implementations: `TwoPhaseConsensusCommit`, `TwoPhaseConsensusCommitManager`.
  - Provider / factory entry points that expose the old 2PC: `DistributedTransactionProvider.createTwoPhaseCommitTransactionManager`, `AbstractDistributedTransactionProvider.create[Raw]TwoPhaseCommitTransactionManager` and the concrete providers, `TransactionFactory.getTwoPhaseCommitTransactionManager`, `ProviderManager`.
- Align the removal version of the already-deprecated `TwoPhaseCommitTransactionService` to **3.20.0** (keeping its historical "As of" versions).
- Remove now-redundant method-level `@Deprecated` from classes that are themselves class-level `@Deprecated` — a whole-class deprecation already covers its methods, so the per-method annotations (e.g. the CRUD `put`/`delete` overrides) are noise.
- Annotation- and Javadoc-only; no runtime behavior change. The new GlobalTransaction API and the internal 2PC primitives (`TwoPhaseCommitCoordinator` / `TwoPhaseCommitParticipant`, `createGlobalTransactionManager`) are intentionally **not** deprecated.

## Checklist

The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Annotation/Javadoc-only; there is no behavior change, so no new tests were added — the existing unit and integration suites already exercise these classes, and the full `:core:test` suite passes.
- Removal is targeted at **3.20.0** (earlier than the usual 4.0.0) because the new GlobalTransaction API replaces the old two-phase-commit interface.
- No `@SuppressWarnings("deprecation")` was added: the build has no `-Werror`/`-Xlint`, and the codebase already tolerates internal deprecation warnings unsuppressed. Because this deprecates public API that internal/test code still uses, `-Xlint:deprecation` reports warnings by design; the build itself introduces no new failures or Error Prone errors. (`@SuppressWarnings("InlineMeSuggester")` is added to a few deprecated provider methods only to silence Error Prone's `@InlineMe` suggestion.)
- The integration-test base classes for two-phase commit are intentionally **not** deprecated — they are test infrastructure, so they simply keep exercising the (now-deprecated) API.
- Method-level `@Deprecated` was removed only from classes that are class-level `@Deprecated` (redundant there); classes/methods reachable via non-deprecated supertypes keep their own `@Deprecated`, so no deprecation warning is lost.

## Release notes

Deprecated the old two-phase-commit transaction API — `TwoPhaseCommitTransaction`, `TwoPhaseCommitTransactionManager`, and their related classes and factory methods (`TransactionFactory.getTwoPhaseCommitTransactionManager`, `DistributedTransactionProvider.createTwoPhaseCommitTransactionManager`) — for removal in 3.20.0. Use the GlobalTransaction API instead.

