### PR TITLE
Upgrade the PostgreSQL JDBC driver to fix known vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.39.2'
         commonsDbcp2Version = '2.13.0'
-        postgresqlDriverVersion = '42.7.8'
+        postgresqlDriverVersion = '42.7.13'
         oracleDriverVersion = '23.26.0.0.0'
         sqlserverDriverVersion = '12.8.2.jre8'
         sqliteDriverVersion = '3.51.0.0'


### PR DESCRIPTION
## Description

This is a backport of #3758 to branch `3.17` (the version line differs, so it is applied manually: `42.7.8` → `42.7.13`).

The pgjdbc driver bundled in the ScalarDB Schema Loader and ScalarDB Data Loader CLI images has two known HIGH vulnerabilities: CVE-2026-42198 (fixed in 42.7.11) and CVE-2026-54291 (fixed in 42.7.12). See #3758 for details, including why the vulnerability check does not report them (Trivy cannot identify pgjdbc inside the fat `app.jar` because pgjdbc ships no embedded Maven metadata).

Verified that `:schema-loader` `runtimeClasspath` resolves `org.postgresql:postgresql:42.7.13`.

## Related issues and/or PRs

- #3758

## Changes made

- Bumped `postgresqlDriverVersion` from `42.7.8` to `42.7.13`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded the PostgreSQL JDBC driver to fix security issues: CVE-2026-42198 and CVE-2026-54291
