### PR TITLE
Backport to branch(3.17) : Skip the Azurite API version check in the Blob Storage integration test

### DIFF
--- a/ci/tests-config.yaml
+++ b/ci/tests-config.yaml
@@ -15,11 +15,13 @@
 blob-storage:
   - label: blob-storage
     display_name: Blob Storage
+    # Start azurite with `--skipApiVersionCheck` to avoid API version check issues
     setup: |
       docker run -d --name azurite \
         -e AZURITE_ACCOUNTS=test:test \
         -p 10000:10000 \
-        mcr.microsoft.com/azure-storage/azurite
+        mcr.microsoft.com/azure-storage/azurite \
+        azurite --blobHost 0.0.0.0 --location /data --skipApiVersionCheck
     # ScalarDB requires an access key, which has full access to Azure Blob Storage, for authentication.
     create_test_user: # Do nothing
     run: |


### PR DESCRIPTION
## Description

All the Blob Storage integration tests on the `3.17` branch have been failing. For example, see [this CI run](https://github.com/scalar-labs/scalardb/actions/runs/31886521672).

Every test fails at the first Blob Storage access with the following error:

```
com.azure.storage.blob.models.BlobStorageException: Status code 400, "<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Error>
  <Code>InvalidHeaderValue</Code>
  <Message>The API version 2026-06-06 is not supported by Azurite. Please upgrade Azurite to latest version and retry.
  ... Azurite command line parameter "--skipApiVersionCheck" ... can skip this error.</Message>
</Error>"
```

The cause is that #3755 (the backport of #3754 to the `3.17` branch) upgraded the Azure Blob Storage SDK from 12.32.0 to 12.35.0. The new SDK requests the service API version `2026-06-06`, which the Azurite image used in the CI does not support.

The same issue was already fixed on the `master` branch in #3337 by starting Azurite with `--skipApiVersionCheck`, but that CI configuration change was never backported to the `3.17` branch. This PR backports it.

Note that only the `ci/tests-config.yaml` part of #3337 is backported here, since the `3.17` branch already uses a newer Blob Storage SDK version (12.35.0) than the one #3337 introduced (12.33.0).

## Related issues and/or PRs

- Related to #3337
- Related to #3755

## Changes made

- Start Azurite with `--skipApiVersionCheck` in `ci/tests-config.yaml`, so the Blob Storage integration tests are not affected by the API version check.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `3.15` and `3.16` branches do not have the Object Storage support, so they are not affected by this issue.

## Release notes

N/A
