### PR TITLE
Rename TwoPhaseCommitCoordinator.joinParticipant to enlist

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitCoordinator.java
@@ -16,16 +16,16 @@ import javax.annotation.Nullable;
  * spanning multiple participants; {@link TwoPhaseCommitParticipant} is the other role.
  *
  * <p>This is an internal interface for components that orchestrate two-phase commit across multiple
- * participants. Application code does not invoke it directly; callers reach it only through the
- * components that drive the protocol on its behalf. Breaking changes can and will be introduced;
- * users should not depend on it. The primitives are designed with the Consensus Commit protocol in
- * mind.
+ * participants. It is not part of the application-facing transaction API: application code should
+ * drive transactions through that API and leave this role to the components that orchestrate the
+ * protocol on its behalf. Breaking changes can and will be introduced; users should not depend on
+ * it. The primitives are designed with the Consensus Commit protocol in mind.
  *
  * <p>The two roles together make up a multi-participant transaction:
  *
  * <ul>
  *   <li>This {@link TwoPhaseCommitCoordinator} drives the protocol. It owns the per-transaction
- *       state (the joined participants, the canonical transaction ID, and any coordinator-side
+ *       state (the enlisted participants, the canonical transaction ID, and any coordinator-side
  *       resources) and orchestrates the prepare/validate/commit/rollback steps across participants.
  *       Writing the durable state record on the Coordinator table is an internal detail of this
  *       role, not a separate method on this interface.
@@ -55,9 +55,9 @@ import javax.annotation.Nullable;
  *
  * <p>Every transaction begun with {@link #begin} must be terminated with either {@link #commit} or
  * {@link #rollback}. This holds on every path out of the flow above, including a failed {@link
- * #enlist}: the failure does not terminate the transaction — the Coordinator's context and
- * any already-joined participants stay alive — so a caller that gives up must still roll it back.
- * An unterminated transaction leaves the Coordinator's per-transaction state in place until the
+ * #enlist}: the failure does not terminate the transaction — the Coordinator's context and any
+ * already-enlisted participants stay alive — so a caller that gives up must still roll it back. An
+ * unterminated transaction leaves the Coordinator's per-transaction state in place until the
  * implementation's own reaping reclaims it, if it has any.
  *
  * <p>Lazy recovery on the participant side accesses the Coordinator table directly, not through
@@ -86,8 +86,7 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    * <p>If {@code readOnly} is {@code true}, the implementation may optimize for a transaction that
    * will not write.
    *
-   * <p>The transaction begins with no participants; join them afterward via {@link
-   * #enlist}.
+   * <p>The transaction begins with no participants; enlist them afterward via {@link #enlist}.
    *
    * @param transactionId the caller-supplied transaction ID, or {@code null} to have the
    *     implementation generate one
@@ -104,9 +103,9 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
       throws TransactionNotFoundException, TransactionException;
 
   /**
-   * Joins a participant to the transaction.
+   * Enlists a participant in the transaction.
    *
-   * <p>Use this to join each participant to the transaction after {@link #begin}.
+   * <p>Use this to enlist each participant in the transaction after {@link #begin}.
    *
    * <p>The Coordinator adds the participant to its per-transaction state and internally invokes
    * {@link TwoPhaseCommitParticipant#join} on it—forwarding the {@code readOnly} flag and {@code
@@ -114,22 +113,22 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    * the transaction. The {@link TwoPhaseCommitParticipant#join} method is not intended to be
    * invoked directly by callers.
    *
-   * <p>Joining is idempotent per participant ID: if a participant with the same {@link
-   * TwoPhaseCommitParticipant#getId()} is already joined to the transaction, this call is a no-op
+   * <p>Enlisting is idempotent per participant ID: if a participant with the same {@link
+   * TwoPhaseCommitParticipant#getId()} is already enlisted in the transaction, this call is a no-op
    * (its {@link TwoPhaseCommitParticipant#join} is not invoked again).
    *
    * @param transactionId the canonical transaction ID returned by {@link #begin}
-   * @param participant the participant to join
-   * @throws TransactionNotFoundException if joining the participant fails due to transient faults.
-   *     You can retry the transaction from the beginning
-   * @throws TransactionException if joining the participant fails due to transient or nontransient
-   *     faults
+   * @param participant the participant to enlist
+   * @throws TransactionNotFoundException if enlisting the participant fails due to transient
+   *     faults. You can retry the transaction from the beginning
+   * @throws TransactionException if enlisting the participant fails due to transient or
+   *     nontransient faults
    */
   void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionNotFoundException, TransactionException;
 
   /**
-   * Drives the commit protocol across the joined participants.
+   * Drives the commit protocol across the enlisted participants.
    *
    * <p>The flow runs a prepare phase ({@link TwoPhaseCommitParticipant#prepareRecords}), a
    * validation phase ({@link TwoPhaseCommitParticipant#validateRecords}), then—once the outcome is
@@ -140,7 +139,7 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    *
    * <p>The prepare and validate phases are internal to this method, so their failures are not
    * surfaced as {@link PreparationException} or {@link ValidationException}. On such a failure the
-   * Coordinator drives the rollback internally—rolling back the PREPARED records on every joined
+   * Coordinator drives the rollback internally—rolling back the PREPARED records on every enlisted
    * participant, not only the one whose prepare or validate failed—and then reports the outcome as
    * a commit-level exception: a conflict (a retriable failure) as {@link CommitConflictException},
    * any other failure as {@link CommitException}. If the outcome cannot be durably recorded, {@link
@@ -162,19 +161,19 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    *     retry or roll back; determine the outcome (for example, by checking the coordinator state,
    *     which lazy recovery also relies on) before deciding how to proceed
    * @throws TransactionNotFoundException if no transaction with this ID is known to this
-   *     Coordinator (never begun, or already finished by a prior commit/rollback), or if a joined
-   *     participant no longer knows the transaction while preparing or validating (its local
-   *     context is gone, e.g. it expired). You can retry the transaction from the beginning
+   *     Coordinator (never begun, or already finished by a prior commit/rollback), or if an
+   *     enlisted participant no longer knows the transaction while preparing or validating (its
+   *     local context is gone, e.g. it expired). You can retry the transaction from the beginning
    */
   void commit(String transactionId)
       throws CommitConflictException, CommitException, UnknownTransactionStatusException,
           TransactionNotFoundException;
 
   /**
-   * Drives the rollback protocol across the joined participants.
+   * Drives the rollback protocol across the enlisted participants.
    *
    * <p>Drives only the work needed to undo whatever may have been prepared, via {@link
-   * TwoPhaseCommitParticipant#rollbackRecords} on each joined participant.
+   * TwoPhaseCommitParticipant#rollbackRecords} on each enlisted participant.
    *
    * <p>Unlike {@link #commit}, an unknown transaction ID (never begun, or already finished) is a
    * no-op rather than an error: no participants are contacted, and rolling back a transaction the

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitCoordinator.java
@@ -46,8 +46,8 @@ import javax.annotation.Nullable;
  *
  * <pre>
  *   String tx = coordinator.begin(null, readOnly, attrs);
- *   coordinator.joinParticipant(tx, participant1);
- *   coordinator.joinParticipant(tx, participant2);
+ *   coordinator.enlist(tx, participant1);
+ *   coordinator.enlist(tx, participant2);
  *   // ... application CRUD against each participant via its CRUD methods ...
  *   coordinator.commit(tx);
  *   // or coordinator.rollback(tx);
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  *
  * <p>Every transaction begun with {@link #begin} must be terminated with either {@link #commit} or
  * {@link #rollback}. This holds on every path out of the flow above, including a failed {@link
- * #joinParticipant}: the failure does not terminate the transaction — the Coordinator's context and
+ * #enlist}: the failure does not terminate the transaction — the Coordinator's context and
  * any already-joined participants stay alive — so a caller that gives up must still roll it back.
  * An unterminated transaction leaves the Coordinator's per-transaction state in place until the
  * implementation's own reaping reclaims it, if it has any.
@@ -87,7 +87,7 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    * will not write.
    *
    * <p>The transaction begins with no participants; join them afterward via {@link
-   * #joinParticipant}.
+   * #enlist}.
    *
    * @param transactionId the caller-supplied transaction ID, or {@code null} to have the
    *     implementation generate one
@@ -125,7 +125,7 @@ public interface TwoPhaseCommitCoordinator extends AutoCloseable {
    * @throws TransactionException if joining the participant fails due to transient or nontransient
    *     faults
    */
-  void joinParticipant(String transactionId, TwoPhaseCommitParticipant participant)
+  void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionNotFoundException, TransactionException;
 
   /**

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
@@ -85,7 +85,7 @@ public interface TwoPhaseCommitParticipant extends AutoCloseable {
   /**
    * Joins an existing transaction, establishing a local context on this participant.
    *
-   * <p>Invoked by {@link TwoPhaseCommitCoordinator#joinParticipant}; not intended to be invoked
+   * <p>Invoked by {@link TwoPhaseCommitCoordinator#enlist}; not intended to be invoked
    * directly by other callers. {@code transactionId} must be the canonical ID returned by {@link
    * TwoPhaseCommitCoordinator#begin}.
    *

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
@@ -85,8 +85,8 @@ public interface TwoPhaseCommitParticipant extends AutoCloseable {
   /**
    * Joins an existing transaction, establishing a local context on this participant.
    *
-   * <p>Invoked by {@link TwoPhaseCommitCoordinator#enlist}; not intended to be invoked
-   * directly by other callers. {@code transactionId} must be the canonical ID returned by {@link
+   * <p>Invoked by {@link TwoPhaseCommitCoordinator#enlist}; not intended to be invoked directly by
+   * other callers. {@code transactionId} must be the canonical ID returned by {@link
    * TwoPhaseCommitCoordinator#begin}.
    *
    * <p>If {@code readOnly} is {@code true}, the implementation may skip preparation and commit

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Each transaction is tracked from {@link #begin} until its terminal step ({@link #commit} /
  * {@link #rollback} / {@link #releaseTransactionContext}), with a per-transaction expiration time
- * that {@code begin} and {@link #joinParticipant} push {@code expirationTimeMillis} out. The
+ * that {@code begin} and {@link #enlist} push {@code expirationTimeMillis} out. The
  * coordinator observes only those two calls — the CRUD a transaction issues goes directly to its
  * participants — so an elapsed expiration time alone cannot tell an abandoned transaction from a
  * healthy long-running one. A background sweep therefore probes the joined participants of every
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>One boundary of that semantics: a transaction with no joined participants yet (begun but not
  * joined to anything) has nothing to probe, so its expiration time is authoritative and the reap
- * rests on the wall clock alone. {@link #joinParticipant} publishes the participant into the
+ * rests on the wall clock alone. {@link #enlist} publishes the participant into the
  * tracked entry <em>before</em> delegating the join, so this fast path fires only when no join has
  * reached that point — never while a join is in flight, whose participant is already visible to
  * probe (the delegated join can hold the wrapped coordinator's per-context monitor across remote
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
  * own per-transaction work, including {@code releaseTransactionContext} concurrently with any other
  * method for the same transaction ID (for example, by synchronizing every per-transaction method on
  * a per-context monitor) — which makes the sweep's {@code releaseTransactionContext} safe against
- * an in-flight {@code commit}/{@code rollback}. Second, the sweep and {@link #joinParticipant}
+ * an in-flight {@code commit}/{@code rollback}. Second, the sweep and {@link #enlist}
  * shake hands on the tracked entry's monitor: a join pushes the expiration time out under the
  * monitor <em>before</em> delegating to the wrapped coordinator, and the sweep re-checks under the
  * same monitor that the expiration time has not moved before releasing and removing. A reap
@@ -213,7 +213,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   }
 
   @Override
-  public void joinParticipant(String transactionId, TwoPhaseCommitParticipant participant)
+  public void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionException {
     // get() marks the entry as recently used, so an actively-joining transaction is
     // preferentially retained under cap pressure.
@@ -223,7 +223,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
       // the wrapped context is released, so the delegated join is rejected), or a cap eviction
       // is releasing it right now (the join may slip through, but the transaction is doomed
       // regardless). Delegate for the authoritative answer; there is nothing worth tracking.
-      super.joinParticipant(transactionId, participant);
+      super.enlist(transactionId, participant);
       return;
     }
     TrackedTransaction tracked = current.get();
@@ -240,7 +240,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     // unreachable one pins the entry, the fail-open retention used everywhere else.
     tracked.updateExpirationTime(nextExpirationTimeMillis());
     tracked.addParticipant(participant);
-    super.joinParticipant(transactionId, participant);
+    super.enlist(transactionId, participant);
   }
 
   @Override
@@ -361,7 +361,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
         "The transaction is expired and {}; releasing the context. Transaction ID: {}",
         reason,
         transactionId);
-    // Release before removing: a racing joinParticipant that finds the entry already gone
+    // Release before removing: a racing enlist that finds the entry already gone
     // delegates straight to the wrapped coordinator, and only a completed release guarantees the
     // wrapped coordinator rejects that join instead of accepting it onto a context this reap
     // is destroying. releaseTransactionContext is a pure in-memory reap that no-ops on an
@@ -427,13 +427,13 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     private final String transactionId;
 
     // Keyed by TwoPhaseCommitParticipant#getId (first-wins, mirroring the wrapped coordinator's
-    // idempotent join). Written by begin/joinParticipant threads and read by the sweeper, hence
+    // idempotent join). Written by begin/enlist threads and read by the sweeper, hence
     // concurrent.
     private final ConcurrentMap<String, TwoPhaseCommitParticipant> participants =
         new ConcurrentHashMap<>();
 
     // The absolute wall-clock time at which the transaction becomes a probe candidate. Pushed out
-    // by begin/joinParticipant and by a sweep that found (or failed to rule out) a participant
+    // by begin/enlist and by a sweep that found (or failed to rule out) a participant
     // still holding the transaction. Written under the entry monitor (the join-vs-reap
     // handshake, see the class Javadoc); volatile so the sweep's cheap pre-check can read it
     // without the monitor.

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinator.java
@@ -28,12 +28,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Each transaction is tracked from {@link #begin} until its terminal step ({@link #commit} /
  * {@link #rollback} / {@link #releaseTransactionContext}), with a per-transaction expiration time
- * that {@code begin} and {@link #enlist} push {@code expirationTimeMillis} out. The
- * coordinator observes only those two calls — the CRUD a transaction issues goes directly to its
- * participants — so an elapsed expiration time alone cannot tell an abandoned transaction from a
- * healthy long-running one. A background sweep therefore probes the joined participants of every
- * expired transaction ({@link TwoPhaseCommitParticipant#hasTransactionContext}) — in place, while
- * the transaction stays tracked:
+ * that {@code begin} and {@link #enlist} push {@code expirationTimeMillis} out. The coordinator
+ * observes only those two calls — the CRUD a transaction issues goes directly to its participants —
+ * so an elapsed expiration time alone cannot tell an abandoned transaction from a healthy
+ * long-running one. A background sweep therefore probes the enlisted participants of every expired
+ * transaction ({@link TwoPhaseCommitParticipant#hasTransactionContext}) — in place, while the
+ * transaction stays tracked:
  *
  * <ul>
  *   <li>If any participant still holds the transaction — or cannot be probed — the expiration time
@@ -53,23 +53,23 @@ import org.slf4j.LoggerFactory;
  * transaction-lifetime bound: a context lives exactly as long as some participant holds the
  * transaction, or its absence cannot be confirmed. Fail-open probing keeps a context alive with no
  * time limit, and each such retention logs a WARN, so a persistent probe failure is loudly visible.
- * During a total outage of a participant no new transactions can join it, so the affected entries
+ * During a total outage of a participant no new transactions can enlist it, so the affected entries
  * are bounded to the in-flight snapshot at outage time; every cycle re-probes, so they are reaped
  * as soon as probes are answered again; and the registry cap stays the hard memory bound. A
  * participant that is <em>permanently</em> unreachable would keep its snapshot probing forever,
  * cleared only when the coordinator process is restarted.
  *
- * <p>One boundary of that semantics: a transaction with no joined participants yet (begun but not
- * joined to anything) has nothing to probe, so its expiration time is authoritative and the reap
- * rests on the wall clock alone. {@link #enlist} publishes the participant into the
- * tracked entry <em>before</em> delegating the join, so this fast path fires only when no join has
- * reached that point — never while a join is in flight, whose participant is already visible to
- * probe (the delegated join can hold the wrapped coordinator's per-context monitor across remote
- * I/O and outlast a period, so it must not be reapable on the wall clock alone). Probe-before-reap
- * is what makes the sweep tolerant of clock jumps everywhere else; in the begin-to-first-join
- * window a forward jump exceeding one period can reap a healthy just-begun transaction, whose next
- * step then fails with the same retriable {@link TransactionNotFoundException} — accepted, as the
- * window is brief and a monotonic-clock scheme was judged not worth the complexity.
+ * <p>One boundary of that semantics: a transaction with no enlisted participants yet (begun, with
+ * nothing enlisted) has nothing to probe, so its expiration time is authoritative and the reap
+ * rests on the wall clock alone. {@link #enlist} publishes the participant into the tracked entry
+ * <em>before</em> delegating the enlist, so this fast path fires only when no enlist has reached
+ * that point — never while an enlist is in flight, whose participant is already visible to probe
+ * (the delegated enlist can hold the wrapped coordinator's per-context monitor across remote I/O
+ * and outlast a period, so it must not be reapable on the wall clock alone). Probe-before-reap is
+ * what makes the sweep tolerant of clock jumps everywhere else; in the begin-to-first-enlist window
+ * a forward jump exceeding one period can reap a healthy just-begun transaction, whose next step
+ * then fails with the same retriable {@link TransactionNotFoundException} — accepted, as the window
+ * is brief and a monotonic-clock scheme was judged not worth the complexity.
  *
  * <p>The sweep runs every second (or every {@code expirationTimeMillis}, if that is shorter). A
  * pass only reads each entry's expiration time, and a kept transaction is re-probed only after
@@ -93,14 +93,14 @@ import org.slf4j.LoggerFactory;
  * own per-transaction work, including {@code releaseTransactionContext} concurrently with any other
  * method for the same transaction ID (for example, by synchronizing every per-transaction method on
  * a per-context monitor) — which makes the sweep's {@code releaseTransactionContext} safe against
- * an in-flight {@code commit}/{@code rollback}. Second, the sweep and {@link #enlist}
- * shake hands on the tracked entry's monitor: a join pushes the expiration time out under the
- * monitor <em>before</em> delegating to the wrapped coordinator, and the sweep re-checks under the
- * same monitor that the expiration time has not moved before releasing and removing. A reap
- * therefore never overlaps a join that is about to succeed — either the join extends the deadline
- * first and the sweep backs off, or the reap completes first and the delegated join is rejected by
- * the wrapped coordinator, whose context is already released. Probing itself is I/O and runs
- * outside the monitor, so a slow probe never blocks a join.
+ * an in-flight {@code commit}/{@code rollback}. Second, the sweep and {@link #enlist} shake hands
+ * on the tracked entry's monitor: an enlist pushes the expiration time out under the monitor
+ * <em>before</em> delegating to the wrapped coordinator, and the sweep re-checks under the same
+ * monitor that the expiration time has not moved before releasing and removing. A reap therefore
+ * never overlaps an enlist that is about to succeed — either the enlist extends the deadline first
+ * and the sweep backs off, or the reap completes first and the delegated enlist is rejected by the
+ * wrapped coordinator, whose context is already released. Probing itself is I/O and runs outside
+ * the monitor, so a slow probe never blocks an enlist.
  *
  * <p>A reap whose release lands behind an in-flight terminal step for the same transaction blocks
  * on the wrapped coordinator's serialization — on the sweeper thread, under the entry monitor —
@@ -193,7 +193,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     return Executors.newSingleThreadScheduledExecutor(threadFactory);
   }
 
-  // The one rule for how far every deadline reaches - initial tracking, a join, and a kept-alive
+  // The one rule for how far every deadline reaches - initial tracking, an enlist, and a kept-alive
   // verdict all push the expiration time one period out from now.
   private long nextExpirationTimeMillis() {
     return System.currentTimeMillis() + expirationTimeMillis;
@@ -215,13 +215,13 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   @Override
   public void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionException {
-    // get() marks the entry as recently used, so an actively-joining transaction is
+    // get() marks the entry as recently used, so an actively-enlisting transaction is
     // preferentially retained under cap pressure.
     Optional<TrackedTransaction> current = registry.get(transactionId);
     if (!current.isPresent()) {
       // Not tracked: a terminal step or a reap already deregistered the transaction (either way
-      // the wrapped context is released, so the delegated join is rejected), or a cap eviction
-      // is releasing it right now (the join may slip through, but the transaction is doomed
+      // the wrapped context is released, so the delegated enlist is rejected), or a cap eviction
+      // is releasing it right now (the enlist may slip through, but the transaction is doomed
       // regardless). Delegate for the authoritative answer; there is nothing worth tracking.
       super.enlist(transactionId, participant);
       return;
@@ -229,14 +229,14 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     TrackedTransaction tracked = current.get();
     // Push the expiration time out and publish the participant BEFORE delegating (see the class
     // Javadoc). The sweep re-checks the expiration time under the entry monitor before reaping, so
-    // a reap never overlaps a join that is about to succeed; and publishing the participant first
-    // means a sweep firing while the (potentially remote, potentially slow) join is in flight
-    // probes it instead of taking the no-participants fast path and reaping on the wall clock
-    // alone.
-    // First-wins per participant ID, mirroring the wrapped coordinator's idempotent join:
-    // instances joined under the same participant ID front the same stores, so they are
-    // interchangeable for probing. A failed join leaves the participant tracked, which is benign: a
-    // participant that never joined answers false to a probe, so the reap still proceeds; only an
+    // a reap never overlaps an enlist that is about to succeed; and publishing the participant
+    // first means a sweep firing while the (potentially remote, potentially slow) enlist is in
+    // flight probes it instead of taking the no-participants fast path and reaping on the wall
+    // clock alone.
+    // First-wins per participant ID, mirroring the wrapped coordinator's idempotent enlist:
+    // instances enlisted under the same participant ID front the same stores, so they are
+    // interchangeable for probing. A failed enlist leaves the participant tracked, which is benign:
+    // a participant that never joined answers false to a probe, so the reap still proceeds; only an
     // unreachable one pins the entry, the fail-open retention used everywhere else.
     tracked.updateExpirationTime(nextExpirationTimeMillis());
     tracked.addParticipant(participant);
@@ -325,13 +325,13 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
       String transactionId, TrackedTransaction tracked, long observedExpirationTimeMillis) {
     if (tracked.participants.isEmpty()) {
       // Nothing to probe: the coordinator is the only observation point, so its expiration time
-      // is authoritative (e.g. a transaction begun but never joined to any participant).
+      // is authoritative (e.g. a transaction begun with no participant enlisted).
       tracked.reapUnlessExtended(
-          observedExpirationTimeMillis, () -> reap(transactionId, "has no joined participants"));
+          observedExpirationTimeMillis, () -> reap(transactionId, "has no enlisted participants"));
       return;
     }
     // Probing is (potentially remote) I/O, so it runs outside the entry monitor: a slow probe
-    // never blocks a join.
+    // never blocks an enlist.
     String aliveReason = probe(transactionId, tracked);
     if (closed) {
       // close() may have run while the probe was in flight - the per-entry check in sweep()
@@ -363,7 +363,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
         transactionId);
     // Release before removing: a racing enlist that finds the entry already gone
     // delegates straight to the wrapped coordinator, and only a completed release guarantees the
-    // wrapped coordinator rejects that join instead of accepting it onto a context this reap
+    // wrapped coordinator rejects that enlist instead of accepting it onto a context this reap
     // is destroying. releaseTransactionContext is a pure in-memory reap that no-ops on an
     // unknown transaction and does not fail — trusted like the removal below — so it is not
     // guarded per entry. If an implementation broke that contract, the throw would abort the whole
@@ -374,7 +374,7 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
   }
 
   /**
-   * Probes every joined participant and returns why the transaction counts as alive, or {@code
+   * Probes every enlisted participant and returns why the transaction counts as alive, or {@code
    * null} if every participant definitely no longer holds it. Any single positive answer is
    * conclusive. A {@link TransactionNotFoundException} is a definitive "no context" (the probe
    * contract's alternative carrier of {@code false}); any other failure is mapped per participant
@@ -427,14 +427,14 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
     private final String transactionId;
 
     // Keyed by TwoPhaseCommitParticipant#getId (first-wins, mirroring the wrapped coordinator's
-    // idempotent join). Written by begin/enlist threads and read by the sweeper, hence
+    // idempotent enlist). Written by begin/enlist threads and read by the sweeper, hence
     // concurrent.
     private final ConcurrentMap<String, TwoPhaseCommitParticipant> participants =
         new ConcurrentHashMap<>();
 
     // The absolute wall-clock time at which the transaction becomes a probe candidate. Pushed out
     // by begin/enlist and by a sweep that found (or failed to rule out) a participant
-    // still holding the transaction. Written under the entry monitor (the join-vs-reap
+    // still holding the transaction. Written under the entry monitor (the enlist-vs-reap
     // handshake, see the class Javadoc); volatile so the sweep's cheap pre-check can read it
     // without the monitor.
     private volatile long expirationTimeMillis;
@@ -450,14 +450,14 @@ public class ActiveTransactionManagedTwoPhaseCommitCoordinator
 
     /**
      * Runs {@code reap} under the entry monitor, unless the expiration time has moved since the
-     * sweep observed it — the sweep's side of the join-vs-reap handshake (see the class Javadoc):
-     * {@link #updateExpirationTime} takes the same monitor, so a join either extends the expiration
-     * time first (and the reap backs off here) or blocks until the reap — including the release it
-     * performs — has completed.
+     * sweep observed it — the sweep's side of the enlist-vs-reap handshake (see the class Javadoc):
+     * {@link #updateExpirationTime} takes the same monitor, so an enlist either extends the
+     * expiration time first (and the reap backs off here) or blocks until the reap — including the
+     * release it performs — has completed.
      */
     synchronized void reapUnlessExtended(long observedExpirationTimeMillis, Runnable reap) {
       if (expirationTimeMillis != observedExpirationTimeMillis) {
-        // The expiration time moved while the sweep was deciding: a join pushed it out
+        // The expiration time moved while the sweep was deciding: an enlist pushed it out
         // under this monitor before delegating, so the transaction just proved itself alive.
         return;
       }

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A {@link TwoPhaseCommitParticipant} decorator that propagates the transaction-scoped attributes
  * supplied at {@link #join} into every CRUD operation issued for that transaction.
  *
- * <p>Begin-attributes reach the participant via {@link TwoPhaseCommitCoordinator#joinParticipant} →
+ * <p>Begin-attributes reach the participant via {@link TwoPhaseCommitCoordinator#enlist} →
  * {@code join}; this decorator captures them (keyed by transaction ID) and merges them into each
  * operation before delegating, with an attribute set directly on the operation winning over the
  * transaction-scoped one (see {@link OperationAttributeMerger}). It therefore sits <em>outside</em>

--- a/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/common/AttributePropagatingTwoPhaseCommitParticipant.java
@@ -32,9 +32,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * A {@link TwoPhaseCommitParticipant} decorator that propagates the transaction-scoped attributes
  * supplied at {@link #join} into every CRUD operation issued for that transaction.
  *
- * <p>Begin-attributes reach the participant via {@link TwoPhaseCommitCoordinator#enlist} →
- * {@code join}; this decorator captures them (keyed by transaction ID) and merges them into each
- * operation before delegating, with an attribute set directly on the operation winning over the
+ * <p>Begin-attributes reach the participant via {@link TwoPhaseCommitCoordinator#enlist} → {@code
+ * join}; this decorator captures them (keyed by transaction ID) and merges them into each operation
+ * before delegating, with an attribute set directly on the operation winning over the
  * transaction-scoped one (see {@link OperationAttributeMerger}). It therefore sits <em>outside</em>
  * any decorator that reads operation attributes (e.g. ABAC).
  *

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinator.java
@@ -35,9 +35,9 @@ public abstract class DecoratedTwoPhaseCommitCoordinator implements TwoPhaseComm
   }
 
   @Override
-  public void joinParticipant(String transactionId, TwoPhaseCommitParticipant participant)
+  public void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionException {
-    coordinator.joinParticipant(transactionId, participant);
+    coordinator.enlist(transactionId, participant);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransaction.java
@@ -13,9 +13,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 /**
  * Adapts a {@link TwoPhaseCommitCoordinator} to the {@link GlobalTransaction} API.
  *
- * <p>{@link #commit()} drives the full two-phase commit across the joined participants through the
- * coordinator (which generates the prepared/committed timestamps internally); {@link #rollback()}
- * drives the coordinator's rollback. The handle holds no data-store resources itself.
+ * <p>{@link #commit()} drives the full two-phase commit across the enlisted participants through
+ * the coordinator (which generates the prepared/committed timestamps internally); {@link
+ * #rollback()} drives the coordinator's rollback. The handle holds no data-store resources itself.
  *
  * <p>See {@link TwoPhaseCommitBackedGlobalTransactionManager} for how the coordinator is wired and
  * the global transaction and its branches are begun.

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManager.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *   <li>{@code begin} allocates a new distributed transaction via the coordinator and returns a
  *       {@link TwoPhaseCommitBackedGlobalTransaction} — the overall handle used to drive
  *       commit/rollback. The transaction begins with no participants.
- *   <li>{@code beginBranch} joins the in-process participant to the transaction for the given
+ *   <li>{@code beginBranch} enlists the in-process participant in the transaction for the given
  *       global transaction ID and returns a {@link TwoPhaseCommitBackedBranchTransaction} — the
  *       CRUD handle for that branch.
  * </ul>
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * establishes its local context.
  *
  * <p>A single in-process participant is wired in, so a global transaction has at most one
- * meaningful branch (joining is idempotent per participant ID). Calling {@code beginBranch} again
+ * meaningful branch (enlisting is idempotent per participant ID). Calling {@code beginBranch} again
  * for the same transaction returns a new handle fronting that same participant context — the {@link
  * BranchTransaction#end()} bookkeeping is per handle — so begin each branch once and drive it
  * through that one handle. The participant may be {@code null} (coordinator-only), in which case
@@ -77,7 +77,7 @@ public class TwoPhaseCommitBackedGlobalTransactionManager implements GlobalTrans
           CoreError.COORDINATOR_ONLY_GLOBAL_TRANSACTION_MANAGER_BRANCH_NOT_SUPPORTED
               .buildMessage());
     }
-    // Join the in-process participant to the global transaction. enlist establishes the
+    // Enlist the in-process participant in the global transaction. enlist establishes the
     // participant's local context, forwarding the readOnly flag and the transaction-scoped
     // attributes supplied at begin. The per-branch attributes passed here are propagated
     // client-side into each CRUD operation by AttributePropagatingBranchTransaction.

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManager.java
@@ -77,11 +77,11 @@ public class TwoPhaseCommitBackedGlobalTransactionManager implements GlobalTrans
           CoreError.COORDINATOR_ONLY_GLOBAL_TRANSACTION_MANAGER_BRANCH_NOT_SUPPORTED
               .buildMessage());
     }
-    // Join the in-process participant to the global transaction. joinParticipant establishes the
+    // Join the in-process participant to the global transaction. enlist establishes the
     // participant's local context, forwarding the readOnly flag and the transaction-scoped
     // attributes supplied at begin. The per-branch attributes passed here are propagated
     // client-side into each CRUD operation by AttributePropagatingBranchTransaction.
-    coordinator.joinParticipant(transactionId, participant);
+    coordinator.enlist(transactionId, participant);
     BranchTransaction branch =
         new TwoPhaseCommitBackedBranchTransaction(participant, transactionId);
     return attributes.isEmpty()

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -110,7 +110,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommitCoordinator {
   }
 
   @Override
-  public void joinParticipant(String transactionId, TwoPhaseCommitParticipant participant)
+  public void enlist(String transactionId, TwoPhaseCommitParticipant participant)
       throws TransactionException {
     CoordinatorContext context = getContext(transactionId);
     synchronized (context) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -40,11 +40,12 @@ import org.slf4j.LoggerFactory;
 /**
  * Consensus-commit-backed {@link TwoPhaseCommitCoordinator} implementation.
  *
- * <p>Drives the two-phase commit protocol across the participants that joined a transaction
+ * <p>Drives the two-phase commit protocol across the participants enlisted in a transaction
  * (prepare -&gt; validate -&gt; write COMMITTED state -&gt; commit records, with the abort/rollback
  * path on failure) and holds the per-transaction state in an in-memory map keyed by canonical
- * transaction ID. Each entry records the joined participants and the read-only flag and attributes
- * passed at {@code begin}. The map is cleaned up after every {@code commit} or {@code rollback}.
+ * transaction ID. Each entry records the enlisted participants and the read-only flag and
+ * attributes passed at {@code begin}. The map is cleaned up after every {@code commit} or {@code
+ * rollback}.
  *
  * <p>TODO: support group commit on the new Coordinator. The {@code WriteSet} persistence proto's
  * {@code child_id} (group-commit dimension) and {@code participant_id} (two-phase-commit dimension)
@@ -115,17 +116,17 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommitCoordinator {
     CoordinatorContext context = getContext(transactionId);
     synchronized (context) {
       context.checkActive();
-      // Joining is idempotent per participant ID: if a participant with the same getId() is
-      // already joined, this is a no-op (the participant is not joined again). commit() keys
-      // each participant's write set by getId(), so joining the same ID twice would otherwise
+      // Enlisting is idempotent per participant ID: if a participant with the same getId() is
+      // already enlisted, this is a no-op (the participant is not enlisted again). commit() keys
+      // each participant's write set by getId(), so enlisting the same ID twice would otherwise
       // merge into one EntryGroup and misattribute the persisted records.
-      for (TwoPhaseCommitParticipant joined : context.participants) {
-        if (joined.getId().equals(participant.getId())) {
+      for (TwoPhaseCommitParticipant enlisted : context.participants) {
+        if (enlisted.getId().equals(participant.getId())) {
           return;
         }
       }
       // Invoke TwoPhaseCommitParticipant.join first; only on success do we add the participant to
-      // the list so subsequent commit/rollback drives only successfully-joined participants.
+      // the list so subsequent commit/rollback drives only successfully-enlisted participants.
       participant.join(transactionId, context.readOnly, context.attributes);
       context.participants.add(participant);
     }

--- a/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
@@ -199,7 +199,7 @@ class AbstractDistributedTransactionProviderTest {
     // participant is the one wired in.
     ArgumentCaptor<TwoPhaseCommitParticipant> captor =
         ArgumentCaptor.forClass(TwoPhaseCommitParticipant.class);
-    verify(rawCoordinator).joinParticipant(eq("tx-1"), captor.capture());
+    verify(rawCoordinator).enlist(eq("tx-1"), captor.capture());
     assertThat(captor.getValue())
         .isInstanceOf(ActiveTransactionManagedTwoPhaseCommitParticipant.class);
   }

--- a/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionProviderTest.java
@@ -185,7 +185,7 @@ class AbstractDistributedTransactionProviderTest {
     when(config.isActiveTransactionManagementEnabled()).thenReturn(true);
     when(config.getActiveTransactionManagementMaxActiveTransactions()).thenReturn(100);
     when(rawCoordinator.begin(any(), anyBoolean(), anyMap())).thenReturn("tx-1");
-    // The coordinator tracks joined participants keyed by participant ID.
+    // The coordinator tracks enlisted participants keyed by participant ID.
     when(rawParticipant.getId()).thenReturn("participant-1");
 
     GlobalTransactionManager manager = provider.createGlobalTransactionManager(config);

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -83,8 +83,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
   @Test
   void sweep_WhenExpiredWithoutParticipants_ShouldReap() throws Exception {
-    // With no participant joined there is nothing to probe: the coordinator's expiration time
-    // is authoritative (e.g. a transaction begun but never joined to any participant).
+    // With no participant enlisted there is nothing to probe: the coordinator's expiration time
+    // is authoritative (e.g. a transaction begun with no participant enlisted).
     coordinator.begin(null, false, Collections.emptyMap());
     forceExpire(TX);
 
@@ -281,8 +281,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void sweep_WhenJoinLandsDuringProbe_ShouldNotReap() throws Exception {
-    // The reap-vs-join race: a join lands while the probe is in flight. It pushes
+  void sweep_WhenEnlistLandsDuringProbe_ShouldNotReap() throws Exception {
+    // The reap-vs-enlist race: an enlist lands while the probe is in flight. It pushes
     // the expiration time out under the entry monitor before delegating, so the reap re-check
     // must back off even though every probed participant answered absent.
     TwoPhaseCommitParticipant late = mock(TwoPhaseCommitParticipant.class);
@@ -305,28 +305,28 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void sweep_WhenFirstJoinOutlivesExpiration_ShouldProbeNotReap() throws Exception {
-    // A first join that outlives the expiration period. The participant has joined - the client
-    // legitimately owns the transaction on it - but the delegated join call has not returned yet,
-    // so the participant would be invisible to the sweep if it were published only after the join.
-    // It is published before the join instead, so the sweep probes the live participant and keeps
-    // the transaction, rather than taking the no-participants fast path and reaping it on the wall
-    // clock alone.
+  void sweep_WhenFirstEnlistOutlivesExpiration_ShouldProbeNotReap() throws Exception {
+    // A first enlist that outlives the expiration period. The participant has joined - the client
+    // legitimately owns the transaction on it - but the delegated enlist call has not returned yet,
+    // so the participant would be invisible to the sweep if it were published only after the
+    // enlist. It is published before the enlist instead, so the sweep probes the live participant
+    // and keeps the transaction, rather than taking the no-participants fast path and reaping it on
+    // the wall clock alone.
     stubHeld(participant, true);
     coordinator.begin(null, false, Collections.emptyMap());
 
-    CountDownLatch joinStarted = new CountDownLatch(1);
-    CountDownLatch releaseJoin = new CountDownLatch(1);
+    CountDownLatch enlistStarted = new CountDownLatch(1);
+    CountDownLatch releaseEnlist = new CountDownLatch(1);
     doAnswer(
             invocation -> {
-              joinStarted.countDown();
-              releaseJoin.await(5, TimeUnit.SECONDS);
+              enlistStarted.countDown();
+              releaseEnlist.await(5, TimeUnit.SECONDS);
               return null;
             })
         .when(delegate)
         .enlist(eq(TX), any());
 
-    Thread joining =
+    Thread enlisting =
         new Thread(
             () -> {
               try {
@@ -335,17 +335,17 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
                 throw new AssertionError(e);
               }
             });
-    joining.start();
+    enlisting.start();
     try {
-      // Inside the join: the participant is already published, but the join has not returned.
-      assertThat(joinStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      // Inside the enlist: the participant is already published, but the enlist has not returned.
+      assertThat(enlistStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-      // The join outlives the expiration period.
+      // The enlist outlives the expiration period.
       forceExpire(TX);
       coordinator.sweep();
     } finally {
-      releaseJoin.countDown();
-      joining.join(TimeUnit.SECONDS.toMillis(5));
+      releaseEnlist.countDown();
+      enlisting.join(TimeUnit.SECONDS.toMillis(5));
     }
 
     // The sweep probed the live participant and kept the transaction; it did not reap.
@@ -366,7 +366,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
   @Test
   void enlist_ShouldExtendExpiration() throws Exception {
-    // A join is coordinator-observable activity: it pushes the expiration time a full
+    // An enlist is coordinator-observable activity: it pushes the expiration time a full
     // period out, so the next pass must not probe.
     coordinator.begin(null, false, Collections.emptyMap());
     coordinator.enlist(TX, participant);
@@ -383,7 +383,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   @Test
   void enlist_WhenNotTracked_ShouldDelegateWithoutTracking() throws Exception {
     // No tracked entry means the transaction already hit a terminal step or was reaped - the
-    // wrapped coordinator is authoritative and rejects the join (its context is released
+    // wrapped coordinator is authoritative and rejects the enlist (its context is released
     // on those paths). Nothing may be recreated on this path.
     doThrow(new TransactionNotFoundException("no context", TX))
         .when(delegate)
@@ -400,14 +400,13 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void enlist_WhenDelegateThrows_ShouldStillTrackButReapWhenProbeAnswersAbsent()
-      throws Exception {
-    // The participant is published before the join is delegated, so a sweep firing while a slow
-    // join is in flight probes it instead of reaping on the wall clock alone. The consequence is
-    // that a failed join leaves the participant tracked - accepted, and benign: a participant that
-    // never joined answers false to a probe, so the reap still proceeds, and a failed join does not
-    // keep a dead transaction alive forever. (Only an unreachable participant pins the entry, which
-    // is the fail-open retention used everywhere else.)
+  void enlist_WhenDelegateThrows_ShouldStillTrackButReapWhenProbeAnswersAbsent() throws Exception {
+    // The participant is published before the enlist is delegated, so a sweep firing while a slow
+    // enlist is in flight probes it instead of reaping on the wall clock alone. The consequence is
+    // that a failed enlist leaves the participant tracked - accepted, and benign: a participant
+    // that never joined answers false to a probe, so the reap still proceeds, and a failed enlist
+    // does not keep a dead transaction alive forever. (Only an unreachable participant pins the
+    // entry, which is the fail-open retention used everywhere else.)
     coordinator.begin(null, false, Collections.emptyMap());
     doThrow(new TransactionException("boom", TX)).when(delegate).enlist(TX, participant);
 
@@ -430,8 +429,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
 
   @Test
   void enlist_WithDuplicateParticipantId_ShouldKeepFirstInstance() throws Exception {
-    // First-wins per participant ID, mirroring the wrapped coordinator's idempotent join:
-    // the wrapped side joined the first instance, so that is the instance the probe must use.
+    // First-wins per participant ID, mirroring the wrapped coordinator's idempotent enlist:
+    // the wrapped side enlisted the first instance, so that is the instance the probe must use.
     TwoPhaseCommitParticipant second = mock(TwoPhaseCommitParticipant.class);
     when(second.getId()).thenReturn("participant-1");
     stubHeld(participant, false);

--- a/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitCoordinatorTest.java
@@ -72,7 +72,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   @Test
   void sweep_WhenTransactionNotExpired_ShouldNotProbeOrReap() throws Exception {
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
 
     coordinator.sweep();
 
@@ -101,7 +101,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // reports the transaction gone may the reap happen.
     stubHeld(participant, true);
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
 
     forceExpire(TX);
     coordinator.sweep();
@@ -136,7 +136,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
             delegate, spiedRegistry, EXPIRATION_MILLIS);
     stubHeld(participant, true);
     kept.begin(null, false, Collections.emptyMap());
-    kept.joinParticipant(TX, participant);
+    kept.enlist(TX, participant);
     spiedRegistry.get(TX).get().updateExpirationTime(0);
 
     kept.sweep();
@@ -153,8 +153,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     stubHeld(gone, false);
     stubHeld(participant, true);
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
-    coordinator.joinParticipant(TX, gone);
+    coordinator.enlist(TX, participant);
+    coordinator.enlist(TX, gone);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -171,7 +171,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     when(participant.hasTransactionContext(TX))
         .thenThrow(new TransactionException("unreachable", TX));
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -187,12 +187,12 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // probed and reaped.
     when(participant.hasTransactionContext(TX)).thenThrow(new RuntimeException("boom"));
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     TwoPhaseCommitParticipant otherParticipant = mock(TwoPhaseCommitParticipant.class);
     when(otherParticipant.getId()).thenReturn("participant-2");
     when(delegate.begin(eq("tx-2"), eq(false), any())).thenReturn("tx-2");
     coordinator.begin("tx-2", false, Collections.emptyMap());
-    coordinator.joinParticipant("tx-2", otherParticipant);
+    coordinator.enlist("tx-2", otherParticipant);
     forceExpire(TX);
     forceExpire("tx-2");
 
@@ -211,7 +211,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // one to log it and retry on the next interval.
     when(participant.hasTransactionContext(TX)).thenThrow(new LinkageError("boom"));
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     assertThatThrownBy(coordinator::sweep).isInstanceOf(LinkageError.class);
@@ -228,7 +228,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // next interval's retry. Narrowing its catch to Exception would break exactly this.
     when(participant.hasTransactionContext(TX)).thenThrow(new LinkageError("boom"));
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     assertThatCode(coordinator::sweepSafely).doesNotThrowAnyException();
@@ -251,7 +251,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     when(participant.hasTransactionContext(TX))
         .thenThrow(new TransactionNotFoundException("no context on this node", TX));
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -270,8 +270,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
         .thenThrow(new TransactionNotFoundException("no context on this node", TX));
     stubHeld(participant, true);
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
-    coordinator.joinParticipant(TX, gone);
+    coordinator.enlist(TX, participant);
+    coordinator.enlist(TX, gone);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -290,11 +290,11 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     when(participant.hasTransactionContext(TX))
         .thenAnswer(
             invocation -> {
-              coordinator.joinParticipant(TX, late);
+              coordinator.enlist(TX, late);
               return false;
             });
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -324,13 +324,13 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
               return null;
             })
         .when(delegate)
-        .joinParticipant(eq(TX), any());
+        .enlist(eq(TX), any());
 
     Thread joining =
         new Thread(
             () -> {
               try {
-                coordinator.joinParticipant(TX, participant);
+                coordinator.enlist(TX, participant);
               } catch (TransactionException e) {
                 throw new AssertionError(e);
               }
@@ -355,24 +355,24 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_ShouldDelegateAndTrackParticipant() throws Exception {
+  void enlist_ShouldDelegateAndTrackParticipant() throws Exception {
     coordinator.begin(null, false, Collections.emptyMap());
 
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
 
-    verify(delegate).joinParticipant(TX, participant);
+    verify(delegate).enlist(TX, participant);
     assertThat(registry.get(TX).get().hasParticipant("participant-1")).isTrue();
   }
 
   @Test
-  void joinParticipant_ShouldExtendExpiration() throws Exception {
+  void enlist_ShouldExtendExpiration() throws Exception {
     // A join is coordinator-observable activity: it pushes the expiration time a full
     // period out, so the next pass must not probe.
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     coordinator.sweep();
 
     verify(participant, never()).hasTransactionContext(any());
@@ -381,26 +381,26 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_WhenNotTracked_ShouldDelegateWithoutTracking() throws Exception {
+  void enlist_WhenNotTracked_ShouldDelegateWithoutTracking() throws Exception {
     // No tracked entry means the transaction already hit a terminal step or was reaped - the
     // wrapped coordinator is authoritative and rejects the join (its context is released
     // on those paths). Nothing may be recreated on this path.
     doThrow(new TransactionNotFoundException("no context", TX))
         .when(delegate)
-        .joinParticipant(TX, participant);
+        .enlist(TX, participant);
 
     try {
-      coordinator.joinParticipant(TX, participant);
+      coordinator.enlist(TX, participant);
     } catch (TransactionNotFoundException ignored) {
       // expected
     }
 
-    verify(delegate).joinParticipant(TX, participant);
+    verify(delegate).enlist(TX, participant);
     assertThat(registry.get(TX)).isEmpty();
   }
 
   @Test
-  void joinParticipant_WhenDelegateThrows_ShouldStillTrackButReapWhenProbeAnswersAbsent()
+  void enlist_WhenDelegateThrows_ShouldStillTrackButReapWhenProbeAnswersAbsent()
       throws Exception {
     // The participant is published before the join is delegated, so a sweep firing while a slow
     // join is in flight probes it instead of reaping on the wall clock alone. The consequence is
@@ -409,10 +409,10 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     // keep a dead transaction alive forever. (Only an unreachable participant pins the entry, which
     // is the fail-open retention used everywhere else.)
     coordinator.begin(null, false, Collections.emptyMap());
-    doThrow(new TransactionException("boom", TX)).when(delegate).joinParticipant(TX, participant);
+    doThrow(new TransactionException("boom", TX)).when(delegate).enlist(TX, participant);
 
     try {
-      coordinator.joinParticipant(TX, participant);
+      coordinator.enlist(TX, participant);
     } catch (TransactionException ignored) {
       // expected
     }
@@ -429,7 +429,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_WithDuplicateParticipantId_ShouldKeepFirstInstance() throws Exception {
+  void enlist_WithDuplicateParticipantId_ShouldKeepFirstInstance() throws Exception {
     // First-wins per participant ID, mirroring the wrapped coordinator's idempotent join:
     // the wrapped side joined the first instance, so that is the instance the probe must use.
     TwoPhaseCommitParticipant second = mock(TwoPhaseCommitParticipant.class);
@@ -437,8 +437,8 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
     stubHeld(participant, false);
     coordinator.begin(null, false, Collections.emptyMap());
 
-    coordinator.joinParticipant(TX, participant);
-    coordinator.joinParticipant(TX, second);
+    coordinator.enlist(TX, participant);
+    coordinator.enlist(TX, second);
 
     forceExpire(TX);
     coordinator.sweep();
@@ -536,7 +536,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
   void sweep_AfterClose_ShouldNotProbeOrRelease() throws Exception {
     stubHeld(participant, true);
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     coordinator.close();
@@ -561,7 +561,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
               return false;
             });
     coordinator.begin(null, false, Collections.emptyMap());
-    coordinator.joinParticipant(TX, participant);
+    coordinator.enlist(TX, participant);
     forceExpire(TX);
 
     coordinator.sweep();
@@ -580,7 +580,7 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
             delegate, /* expirationTimeMillis= */ 100, /* maxActiveTransactions= */ -1);
     try {
       scheduled.begin(null, false, Collections.emptyMap());
-      scheduled.joinParticipant(TX, participant);
+      scheduled.enlist(TX, participant);
       verify(delegate, timeout(10000)).releaseTransactionContext(TX);
     } finally {
       scheduled.close();
@@ -607,9 +607,9 @@ class ActiveTransactionManagedTwoPhaseCommitCoordinatorTest {
             localDelegate, /* expirationTimeMillis= */ -1, /* maxActiveTransactions= */ 1);
     try {
       capped.begin("tx-a", false, Collections.emptyMap());
-      capped.joinParticipant("tx-a", participant);
+      capped.enlist("tx-a", participant);
       capped.begin("tx-b", false, Collections.emptyMap());
-      capped.joinParticipant("tx-b", participant);
+      capped.enlist("tx-b", participant);
 
       // Caffeine decides size-based eviction during maintenance, and maintenance is re-triggered
       // by cache writes; two racing writes can leave the cache over capacity but quiescent, with

--- a/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/common/DecoratedTwoPhaseCommitCoordinatorTest.java
@@ -37,9 +37,9 @@ class DecoratedTwoPhaseCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_ShouldDelegate() throws Exception {
-    coordinator.joinParticipant(TX, participant);
-    verify(delegate).joinParticipant(TX, participant);
+  void enlist_ShouldDelegate() throws Exception {
+    coordinator.enlist(TX, participant);
+    verify(delegate).enlist(TX, participant);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
@@ -73,7 +73,7 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
       throws Exception {
     BranchTransaction branch = manager().beginBranch(TX_ID, Collections.emptyMap());
 
-    verify(coordinator).joinParticipant(TX_ID, participant);
+    verify(coordinator).enlist(TX_ID, participant);
     assertThat(branch).isInstanceOf(TwoPhaseCommitBackedBranchTransaction.class);
     assertThat(branch).isNotInstanceOf(AttributePropagatingBranchTransaction.class);
     assertThat(branch.getId()).isEqualTo(TX_ID);
@@ -84,7 +84,7 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
       throws Exception {
     BranchTransaction branch = manager().beginBranch(TX_ID, attrs("k", "v"));
 
-    verify(coordinator).joinParticipant(TX_ID, participant);
+    verify(coordinator).enlist(TX_ID, participant);
     assertThat(branch).isInstanceOf(AttributePropagatingBranchTransaction.class);
   }
 
@@ -93,7 +93,7 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
     // A registration failure other than not-found reaches the caller as-is, not masked as
     // not-found: beginBranch is the surface where non-not-found registration failures propagate.
     TransactionException exception = new TransactionException("join failed", TX_ID);
-    doThrow(exception).when(coordinator).joinParticipant(TX_ID, participant);
+    doThrow(exception).when(coordinator).enlist(TX_ID, participant);
 
     assertThatThrownBy(() -> manager().beginBranch(TX_ID, Collections.emptyMap()))
         .isSameAs(exception);

--- a/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/TwoPhaseCommitBackedGlobalTransactionManagerTest.java
@@ -69,7 +69,7 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
   }
 
   @Test
-  void beginBranch_WithEmptyAttributes_ShouldJoinParticipantAndReturnPlainBranchTransaction()
+  void beginBranch_WithEmptyAttributes_ShouldEnlistParticipantAndReturnPlainBranchTransaction()
       throws Exception {
     BranchTransaction branch = manager().beginBranch(TX_ID, Collections.emptyMap());
 
@@ -89,10 +89,10 @@ class TwoPhaseCommitBackedGlobalTransactionManagerTest {
   }
 
   @Test
-  void beginBranch_WhenJoinParticipantFails_ShouldPropagateTransactionException() throws Exception {
+  void beginBranch_WhenEnlistFails_ShouldPropagateTransactionException() throws Exception {
     // A registration failure other than not-found reaches the caller as-is, not masked as
     // not-found: beginBranch is the surface where non-not-found registration failures propagate.
-    TransactionException exception = new TransactionException("join failed", TX_ID);
+    TransactionException exception = new TransactionException("enlist failed", TX_ID);
     doThrow(exception).when(coordinator).enlist(TX_ID, participant);
 
     assertThatThrownBy(() -> manager().beginBranch(TX_ID, Collections.emptyMap()))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -102,8 +102,7 @@ class ConsensusCommitCoordinatorTest {
     // Act Assert
     assertThatThrownBy(
             () ->
-                consensusCommitCoordinator.enlist(
-                    "unknown", mock(TwoPhaseCommitParticipant.class)))
+                consensusCommitCoordinator.enlist("unknown", mock(TwoPhaseCommitParticipant.class)))
         .isInstanceOf(TransactionNotFoundException.class);
   }
 
@@ -198,8 +197,8 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — prepare/validate succeed on both participants, but the COMMITTED-state write loses
     // a putState race that resolves to ABORTED (CommitConflictException).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedWritingParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedWritingParticipant("tx-1", "participant-2");
     doThrow(new CommitConflictException("conflict", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -224,8 +223,8 @@ class ConsensusCommitCoordinatorTest {
     // prepareRecords, so the Coordinator rolls back only toCommit (the writer), not every
     // participant.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant writer = joinedWritingParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant writeLess = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant writer = enlistedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant writeLess = enlistedParticipant("tx-1", "participant-2");
     doThrow(new CommitConflictException("conflict", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -248,7 +247,7 @@ class ConsensusCommitCoordinatorTest {
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
 
     // Act
     consensusCommitCoordinator.commit("tx-1");
@@ -271,7 +270,7 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("validation conflict", "tx-1"))
         .when(participant)
         .validateRecords("tx-1");
@@ -296,7 +295,7 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(writeSet(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(writeSet(), true));
     doThrow(new ValidationConflictException("validation conflict", "tx-1"))
         .when(participant)
         .validateRecords("tx-1");
@@ -328,7 +327,7 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
     doThrow(new TransactionNotFoundException("transaction not found", "tx-1"))
         .when(participant)
         .validateRecords("tx-1");
@@ -353,7 +352,7 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(writeSet(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(writeSet(), true));
     doThrow(new TransactionNotFoundException("transaction not found", "tx-1"))
         .when(participant)
         .validateRecords("tx-1");
@@ -382,7 +381,7 @@ class ConsensusCommitCoordinatorTest {
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(participant)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -406,7 +405,7 @@ class ConsensusCommitCoordinatorTest {
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(participant)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -430,7 +429,7 @@ class ConsensusCommitCoordinatorTest {
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
     doThrow(new TransactionNotFoundException("transaction not found", "tx-1"))
         .when(participant)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -452,7 +451,7 @@ class ConsensusCommitCoordinatorTest {
     // every terminated transaction leaves a Coordinator state row is preserved, mirroring the
     // commit-success path's gate.
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(participant)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -478,7 +477,7 @@ class ConsensusCommitCoordinatorTest {
   void rollback_ShouldDriveRollbackRecordsAndReleaseWithoutWritingAbortedState() throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant participant = enlistedParticipant("tx-1");
 
     // Act
     consensusCommitCoordinator.rollback("tx-1");
@@ -503,7 +502,7 @@ class ConsensusCommitCoordinatorTest {
       throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant participant = joinedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant participant = enlistedWritingParticipant("tx-1", "participant-1");
 
     // Act
     consensusCommitCoordinator.releaseTransactionContext("tx-1");
@@ -544,9 +543,7 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator.commit("tx-1");
 
     assertThatThrownBy(
-            () ->
-                consensusCommitCoordinator.enlist(
-                    "tx-1", mock(TwoPhaseCommitParticipant.class)))
+            () -> consensusCommitCoordinator.enlist("tx-1", mock(TwoPhaseCommitParticipant.class)))
         .isInstanceOf(TransactionNotFoundException.class);
   }
 
@@ -573,15 +570,15 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void commit_TwoParticipants_ShouldDriveFullTwoPhaseCommitInJoinOrder() throws Exception {
+  void commit_TwoParticipants_ShouldDriveFullTwoPhaseCommitInEnlistOrder() throws Exception {
     // Arrange — both participants write and require validation, so every record-level step is
     // driven.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant p1 =
-        joinedParticipant(
+        enlistedParticipant(
             "tx-1", "participant-1", preparation(writeSet(), /* validationRequired= */ true));
     TwoPhaseCommitParticipant p2 =
-        joinedParticipant(
+        enlistedParticipant(
             "tx-1", "participant-2", preparation(writeSet(), /* validationRequired= */ true));
 
     // Act
@@ -604,7 +601,7 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — the participant writes but does not require validation.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(writeSet(), false));
+        enlistedParticipant("tx-1", "participant-1", preparation(writeSet(), false));
 
     // Act
     consensusCommitCoordinator.commit("tx-1");
@@ -622,7 +619,7 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — the participant has no writes but requires validation.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant =
-        joinedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
 
     // Act
     consensusCommitCoordinator.commit("tx-1");
@@ -642,11 +639,11 @@ class ConsensusCommitCoordinatorTest {
     //   writeLessNoVal: no writes, no validation      -> prepare only
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant writer =
-        joinedParticipant("tx-1", "participant-1", preparation(writeSet(), false));
+        enlistedParticipant("tx-1", "participant-1", preparation(writeSet(), false));
     TwoPhaseCommitParticipant writeLessVal =
-        joinedParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
     TwoPhaseCommitParticipant writeLessNoVal =
-        joinedParticipant("tx-1", "participant-3", preparation(Collections.emptyList(), false));
+        enlistedParticipant("tx-1", "participant-3", preparation(Collections.emptyList(), false));
 
     // Act
     consensusCommitCoordinator.commit("tx-1");
@@ -673,8 +670,8 @@ class ConsensusCommitCoordinatorTest {
       throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new PreparationConflictException("conflict on p2", "tx-1"))
         .when(p2)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -699,8 +696,8 @@ class ConsensusCommitCoordinatorTest {
           throws Exception {
     // Arrange — the second participant no longer knows the transaction (its local context is gone).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new TransactionNotFoundException("gone on p2", "tx-1"))
         .when(p2)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -726,7 +723,7 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — the participant requires validation, and validation fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant p1 =
-        joinedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-1", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("validation conflict", "tx-1"))
         .when(p1)
         .validateRecords("tx-1");
@@ -751,7 +748,7 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — a plain (non-conflict) PreparationException, e.g. an I/O failure during prepare
     // rather than a write conflict.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1");
     doThrow(new PreparationException("prepare failed", "tx-1"))
         .when(p1)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -773,7 +770,7 @@ class ConsensusCommitCoordinatorTest {
     // (no writes, validation required) so the Coordinator actually drives validateRecords on it.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant p1 =
-        joinedParticipant(
+        enlistedParticipant(
             "tx-1",
             "participant-1",
             preparation(Collections.emptyList(), /* validationRequired= */ true));
@@ -799,7 +796,7 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — a writing participant, so the Coordinator drives commitRecords on it (a write-less
     // participant would be skipped and the doThrow stub below would never fire).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
     doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
 
     // Act Assert — commitRecords is best-effort: the failure is swallowed and commit completes.
@@ -811,7 +808,7 @@ class ConsensusCommitCoordinatorTest {
   void commit_WhenRollbackRecordsThrows_ShouldSwallowAndPropagateOriginal() throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(p1)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -831,8 +828,8 @@ class ConsensusCommitCoordinatorTest {
     // successfully through prepare/commitState; the first participant's best-effort commitRecords
     // then fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedWritingParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedWritingParticipant("tx-1", "participant-2");
     doThrow(new RuntimeException("network blip")).when(p1).commitRecords(eq("tx-1"), anyLong());
 
     // Act — commitRecords is best-effort, so the first participant's failure is swallowed.
@@ -850,9 +847,9 @@ class ConsensusCommitCoordinatorTest {
     // therefore must require validation), then make the first participant's best-effort
     // rollbackRecords fail.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
     TwoPhaseCommitParticipant p2 =
-        joinedParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
+        enlistedParticipant("tx-1", "participant-2", preparation(Collections.emptyList(), true));
     doThrow(new ValidationConflictException("conflict", "tx-1")).when(p2).validateRecords("tx-1");
     doThrow(new RuntimeException("network blip")).when(p1).rollbackRecords("tx-1");
 
@@ -872,8 +869,8 @@ class ConsensusCommitCoordinatorTest {
     // not-found channel (typical for a remote participant that already self-released or was
     // idle-reaped), which the contract defines as an alternative carrier of the no-op outcome.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new TransactionNotFoundException("gone", "tx-1")).when(p1).rollbackRecords("tx-1");
 
     // Act — the rollback completes normally; the not-found is treated exactly like a no-op return.
@@ -891,7 +888,7 @@ class ConsensusCommitCoordinatorTest {
     // (a real coordinator failure, not a mere putState conflict, which the handler would resolve to
     // ABORTED).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(p1)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -917,8 +914,8 @@ class ConsensusCommitCoordinatorTest {
     // ABORTED-state write fails with unknown status. Both participants joined, so the
     // abort path holds a context for each.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(p1)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -927,7 +924,7 @@ class ConsensusCommitCoordinatorTest {
         .abortState(anyString(), any());
 
     // Act Assert — the unknown status surfaces, records are not rolled back on either participant,
-    // and the abort path releases every joined participant's context (unlike the commit-state
+    // and the abort path releases every enlisted participant's context (unlike the commit-state
     // path's toCommit scoping, a participant that never prepared still holds an ACTIVE context
     // here).
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
@@ -945,8 +942,8 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — the internal abort path with an unknown-status ABORTED write, and the first
     // participant's release itself fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new PreparationConflictException("conflict", "tx-1"))
         .when(p1)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -972,7 +969,7 @@ class ConsensusCommitCoordinatorTest {
       throws Exception {
     // Arrange — a writing participant, and the COMMITTED state write fails with unknown status.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -1003,7 +1000,7 @@ class ConsensusCommitCoordinatorTest {
     // remote participant, which is likely correlated with the coordinator-table trouble that
     // caused the unknown status in the first place).
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -1024,8 +1021,8 @@ class ConsensusCommitCoordinatorTest {
     // unknown status. The write-less participant already self-released at prepareRecords, so only
     // toCommit (the writer) still holds a context.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant writer = joinedWritingParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant writeLess = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant writer = enlistedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant writeLess = enlistedParticipant("tx-1", "participant-2");
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -1046,8 +1043,8 @@ class ConsensusCommitCoordinatorTest {
     // Arrange — two writing participants; the COMMITTED-state write fails with unknown status and
     // the first participant's release itself fails.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant p1 = joinedWritingParticipant("tx-1", "participant-1");
-    TwoPhaseCommitParticipant p2 = joinedWritingParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p1 = enlistedWritingParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant p2 = enlistedWritingParticipant("tx-1", "participant-2");
     doThrow(new UnknownTransactionStatusException("unknown", "tx-1"))
         .when(coordinatorCommitHandler)
         .commitState(anyString(), any());
@@ -1066,13 +1063,13 @@ class ConsensusCommitCoordinatorTest {
 
   @Test
   void enlist_WhenDuplicateParticipantId_ShouldBeNoOp() throws Exception {
-    // Arrange — one participant with a given ID is already joined.
+    // Arrange — one participant with a given ID is already enlisted.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    TwoPhaseCommitParticipant original = joinedParticipant("tx-1", "participant-1");
+    TwoPhaseCommitParticipant original = enlistedParticipant("tx-1", "participant-1");
     TwoPhaseCommitParticipant duplicate = mock(TwoPhaseCommitParticipant.class);
     when(duplicate.getId()).thenReturn("participant-1");
 
-    // Act — joining a second participant that returns the same getId() is a no-op.
+    // Act — enlisting a second participant that returns the same getId() is a no-op.
     consensusCommitCoordinator.enlist("tx-1", duplicate);
 
     // Assert — the duplicate is never joined, and only the original participant is tracked (a
@@ -1093,12 +1090,12 @@ class ConsensusCommitCoordinatorTest {
     when(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).thenReturn(true);
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
-    joinedParticipantWithWrites(
+    enlistedParticipantWithWrites(
         "tx-1",
         "participant-1",
         writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 1), Optional.empty()),
         writeSetEntry(WriteSetEntry.Type.DELETE, Key.ofInt("pk", 2), Optional.empty()));
-    joinedParticipantWithWrites(
+    enlistedParticipantWithWrites(
         "tx-1",
         "participant-2",
         writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 3), Optional.empty()));
@@ -1107,10 +1104,10 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator.commit("tx-1");
 
     // Assert — the COMMITTED state is written (hasWrites=true overrides write omission) with a
-    // WriteSet that has one EntryGroup per participant, in join order, each entry stamped with the
-    // owning participant id. Each entry's partition key is asserted too: the participant id alone
-    // would not distinguish the two entries of participant-1 from each other, so the assertions
-    // would hold even if the encoder emitted one of them twice or swapped them.
+    // WriteSet that has one EntryGroup per participant, in enlist order, each entry stamped with
+    // the owning participant id. Each entry's partition key is asserted too: the participant id
+    // alone would not distinguish the two entries of participant-1 from each other, so the
+    // assertions would hold even if the encoder emitted one of them twice or swapped them.
     ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
     verify(coordinatorCommitHandler).commitState(eq("tx-1"), captor.capture());
     WriteSet writeSet = captor.getValue();
@@ -1140,7 +1137,7 @@ class ConsensusCommitCoordinatorTest {
     // aggregated write set is complete — the same map the commit path would persist.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant p1 =
-        joinedParticipant(
+        enlistedParticipant(
             "tx-1",
             "participant-1",
             preparation(
@@ -1149,7 +1146,7 @@ class ConsensusCommitCoordinatorTest {
                     writeSetEntry(WriteSetEntry.Type.DELETE, Key.ofInt("pk", 2), Optional.empty())),
                 /* validationRequired= */ true));
     TwoPhaseCommitParticipant p2 =
-        joinedParticipant(
+        enlistedParticipant(
             "tx-1",
             "participant-2",
             preparation(
@@ -1161,7 +1158,7 @@ class ConsensusCommitCoordinatorTest {
         .validateRecords("tx-1");
 
     // Act Assert — the ABORTED row carries the same participant-grouped, keys-only write set the
-    // commit path encodes (one EntryGroup per participant in join order), so active
+    // commit path encodes (one EntryGroup per participant in enlist order), so active
     // recovery can find the touched records.
     assertThatThrownBy(() -> consensusCommitCoordinator.commit("tx-1"))
         .isInstanceOf(CommitConflictException.class)
@@ -1193,11 +1190,11 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator = new ConsensusCommitCoordinator(coordinatorCommitHandler, config);
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant p1 =
-        joinedParticipantWithWrites(
+        enlistedParticipantWithWrites(
             "tx-1",
             "participant-1",
             writeSetEntry(WriteSetEntry.Type.WRITE, Key.ofInt("pk", 1), Optional.empty()));
-    TwoPhaseCommitParticipant p2 = joinedParticipant("tx-1", "participant-2");
+    TwoPhaseCommitParticipant p2 = enlistedParticipant("tx-1", "participant-2");
     doThrow(new PreparationConflictException("conflict on p2", "tx-1"))
         .when(p2)
         .prepareRecords(eq("tx-1"), anyLong(), eq(WriteSetDetailLevel.KEYS_ONLY));
@@ -1217,16 +1214,16 @@ class ConsensusCommitCoordinatorTest {
     verify(p2).rollbackRecords("tx-1");
   }
 
-  private TwoPhaseCommitParticipant joinedParticipant(String transactionId) throws Exception {
-    return joinedParticipant(transactionId, "participant-1");
+  private TwoPhaseCommitParticipant enlistedParticipant(String transactionId) throws Exception {
+    return enlistedParticipant(transactionId, "participant-1");
   }
 
-  private TwoPhaseCommitParticipant joinedParticipant(String transactionId, String participantId)
+  private TwoPhaseCommitParticipant enlistedParticipant(String transactionId, String participantId)
       throws Exception {
-    return joinedParticipant(transactionId, participantId, emptyPreparation());
+    return enlistedParticipant(transactionId, participantId, emptyPreparation());
   }
 
-  private TwoPhaseCommitParticipant joinedParticipant(
+  private TwoPhaseCommitParticipant enlistedParticipant(
       String transactionId, String participantId, PreparationResult preparationResult)
       throws Exception {
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
@@ -1236,10 +1233,10 @@ class ConsensusCommitCoordinatorTest {
     return participant;
   }
 
-  // A joined participant that produces a write (so the Coordinator drives commitRecords on it).
-  private TwoPhaseCommitParticipant joinedWritingParticipant(
+  // An enlisted participant that produces a write (so the Coordinator drives commitRecords on it).
+  private TwoPhaseCommitParticipant enlistedWritingParticipant(
       String transactionId, String participantId) throws Exception {
-    return joinedParticipant(transactionId, participantId, writePreparation());
+    return enlistedParticipant(transactionId, participantId, writePreparation());
   }
 
   private static PreparationResult preparation(
@@ -1306,9 +1303,9 @@ class ConsensusCommitCoordinatorTest {
         });
   }
 
-  // Joins a participant whose prepareRecords returns the given (non-empty) write set, so
+  // Enlists a participant whose prepareRecords returns the given (non-empty) write set, so
   // commit() exercises the hasWrites=true aggregation/encoding path.
-  private TwoPhaseCommitParticipant joinedParticipantWithWrites(
+  private TwoPhaseCommitParticipant enlistedParticipantWithWrites(
       String transactionId, String participantId, WriteSetEntry... entries) throws Exception {
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
     when(participant.getId()).thenReturn(participantId);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -98,17 +98,17 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_UnknownTransaction_ShouldThrowTransactionNotFoundException() {
+  void enlist_UnknownTransaction_ShouldThrowTransactionNotFoundException() {
     // Act Assert
     assertThatThrownBy(
             () ->
-                consensusCommitCoordinator.joinParticipant(
+                consensusCommitCoordinator.enlist(
                     "unknown", mock(TwoPhaseCommitParticipant.class)))
         .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  void joinParticipant_ShouldInvokeJoinAndTrackParticipant() throws Exception {
+  void enlist_ShouldInvokeJoinAndTrackParticipant() throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap());
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
@@ -118,7 +118,7 @@ class ConsensusCommitCoordinatorTest {
         .thenReturn(preparation(writeSet(), true));
 
     // Act
-    consensusCommitCoordinator.joinParticipant("tx-1", participant);
+    consensusCommitCoordinator.enlist("tx-1", participant);
 
     // Assert — join is invoked with the begin-time readOnly flag and attributes ...
     verify(participant).join("tx-1", true, Collections.emptyMap());
@@ -130,7 +130,7 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_WhenJoinThrows_ShouldNotTrackParticipant() throws Exception {
+  void enlist_WhenJoinThrows_ShouldNotTrackParticipant() throws Exception {
     // Arrange
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
@@ -139,7 +139,7 @@ class ConsensusCommitCoordinatorTest {
         .join("tx-1", false, Collections.emptyMap());
 
     // Act
-    assertThatThrownBy(() -> consensusCommitCoordinator.joinParticipant("tx-1", participant))
+    assertThatThrownBy(() -> consensusCommitCoordinator.enlist("tx-1", participant))
         .isInstanceOf(TransactionException.class);
 
     // Assert — a failed join leaves the participant untracked, so rollback never touches it.
@@ -148,7 +148,7 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_AfterBegin_ShouldJoinOnParticipantAndTrackIt() throws Exception {
+  void enlist_AfterBegin_ShouldJoinOnParticipantAndTrackIt() throws Exception {
     // Arrange
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
     when(participant.getId()).thenReturn("participant-1");
@@ -156,7 +156,7 @@ class ConsensusCommitCoordinatorTest {
 
     // Act
     consensusCommitCoordinator.begin("tx-1", true, Collections.emptyMap());
-    consensusCommitCoordinator.joinParticipant("tx-1", participant);
+    consensusCommitCoordinator.enlist("tx-1", participant);
 
     // Assert — join is invoked on the participant with the begin-time readOnly flag and attributes
     // ...
@@ -539,13 +539,13 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_AfterCommit_ShouldThrowTransactionNotFoundException() throws Exception {
+  void enlist_AfterCommit_ShouldThrowTransactionNotFoundException() throws Exception {
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     consensusCommitCoordinator.commit("tx-1");
 
     assertThatThrownBy(
             () ->
-                consensusCommitCoordinator.joinParticipant(
+                consensusCommitCoordinator.enlist(
                     "tx-1", mock(TwoPhaseCommitParticipant.class)))
         .isInstanceOf(TransactionNotFoundException.class);
   }
@@ -1065,7 +1065,7 @@ class ConsensusCommitCoordinatorTest {
   }
 
   @Test
-  void joinParticipant_WhenDuplicateParticipantId_ShouldBeNoOp() throws Exception {
+  void enlist_WhenDuplicateParticipantId_ShouldBeNoOp() throws Exception {
     // Arrange — one participant with a given ID is already joined.
     consensusCommitCoordinator.begin("tx-1", false, Collections.emptyMap());
     TwoPhaseCommitParticipant original = joinedParticipant("tx-1", "participant-1");
@@ -1073,7 +1073,7 @@ class ConsensusCommitCoordinatorTest {
     when(duplicate.getId()).thenReturn("participant-1");
 
     // Act — joining a second participant that returns the same getId() is a no-op.
-    consensusCommitCoordinator.joinParticipant("tx-1", duplicate);
+    consensusCommitCoordinator.enlist("tx-1", duplicate);
 
     // Assert — the duplicate is never joined, and only the original participant is tracked (a
     // subsequent commit drives the original, not the duplicate).
@@ -1232,7 +1232,7 @@ class ConsensusCommitCoordinatorTest {
     TwoPhaseCommitParticipant participant = mock(TwoPhaseCommitParticipant.class);
     when(participant.getId()).thenReturn(participantId);
     when(participant.prepareRecords(anyString(), anyLong(), any())).thenReturn(preparationResult);
-    consensusCommitCoordinator.joinParticipant(transactionId, participant);
+    consensusCommitCoordinator.enlist(transactionId, participant);
     return participant;
   }
 
@@ -1317,7 +1317,7 @@ class ConsensusCommitCoordinatorTest {
     // aggregates the write set); validation is not required for these encoding-focused tests.
     when(participant.prepareRecords(anyString(), anyLong(), any()))
         .thenReturn(preparation(writeSet, /* validationRequired= */ false));
-    consensusCommitCoordinator.joinParticipant(transactionId, participant);
+    consensusCommitCoordinator.enlist(transactionId, participant);
     return participant;
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBase.java
@@ -89,7 +89,7 @@ public abstract class TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBa
 
   /**
    * Backing-specific scenario, so it lives here rather than in the shared corpus: the coordinator
-   * observes only begin and joinParticipant — the CRUD a branch issues goes to the participant — so
+   * observes only begin and enlist — the CRUD a branch issues goes to the participant — so
    * a healthy long-running global transaction is silent from the coordinator's point of view for
    * its whole lifetime, and only the expiry-time participant probe keeps it from being reaped as
    * abandoned.

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBase.java
@@ -89,9 +89,9 @@ public abstract class TwoPhaseCommitBackedConsensusCommitGlobalTransactionTestBa
 
   /**
    * Backing-specific scenario, so it lives here rather than in the shared corpus: the coordinator
-   * observes only begin and enlist — the CRUD a branch issues goes to the participant — so
-   * a healthy long-running global transaction is silent from the coordinator's point of view for
-   * its whole lifetime, and only the expiry-time participant probe keeps it from being reaped as
+   * observes only begin and enlist — the CRUD a branch issues goes to the participant — so a
+   * healthy long-running global transaction is silent from the coordinator's point of view for its
+   * whole lifetime, and only the expiry-time participant probe keeps it from being reaped as
    * abandoned.
    */
   @Test

--- a/integration-test/src/test/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManagerTest.java
+++ b/integration-test/src/test/java/com/scalar/db/common/GlobalTransactionBackedDistributedTransactionManagerTest.java
@@ -58,7 +58,7 @@ class GlobalTransactionBackedDistributedTransactionManagerTest {
     // Assert — the transaction is begun, then the configured participant is registered afterward
     // (the facade owns begin-then-register and its cleanup-on-failure).
     verify(coordinator).begin(any(), eq(false), anyMap());
-    verify(coordinator).joinParticipant(any(), eq(participant));
+    verify(coordinator).enlist(any(), eq(participant));
     assertThat(transaction.getId()).isEqualTo(CANONICAL_ID);
   }
 
@@ -66,7 +66,7 @@ class GlobalTransactionBackedDistributedTransactionManagerTest {
   void beginReadOnly_ShouldBeginReadOnlyViaCoordinatorWithParticipant() throws Exception {
     manager.beginReadOnly();
     verify(coordinator).begin(any(), eq(true), anyMap());
-    verify(coordinator).joinParticipant(any(), eq(participant));
+    verify(coordinator).enlist(any(), eq(participant));
   }
 
   @Test
@@ -120,7 +120,7 @@ class GlobalTransactionBackedDistributedTransactionManagerTest {
     // Assert — an all-Selection batch begins the transaction read-only, mirroring
     // ConsensusCommitManager.
     verify(coordinator).begin(any(), eq(true), anyMap());
-    verify(coordinator).joinParticipant(any(), eq(participant));
+    verify(coordinator).enlist(any(), eq(participant));
   }
 
   @Test
@@ -140,7 +140,7 @@ class GlobalTransactionBackedDistributedTransactionManagerTest {
 
     // Assert — a write-bearing batch begins a writable transaction.
     verify(coordinator).begin(any(), eq(false), anyMap());
-    verify(coordinator).joinParticipant(any(), eq(participant));
+    verify(coordinator).enlist(any(), eq(participant));
   }
 
   @Test


### PR DESCRIPTION
## Description

`TwoPhaseCommitCoordinator.joinParticipant` carries a suffix that exists only to disambiguate its name. The `join` verb is already spoken for in ScalarDB, in two different senses, neither of which is the coordinator's:

| Method | Meaning |
|---|---|
| `DistributedTransactionManager.join(txId)` | A process joins an ongoing transaction |
| `TwoPhaseCommitTransactionManager.join(txId)` | Same, on the two-phase-commit manager |
| `TwoPhaseCommitParticipant.join(txId, readOnly, attributes)` | A participant establishes its local context |

So `join` alone was not available for the coordinator's "add this participant to the transaction" primitive, and `Participant` was appended to keep it apart from the others.

This PR renames the coordinator primitive to `enlist`, the standard XA/JTA term for a transaction manager taking on a resource (`Transaction.enlistResource(XAResource)`). The direction matches exactly, it collides with nothing in the codebase, and it needs no suffix.

The participant role is deliberately left alone. `TwoPhaseCommitParticipant.join` keeps its name, so the two halves read as: **the Coordinator enlists a participant, and the participant thereby joins the transaction** — the same asymmetry JTA has between `Transaction.enlistResource()` and `XAResource.start()`.

| Member | Before | After |
|---|---|---|
| `TwoPhaseCommitCoordinator.joinParticipant` | `joinParticipant(transactionId, participant)` | `enlist(transactionId, participant)` — signature and exceptions unchanged |
| `TwoPhaseCommitParticipant.join` | unchanged | unchanged |

## Related issues and/or PRs

Follows #3735, which renamed this member from `registerParticipant` to `joinParticipant`.

## Changes made

- Renamed `TwoPhaseCommitCoordinator.joinParticipant` to `enlist`, and updated every implementation, decorator, caller, and test (14 files, 85 occurrences). `ConsensusCommitCoordinator`, `DecoratedTwoPhaseCommitCoordinator`, `ActiveTransactionManagedTwoPhaseCommitCoordinator`, and `TwoPhaseCommitBackedGlobalTransactionManager` are affected; `AttributePropagatingTwoPhaseCommitParticipant` and `TwoPhaseCommitParticipant` only carry `{@link}` references.
- Aligned the surrounding prose with the new verb, deciding per sentence by its subject: `enlist`/`enlisted` where the Coordinator acts ("the enlisted participants", "an enlist that races a reap", the "enlist-vs-reap handshake"), and `join`/`joined` where the participant does ("a participant that never joined answers false to a probe", `TwoPhaseCommitParticipant#join`).
- Renamed the identifiers that named the coordinator primitive: the `ConsensusCommitCoordinatorTest` fixtures (`enlistedParticipant`), the latches and thread in the reap-vs-enlist race test, and the test methods that described it (`sweep_WhenEnlistLandsDuringProbe`, `beginBranch_WhenEnlistFails`, `commit_TwoParticipants_ShouldDriveFullTwoPhaseCommitInEnlistOrder`). Also updated the reap log message to `has no enlisted participants`.
- While here, sharpened the interface Javadoc on who may call this role: it is not part of the application-facing transaction API, and application code should drive transactions through that API instead.

No behavior changes: the contract, the per-participant-ID idempotency, and every exception are untouched, so no tests were added or removed.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- `TwoPhaseCommitCoordinator` is an internal interface that documents breaking changes as expected, so the rename needs no deprecation path.
- The rename is split into two commits on purpose: the first is the mechanical symbol rename, the second is the prose pass that needs judgment. Reviewing the second one alone shows every sentence where the subject had to be decided.
- Stacked on `feature/refactor-write-set-entry-representation`.

## Release notes

N/A
