### PR TITLE
Upgrade the PostgreSQL JDBC driver to fix known vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.42.4'
         hikariCpVersion = '4.0.3'
-        postgresqlDriverVersion = '42.7.10'
+        postgresqlDriverVersion = '42.7.13'
         oracleDriverVersion = '23.26.1.0.0'
         sqlserverDriverVersion = '12.8.2.jre8'
         sqliteDriverVersion = '3.53.0.0'


### PR DESCRIPTION
## Description

The pgjdbc driver bundled in the ScalarDB Schema Loader and ScalarDB Data Loader CLI images has two known HIGH vulnerabilities:

| Library | Bundled | CVE | Fixed in |
| --- | --- | --- | --- |
| `org.postgresql:postgresql` | 42.7.10 | CVE-2026-42198 | 42.7.11 |
| `org.postgresql:postgresql` | 42.7.10 | CVE-2026-54291 | 42.7.12 |

Both are SCRAM-authentication issues (a client-side DoS via a malicious server response, and an MITM-protection bypass via channel binding), so they sit on code paths that Schema Loader and Data Loader actually exercise when connecting to PostgreSQL.

Note that the vulnerability check does **not** report these findings, but that is a false negative rather than an absence of the vulnerability: pgjdbc is built with Gradle and ships no `META-INF/maven/.../pom.properties`, so Trivy cannot identify it inside the fat `app.jar` (unlike `mssql-jdbc`, which is Maven-built and is detected in the same jar). Anything that bundles the driver as an individual jar file does get flagged by scanners, so upgrading here is necessary even though this repository's check stays green.

`42.7.13` matches what `master` uses. Verified that `:schema-loader` `runtimeClasspath` resolves `org.postgresql:postgresql:42.7.13`.

## Related issues and/or PRs

- #3754

## Changes made

- Bumped `postgresqlDriverVersion` from `42.7.10` to `42.7.13`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The same bump is needed on `3.17`, `3.16`, and `3.15` (their pgjdbc versions are 42.7.8 / 42.7.7 / 42.7.7); separate PRs are opened for each branch since the version lines differ. On `3.16` / `3.15` the PR also adds Netty DNS forces to fix the remaining findings there.

## Release notes

Upgraded the PostgreSQL JDBC driver to fix security issues: CVE-2026-42198 and CVE-2026-54291
