### PR TITLE
Backport to branch(3) : Record only record identities in the Coordinator write set

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitParticipant.java
@@ -11,7 +11,6 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
 import java.util.List;
 import java.util.Map;
@@ -285,12 +284,10 @@ public interface TwoPhaseCommitParticipant extends AutoCloseable {
    * sets across all participants.
    *
    * <p>{@code detailLevel} controls only how much of each record the returned {@link
-   * WriteSetEntry}s carry (see {@link WriteSetDetailLevel}): under {@link
-   * WriteSetDetailLevel#KEYS_ONLY} every entry's {@link WriteSetEntry#getColumns()} must be empty,
-   * while under {@link WriteSetDetailLevel#FULL} every {@link WriteSetEntry.Type#WRITE} entry
-   * carries the non-key columns it writes. It never changes which entries are returned: the entries
-   * and their keys are identical at either level, so an empty write set means a write-less
-   * participant regardless of the requested detail.
+   * WriteSetEntry}s carry (see {@link WriteSetDetailLevel}). It never changes which entries are
+   * returned: the entries and their keys are identical at every level, so an empty write set means
+   * a write-less participant regardless of the requested detail. {@link
+   * WriteSetDetailLevel#KEYS_ONLY} is currently the only level.
    *
    * @param transactionId the canonical transaction ID
    * @param preparedAt the timestamp written as the {@code prepared_at} column on the PREPARED
@@ -554,17 +551,6 @@ public interface TwoPhaseCommitParticipant extends AutoCloseable {
      * @return an {@code Optional} containing the clustering key, or empty if the table has none
      */
     Optional<Key> getClusteringKey();
-
-    /**
-     * Returns the non-key columns written by this entry.
-     *
-     * <p>Always empty when {@link #getType} is {@link Type#DELETE}, and always empty — even for
-     * {@link Type#WRITE} — when the Coordinator requested {@link WriteSetDetailLevel#KEYS_ONLY}
-     * from {@link TwoPhaseCommitParticipant#prepareRecords}.
-     *
-     * @return the columns
-     */
-    List<Column<?>> getColumns();
   }
 
   /**
@@ -572,27 +558,22 @@ public interface TwoPhaseCommitParticipant extends AutoCloseable {
    * TwoPhaseCommitParticipant#prepareRecords} must carry, as requested by the Coordinator.
    *
    * <p>The detail level never affects which entries a write set contains — the entries and their
-   * primary keys are identical at every level; it only controls whether {@link
-   * WriteSetEntry#getColumns()} is populated. {@link WriteSetEntry.Type#DELETE} entries never carry
-   * columns at any level.
+   * primary keys are identical at every level. {@link #KEYS_ONLY} is currently the only level, so
+   * today the request carries no choice; the parameter exists so that a level conveying more of the
+   * record content can be added as a new constant, without changing this method's signature or the
+   * request contract of the transports that carry it.
+   *
+   * <p>What such a level should look like is deliberately left open. A single ordered axis of
+   * record-content detail is one option, but a consumer that needs transaction metadata (a previous
+   * transaction ID, a before image) may want those on separate axes instead. That choice belongs
+   * with the consumer that first needs it.
    */
   enum WriteSetDetailLevel {
     /**
-     * Every entry carries only its primary keys; {@link WriteSetEntry#getColumns()} must be empty.
-     * Sufficient when the Coordinator does not persist column values (for example, when the write
-     * set is recorded for the active-recovery use case), and keeps the prepare result minimal.
+     * Every entry carries only its primary keys. Sufficient when the Coordinator does not persist
+     * column values (for example, when the write set is recorded for the active-recovery use case),
+     * and keeps the prepare result minimal.
      */
-    KEYS_ONLY,
-
-    /**
-     * Every {@link WriteSetEntry.Type#WRITE} entry additionally carries the non-key columns it
-     * writes — the full user-visible record content of the write. Implementation-internal columns
-     * (for example, transaction-metadata columns) are not part of the record content at this
-     * interface and are never included. Note that this is the write's own content, not a full row
-     * image: a partial update carries exactly the columns it sets, not the rest of the row.
-     * Intended for use cases that persist the record content (for example, backup/changelog
-     * capture).
-     */
-    FULL
+    KEYS_ONLY
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
  * TwoPhaseConsensusCommit}) can drive individual commit phases without depending on the specialized
  * handlers directly. {@code prepareRecords}, {@code commitRecords}, {@code rollbackRecords}, {@code
  * commitStateWithoutWriteSet}, and {@code abortStateWithoutWriteSet} are thin pass-throughs. {@code
- * commitState} and {@code abortState} are not: they encode the transaction's write set via the
- * orchestrator-owned {@link WriteSetEncoder} before delegating to the Coordinator-side handler.
+ * commitState} and {@code abortState} are not: they encode the transaction's write set via {@link
+ * WriteSetEncoder} before delegating to the Coordinator-side handler.
  */
 @ThreadSafe
 public class CommitHandler {
@@ -53,7 +53,6 @@ public class CommitHandler {
 
   private final CoordinatorCommitHandler coordinatorCommitHandler;
   private final ParticipantCommitHandler participantCommitHandler;
-  protected final WriteSetEncoder writeSetEncoder;
   protected final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
   protected final boolean coordinatorWriteSetLoggingEnabled;
 
@@ -71,7 +70,6 @@ public class CommitHandler {
       boolean onePhaseCommitEnabled) {
     this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
     this.coordinatorWriteSetLoggingEnabled = coordinatorWriteSetLoggingEnabled;
-    this.writeSetEncoder = new WriteSetEncoder(tableMetadataManager);
     this.coordinatorCommitHandler = new CoordinatorCommitHandler(coordinator);
     this.participantCommitHandler =
         new ParticipantCommitHandler(
@@ -90,12 +88,10 @@ public class CommitHandler {
   protected CommitHandler(
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean coordinatorWriteSetLoggingEnabled,
-      WriteSetEncoder writeSetEncoder,
       CoordinatorCommitHandler coordinatorCommitHandler,
       ParticipantCommitHandler participantCommitHandler) {
     this.coordinatorWriteOmissionOnReadOnlyEnabled = coordinatorWriteOmissionOnReadOnlyEnabled;
     this.coordinatorWriteSetLoggingEnabled = coordinatorWriteSetLoggingEnabled;
-    this.writeSetEncoder = checkNotNull(writeSetEncoder);
     this.coordinatorCommitHandler = checkNotNull(coordinatorCommitHandler);
     this.participantCommitHandler = checkNotNull(participantCommitHandler);
   }
@@ -320,7 +316,7 @@ public class CommitHandler {
   @Nullable
   private WriteSet encodeWriteSetIfLoggingEnabled(TransactionContext context) {
     return coordinatorWriteSetLoggingEnabled
-        ? writeSetEncoder.encodeSingleGroupWriteSet(context, false)
+        ? WriteSetEncoder.encodeSingleGroupWriteSet(context)
         : null;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -36,7 +36,6 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
       boolean onePhaseCommitEnabled,
       CoordinatorGroupCommitter groupCommitter) {
     this(
-        tableMetadataManager,
         coordinatorWriteOmissionOnReadOnlyEnabled,
         coordinatorWriteSetLoggingEnabled,
         new ParticipantCommitHandler(
@@ -52,7 +51,6 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   // Second-stage delegating constructor that builds the two specialized handlers before handing
   // them to the package-private constructor.
   private CommitHandlerWithGroupCommit(
-      TransactionTableMetadataManager tableMetadataManager,
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean coordinatorWriteSetLoggingEnabled,
       ParticipantCommitHandler participantCommitHandler,
@@ -61,7 +59,6 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
     this(
         coordinatorWriteOmissionOnReadOnlyEnabled,
         coordinatorWriteSetLoggingEnabled,
-        new WriteSetEncoder(tableMetadataManager),
         new CoordinatorCommitHandlerWithGroupCommit(
             coordinator, groupCommitter, coordinatorWriteSetLoggingEnabled),
         participantCommitHandler);
@@ -73,13 +70,11 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   CommitHandlerWithGroupCommit(
       boolean coordinatorWriteOmissionOnReadOnlyEnabled,
       boolean coordinatorWriteSetLoggingEnabled,
-      WriteSetEncoder writeSetEncoder,
       CoordinatorCommitHandlerWithGroupCommit coordinatorHandler,
       ParticipantCommitHandler participantCommitHandler) {
     super(
         coordinatorWriteOmissionOnReadOnlyEnabled,
         coordinatorWriteSetLoggingEnabled,
-        writeSetEncoder,
         coordinatorHandler,
         participantCommitHandler);
     this.coordinatorHandler = coordinatorHandler;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinator.java
@@ -489,8 +489,8 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommitCoordinator {
     coordinatorCommitHandler.abortState(transactionId, writeSet);
   }
 
-  // Keys only (includeColumns=false), matching the KEYS_ONLY detail requested at prepareRecords:
-  // the Coordinator persists which records the transaction touched, not their column values.
+  // Matches the KEYS_ONLY detail requested at prepareRecords: the Coordinator persists which
+  // records the transaction touched, not their column values.
   //
   // The tx_write_set column is part of the Coordinator schema only when the opt-in
   // `coordinator.write_set_logging.enabled` config is on. When it is off, skip encoding entirely so
@@ -504,7 +504,7 @@ public class ConsensusCommitCoordinator implements TwoPhaseCommitCoordinator {
   private WriteSet encodeWriteSetIfLoggingEnabled(
       Map<String, List<WriteSetEntry>> writeSetsByParticipant) {
     return coordinatorWriteSetLoggingEnabled
-        ? WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant, false)
+        ? WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant)
         : null;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -635,7 +635,20 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     // composer-level NoMutationException absorption still acts as the safety net for races against
     // concurrent recovery.
     WriteSet writeSet = state.getWriteSet().get();
-    for (EntryGroup entryGroup : writeSet.getEntryGroupsList()) {
+
+    // Holds by construction today: ENTRY_GROUPS is the payload oneof's only case, and the encoder
+    // always sets it — a read-only commit is encoded as an empty EntryGroups, never as an unset
+    // payload. It stops holding the moment a second case (e.g., the compressed encoding the oneof
+    // was introduced for) ships, because such a row parses here with the case unset: getEntryGroups
+    // then returns an empty default instance, the loop below does nothing, and the Coordinator
+    // state row is deleted anyway — leaving the still-PREPARED records of a committed transaction
+    // to be rolled back by lazy recovery. Note that adding a payload case does not bump
+    // schema_version (see the proto), so a version check would not catch this either. Whoever adds
+    // that case must replace this assertion with a recoverable error: reading a row written by a
+    // newer binary is an operational situation, not a bug.
+    assert writeSet.getPayloadCase() == WriteSet.PayloadCase.ENTRY_GROUPS;
+
+    for (EntryGroup entryGroup : writeSet.getEntryGroups().getEntryGroupsList()) {
       String expectedTxId =
           entryGroup.hasChildId()
               ? KEY_MANIPULATOR.fullKey(state.getId(), entryGroup.getChildId())

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipant.java
@@ -14,7 +14,6 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TwoPhaseCommitCoordinator;
 import com.scalar.db.api.TwoPhaseCommitParticipant;
@@ -35,12 +34,10 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -575,48 +572,34 @@ public class ConsensusCommitParticipant implements TwoPhaseCommitParticipant {
 
   private List<TwoPhaseCommitParticipant.WriteSetEntry> buildWriteSetEntries(
       TransactionContext context, TwoPhaseCommitParticipant.WriteSetDetailLevel detailLevel) {
+    // KEYS_ONLY is the only level this participant knows how to build. A level added later must
+    // fail here rather than be served silently as KEYS_ONLY, which would ship the Coordinator a
+    // write set quietly poorer than the one it requested.
+    if (detailLevel != TwoPhaseCommitParticipant.WriteSetDetailLevel.KEYS_ONLY) {
+      throw new AssertionError("Unknown write-set detail: " + detailLevel);
+    }
     Snapshot snapshot = context.snapshot;
     List<TwoPhaseCommitParticipant.WriteSetEntry> entries = new ArrayList<>();
     // Returns empty iff !snapshot.hasWritesOrDeletes(), so the write set shipped to the Coordinator
     // is empty exactly for a write-less participant, regardless of detailLevel (which controls only
-    // whether WRITE entries carry non-key columns, never which entries exist). The Coordinator
-    // gates writing the COMMITTED state row on this write set being non-empty, which must agree
-    // with isCommitRequired and the validate-step self-release (all derived from
+    // how much of each record an entry carries, never which entries exist). The Coordinator gates
+    // writing the COMMITTED state row on this write set being non-empty, which must agree with
+    // isCommitRequired and the validate-step self-release (all derived from
     // context.isCommitRequired()); preserve this empty-iff-write-less guarantee if this method ever
     // starts filtering entries.
     if (!snapshot.hasWritesOrDeletes()) {
       return entries;
     }
+    // KEYS_ONLY is the only detail level, so every entry carries just its primary keys.
     for (Map.Entry<Snapshot.Key, Put> e : snapshot.getWriteSet()) {
       Put put = e.getValue();
-      List<Column<?>> columns;
-      switch (detailLevel) {
-        case KEYS_ONLY:
-          // KEYS_ONLY entries must carry no non-key columns. Skipping the column pass also skips
-          // the table-metadata lookup, which is needed only to filter transaction-meta columns.
-          columns = Collections.emptyList();
-          break;
-        case FULL:
-          TableMetadata metadata = getTableMetadataForMutation(put);
-          List<Column<?>> filteredColumns = new ArrayList<>();
-          for (Column<?> column : put.getColumns().values()) {
-            if (!ConsensusCommitUtils.isTransactionMetaColumn(column.getName(), metadata)) {
-              filteredColumns.add(column);
-            }
-          }
-          columns = Collections.unmodifiableList(filteredColumns);
-          break;
-        default:
-          throw new AssertionError("Unknown write-set detail: " + detailLevel);
-      }
       entries.add(
           new WriteSetEntryImpl(
               TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE,
               put.forNamespace().get(),
               put.forTable().get(),
               put.getPartitionKey(),
-              put.getClusteringKey(),
-              columns));
+              put.getClusteringKey()));
     }
     for (Map.Entry<Snapshot.Key, Delete> e : snapshot.getDeleteSet()) {
       Delete delete = e.getValue();
@@ -626,23 +609,9 @@ public class ConsensusCommitParticipant implements TwoPhaseCommitParticipant {
               delete.forNamespace().get(),
               delete.forTable().get(),
               delete.getPartitionKey(),
-              delete.getClusteringKey(),
-              Collections.emptyList()));
+              delete.getClusteringKey()));
     }
     return entries;
-  }
-
-  private TableMetadata getTableMetadataForMutation(Mutation mutation) {
-    try {
-      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, mutation)
-          .getTableMetadata();
-    } catch (ExecutionException e) {
-      throw new AssertionError(
-          "Failed to retrieve transaction table metadata while building write set entries."
-              + " Operation: "
-              + mutation,
-          e);
-    }
   }
 
   @Override
@@ -690,21 +659,18 @@ public class ConsensusCommitParticipant implements TwoPhaseCommitParticipant {
     private final String tableName;
     private final Key partitionKey;
     private final Optional<Key> clusteringKey;
-    private final List<Column<?>> columns;
 
     WriteSetEntryImpl(
         Type type,
         String namespaceName,
         String tableName,
         Key partitionKey,
-        Optional<Key> clusteringKey,
-        List<Column<?>> columns) {
+        Optional<Key> clusteringKey) {
       this.type = type;
       this.namespaceName = namespaceName;
       this.tableName = tableName;
       this.partitionKey = partitionKey;
       this.clusteringKey = clusteringKey;
-      this.columns = columns;
     }
 
     @Override
@@ -730,11 +696,6 @@ public class ConsensusCommitParticipant implements TwoPhaseCommitParticipant {
     @Override
     public Optional<Key> getClusteringKey() {
       return clusteringKey;
-    }
-
-    @Override
-    public List<Column<?>> getColumns() {
-      return columns;
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetDecoder.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetDecoder.java
@@ -31,9 +31,9 @@ import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
  *
  * <p>Currently used only for primary-key columns (partition and clustering keys), which are
  * non-nullable by ScalarDB's API contract. The decoder throws {@link AssertionError} on a missing
- * value to surface that invariant violation. If a future change uses this decoder for non-key
- * columns (e.g., a backup-window use case with {@code includeColumns=true}), those branches must
- * become recoverable or the call site must filter null-valued Columns first.
+ * value to surface that invariant violation. A schema version that records non-key columns (e.g.,
+ * for a backup/changelog use case) would decode nullable values here, so those branches must become
+ * recoverable — or the call site must filter null-valued Columns first — before that happens.
  */
 final class WriteSetDecoder {
   private WriteSetDecoder() {}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoder.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoder.java
@@ -7,9 +7,7 @@ import com.google.protobuf.ByteString;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
-import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TwoPhaseCommitParticipant;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BlobColumn;
 import com.scalar.db.io.BooleanColumn;
@@ -37,6 +35,7 @@ import com.scalar.db.transaction.consensuscommit.proto.v1.Column.TimestampTZValu
 import com.scalar.db.transaction.consensuscommit.proto.v1.Column.TimestampValue;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
+import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import java.nio.ByteBuffer;
@@ -48,13 +47,11 @@ import javax.annotation.Nullable;
  * Encodes the proto {@link WriteSet} / {@link EntryGroup} payload persisted in the Coordinator
  * table's {@code tx_write_set} column.
  *
- * <p>Primary keys (namespace, table, partition key, optional clustering key) are always recorded.
- * Non-key column values are only included when {@code includeColumns} is true — this is intended
- * for backup/changelog use cases that need the full record content; the default mode keeps the
- * persisted BLOB compact. When {@code includeColumns} is true, transaction-meta columns (e.g.,
- * {@code tx_state}, {@code tx_version}, {@code before_*}) that the snapshot may have injected for
- * ConsensusCommit's own bookkeeping are filtered out so the persisted payload contains only user
- * data.
+ * <p>An {@link Entry} currently records only a record's identity — namespace, table, partition key,
+ * optional clustering key — plus the owning participant on the multi-participant TwoPhaseCommit
+ * path. The written column values are not recorded, and neither is whether the record was put or
+ * deleted (that is recoverable from the record's own {@code tx_state}). The proto's {@code
+ * schema_version} comment states which of those can be added without bumping the version.
  */
 final class WriteSetEncoder {
   /**
@@ -64,102 +61,65 @@ final class WriteSetEncoder {
    */
   private static final int SCHEMA_VERSION = 1;
 
-  private final TransactionTableMetadataManager tableMetadataManager;
-
-  WriteSetEncoder(TransactionTableMetadataManager tableMetadataManager) {
-    this.tableMetadataManager = checkNotNull(tableMetadataManager);
-  }
+  private WriteSetEncoder() {}
 
   /**
    * Encodes a {@link WriteSet} for a single-group transaction (non-group-commit, or a delayed group
    * commit that contains only this transaction).
    *
-   * <p>For a transaction with writes/deletes, the returned WriteSet contains a single populated
-   * {@link EntryGroup}. For a read-only transaction, the returned WriteSet has no EntryGroups
-   * (empty WriteSet) — explicitly recording that the transaction had nothing to write. {@code
+   * <p>For a transaction with writes/deletes, the returned WriteSet carries a single populated
+   * {@link EntryGroup}. For a read-only transaction, it carries an {@link EntryGroups} with an
+   * empty {@code entry_groups} list — the payload oneof is always set, explicitly recording that
+   * the transaction had nothing to write rather than leaving the payload absent. {@code
    * schema_version} is always set so that the persisted BLOB is unambiguously non-null on every
    * storage backend, distinguishing it from a NULL column (which indicates "no info" for
    * lazy-recovery aborts or pre-feature rows).
    *
    * @param context the transaction context
-   * @param includeColumns whether to include non-key column values for {@code Put} entries
    * @return the encoded {@link WriteSet}
    */
-  WriteSet encodeSingleGroupWriteSet(TransactionContext context, boolean includeColumns) {
-    WriteSet.Builder builder = WriteSet.newBuilder().setSchemaVersion(SCHEMA_VERSION);
+  static WriteSet encodeSingleGroupWriteSet(TransactionContext context) {
+    EntryGroups.Builder entryGroups = EntryGroups.newBuilder();
     if (context.snapshot.hasWritesOrDeletes()) {
-      builder.addEntryGroups(encodeEntryGroup(context.snapshot, null, includeColumns));
+      entryGroups.addEntryGroups(encodeEntryGroup(context.snapshot, null));
     }
-    return builder.build();
+    return WriteSet.newBuilder()
+        .setSchemaVersion(SCHEMA_VERSION)
+        .setEntryGroups(entryGroups)
+        .build();
   }
 
   /**
    * Encodes an {@link EntryGroup} from the {@link Snapshot}'s write/delete sets.
    *
    * <p>Visible for testing only — production callers go through {@link
-   * #encodeSingleGroupWriteSet(TransactionContext, boolean)}.
+   * #encodeSingleGroupWriteSet(TransactionContext)}.
    *
    * @param snapshot the snapshot of the transaction
    * @param childId the child id within a group commit, or {@code null} for non-group-commit
-   * @param includeColumns whether to include non-key column values for {@code Put} entries; when
-   *     {@code false}, only primary keys are recorded. Transaction-meta columns are always filtered
-   *     out when {@code includeColumns} is true
    * @return the encoded {@link EntryGroup}
    */
   @VisibleForTesting
-  EntryGroup encodeEntryGroup(Snapshot snapshot, @Nullable String childId, boolean includeColumns) {
+  static EntryGroup encodeEntryGroup(Snapshot snapshot, @Nullable String childId) {
     EntryGroup.Builder builder = EntryGroup.newBuilder();
     if (childId != null) {
       builder.setChildId(childId);
     }
     for (Map.Entry<Snapshot.Key, Put> e : snapshot.getWriteSet()) {
-      Put put = e.getValue();
-      TableMetadata tableMetadata = includeColumns ? getTableMetadata(put) : null;
-      builder.addEntries(
-          encodeEntry(put, Entry.EntryType.ENTRY_TYPE_WRITE, includeColumns, tableMetadata));
+      builder.addEntries(encodeEntry(e.getValue()));
     }
     for (Map.Entry<Snapshot.Key, Delete> e : snapshot.getDeleteSet()) {
-      // Delete entries never carry non-key columns, so no meta-column filtering is needed.
-      builder.addEntries(encodeEntry(e.getValue(), Entry.EntryType.ENTRY_TYPE_DELETE, false, null));
+      builder.addEntries(encodeEntry(e.getValue()));
     }
     return builder.build();
   }
 
-  private TableMetadata getTableMetadata(Mutation mutation) {
-    try {
-      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, mutation)
-          .getTableMetadata();
-    } catch (ExecutionException e) {
-      // Table metadata is expected to be cached by commit time. Surface the unexpected failure
-      // loudly rather than silently emitting an unfiltered payload.
-      throw new AssertionError(
-          "Failed to retrieve transaction table metadata while encoding the write set. Operation: "
-              + mutation,
-          e);
-    }
-  }
-
-  private static Entry encodeEntry(
-      Mutation mutation,
-      Entry.EntryType type,
-      boolean includeColumns,
-      @Nullable TableMetadata tableMetadata) {
-    Entry.Builder builder = Entry.newBuilder().setEntryType(type);
+  private static Entry encodeEntry(Mutation mutation) {
+    Entry.Builder builder = Entry.newBuilder();
     mutation.forNamespace().ifPresent(builder::setNamespaceName);
     mutation.forTable().ifPresent(builder::setTableName);
     builder.setPartitionKey(encodeKey(mutation.getPartitionKey()));
     mutation.getClusteringKey().ifPresent(ck -> builder.setClusteringKey(encodeKey(ck)));
-    if (includeColumns && mutation instanceof Put) {
-      for (Column<?> column : ((Put) mutation).getColumns().values()) {
-        if (tableMetadata != null
-            && ConsensusCommitUtils.isTransactionMetaColumn(column.getName(), tableMetadata)) {
-          // Skip ConsensusCommit-internal columns (tx_state, tx_version, before_*, etc.) that the
-          // snapshot may have injected. Only user columns belong in the persisted write set.
-          continue;
-        }
-        builder.addColumns(encodeColumn(column));
-      }
-    }
     return builder.build();
   }
 
@@ -301,20 +261,13 @@ final class WriteSetEncoder {
    * writes are skipped. {@code child_id} is not used in this path (it is reserved for the existing
    * group-commit grouping).
    *
-   * <p>When {@code includeColumns} is true, each {@code WRITE} entry's non-key columns are encoded
-   * too; when false, only primary keys are persisted (the default commit-state convention). The
-   * supplied {@link TwoPhaseCommitParticipant.WriteSetEntry}s already exclude
-   * ConsensusCommit-internal columns, so no meta-column filtering is needed here.
-   *
    * @param writeSetsByParticipant the write set produced by each participant, keyed by participant
    *     ID
-   * @param includeColumns whether to include non-key column values for {@code WRITE} entries
    * @return the encoded {@link WriteSet}
    */
   static WriteSet encodeFromWriteSetEntries(
-      Map<String, List<TwoPhaseCommitParticipant.WriteSetEntry>> writeSetsByParticipant,
-      boolean includeColumns) {
-    WriteSet.Builder builder = WriteSet.newBuilder().setSchemaVersion(SCHEMA_VERSION);
+      Map<String, List<TwoPhaseCommitParticipant.WriteSetEntry>> writeSetsByParticipant) {
+    EntryGroups.Builder entryGroups = EntryGroups.newBuilder();
     for (Map.Entry<String, List<TwoPhaseCommitParticipant.WriteSetEntry>> e :
         writeSetsByParticipant.entrySet()) {
       String participantId = checkNotNull(e.getKey());
@@ -324,33 +277,25 @@ final class WriteSetEncoder {
       }
       EntryGroup.Builder groupBuilder = EntryGroup.newBuilder();
       for (TwoPhaseCommitParticipant.WriteSetEntry entry : entries) {
-        groupBuilder.addEntries(encodeWriteSetEntry(entry, participantId, includeColumns));
+        groupBuilder.addEntries(encodeWriteSetEntry(entry, participantId));
       }
-      builder.addEntryGroups(groupBuilder.build());
+      entryGroups.addEntryGroups(groupBuilder.build());
     }
-    return builder.build();
+    return WriteSet.newBuilder()
+        .setSchemaVersion(SCHEMA_VERSION)
+        .setEntryGroups(entryGroups)
+        .build();
   }
 
   private static Entry encodeWriteSetEntry(
-      TwoPhaseCommitParticipant.WriteSetEntry entry, String participantId, boolean includeColumns) {
+      TwoPhaseCommitParticipant.WriteSetEntry entry, String participantId) {
     Entry.Builder builder =
         Entry.newBuilder()
-            .setEntryType(
-                entry.getType() == TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE
-                    ? Entry.EntryType.ENTRY_TYPE_WRITE
-                    : Entry.EntryType.ENTRY_TYPE_DELETE)
             .setNamespaceName(entry.getNamespaceName())
             .setTableName(entry.getTableName())
             .setPartitionKey(encodeKey(entry.getPartitionKey()))
             .setParticipantId(participantId);
     entry.getClusteringKey().ifPresent(ck -> builder.setClusteringKey(encodeKey(ck)));
-    if (includeColumns && entry.getType() == TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE) {
-      // The entry's columns are already free of ConsensusCommit-internal columns (filtered when the
-      // participant built the write set), so encode them as-is.
-      for (Column<?> column : entry.getColumns()) {
-        builder.addColumns(encodeColumn(column));
-      }
-    }
     return builder.build();
   }
 
@@ -369,16 +314,25 @@ final class WriteSetEncoder {
    * @return the merged parent-row {@link WriteSet}
    */
   static WriteSet mergeChildWriteSets(List<ChildWriteSet> children) {
-    WriteSet.Builder builder = WriteSet.newBuilder().setSchemaVersion(SCHEMA_VERSION);
+    EntryGroups.Builder entryGroups = EntryGroups.newBuilder();
     for (ChildWriteSet child : children) {
       if (child.writeSet == null) {
         continue;
       }
-      for (EntryGroup entryGroup : child.writeSet.getEntryGroupsList()) {
-        builder.addEntryGroups(entryGroup.toBuilder().setChildId(child.childId).build());
+      // Every child is encoded in-process by this same encoder, so the payload case is always
+      // ENTRY_GROUPS here. Unlike the reader in ConsensusCommitManager#finishTransaction, this can
+      // never meet a row written by a newer binary; the assertion would only fail if the encoder
+      // itself started emitting a second payload case, and then getEntryGroups would return an
+      // empty default instance and drop that child's entries from the parent row in silence.
+      assert child.writeSet.getPayloadCase() == WriteSet.PayloadCase.ENTRY_GROUPS;
+      for (EntryGroup entryGroup : child.writeSet.getEntryGroups().getEntryGroupsList()) {
+        entryGroups.addEntryGroups(entryGroup.toBuilder().setChildId(child.childId).build());
       }
     }
-    return builder.build();
+    return WriteSet.newBuilder()
+        .setSchemaVersion(SCHEMA_VERSION)
+        .setEntryGroups(entryGroups)
+        .build();
   }
 
   /**

--- a/core/src/main/proto/consensus_commit.proto
+++ b/core/src/main/proto/consensus_commit.proto
@@ -150,17 +150,23 @@ message Key {
 //
 // Records the set of records a transaction wrote on commit/abort.
 //
-// For non-group-commit transactions that performed at least one write or delete, the WriteSet
+// An Entry currently identifies a record and, on the multi-participant TwoPhaseCommit path, names
+// the participant that wrote it. It records neither the written column values nor whether the
+// record was put or deleted: the former has no consumer yet, and the latter is recoverable from
+// the record's own `tx_state`. See `schema_version` for which of those can be added without
+// bumping the version.
+//
+// For non-group-commit transactions that performed at least one write or delete, the payload
 // contains exactly one EntryGroup (with no `child_id`). For group-commit transactions, the
 // parent state row carries one EntryGroup per child that performed writes; read-only children
-// are omitted entirely from `entry_groups`.
+// are omitted entirely.
 //
-// A WriteSet with an empty `entry_groups` list is meaningful: it represents a read-only commit
-// (or a group commit in which every child was read-only). The reader treats it as "the
-// transaction had no writes" and is distinct from the absent-column case (NULL bytes), which
-// represents "no information" — a row written before this feature, by the lazy-recovery abort
-// path, or on a deployment where the feature is disabled. The reader falls back to per-record
-// lazy recovery when the column is NULL.
+// A WriteSet whose payload is an `EntryGroups` with an empty `entry_groups` list is meaningful: it
+// represents a read-only commit (or a group commit in which every child was read-only). The
+// reader treats it as "the transaction had no writes" and is distinct from the absent-column case
+// (NULL bytes), which represents "no information" — a row written before this feature, by the
+// lazy-recovery abort path, or on a deployment where the feature is disabled. The reader falls
+// back to per-record lazy recovery when the column is NULL.
 message WriteSet {
   // Schema version of this WriteSet. Currently 1.
   //
@@ -172,14 +178,51 @@ message WriteSet {
   // The writer always sets this field to a non-zero value so that the persisted BLOB is
   // unambiguously non-empty on every storage backend. This guarantees the wire-level
   // distinction between "empty WriteSet (no writes recorded)" and "no WriteSet column written".
+  //
+  // This is not an inventory of the fields a row carries. It is bumped only for a change a reader
+  // cannot detect from the payload itself, so adding a field that carries its own presence — an
+  // `optional` scalar, a message field, or a new `payload` case — leaves it untouched: a reader
+  // that does not know the field ignores it, and one that does can tell whether the writer set it.
+  // A plain enum works too, but by convention rather than by presence: give it an `UNSPECIFIED`
+  // zero value that readers treat as "not supplied". On the wire an explicit zero and an absent
+  // field are identical, so the sentinel value is what carries the meaning, not presence. The set
+  // of fields present in a version-1 row may therefore grow over time, and readers must not assume
+  // otherwise.
+  //
+  // A field with no presence is the exception, because "written empty" and "never written" are
+  // identical on the wire. `repeated` fields are the practical case: recording the written column
+  // values on an Entry needs either a bump here or a companion field marking that the writer
+  // recorded them. Until one of those exists, no row carries column values, and a reader may treat
+  // their absence as definitive.
   int32 schema_version = 1;
 
+  // The entry groups this WriteSet carries, in one of the supported payload encodings.
+  //
+  // The writer always sets a case here, even for a read-only commit — which is encoded as an
+  // `EntryGroups` with an empty `entry_groups` list, never as an unset payload. A reader that finds
+  // the payload unset, or finds a case it does not know, is looking at a WriteSet written by a
+  // newer writer; it must not read that as "no entry groups".
+  //
+  // A future schema version can add a compressed encoding as an additional case here, which keeps
+  // `schema_version` free for genuinely incompatible shape changes. `EntryGroups` is a named
+  // message precisely so that such a case can carry a well-typed serialized payload.
+  oneof payload {
+    EntryGroups entry_groups = 2;
+  }
+}
+
+// The entry groups of a WriteSet.
+//
+// A wrapper around the repeated field, so that the payload can be carried as a `oneof` case (a
+// `oneof` cannot hold a repeated field directly) and so that a future compressed encoding has a
+// well-defined message type to serialize.
+message EntryGroups {
   // One EntryGroup per writing transaction within the Coordinator state row. For non-group-
   // commit, this list contains exactly one element when the transaction performed at least one
   // write or delete (and is empty otherwise, e.g., for a read-only commit). For group commit, it
   // contains one element per child that wrote at least one record; read-only children are
   // omitted.
-  repeated EntryGroup entry_groups = 2;
+  repeated EntryGroup entry_groups = 1;
 }
 
 // A group of write entries belonging to a single transaction.
@@ -197,26 +240,19 @@ message EntryGroup {
   //      partition key in this case.
   optional string child_id = 1;
 
-  // The records the transaction wrote, in writer-determined order. The current writer emits
-  // WRITE entries (puts) before DELETE entries (deletes); readers must not rely on this order
-  // beyond what the EntryType field signals.
+  // The records the transaction wrote, in writer-determined order. The current writer emits the
+  // puts before the deletes, but readers must not rely on that: at this schema version an Entry
+  // does not say which of the two it was, so the order carries no meaning.
   repeated Entry entries = 2;
 }
 
-// A single record write performed by a transaction. Captures the storage-layer mutation that
-// the transaction applied (or attempted to apply) to a user table.
+// A single record write performed by a transaction. Identifies a record the transaction wrote or
+// deleted in a user table.
+//
+// An Entry currently carries only the record's identity. Whether the record was put or deleted is
+// recoverable from the record's own `tx_state`, and the written column values are not recorded at
+// all. Both may be added later; see `WriteSet.schema_version` for what that costs.
 message Entry {
-  // The kind of record write.
-  enum EntryType {
-    ENTRY_TYPE_UNSPECIFIED = 0;
-
-    // The transaction wrote the record (storage-layer Put).
-    ENTRY_TYPE_WRITE = 1;
-
-    // The transaction deleted the record (storage-layer Delete).
-    ENTRY_TYPE_DELETE = 2;
-  }
-
   // The stable logical identifier of the participant that produced this entry.
   //
   // Unset for entries produced by the existing single-participant `ConsensusCommit` path (the
@@ -226,24 +262,15 @@ message Entry {
   // and is unique within the Coordinator deployment.
   optional string participant_id = 1;
 
-  // The entry type (write or delete) of this record.
-  EntryType entry_type = 2;
-
   // The namespace name of the user table the record belongs to.
-  string namespace_name = 3;
+  string namespace_name = 2;
 
   // The table name of the user table the record belongs to.
-  string table_name = 4;
+  string table_name = 3;
 
   // The partition key of the record. Always present.
-  Key partition_key = 5;
+  Key partition_key = 4;
 
   // The clustering key of the record. Absent when the user table has no clustering key.
-  optional Key clustering_key = 6;
-
-  // The non-key columns of the record. Only populated when `entry_type` is
-  // `ENTRY_TYPE_WRITE`, and even then it is not always populated — the writer may persist just
-  // the primary keys (e.g., the active-recovery use case) and leave this field empty.
-  // `ENTRY_TYPE_DELETE` entries always leave this field empty.
-  repeated Column columns = 7;
+  optional Key clustering_key = 5;
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -50,7 +50,6 @@ public class CommitHandlerTest {
 
   @Mock protected ParticipantCommitHandler participantCommitHandler;
   @Mock protected CoordinatorCommitHandler coordinatorCommitHandler;
-  @Mock protected WriteSetEncoder writeSetEncoder;
   @Mock protected BeforePreparationHook beforePreparationHook;
   @Mock protected Future<Void> beforePreparationHookFuture;
 
@@ -82,7 +81,6 @@ public class CommitHandlerTest {
     return new CommitHandler(
         coordinatorWriteOmissionOnReadOnlyEnabled,
         coordinatorWriteSetLoggingEnabled,
-        writeSetEncoder,
         coordinatorCommitHandler,
         participantCommitHandler);
   }
@@ -722,18 +720,16 @@ public class CommitHandlerTest {
   @Test
   public void commitState_ShouldPassSnapshotEncodedWriteSetToCoordinatorHandler() throws Exception {
     // Pins the orchestrator -> coordinator wiring: the WriteSet the orchestrator encodes from the
-    // snapshot (via the orchestrator-owned WriteSetEncoder) is the one passed to commitState. A
-    // regression that dropped the encoder call or passed a different/null WriteSet would fail here.
+    // snapshot (via WriteSetEncoder) is the one passed to commitState. A regression that dropped
+    // the encoder call or passed a different/null WriteSet would fail here.
     Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-    WriteSet encoded = WriteSet.newBuilder().setSchemaVersion(1).build();
-    doReturn(encoded).when(writeSetEncoder).encodeSingleGroupWriteSet(context, false);
+    WriteSet expected = WriteSetEncoder.encodeSingleGroupWriteSet(context);
 
     handler.commitState(context);
 
-    verify(writeSetEncoder).encodeSingleGroupWriteSet(context, false);
-    verifyCommitStateDelegatedWithWriteSet(context, encoded);
+    verifyCommitStateDelegatedWithWriteSet(context, expected);
   }
 
   @Test
@@ -742,13 +738,11 @@ public class CommitHandlerTest {
     Snapshot snapshot = snapshotWithWrites();
     TransactionContext context =
         createTransactionContext(anyId(), snapshot, Isolation.SNAPSHOT, false, false);
-    WriteSet encoded = WriteSet.newBuilder().setSchemaVersion(1).build();
-    doReturn(encoded).when(writeSetEncoder).encodeSingleGroupWriteSet(context, false);
+    WriteSet expected = WriteSetEncoder.encodeSingleGroupWriteSet(context);
 
     handler.abortState(context);
 
-    verify(writeSetEncoder).encodeSingleGroupWriteSet(context, false);
-    verify(coordinatorCommitHandler).abortState(eq(context.transactionId), eq(encoded));
+    verify(coordinatorCommitHandler).abortState(eq(context.transactionId), eq(expected));
   }
 
   @Test
@@ -766,7 +760,6 @@ public class CommitHandlerTest {
 
     handlerWithoutLogging.commitState(context);
 
-    verify(writeSetEncoder, never()).encodeSingleGroupWriteSet(any(), eq(false));
     verify(coordinatorCommitHandler).commitState(context.transactionId, null);
   }
 
@@ -784,7 +777,6 @@ public class CommitHandlerTest {
 
     handlerWithoutLogging.abortState(context);
 
-    verify(writeSetEncoder, never()).encodeSingleGroupWriteSet(any(), eq(false));
     verify(coordinatorCommitHandler).abortState(context.transactionId, null);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -48,7 +48,6 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     return new CommitHandlerWithGroupCommit(
         coordinatorWriteOmissionOnReadOnlyEnabled,
         /* coordinatorWriteSetLoggingEnabled= */ true,
-        writeSetEncoder,
         groupCommitCoordinatorHandler,
         participantCommitHandler);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCoordinatorTest.java
@@ -27,9 +27,7 @@ import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import java.util.Arrays;
@@ -315,11 +313,10 @@ class ConsensusCommitCoordinatorTest {
     ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
     verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
     WriteSet writeSet = captor.getValue();
-    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
-    EntryGroup group = writeSet.getEntryGroups(0);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(1);
+    EntryGroup group = writeSet.getEntryGroups().getEntryGroups(0);
     assertThat(group.getEntriesList()).hasSize(1);
     assertThat(group.getEntries(0).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     verify(participant).rollbackRecords("tx-1");
   }
 
@@ -373,11 +370,10 @@ class ConsensusCommitCoordinatorTest {
     ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
     verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
     WriteSet writeSet = captor.getValue();
-    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
-    EntryGroup group = writeSet.getEntryGroups(0);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(1);
+    EntryGroup group = writeSet.getEntryGroups().getEntryGroups(0);
     assertThat(group.getEntriesList()).hasSize(1);
     assertThat(group.getEntries(0).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     verify(participant).rollbackRecords("tx-1");
   }
 
@@ -748,7 +744,7 @@ class ConsensusCommitCoordinatorTest {
     verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
     // A non-null but empty write set (no entry groups), not null — the write-less validate-phase
     // abort proves the transaction touched no records, mirroring the write-less commit path.
-    assertThat(captor.getValue().getEntryGroupsList()).isEmpty();
+    assertThat(captor.getValue().getEntryGroups().getEntryGroupsList()).isEmpty();
     verify(p1).rollbackRecords("tx-1");
   }
 
@@ -797,7 +793,7 @@ class ConsensusCommitCoordinatorTest {
     verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
     // A non-null but empty write set (no entry groups), not null — the write-less validate-phase
     // abort proves the transaction touched no records, mirroring the write-less commit path.
-    assertThat(captor.getValue().getEntryGroupsList()).isEmpty();
+    assertThat(captor.getValue().getEntryGroups().getEntryGroupsList()).isEmpty();
     verify(p1).rollbackRecords("tx-1");
   }
 
@@ -1114,24 +1110,29 @@ class ConsensusCommitCoordinatorTest {
     consensusCommitCoordinator.commit("tx-1");
 
     // Assert — the COMMITTED state is written (hasWrites=true overrides write omission) with a
-    // WriteSet that has one EntryGroup per participant, in join order, each entry stamped
-    // with the owning participant id and the right entry type.
+    // WriteSet that has one EntryGroup per participant, in join order, each entry stamped with the
+    // owning participant id. Each entry's partition key is asserted too: the participant id alone
+    // would not distinguish the two entries of participant-1 from each other, so the assertions
+    // would hold even if the encoder emitted one of them twice or swapped them.
     ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
     verify(coordinatorCommitHandler).commitState(eq("tx-1"), captor.capture());
     WriteSet writeSet = captor.getValue();
-    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(2);
 
-    EntryGroup group1 = writeSet.getEntryGroups(0);
+    EntryGroup group1 = writeSet.getEntryGroups().getEntryGroups(0);
     assertThat(group1.getEntriesList()).hasSize(2);
     assertThat(group1.getEntries(0).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group1.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+    assertThat(group1.getEntries(0).getPartitionKey().getColumns(0).getIntValue().getValue())
+        .isEqualTo(1);
     assertThat(group1.getEntries(1).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group1.getEntries(1).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
+    assertThat(group1.getEntries(1).getPartitionKey().getColumns(0).getIntValue().getValue())
+        .isEqualTo(2);
 
-    EntryGroup group2 = writeSet.getEntryGroups(1);
+    EntryGroup group2 = writeSet.getEntryGroups().getEntryGroups(1);
     assertThat(group2.getEntriesList()).hasSize(1);
     assertThat(group2.getEntries(0).getParticipantId()).isEqualTo("participant-2");
-    assertThat(group2.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
+    assertThat(group2.getEntries(0).getPartitionKey().getColumns(0).getIntValue().getValue())
+        .isEqualTo(3);
   }
 
   @Test
@@ -1171,19 +1172,16 @@ class ConsensusCommitCoordinatorTest {
     ArgumentCaptor<WriteSet> captor = ArgumentCaptor.forClass(WriteSet.class);
     verify(coordinatorCommitHandler).abortState(eq("tx-1"), captor.capture());
     WriteSet writeSet = captor.getValue();
-    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(2);
 
-    EntryGroup group1 = writeSet.getEntryGroups(0);
+    EntryGroup group1 = writeSet.getEntryGroups().getEntryGroups(0);
     assertThat(group1.getEntriesList()).hasSize(2);
     assertThat(group1.getEntries(0).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group1.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     assertThat(group1.getEntries(1).getParticipantId()).isEqualTo("participant-1");
-    assertThat(group1.getEntries(1).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
 
-    EntryGroup group2 = writeSet.getEntryGroups(1);
+    EntryGroup group2 = writeSet.getEntryGroups().getEntryGroups(1);
     assertThat(group2.getEntriesList()).hasSize(1);
     assertThat(group2.getEntries(0).getParticipantId()).isEqualTo("participant-2");
-    assertThat(group2.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
 
     verify(p1).rollbackRecords("tx-1");
     verify(p2).rollbackRecords("tx-1");
@@ -1353,11 +1351,6 @@ class ConsensusCommitCoordinatorTest {
           public Optional<Key> getClusteringKey() {
             return Optional.empty();
           }
-
-          @Override
-          public List<Column<?>> getColumns() {
-            return Collections.emptyList();
-          }
         });
   }
 
@@ -1376,8 +1369,8 @@ class ConsensusCommitCoordinatorTest {
     return participant;
   }
 
-  // A minimal WriteSetEntry stub sufficient for encoding (includeColumns=false, so getColumns is
-  // not read). The namespace/table are stubbed non-null because the encoder sets them on the proto.
+  // A minimal WriteSetEntry stub sufficient for encoding, which records record identities only.
+  // The namespace/table are stubbed non-null because the encoder sets them on the proto.
   private static WriteSetEntry writeSetEntry(
       WriteSetEntry.Type type, Key partitionKey, Optional<Key> clusteringKey) {
     WriteSetEntry entry = mock(WriteSetEntry.class);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -1849,9 +1849,11 @@ public class ConsensusCommitManagerTest {
   private com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet writeSetWithSinglePutEntry() {
     return com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet.newBuilder()
         .setSchemaVersion(1)
-        .addEntryGroups(
-            com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
-                .addEntries(putEntry("pk-1")))
+        .setEntryGroups(
+            com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups.newBuilder()
+                .addEntryGroups(
+                    com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
+                        .addEntries(putEntry("pk-1"))))
         .build();
   }
 
@@ -1865,8 +1867,6 @@ public class ConsensusCommitManagerTest {
 
   private com.scalar.db.transaction.consensuscommit.proto.v1.Entry putEntry(String pkValue) {
     return com.scalar.db.transaction.consensuscommit.proto.v1.Entry.newBuilder()
-        .setEntryType(
-            com.scalar.db.transaction.consensuscommit.proto.v1.Entry.EntryType.ENTRY_TYPE_WRITE)
         .setNamespaceName(ANY_NAMESPACE)
         .setTableName(ANY_TABLE)
         .setPartitionKey(
@@ -1942,21 +1942,23 @@ public class ConsensusCommitManagerTest {
     com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet writeSet =
         com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet.newBuilder()
             .setSchemaVersion(1)
-            .addEntryGroups(
-                com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
-                    .setChildId("child-1")
-                    .addEntries(putEntry("pk-1a"))
-                    .addEntries(putEntry("pk-1b")))
-            .addEntryGroups(
-                com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
-                    .setChildId("child-2")
-                    .addEntries(putEntry("pk-2a"))
-                    .addEntries(putEntry("pk-2b")))
-            .addEntryGroups(
-                com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
-                    .setChildId("child-3")
-                    .addEntries(putEntry("pk-3a"))
-                    .addEntries(putEntry("pk-3b")))
+            .setEntryGroups(
+                com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups.newBuilder()
+                    .addEntryGroups(
+                        com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
+                            .setChildId("child-1")
+                            .addEntries(putEntry("pk-1a"))
+                            .addEntries(putEntry("pk-1b")))
+                    .addEntryGroups(
+                        com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
+                            .setChildId("child-2")
+                            .addEntries(putEntry("pk-2a"))
+                            .addEntries(putEntry("pk-2b")))
+                    .addEntryGroups(
+                        com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup.newBuilder()
+                            .setChildId("child-3")
+                            .addEntries(putEntry("pk-3a"))
+                            .addEntries(putEntry("pk-3b"))))
             .build();
     String fullChildId2 = keyManipulator.fullKey(parentId, "child-2");
     String fullChildId3 = keyManipulator.fullKey(parentId, "child-3");
@@ -2077,12 +2079,15 @@ public class ConsensusCommitManagerTest {
 
   @Test
   public void finishTransaction_ReadOnlyCommit_ShouldSkipRecoveryAndDeleteState() throws Exception {
-    // Arrange — A read-only commit persists a non-null WriteSet with an empty entry_groups list
-    // (when coordinatorWriteOmissionOnReadOnlyEnabled=false). The no-write-set rejection should
-    // not fire, no recovery runs, and the state row is still cleaned up.
+    // Arrange — A read-only commit persists a non-null WriteSet whose payload is an EntryGroups
+    // with an empty values list (when coordinatorWriteOmissionOnReadOnlyEnabled=false). The payload
+    // oneof is set, so the unsupported-payload rejection must not fire either. No recovery runs,
+    // and the state row is still cleaned up.
     com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet emptyWriteSet =
         com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet.newBuilder()
             .setSchemaVersion(1)
+            .setEntryGroups(
+                com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups.getDefaultInstance())
             .build();
     State state =
         new State(ANY_TX_ID, emptyWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());
@@ -2096,6 +2101,33 @@ public class ConsensusCommitManagerTest {
     verify(storage, never()).get(any(Get.class));
     verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
     verify(coordinator).deleteState(ANY_TX_ID);
+  }
+
+  @Test
+  public void finishTransaction_WriteSetWithUnsetPayload_ShouldFailAssertionWithoutDeletingState()
+      throws Exception {
+    // Arrange — The encoder always sets a payload case, so an unset one is unreachable by
+    // construction and is guarded by an assertion. What matters is that recovery does not run and
+    // the state row survives, rather than the loop silently treating the row as having no entry
+    // groups and deleting the state row anyway.
+    com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet writeSetWithUnsetPayload =
+        com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet.newBuilder()
+            .setSchemaVersion(1)
+            .build();
+    State state =
+        new State(
+            ANY_TX_ID,
+            writeSetWithUnsetPayload,
+            TransactionState.COMMITTED,
+            System.currentTimeMillis());
+    when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(state));
+
+    // Act + Assert
+    assertThatThrownBy(() -> manager.finishTransaction(ANY_TX_ID))
+        .isInstanceOf(AssertionError.class);
+    verify(storage, never()).get(any(Get.class));
+    verify(recoveryExecutor, never()).executeSynchronously(any(), any(), any(State.class));
+    verify(coordinator, never()).deleteState(anyString());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitParticipantTest.java
@@ -33,7 +33,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
-import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import java.util.Collections;
@@ -575,7 +574,7 @@ class ConsensusCommitParticipantTest {
   void prepareRecords_WithWriteAndDelete_ShouldReturnEntriesStampedWithParticipantId()
       throws Exception {
     TwoPhaseCommitParticipant.PreparationResult result =
-        prepareRecordsWithWriteAndDelete(TwoPhaseCommitParticipant.WriteSetDetailLevel.FULL);
+        prepareRecordsWithWriteAndDelete(TwoPhaseCommitParticipant.WriteSetDetailLevel.KEYS_ONLY);
     // Has writes -> commit required; parity with !getWriteSet().isEmpty().
     assertThat(result.isCommitRequired()).isTrue();
     List<TwoPhaseCommitParticipant.WriteSetEntry> entries = result.getWriteSet();
@@ -595,31 +594,9 @@ class ConsensusCommitParticipantTest {
   }
 
   @Test
-  void prepareRecords_Full_ShouldCarryUserColumnsAndExcludeTransactionMetaColumns()
-      throws Exception {
-    TwoPhaseCommitParticipant.PreparationResult result =
-        prepareRecordsWithWriteAndDelete(TwoPhaseCommitParticipant.WriteSetDetailLevel.FULL);
-    List<TwoPhaseCommitParticipant.WriteSetEntry> entries = result.getWriteSet();
-    assertThat(entries).hasSize(2);
-    for (TwoPhaseCommitParticipant.WriteSetEntry entry : entries) {
-      if (entry.getType() == TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE) {
-        // The injected Put carries the user column "v" plus the ConsensusCommit-internal "tx_id";
-        // only the user column may appear in the write set.
-        assertThat(entry.getColumns()).extracting(Column::getName).containsExactly("v");
-      } else {
-        // DELETE entries never carry columns.
-        assertThat(entry.getColumns()).isEmpty();
-      }
-    }
-  }
-
-  @Test
-  void prepareRecords_KeysOnly_ShouldReturnSameEntriesWithoutColumns() throws Exception {
+  void prepareRecords_KeysOnly_ShouldReturnEntriesCarryingOnlyPrimaryKeys() throws Exception {
     TwoPhaseCommitParticipant.PreparationResult result =
         prepareRecordsWithWriteAndDelete(TwoPhaseCommitParticipant.WriteSetDetailLevel.KEYS_ONLY);
-    // KEYS_ONLY never changes which entries are returned — only their column payload: same entry
-    // count and keys as FULL, but every getColumns() is empty (the must-not-carry-columns
-    // contract).
     List<TwoPhaseCommitParticipant.WriteSetEntry> entries = result.getWriteSet();
     assertThat(entries).hasSize(2);
     assertThat(entries)
@@ -627,14 +604,10 @@ class ConsensusCommitParticipantTest {
         .containsExactlyInAnyOrder(
             TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE,
             TwoPhaseCommitParticipant.WriteSetEntry.Type.DELETE);
-    assertThat(entries)
-        .allSatisfy(
-            e -> {
-              assertThat(e.getPartitionKey().getColumns()).isNotEmpty();
-              assertThat(e.getColumns()).isEmpty();
-            });
-    // Skipping the column pass must also skip the table-metadata lookup (needed only to filter
-    // transaction-meta columns), so a KEYS_ONLY prepare cannot fail on metadata retrieval.
+    assertThat(entries).allSatisfy(e -> assertThat(e.getPartitionKey().getColumns()).isNotEmpty());
+    // Building keys-only entries must not require table metadata (which was needed only to filter
+    // transaction-meta columns out of the record content), so a prepare cannot fail on metadata
+    // retrieval.
     verify(tableMetadataManager, never()).getTransactionTableMetadata(any());
   }
 
@@ -666,7 +639,8 @@ class ConsensusCommitParticipantTest {
     // CrudHandler is mocked, so the snapshot stays empty unless we populate it directly. Reach
     // into the per-tx Snapshot and inject a write + delete, mirroring what the real CrudHandler
     // would do for the insert + delete above. The write additionally carries the "tx_id"
-    // transaction-meta column so the FULL meta-column filtering is observable.
+    // transaction-meta column, so a write whose content would need meta-column filtering still
+    // builds its entry without consulting the table metadata.
     TransactionContext context = getContext(ANY_TX_ID);
     Put put = Put.newBuilder(buildPutFromInsert(insert)).textValue("tx_id", "meta").build();
     context.snapshot.putIntoWriteSet(new Snapshot.Key(put), put);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorCommitHandlerWithGroupCommitTest.java
@@ -58,7 +58,6 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   private final CoordinatorGroupCommitKeyManipulator keyManipulator =
       new CoordinatorGroupCommitKeyManipulator();
   // Builds the pre-encoded write sets the tests feed to the handler.
-  private WriteSetEncoder writeSetEncoder;
   private String fullId;
   private CoordinatorGroupCommitter groupCommitter;
   private CoordinatorCommitHandlerWithGroupCommit handler;
@@ -66,7 +65,6 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   @BeforeEach
   void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    writeSetEncoder = new WriteSetEncoder(tableMetadataManager);
     groupCommitter =
         spy(new CoordinatorGroupCommitter(new GroupCommitConfig(4, 100, 500, 60000, 10)));
     // The handler's constructor wires the Emitter into the groupCommitter via setEmitter(); the
@@ -116,14 +114,14 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
   private CoordinatorGroupCommitValue valueWithWrite(String id) throws CrudException {
     Snapshot snapshot = prepareSnapshotWithWrite(id);
     WriteSet writeSet =
-        writeSetEncoder.encodeSingleGroupWriteSet(createContext(id, snapshot, true), false);
+        WriteSetEncoder.encodeSingleGroupWriteSet(createContext(id, snapshot, true));
     return new CoordinatorGroupCommitValue(id, writeSet);
   }
 
   private CoordinatorGroupCommitValue valueReadOnly(String id) {
     Snapshot snapshot = prepareEmptySnapshot(id);
     WriteSet writeSet =
-        writeSetEncoder.encodeSingleGroupWriteSet(createContext(id, snapshot, true), false);
+        WriteSetEncoder.encodeSingleGroupWriteSet(createContext(id, snapshot, true));
     return new CoordinatorGroupCommitValue(id, writeSet);
   }
 
@@ -135,8 +133,8 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     // Arrange
     long emitCommittedAt = 1234567890123L;
     WriteSet writeSet =
-        writeSetEncoder.encodeSingleGroupWriteSet(
-            createContext(fullId, prepareSnapshotWithWrite(fullId), true), false);
+        WriteSetEncoder.encodeSingleGroupWriteSet(
+            createContext(fullId, prepareSnapshotWithWrite(fullId), true));
     // groupCommitter is a spy, so stub with doReturn to avoid invoking the real ready().
     doReturn(emitCommittedAt)
         .when(groupCommitter)
@@ -286,11 +284,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     assertThat(capturedState.getWriteSet()).isPresent();
     WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).hasSize(2);
-    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("child-1");
-    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
-    assertThat(captured.getEntryGroups(1).getChildId()).isEqualTo("child-2");
-    assertThat(captured.getEntryGroups(1).getEntriesList()).isNotEmpty();
+    assertThat(captured.getEntryGroups().getEntryGroupsList()).hasSize(2);
+    assertThat(captured.getEntryGroups().getEntryGroups(0).getChildId()).isEqualTo("child-1");
+    assertThat(captured.getEntryGroups().getEntryGroups(0).getEntriesList()).isNotEmpty();
+    assertThat(captured.getEntryGroups().getEntryGroups(1).getChildId()).isEqualTo("child-2");
+    assertThat(captured.getEntryGroups().getEntryGroups(1).getEntriesList()).isNotEmpty();
   }
 
   @Test
@@ -322,8 +320,8 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
     assertThat(capturedState.getWriteSet()).isPresent();
 
     WriteSet captured = capturedState.getWriteSet().get();
-    assertThat(captured.getEntryGroupsList()).hasSize(1);
-    assertThat(captured.getEntryGroups(0).getChildId()).isEqualTo("writing");
+    assertThat(captured.getEntryGroups().getEntryGroupsList()).hasSize(1);
+    assertThat(captured.getEntryGroups().getEntryGroups(0).getChildId()).isEqualTo("writing");
   }
 
   @Test
@@ -350,7 +348,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
     WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).isEmpty();
+    assertThat(captured.getEntryGroups().getEntryGroupsList()).isEmpty();
   }
 
   @Test
@@ -400,11 +398,11 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
     WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).hasSize(1);
+    assertThat(captured.getEntryGroups().getEntryGroupsList()).hasSize(1);
     // Delayed group commit emits a single EntryGroup with child_id unset, distinguishing it from
     // a normal group commit row where each EntryGroup carries the child id.
-    assertThat(captured.getEntryGroups(0).hasChildId()).isFalse();
-    assertThat(captured.getEntryGroups(0).getEntriesList()).isNotEmpty();
+    assertThat(captured.getEntryGroups().getEntryGroups(0).hasChildId()).isFalse();
+    assertThat(captured.getEntryGroups().getEntryGroups(0).getEntriesList()).isNotEmpty();
   }
 
   @Test
@@ -434,7 +432,7 @@ class CoordinatorCommitHandlerWithGroupCommitTest {
 
     WriteSet captured = capturedState.getWriteSet().get();
     assertThat(captured.getSchemaVersion()).isEqualTo(1);
-    assertThat(captured.getEntryGroupsList()).isEmpty();
+    assertThat(captured.getEntryGroups().getEntryGroupsList()).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorStateAccessorTest.java
@@ -32,6 +32,7 @@ import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor.State;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Column;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
+import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Key;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import java.util.Arrays;
@@ -894,7 +895,6 @@ public class CoordinatorStateAccessorTest {
     // Arrange — build a State that carries a populated WriteSet.
     Entry writeEntry =
         Entry.newBuilder()
-            .setEntryType(Entry.EntryType.ENTRY_TYPE_WRITE)
             .setNamespaceName("ns")
             .setTableName("tbl")
             .setPartitionKey(
@@ -908,7 +908,9 @@ public class CoordinatorStateAccessorTest {
     WriteSet originalWriteSet =
         WriteSet.newBuilder()
             .setSchemaVersion(1)
-            .addEntryGroups(EntryGroup.newBuilder().addEntries(writeEntry))
+            .setEntryGroups(
+                EntryGroups.newBuilder()
+                    .addEntryGroups(EntryGroup.newBuilder().addEntries(writeEntry)))
             .build();
     State state =
         new State(
@@ -991,9 +993,14 @@ public class CoordinatorStateAccessorTest {
   @Test
   public void state_EmptyWriteSet_ShouldPersistColumnWithNonEmptyBytes()
       throws CoordinatorException {
-    // Arrange — State with an empty (but non-null) WriteSet that explicitly carries schema_version,
-    // mirroring what WriteSetEncoder#encodeSingleGroupWriteSet emits for read-only commits.
-    WriteSet emptyWriteSet = WriteSet.newBuilder().setSchemaVersion(1).build();
+    // Arrange — State with a WriteSet that carries schema_version and an explicitly-set but empty
+    // EntryGroups payload, mirroring what WriteSetEncoder#encodeSingleGroupWriteSet emits for
+    // read-only commits.
+    WriteSet emptyWriteSet =
+        WriteSet.newBuilder()
+            .setSchemaVersion(1)
+            .setEntryGroups(EntryGroups.getDefaultInstance())
+            .build();
     State state =
         new State(ANY_ID_1, emptyWriteSet, TransactionState.COMMITTED, System.currentTimeMillis());
 
@@ -1013,10 +1020,14 @@ public class CoordinatorStateAccessorTest {
     when(result.getBlobAsBytes(Attribute.WRITE_SET)).thenReturn(serializedBytes);
     State parsedState = new State(result);
 
-    // Assert — empty WriteSet survives the round trip and is distinguishable from null.
+    // Assert — empty WriteSet survives the round trip and is distinguishable from null. The payload
+    // case survives too: it must read back as ENTRY_GROUPS, not PAYLOAD_NOT_SET, or the recovery
+    // path would reject this row as one written by a newer schema version.
     assertThat(parsedState.getWriteSet()).isPresent();
     assertThat(parsedState.getWriteSet().get().getSchemaVersion()).isEqualTo(1);
-    assertThat(parsedState.getWriteSet().get().getEntryGroupsList()).isEmpty();
+    assertThat(parsedState.getWriteSet().get().getPayloadCase())
+        .isEqualTo(WriteSet.PayloadCase.ENTRY_GROUPS);
+    assertThat(parsedState.getWriteSet().get().getEntryGroups().getEntryGroupsList()).isEmpty();
   }
 
   @Test
@@ -1043,7 +1054,9 @@ public class CoordinatorStateAccessorTest {
     WriteSet writeSet2 =
         WriteSet.newBuilder()
             .setSchemaVersion(1)
-            .addEntryGroups(EntryGroup.newBuilder().setChildId("child-1"))
+            .setEntryGroups(
+                EntryGroups.newBuilder()
+                    .addEntryGroups(EntryGroup.newBuilder().setChildId("child-1")))
             .build();
     long createdAt = System.currentTimeMillis();
     State stateWithNullWriteSet = new State(ANY_ID_1, TransactionState.COMMITTED, createdAt);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetDecoderTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetDecoderTest.java
@@ -32,7 +32,6 @@ class WriteSetDecoderTest {
 
   private TransactionTableMetadataManager tableMetadataManager;
   private ParallelExecutor parallelExecutor;
-  private WriteSetEncoder writeSetEncoder;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -54,7 +53,6 @@ class WriteSetDecoderTest {
         .thenReturn(transactionTableMetadata);
 
     parallelExecutor = new ParallelExecutor(mock(ConsensusCommitConfig.class));
-    writeSetEncoder = new WriteSetEncoder(tableMetadataManager);
   }
 
   private Snapshot newSnapshot() {
@@ -82,7 +80,7 @@ class WriteSetDecoderTest {
             .textValue("v", "val")
             .build();
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, false);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, null);
     return group.getEntries(0);
   }
 
@@ -184,7 +182,7 @@ class WriteSetDecoderTest {
             .textValue("v", "val")
             .build();
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-    Entry entry = writeSetEncoder.encodeEntryGroup(snapshot, null, false).getEntries(0);
+    Entry entry = WriteSetEncoder.encodeEntryGroup(snapshot, null).getEntries(0);
 
     // Act
     Get get = WriteSetDecoder.toGet(entry);
@@ -210,7 +208,7 @@ class WriteSetDecoderTest {
             .textValue("v", "val")
             .build();
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-    Entry entry = writeSetEncoder.encodeEntryGroup(snapshot, null, false).getEntries(0);
+    Entry entry = WriteSetEncoder.encodeEntryGroup(snapshot, null).getEntries(0);
 
     // Act
     Get get = WriteSetDecoder.toGet(entry);
@@ -247,7 +245,7 @@ class WriteSetDecoderTest {
             .textValue("v", "val")
             .build();
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-    Entry entry = writeSetEncoder.encodeEntryGroup(snapshot, null, false).getEntries(0);
+    Entry entry = WriteSetEncoder.encodeEntryGroup(snapshot, null).getEntries(0);
 
     // Act
     Get get = WriteSetDecoder.toGet(entry);
@@ -265,7 +263,6 @@ class WriteSetDecoderTest {
     // ScalarDB primary keys are non-nullable.
     Entry entry =
         Entry.newBuilder()
-            .setEntryType(Entry.EntryType.ENTRY_TYPE_WRITE)
             .setNamespaceName(NAMESPACE)
             .setTableName(TABLE)
             .setPartitionKey(
@@ -285,7 +282,6 @@ class WriteSetDecoderTest {
     // Arrange — a proto Entry whose partition key Column has no value oneof set (VALUE_NOT_SET).
     Entry entry =
         Entry.newBuilder()
-            .setEntryType(Entry.EntryType.ENTRY_TYPE_WRITE)
             .setNamespaceName(NAMESPACE)
             .setTableName(TABLE)
             .setPartitionKey(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoderTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/WriteSetEncoderTest.java
@@ -10,11 +10,9 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitParticipant;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.TextColumn;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
@@ -31,8 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class WriteSetEncoderTest {
 
@@ -42,7 +38,6 @@ class WriteSetEncoderTest {
 
   private TransactionTableMetadataManager tableMetadataManager;
   private ParallelExecutor parallelExecutor;
-  private WriteSetEncoder writeSetEncoder;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -64,17 +59,15 @@ class WriteSetEncoderTest {
         .thenReturn(transactionTableMetadata);
 
     parallelExecutor = new ParallelExecutor(mock(ConsensusCommitConfig.class));
-    writeSetEncoder = new WriteSetEncoder(tableMetadataManager);
   }
 
   private Snapshot newSnapshot() {
     return new Snapshot(TX_ID, tableMetadataManager, parallelExecutor);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_NonGroupCommitWithPutAndDelete_ShouldEncodeEntryGroupWithoutChildId(
-      boolean includeColumns) throws Exception {
+  @Test
+  void encodeEntryGroup_NonGroupCommitWithPutAndDelete_ShouldEncodeEntryGroupWithoutChildId()
+      throws Exception {
     // Arrange
     Snapshot snapshot = newSnapshot();
     Put put =
@@ -96,14 +89,13 @@ class WriteSetEncoderTest {
     snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
 
     // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, includeColumns);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, null);
 
     // Assert
     assertThat(group.hasChildId()).isFalse();
     assertThat(group.getEntriesList()).hasSize(2);
 
     Entry put1 = group.getEntries(0);
-    assertThat(put1.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     assertThat(put1.getNamespaceName()).isEqualTo(NAMESPACE);
     assertThat(put1.getTableName()).isEqualTo(TABLE);
     assertThat(put1.getPartitionKey().getColumnsList()).hasSize(1);
@@ -111,27 +103,16 @@ class WriteSetEncoderTest {
     assertThat(put1.getPartitionKey().getColumns(0).getTextValue().getValue()).isEqualTo("p1");
     assertThat(put1.hasClusteringKey()).isTrue();
     assertThat(put1.getClusteringKey().getColumns(0).getIntValue().getValue()).isEqualTo(10);
-    if (includeColumns) {
-      assertThat(put1.getColumnsList()).hasSize(1);
-      assertThat(put1.getColumns(0).getName()).isEqualTo("v");
-      assertThat(put1.getColumns(0).getTextValue().getValue()).isEqualTo("val1");
-    } else {
-      assertThat(put1.getColumnsList()).isEmpty();
-    }
 
-    // Delete entries never carry non-key columns regardless of includeColumns.
     Entry delete1 = group.getEntries(1);
-    assertThat(delete1.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
     assertThat(delete1.getNamespaceName()).isEqualTo(NAMESPACE);
     assertThat(delete1.getTableName()).isEqualTo(TABLE);
     assertThat(delete1.getPartitionKey().getColumns(0).getTextValue().getValue()).isEqualTo("p2");
     assertThat(delete1.getClusteringKey().getColumns(0).getIntValue().getValue()).isEqualTo(20);
-    assertThat(delete1.getColumnsList()).isEmpty();
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_GroupCommitChild_ShouldSetChildId(boolean includeColumns) throws Exception {
+  @Test
+  void encodeEntryGroup_GroupCommitChild_ShouldSetChildId() throws Exception {
     // Arrange
     Snapshot snapshot = newSnapshot();
     Put put =
@@ -145,33 +126,46 @@ class WriteSetEncoderTest {
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, "child-1", includeColumns);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, "child-1");
 
     // Assert
     assertThat(group.hasChildId()).isTrue();
     assertThat(group.getChildId()).isEqualTo("child-1");
     assertThat(group.getEntriesList()).hasSize(1);
-    assertThat(group.getEntries(0).getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_NoWritesOrDeletes_ShouldEncodeEmptyEntryGroup(boolean includeColumns) {
+  @Test
+  void encodeEntryGroup_NoWritesOrDeletes_ShouldEncodeEmptyEntryGroup() {
     // Arrange
     Snapshot snapshot = newSnapshot();
 
     // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, includeColumns);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, null);
 
     // Assert
     assertThat(group.hasChildId()).isFalse();
     assertThat(group.getEntriesList()).isEmpty();
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_CompositeKey_ShouldEncodeAllKeyColumns(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeSingleGroupWriteSet_ReadOnly_ShouldSetEmptyEntryGroupsPayload() {
+    // Arrange
+    TransactionContext context =
+        new TransactionContext(TX_ID, newSnapshot(), Isolation.SNAPSHOT, false, false, false);
+
+    // Act
+    WriteSet writeSet = WriteSetEncoder.encodeSingleGroupWriteSet(context);
+
+    // Assert — the payload oneof is always set, never left absent. The unsupported-payload guard
+    // in ConsensusCommitManager reads an unset payload as "written by a newer schema version", so
+    // a read-only commit must still set the case rather than omit the payload.
+    assertThat(writeSet.getPayloadCase()).isEqualTo(WriteSet.PayloadCase.ENTRY_GROUPS);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).isEmpty();
+    assertThat(writeSet.getSchemaVersion()).isEqualTo(1);
+  }
+
+  @Test
+  void encodeEntryGroup_CompositeKey_ShouldEncodeAllKeyColumns() throws Exception {
     // Arrange
     TableMetadata compositeKeyMetadata =
         TableMetadata.newBuilder()
@@ -202,7 +196,7 @@ class WriteSetEncoderTest {
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, includeColumns);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, null);
 
     // Assert
     Entry entry = group.getEntries(0);
@@ -216,61 +210,52 @@ class WriteSetEncoderTest {
     assertThat(entry.getClusteringKey().getColumns(1).getTextValue().getValue()).isEqualTo("c");
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_BooleanKey_ShouldEncodeBooleanValue(boolean includeColumns)
-      throws Exception {
-    EntryGroup group = encodeKey(DataType.BOOLEAN, Key.ofBoolean("pk", true), includeColumns);
+  @Test
+  void encodeEntryGroup_BooleanKey_ShouldEncodeBooleanValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.BOOLEAN, Key.ofBoolean("pk", true));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getBooleanValue().getValue())
         .isTrue();
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_IntKey_ShouldEncodeIntValue(boolean includeColumns) throws Exception {
-    EntryGroup group = encodeKey(DataType.INT, Key.ofInt("pk", 42), includeColumns);
+  @Test
+  void encodeEntryGroup_IntKey_ShouldEncodeIntValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.INT, Key.ofInt("pk", 42));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getIntValue().getValue())
         .isEqualTo(42);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_TextKey_ShouldEncodeTextValue(boolean includeColumns) throws Exception {
-    EntryGroup group = encodeKey(DataType.TEXT, Key.ofText("pk", "hello"), includeColumns);
+  @Test
+  void encodeEntryGroup_TextKey_ShouldEncodeTextValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.TEXT, Key.ofText("pk", "hello"));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getTextValue().getValue())
         .isEqualTo("hello");
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_BigIntKey_ShouldEncodeBigIntValue(boolean includeColumns) throws Exception {
-    EntryGroup group =
-        encodeKey(DataType.BIGINT, Key.ofBigInt("pk", 12345678901234L), includeColumns);
+  @Test
+  void encodeEntryGroup_BigIntKey_ShouldEncodeBigIntValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.BIGINT, Key.ofBigInt("pk", 12345678901234L));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getBigintValue().getValue())
         .isEqualTo(12345678901234L);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_FloatKey_ShouldEncodeFloatValue(boolean includeColumns) throws Exception {
-    EntryGroup group = encodeKey(DataType.FLOAT, Key.ofFloat("pk", 1.25f), includeColumns);
+  @Test
+  void encodeEntryGroup_FloatKey_ShouldEncodeFloatValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.FLOAT, Key.ofFloat("pk", 1.25f));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getFloatValue().getValue())
         .isEqualTo(1.25f);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_DoubleKey_ShouldEncodeDoubleValue(boolean includeColumns) throws Exception {
-    EntryGroup group = encodeKey(DataType.DOUBLE, Key.ofDouble("pk", 12.345), includeColumns);
+  @Test
+  void encodeEntryGroup_DoubleKey_ShouldEncodeDoubleValue() throws Exception {
+    EntryGroup group = encodeKey(DataType.DOUBLE, Key.ofDouble("pk", 12.345));
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getDoubleValue().getValue())
         .isEqualTo(12.345);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_BlobKey_ShouldEncodeBlobValue(boolean includeColumns) throws Exception {
+  @Test
+  void encodeEntryGroup_BlobKey_ShouldEncodeBlobValue() throws Exception {
     byte[] blobValue = new byte[] {1, 2, 3, 4};
-    EntryGroup group = encodeKey(DataType.BLOB, Key.ofBlob("pk", blobValue), includeColumns);
+    EntryGroup group = encodeKey(DataType.BLOB, Key.ofBlob("pk", blobValue));
     assertThat(
             group
                 .getEntries(0)
@@ -282,46 +267,37 @@ class WriteSetEncoderTest {
         .containsExactly(blobValue);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_DateKey_ShouldEncodeDateValueAsEpochDay(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeEntryGroup_DateKey_ShouldEncodeDateValueAsEpochDay() throws Exception {
     LocalDate date = LocalDate.of(2026, 5, 10);
-    EntryGroup group = encodeKey(DataType.DATE, Key.ofDate("pk", date), includeColumns);
+    EntryGroup group = encodeKey(DataType.DATE, Key.ofDate("pk", date));
     int expected = TimeRelatedColumnEncodingUtils.encode(date);
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getDateValue().getValue())
         .isEqualTo(expected);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_TimeKey_ShouldEncodeTimeValueAsNanoOfDay(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeEntryGroup_TimeKey_ShouldEncodeTimeValueAsNanoOfDay() throws Exception {
     LocalTime time = LocalTime.of(12, 34, 56);
-    EntryGroup group = encodeKey(DataType.TIME, Key.ofTime("pk", time), includeColumns);
+    EntryGroup group = encodeKey(DataType.TIME, Key.ofTime("pk", time));
     long expected = TimeRelatedColumnEncodingUtils.encode(time);
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getTimeValue().getValue())
         .isEqualTo(expected);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_TimestampKey_ShouldEncodeTimestampValue(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeEntryGroup_TimestampKey_ShouldEncodeTimestampValue() throws Exception {
     LocalDateTime ts = LocalDateTime.of(2026, 5, 10, 12, 34, 56);
-    EntryGroup group = encodeKey(DataType.TIMESTAMP, Key.ofTimestamp("pk", ts), includeColumns);
+    EntryGroup group = encodeKey(DataType.TIMESTAMP, Key.ofTimestamp("pk", ts));
     long expected = TimeRelatedColumnEncodingUtils.encode(ts);
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getTimestampValue().getValue())
         .isEqualTo(expected);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_TimestampTZKey_ShouldEncodeTimestampTZValue(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeEntryGroup_TimestampTZKey_ShouldEncodeTimestampTZValue() throws Exception {
     Instant instant = Instant.ofEpochSecond(1747000000L);
-    EntryGroup group =
-        encodeKey(DataType.TIMESTAMPTZ, Key.ofTimestampTZ("pk", instant), includeColumns);
+    EntryGroup group = encodeKey(DataType.TIMESTAMPTZ, Key.ofTimestampTZ("pk", instant));
     long expected = TimeRelatedColumnEncodingUtils.encode(instant);
     assertThat(group.getEntries(0).getPartitionKey().getColumns(0).getTimestamptzValue().getValue())
         .isEqualTo(expected);
@@ -333,12 +309,10 @@ class WriteSetEncoderTest {
    *
    * @param pkType the data type of the partition key column
    * @param partitionKey the partition key value
-   * @param includeColumns whether to include non-key column values in the resulting entries
    * @return the encoded {@link EntryGroup}
    * @throws Exception if table metadata setup fails
    */
-  private EntryGroup encodeKey(DataType pkType, Key partitionKey, boolean includeColumns)
-      throws Exception {
+  private EntryGroup encodeKey(DataType pkType, Key partitionKey) throws Exception {
     TableMetadata metadata =
         TableMetadata.newBuilder()
             .addColumn("pk", pkType)
@@ -359,13 +333,11 @@ class WriteSetEncoderTest {
             .textValue("v", "val")
             .build();
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-    return writeSetEncoder.encodeEntryGroup(snapshot, null, includeColumns);
+    return WriteSetEncoder.encodeEntryGroup(snapshot, null);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void encodeEntryGroup_PartitionKeyOnly_ShouldOmitClusteringKey(boolean includeColumns)
-      throws Exception {
+  @Test
+  void encodeEntryGroup_PartitionKeyOnly_ShouldOmitClusteringKey() throws Exception {
     // Arrange
     Snapshot snapshot = newSnapshot();
     TableMetadata pkOnlyMetadata =
@@ -389,68 +361,13 @@ class WriteSetEncoderTest {
     snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, includeColumns);
+    EntryGroup group = WriteSetEncoder.encodeEntryGroup(snapshot, null);
 
     // Assert
     assertThat(group.getEntriesList()).hasSize(1);
     Entry entry = group.getEntries(0);
     assertThat(entry.hasClusteringKey()).isFalse();
     assertThat(entry.getPartitionKey().getColumns(0).getName()).isEqualTo("pk");
-  }
-
-  @Test
-  void encodeEntryGroup_IncludeColumnsTrue_WithNullValuedColumn_ShouldEmitEmptyInnerValue()
-      throws Exception {
-    // Arrange — a Put with a null-valued non-key column. The encoding visitor should encode
-    // it as a Column whose inner TextValue carries no `value` field (proto3 default).
-    Snapshot snapshot = newSnapshot();
-    Put put =
-        Put.newBuilder()
-            .namespace(NAMESPACE)
-            .table(TABLE)
-            .partitionKey(Key.ofText("pk", "p1"))
-            .clusteringKey(Key.ofInt("ck", 1))
-            .textValue("v", null)
-            .build();
-    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-
-    // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, true);
-
-    // Assert
-    Entry putEntry = group.getEntries(0);
-    assertThat(putEntry.getColumnsList()).hasSize(1);
-    assertThat(putEntry.getColumns(0).getName()).isEqualTo("v");
-    // hasValue() on the inner TextValue is false because the proto field is unset (null marker).
-    assertThat(putEntry.getColumns(0).getTextValue().hasValue()).isFalse();
-  }
-
-  @Test
-  void encodeEntryGroup_IncludeColumnsTrue_ShouldFilterTransactionMetaColumns() throws Exception {
-    // Arrange — a Put that carries both a user column ("v") and ConsensusCommit-injected
-    // transaction-meta columns (tx_state and before_v). The latter must not appear in the emitted
-    // entry when includeColumns is true.
-    Snapshot snapshot = newSnapshot();
-    Put put =
-        Put.newBuilder()
-            .namespace(NAMESPACE)
-            .table(TABLE)
-            .partitionKey(Key.ofText("pk", "p1"))
-            .clusteringKey(Key.ofInt("ck", 1))
-            .textValue("v", "user-value")
-            .intValue(Attribute.STATE, TransactionState.PREPARED.get())
-            .textValue(Attribute.BEFORE_PREFIX + "v", "old-value")
-            .build();
-    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
-
-    // Act
-    EntryGroup group = writeSetEncoder.encodeEntryGroup(snapshot, null, true);
-
-    // Assert — only the user column survives the filter.
-    Entry putEntry = group.getEntries(0);
-    assertThat(putEntry.getColumnsList()).hasSize(1);
-    assertThat(putEntry.getColumns(0).getName()).isEqualTo("v");
-    assertThat(putEntry.getColumns(0).getTextValue().getValue()).isEqualTo("user-value");
   }
 
   @Test
@@ -479,60 +396,36 @@ class WriteSetEncoderTest {
     writeSetsByParticipant.put("p2", Collections.singletonList(p2Write));
 
     // Act
-    WriteSet writeSet =
-        WriteSetEncoder.encodeFromWriteSetEntries(
-            writeSetsByParticipant, /* includeColumns= */ false);
+    WriteSet writeSet = WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant);
 
-    // Assert — two groups in map iteration order (p1, then p2); p1 holds both its entries.
+    // Assert — two groups in map iteration order (p1, then p2); p1 holds both its entries, in the
+    // order they were listed. Each entry's partition key is asserted too: the participant id alone
+    // would not distinguish p1's two entries from each other, so the assertions would hold even if
+    // the encoder emitted one of them twice or swapped them.
     assertThat(writeSet.getSchemaVersion()).isEqualTo(1);
-    assertThat(writeSet.getEntryGroupsList()).hasSize(2);
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(2);
 
-    EntryGroup p1Group = writeSet.getEntryGroups(0);
+    EntryGroup p1Group = writeSet.getEntryGroups().getEntryGroups(0);
     assertThat(p1Group.hasChildId()).isFalse();
     assertThat(p1Group.getEntriesList()).hasSize(2);
     Entry p1FirstEntry = p1Group.getEntries(0);
     assertThat(p1FirstEntry.getParticipantId()).isEqualTo("p1");
-    assertThat(p1FirstEntry.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_WRITE);
     assertThat(p1FirstEntry.getNamespaceName()).isEqualTo(NAMESPACE);
     assertThat(p1FirstEntry.getTableName()).isEqualTo(TABLE);
+    assertThat(p1FirstEntry.getPartitionKey().getColumns(0).getTextValue().getValue())
+        .isEqualTo("a");
     assertThat(p1FirstEntry.hasClusteringKey()).isTrue();
-    // includeColumns=false: non-key columns are not persisted.
-    assertThat(p1FirstEntry.getColumnsList()).isEmpty();
     Entry p1SecondEntry = p1Group.getEntries(1);
     assertThat(p1SecondEntry.getParticipantId()).isEqualTo("p1");
-    assertThat(p1SecondEntry.getEntryType()).isEqualTo(Entry.EntryType.ENTRY_TYPE_DELETE);
+    assertThat(p1SecondEntry.getPartitionKey().getColumns(0).getTextValue().getValue())
+        .isEqualTo("c");
 
-    EntryGroup p2Group = writeSet.getEntryGroups(1);
+    EntryGroup p2Group = writeSet.getEntryGroups().getEntryGroups(1);
     assertThat(p2Group.getEntriesList()).hasSize(1);
     Entry p2Entry = p2Group.getEntries(0);
     assertThat(p2Entry.getParticipantId()).isEqualTo("p2");
+    assertThat(p2Entry.getPartitionKey().getColumns(0).getTextValue().getValue()).isEqualTo("b");
     assertThat(p2Entry.hasClusteringKey()).isFalse();
-  }
-
-  @Test
-  void encodeFromWriteSetEntries_WhenIncludeColumns_ShouldEncodeNonKeyColumnsOfWriteEntries() {
-    // Arrange — a WRITE entry carrying one non-key column (the participant already filtered out any
-    // ConsensusCommit-internal columns).
-    TwoPhaseCommitParticipant.WriteSetEntry write =
-        writeSetEntry(
-            TwoPhaseCommitParticipant.WriteSetEntry.Type.WRITE,
-            Key.ofText("pk", "a"),
-            Optional.empty());
-    when(write.getColumns()).thenReturn(Collections.singletonList(TextColumn.of("v", "val")));
-    Map<String, List<TwoPhaseCommitParticipant.WriteSetEntry>> writeSetsByParticipant =
-        new LinkedHashMap<>();
-    writeSetsByParticipant.put("p1", Collections.singletonList(write));
-
-    // Act
-    WriteSet writeSet =
-        WriteSetEncoder.encodeFromWriteSetEntries(
-            writeSetsByParticipant, /* includeColumns= */ true);
-
-    // Assert — the non-key column is encoded on the entry.
-    Entry entry = writeSet.getEntryGroups(0).getEntries(0);
-    assertThat(entry.getColumnsList()).hasSize(1);
-    assertThat(entry.getColumns(0).getName()).isEqualTo("v");
-    assertThat(entry.getColumns(0).getTextValue().getValue()).isEqualTo("val");
   }
 
   @Test
@@ -550,13 +443,12 @@ class WriteSetEncoderTest {
     writeSetsByParticipant.put("p2", Collections.emptyList());
 
     // Act
-    WriteSet writeSet =
-        WriteSetEncoder.encodeFromWriteSetEntries(
-            writeSetsByParticipant, /* includeColumns= */ false);
+    WriteSet writeSet = WriteSetEncoder.encodeFromWriteSetEntries(writeSetsByParticipant);
 
     // Assert — only p1's group is emitted; the empty p2 is skipped.
-    assertThat(writeSet.getEntryGroupsList()).hasSize(1);
-    assertThat(writeSet.getEntryGroups(0).getEntries(0).getParticipantId()).isEqualTo("p1");
+    assertThat(writeSet.getEntryGroups().getEntryGroupsList()).hasSize(1);
+    assertThat(writeSet.getEntryGroups().getEntryGroups(0).getEntries(0).getParticipantId())
+        .isEqualTo("p1");
   }
 
   private static TwoPhaseCommitParticipant.WriteSetEntry writeSetEntry(

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -60,6 +60,7 @@ import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.Coord
 import com.scalar.db.transaction.consensuscommit.proto.v1.Column;
 import com.scalar.db.transaction.consensuscommit.proto.v1.Entry;
 import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroup;
+import com.scalar.db.transaction.consensuscommit.proto.v1.EntryGroups;
 import com.scalar.db.transaction.consensuscommit.proto.v1.WriteSet;
 import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import java.time.Duration;
@@ -10772,7 +10773,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     WriteSet writeSet = state.get().getWriteSet().get();
     assertThat(writeSet.getSchemaVersion()).isEqualTo(1);
     int totalEntries =
-        writeSet.getEntryGroupsList().stream().mapToInt(g -> g.getEntriesCount()).sum();
+        writeSet.getEntryGroups().getEntryGroupsList().stream()
+            .mapToInt(g -> g.getEntriesCount())
+            .sum();
     assertThat(totalEntries).isEqualTo(2);
   }
 
@@ -11004,10 +11007,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     WriteSet writeSet =
         WriteSet.newBuilder()
             .setSchemaVersion(1)
-            .addEntryGroups(
-                EntryGroup.newBuilder()
-                    .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 0))
-                    .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 1)))
+            .setEntryGroups(
+                EntryGroups.newBuilder()
+                    .addEntryGroups(
+                        EntryGroup.newBuilder()
+                            .addEntries(intKeyEntry(namespace1, TABLE_1, 0, 0))
+                            .addEntries(intKeyEntry(namespace1, TABLE_1, 0, 1))))
             .build();
     coordinator.putState(
         new CoordinatorStateAccessor.State(
@@ -11093,14 +11098,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     WriteSet writeSet =
         WriteSet.newBuilder()
             .setSchemaVersion(1)
-            .addEntryGroups(
-                EntryGroup.newBuilder()
-                    .setChildId(ANY_ID_1)
-                    .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 0, 0)))
-            .addEntryGroups(
-                EntryGroup.newBuilder()
-                    .setChildId(ANY_ID_2)
-                    .addEntries(intKeyWriteEntry(namespace1, TABLE_1, 1, 0)))
+            .setEntryGroups(
+                EntryGroups.newBuilder()
+                    .addEntryGroups(
+                        EntryGroup.newBuilder()
+                            .setChildId(ANY_ID_1)
+                            .addEntries(intKeyEntry(namespace1, TABLE_1, 0, 0)))
+                    .addEntryGroups(
+                        EntryGroup.newBuilder()
+                            .setChildId(ANY_ID_2)
+                            .addEntries(intKeyEntry(namespace1, TABLE_1, 1, 0))))
             .build();
     CoordinatorGroupCommitKeyManipulator km = new CoordinatorGroupCommitKeyManipulator();
     List<String> childIds =
@@ -11195,10 +11202,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     originalStorage.put(put);
   }
 
-  private static Entry intKeyWriteEntry(
+  private static Entry intKeyEntry(
       String namespace, String table, int partitionKeyValue, int clusteringKeyValue) {
     return Entry.newBuilder()
-        .setEntryType(Entry.EntryType.ENTRY_TYPE_WRITE)
         .setNamespaceName(namespace)
         .setTableName(table)
         .setPartitionKey(


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3765
- **Commit to backport:** 3538c5a44ec554750a6b70e3ee76c598242a3007

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3765 &&
git cherry-pick --no-rerere-autoupdate -m1 3538c5a44ec554750a6b70e3ee76c598242a3007
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!