### PR TITLE
Fix reviewer assignment in the THIRD-PARTY-NOTICES.txt update workflow

### DIFF
--- a/.github/workflows/update-third-party-notices.yaml
+++ b/.github/workflows/update-third-party-notices.yaml
@@ -53,7 +53,8 @@ jobs:
       - name: Create pull request
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Requesting a team review needs organization read access, which `GITHUB_TOKEN` lacks.
+          GH_TOKEN: ${{ secrets.CR_PAT }}
         run: |
           BRANCH="update-third-party-notices-$(date +%Y%m%d)"
 


### PR DESCRIPTION
## Description

The action that triggers quarterly to update the `THIRD-PARTY-NOTICES.txt` file creates a PR without assigning reviewers. This PR fixes it.

## Related issues and/or PRs

- Related to #3676, the pull request that was created without a reviewer.

## Changes made

- The `Create pull request` step of `update-third-party-notices.yaml` now uses `secrets.CR_PAT`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
