### PR TITLE
Fix known vulnerabilities in the PostgreSQL JDBC driver and Netty DNS artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.31.3'
         commonsDbcp2Version = '2.13.0'
-        postgresqlDriverVersion = '42.7.7'
+        postgresqlDriverVersion = '42.7.13'
         oracleDriverVersion = '23.8.0.25.04'
         sqlserverDriverVersion = '12.8.2.jre8'
         sqliteDriverVersion = '3.50.1.0'
@@ -66,8 +66,10 @@ subprojects {
     configurations.all {
         resolutionStrategy {
             force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+            force "io.netty:netty-codec-dns:${nettyVersion}"
             force "io.netty:netty-codec-http:${nettyVersion}"
             force "io.netty:netty-codec-http2:${nettyVersion}"
+            force "io.netty:netty-resolver-dns:${nettyVersion}"
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes the remaining known vulnerabilities on this branch, in two parts.

**1. PostgreSQL JDBC driver (manual application of #3758 to this branch)**

The bundled pgjdbc 42.7.7 has two known HIGH vulnerabilities: CVE-2026-42198 (fixed in 42.7.11) and CVE-2026-54291 (fixed in 42.7.12). Both are SCRAM-authentication issues on code paths Schema Loader and Data Loader actually exercise when connecting to PostgreSQL. The vulnerability check does not report them — a false negative, not an absence: pgjdbc ships no embedded Maven metadata, so Trivy cannot identify it inside the fat `app.jar` (see #3758 for details). `42.7.13` matches `master`.

**2. Netty DNS artifacts**

After the Jackson/Netty upgrade was backported (#3756), the vulnerability check still reports 3 HIGH findings on this branch ([run 30352392869](https://github.com/scalar-labs/scalardb/actions/runs/30352392869)):

| Library | Detected | CVE | Fixed in |
| --- | --- | --- | --- |
| `netty-codec-dns` | 4.1.131.Final | CVE-2026-42579 | 4.1.133.Final |
| `netty-resolver-dns` | 4.1.131.Final | CVE-2026-45674, CVE-2026-47691 | 4.1.135.Final |

On `3.18` / `3.17` these are lifted transitively by `azure-storage-blob` 12.35.0 (→ `azure-core-http-netty` 1.16.5 → `reactor-netty` 1.2.18 → Netty DNS 4.1.135.Final). This branch has no `azure-storage-blob` dependency, and `azure-cosmos` 4.81.0 only reaches `azure-core-http-netty` 1.16.4 → Netty DNS 4.1.131.Final, so there is no dependency whose upgrade lifts them transitively. This PR instead adds the two artifacts to the existing `resolutionStrategy` force list at `${nettyVersion}` (4.1.136.Final).

Verified that `:schema-loader` `runtimeClasspath` resolves `org.postgresql:postgresql:42.7.13` and both Netty DNS artifacts at `4.1.136.Final (forced)`.

## Related issues and/or PRs

- #3758
- #3756

## Changes made

- Bumped `postgresqlDriverVersion` from `42.7.7` to `42.7.13`.
- Added `resolutionStrategy` `force` entries for `io.netty:netty-codec-dns` and `io.netty:netty-resolver-dns`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The remaining `mssql-jdbc` CVE-2025-59250 finding is a known false positive (see #3754).

## Release notes

Upgraded the PostgreSQL JDBC driver and the Netty library to fix security issues: CVE-2026-42198, CVE-2026-42579, CVE-2026-45674, CVE-2026-47691, and CVE-2026-54291
