### PR TITLE
Support the AWS Advanced JDBC Wrapper for Aurora failover

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ subprojects {
         alloyDbJdbcConnectorVersion = '1.3.2'
         googleCloudStorageVersion = '2.71.0'
         spannerDriverVersion = '2.42.0'
+        awsAdvancedJdbcWrapperVersion = '4.3.0'
         picocliVersion = '4.7.7'
         commonsTextVersion = '1.15.0'
         caffeineVersion = '2.9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ subprojects {
         sqliteDriverVersion = '3.53.2.1'
         yugabyteDriverVersion = '42.7.3-yb-4'
         db2DriverVersion = '12.1.5.0'
+        // Bumping the major version means updating the wrapperTargetDriverDialect value in
+        // RdbEngineMysql too -- the AWS wrapper names its MariaDB dialect after the driver's major
+        // version, and only defines one for v3.
         mariadDbDriverVersion = '3.5.10'
         alloyDbJdbcConnectorVersion = '1.3.2'
         googleCloudStorageVersion = '2.71.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -199,6 +199,8 @@ dependencies {
     implementation("com.google.cloud:google-cloud-spanner-jdbc:${spannerDriverVersion}") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    // Enables fast Aurora failover by discovering the cluster topology instead of waiting for DNS
+    implementation "software.amazon.jdbc:aws-advanced-jdbc-wrapper:${awsAdvancedJdbcWrapperVersion}"
     implementation "org.apache.commons:commons-text:${commonsTextVersion}"
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     implementation "com.google.protobuf:protobuf-java:${protobufVersion}"

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1151,6 +1151,12 @@ public enum CoreError implements ScalarDbError {
       "The RDB engine is not supported with the AWS Advanced JDBC Wrapper. Only Aurora PostgreSQL and Aurora MySQL are supported. JDBC connection URL: %s",
       "",
       ""),
+  JDBC_HIKARICP_EXCEPTION_OVERRIDE_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0303",
+      "The HikariCP exceptionOverrideClassName setting is not supported. ScalarDB determines whether a failed commit left the transaction in an unknown state by checking whether the connection survived, which relies on HikariCP discarding a connection that reports a connection exception. An override that keeps such a connection alive would make an unknown outcome be reported as a definite failure, which the caller is told is safe to retry. Configured class: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -1145,6 +1145,12 @@ public enum CoreError implements ScalarDbError {
       "Some scanners were not closed. All scanners must be closed before ending the branch. Transaction ID: %s",
       "",
       ""),
+  JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER(
+      Category.USER_ERROR,
+      "0302",
+      "The RDB engine is not supported with the AWS Advanced JDBC Wrapper. Only Aurora PostgreSQL and Aurora MySQL are supported. JDBC connection URL: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
+import com.scalar.db.common.CoreError;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.nio.charset.StandardCharsets;
@@ -80,6 +81,18 @@ public final class JdbcUtils {
       @Nullable Long maxLifetime,
       @Nullable Long keepaliveTime) {
     HikariConfig hikariConfig = new HikariConfig();
+
+    // The constructor above also reads whatever the hikaricp.configurationFile system property
+    // points at, so this setting can arrive without ScalarDB configuration being involved at all --
+    // and AWS documentation recommends setting it when using their JDBC wrapper. Refuse to start
+    // rather than run with the inference in JdbcTransaction#commit() quietly broken. That failure
+    // would only surface during a failover, would look like an ordinary retry, and would be found
+    // by noticing duplicated data.
+    if (hikariConfig.getExceptionOverrideClassName() != null) {
+      throw new IllegalArgumentException(
+          CoreError.JDBC_HIKARICP_EXCEPTION_OVERRIDE_NOT_SUPPORTED.buildMessage(
+              hikariConfig.getExceptionOverrideClassName()));
+    }
 
     // Do not set exceptionOverrideClassName here. JdbcTransaction#commit() infers an unknown
     // outcome from HikariCP evicting a connection whose SQLState starts with "08"; see that method

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -19,6 +19,8 @@ public final class JdbcUtils {
   // SQL Server: 128).
   @VisibleForTesting static final int MAX_INDEX_NAME_LENGTH = 63;
 
+  private static final String AWS_WRAPPER_URL_PREFIX = "jdbc:aws-wrapper:";
+
   private JdbcUtils() {}
 
   public static HikariDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
@@ -79,12 +81,16 @@ public final class JdbcUtils {
       @Nullable Long keepaliveTime) {
     HikariConfig hikariConfig = new HikariConfig();
 
+    // Do not set exceptionOverrideClassName here. JdbcTransaction#commit() infers an unknown
+    // outcome from HikariCP evicting a connection whose SQLState starts with "08"; see that method
+    // for why AWS recommends the override and why setting it would break the inference.
+
     /*
      * We need to set the driver class of an underlying database to the dataSource in order
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    hikariConfig.setDriverClassName(rdbEngine.getDriverClassName());
+    hikariConfig.setDriverClassName(getDriverClassName(config, rdbEngine));
 
     hikariConfig.setJdbcUrl(rdbEngine.adjustJdbcUrl(config.getJdbcUrl()));
     rdbEngine.setConnectionCredentials(config, hikariConfig);
@@ -126,6 +132,32 @@ public final class JdbcUtils {
   @VisibleForTesting
   static HikariDataSource createDataSource(HikariConfig hikariConfig) {
     return new HikariDataSource(hikariConfig);
+  }
+
+  static boolean isAwsWrapperUrl(String jdbcUrl) {
+    return jdbcUrl != null && jdbcUrl.startsWith(AWS_WRAPPER_URL_PREFIX);
+  }
+
+  /**
+   * Exposes the URL of the underlying database. Use this only to decide which RDB engine to use:
+   * the URL passed to the connection pool must keep the prefix, because that is what makes the
+   * wrapper handle the connection.
+   */
+  static String removeAwsWrapperPrefix(String jdbcUrl) {
+    assert isAwsWrapperUrl(jdbcUrl);
+    return "jdbc:" + jdbcUrl.substring(AWS_WRAPPER_URL_PREFIX.length());
+  }
+
+  /**
+   * The AWS Advanced JDBC Wrapper supplies its own driver, so the underlying database's driver
+   * class must not be used when the URL routes through it. The engine's own {@code
+   * getDriverClassName()} is left untouched; the substitution happens only here.
+   */
+  private static String getDriverClassName(JdbcConfig config, RdbEngineStrategy rdbEngine) {
+    if (isAwsWrapperUrl(config.getJdbcUrl())) {
+      return software.amazon.jdbc.Driver.class.getName();
+    }
+    return rdbEngine.getDriverClassName();
   }
 
   private static String toHikariTransactionIsolation(Isolation isolation) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
@@ -14,6 +14,10 @@ public final class RdbEngineFactory {
   public static RdbEngineStrategy create(JdbcConfig config) {
     String jdbcUrl = config.getJdbcUrl();
 
+    if (JdbcUtils.isAwsWrapperUrl(jdbcUrl)) {
+      return createForAwsWrapper(config, jdbcUrl);
+    }
+
     if (jdbcUrl.startsWith("jdbc:mysql:")) {
       return createMysqlOrTidbEngine(config);
     } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
@@ -36,6 +40,36 @@ public final class RdbEngineFactory {
       throw new IllegalArgumentException(
           CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED.buildMessage(jdbcUrl));
     }
+  }
+
+  /**
+   * Selects the engine for a URL that routes through the AWS Advanced JDBC Wrapper.
+   *
+   * <p>Only Aurora PostgreSQL and Aurora MySQL are supported. The wrapper itself also accepts
+   * MariaDB, but allowing a combination that is never tested would let it fail in subtler ways than
+   * an unsupported-engine error at startup. TiDB is rejected for the same reason: it shares MySQL's
+   * connection string, so it is only recognized after the metadata probe.
+   *
+   * @param config the config
+   * @param jdbcUrl the original JDBC URL, including the wrapper prefix
+   * @return the engine for the underlying database
+   */
+  private static RdbEngineStrategy createForAwsWrapper(JdbcConfig config, String jdbcUrl) {
+    String underlyingUrl = JdbcUtils.removeAwsWrapperPrefix(jdbcUrl);
+
+    if (underlyingUrl.startsWith("jdbc:postgresql:")) {
+      return new RdbEnginePostgresql();
+    } else if (underlyingUrl.startsWith("jdbc:mysql:")) {
+      RdbEngineStrategy engine = createMysqlOrTidbEngine(config);
+      if (!(engine instanceof RdbEngineTidb)) {
+        return engine;
+      }
+    }
+
+    // Report the URL the user actually configured, not the one left after stripping the prefix.
+    throw new IllegalArgumentException(
+        CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER.buildMessage(
+            jdbcUrl));
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -505,6 +505,10 @@ class RdbEngineMysql extends AbstractRdbEngine {
     // The AWS Advanced JDBC Wrapper, however, defaults to the MySQL Connector/J dialect for a
     // "jdbc:mysql://" URL, so without this the wrapper asks for a driver that is not on the
     // classpath. Users who set the dialect themselves keep their choice.
+    //
+    // The trailing "3" is MariaDB Connector/J's major version, which the wrapper builds into the
+    // dialect name -- it defines no equivalent for any other major version. Moving ScalarDB to a
+    // v4 driver therefore needs a wrapper that names a v4 dialect, and this value updated to match.
     if (JdbcUtils.isAwsWrapperUrl(jdbcUrl)
         && !adjustedJdbcUrl.contains(WRAPPER_TARGET_DRIVER_DIALECT_PARAMETER)) {
       adjustedJdbcUrl =

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -26,6 +26,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class RdbEngineMysql extends AbstractRdbEngine {
+
+  private static final String PERMIT_MYSQL_SCHEME_PARAMETER = "permitMysqlScheme";
+  private static final String WRAPPER_TARGET_DRIVER_DIALECT_PARAMETER =
+      "wrapperTargetDriverDialect";
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineMysql.class);
   private final String keyColumnSize;
   private final RdbEngineTimeTypeMysql timeTypeEngine;
@@ -209,6 +213,11 @@ class RdbEngineMysql extends AbstractRdbEngine {
     // Error number: 1205; Symbol: ER_LOCK_WAIT_TIMEOUT; SQLSTATE: HY000
     // Message: Lock wait timeout exceeded; try restarting transaction
 
+    // Do not add the AWS Advanced JDBC Wrapper failover SQLStates (08001, 08S02, 08007) here.
+    // A conflict is converted into a RetriableExecutionException by JdbcDatabase, which tells the
+    // caller the operation definitely did not apply and is safe to retry. A failover gives no such
+    // guarantee: the outcome may be unknown, or the write may already have been applied on the old
+    // writer. See RdbEngineMysqlTest#isConflict_GivenFailoverSqlStates_ShouldReturnFalse.
     return e.getErrorCode() == 1213 || e.getErrorCode() == 1205;
   }
 
@@ -482,14 +491,32 @@ class RdbEngineMysql extends AbstractRdbEngine {
 
   @Override
   public String adjustJdbcUrl(String jdbcUrl) {
+    String adjustedJdbcUrl = jdbcUrl;
+
     // MariaDB Connector/J checks for "permitMysqlScheme" in the JDBC URL during URL parsing before
     // any connection properties are applied. If the URL starts with "jdbc:mysql:" and doesn't
     // contain "permitMysqlScheme", the driver rejects the URL entirely. That's why we need to embed
     // it directly in the JDBC URL rather than using getConnectionProperties().
-    if (jdbcUrl.contains("permitMysqlScheme")) {
-      return jdbcUrl;
+    if (!adjustedJdbcUrl.contains(PERMIT_MYSQL_SCHEME_PARAMETER)) {
+      adjustedJdbcUrl = appendParameter(adjustedJdbcUrl, PERMIT_MYSQL_SCHEME_PARAMETER + "=true");
     }
-    return jdbcUrl + (jdbcUrl.contains("?") ? "&" : "?") + "permitMysqlScheme=true";
+
+    // ScalarDB talks to MySQL through MariaDB Connector/J and does not bundle MySQL Connector/J.
+    // The AWS Advanced JDBC Wrapper, however, defaults to the MySQL Connector/J dialect for a
+    // "jdbc:mysql://" URL, so without this the wrapper asks for a driver that is not on the
+    // classpath. Users who set the dialect themselves keep their choice.
+    if (JdbcUtils.isAwsWrapperUrl(jdbcUrl)
+        && !adjustedJdbcUrl.contains(WRAPPER_TARGET_DRIVER_DIALECT_PARAMETER)) {
+      adjustedJdbcUrl =
+          appendParameter(
+              adjustedJdbcUrl, WRAPPER_TARGET_DRIVER_DIALECT_PARAMETER + "=mariadb-connector-j-3");
+    }
+
+    return adjustedJdbcUrl;
+  }
+
+  private static String appendParameter(String jdbcUrl, String parameter) {
+    return jdbcUrl + (jdbcUrl.contains("?") ? "&" : "?") + parameter;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -173,6 +173,12 @@ class RdbEnginePostgresql extends AbstractRdbEngine {
     }
     // 40001: serialization_failure
     // 40P01: deadlock_detected
+
+    // Do not add the AWS Advanced JDBC Wrapper failover SQLStates (08001, 08S02, 08007) here.
+    // A conflict is converted into a RetriableExecutionException by JdbcDatabase, which tells the
+    // caller the operation definitely did not apply and is safe to retry. A failover gives no such
+    // guarantee: the outcome may be unknown, or the write may already have been applied on the old
+    // writer. See RdbEnginePostgresqlTest#isConflict_GivenFailoverSqlStates_ShouldReturnFalse.
     return e.getSQLState().equals("40001") || e.getSQLState().equals("40P01");
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -117,7 +117,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
         try {
           return scanner.one();
         } catch (ExecutionException e) {
-          throw new CrudException(e.getMessage(), e, txId);
+          throw createCrudException(e);
         }
       }
 
@@ -126,7 +126,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
         try {
           return scanner.all();
         } catch (ExecutionException e) {
-          throw new CrudException(e.getMessage(), e, txId);
+          throw createCrudException(e);
         }
       }
 
@@ -287,14 +287,30 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     try {
       connection.commit();
     } catch (SQLException e) {
+      // The outcome of the failed commit is inferred from whether the rollback below succeeds. That
+      // works because HikariCP evicts a connection whose SQLState starts with "08" (a connection
+      // exception, which is also what the AWS Advanced JDBC Wrapper reports on an Aurora failover),
+      // leaving the rollback to fail and the outcome correctly reported as unknown.
+      //
+      // Do not set HikariCP's exceptionOverrideClassName. AWS recommends it, but its implementation
+      // returns DO_NOT_EVICT for 08007 -- precisely the state that means "outcome unknown". The
+      // connection would then survive, this rollback would succeed as a no-op, and an unknown
+      // outcome would be reported as a CommitException, whose contract tells the caller it is safe
+      // to retry from the beginning. See JdbcTransactionTest and JdbcFailoverExceptionBehaviorTest.
       try {
         connection.rollback();
       } catch (SQLException sqlException) {
-        throw new UnknownTransactionStatusException(
-            CoreError.JDBC_TRANSACTION_UNKNOWN_TRANSACTION_STATUS.buildMessage(
-                sqlException.getMessage()),
-            sqlException,
-            txId);
+        UnknownTransactionStatusException exception =
+            new UnknownTransactionStatusException(
+                CoreError.JDBC_TRANSACTION_UNKNOWN_TRANSACTION_STATUS.buildMessage(
+                    sqlException.getMessage()),
+                sqlException,
+                txId);
+        // Keep the commit failure too. It carries the SQLState explaining why the outcome is
+        // unknown, and without it the caller only sees that a rollback failed, which says nothing
+        // about whether this was an infrastructure event such as an Aurora failover.
+        exception.addSuppressed(e);
+        throw exception;
       }
       throw createCommitException(e);
     } finally {
@@ -357,14 +373,54 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
   }
 
   private CrudException createCrudException(SQLException e, String message) {
-    if (rdbEngine.isConflict(e)) {
+    if (rdbEngine.isConflict(e) || isConnectionException(e)) {
       return new CrudConflictException(
           CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED.buildMessage(e.getMessage()), e, txId);
     }
     return new CrudException(message, e, txId);
   }
 
+  /**
+   * Classifies what a scanner threw the same way a single CRUD operation's {@link SQLException} is
+   * classified.
+   *
+   * <p>The scanner reports a failure while reading the result set as an {@link ExecutionException}
+   * that carries the {@link SQLException} as its cause. Without unwrapping it here, iterating a
+   * scanner would be the one CRUD path where a lost connection is not reported as retriable, even
+   * though the reasoning in {@link #isConnectionException(SQLException)} applies to it just as much
+   * -- more so, since a scan applies nothing at all.
+   */
+  private CrudException createCrudException(ExecutionException e) {
+    if (e.getCause() instanceof SQLException) {
+      return createCrudException((SQLException) e.getCause(), e.getMessage());
+    }
+    return new CrudException(e.getMessage(), e, txId);
+  }
+
+  /**
+   * Returns whether the exception is a connection exception (SQLState class "08"), which includes
+   * everything the AWS Advanced JDBC Wrapper reports on an Aurora failover.
+   *
+   * <p>Losing the connection here, before {@link #commit()} runs, means the transaction was never
+   * committed: the pool opens transactional connections with autoCommit disabled, so nothing has
+   * been applied, and the server discards the open transaction when the connection dies. The
+   * transaction is therefore safe to retry from the beginning.
+   *
+   * <p>This reasoning holds only in the CRUD phase. Do not reuse it for {@link #commit()}, where a
+   * lost connection leaves the outcome genuinely unknown, nor for {@code
+   * RdbEngineStrategy#isConflict}, which the storage layer uses without knowing which phase it is
+   * serving.
+   */
+  private static boolean isConnectionException(SQLException e) {
+    String sqlState = e.getSQLState();
+    return sqlState != null && sqlState.startsWith("08");
+  }
+
   private CommitException createCommitException(SQLException e) {
+    // Unlike createCrudException, connection exceptions (SQLState class "08") are deliberately not
+    // treated as conflicts here. A connection lost during commit leaves the outcome unknown, and a
+    // conflict tells the caller it is safe to retry. They normally never reach this method anyway:
+    // commit() turns them into UnknownTransactionStatusException when the rollback fails.
     if (rdbEngine.isConflict(e)) {
       return new CommitConflictException(
           CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED.buildMessage(e.getMessage()), e, txId);

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -373,7 +373,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
   }
 
   private CrudException createCrudException(SQLException e, String message) {
-    if (rdbEngine.isConflict(e) || isConnectionException(e)) {
+    if (rdbEngine.isConflict(e)) {
       return new CrudConflictException(
           CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED.buildMessage(e.getMessage()), e, txId);
     }
@@ -386,9 +386,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
    *
    * <p>The scanner reports a failure while reading the result set as an {@link ExecutionException}
    * that carries the {@link SQLException} as its cause. Without unwrapping it here, iterating a
-   * scanner would be the one CRUD path where a lost connection is not reported as retriable, even
-   * though the reasoning in {@link #isConnectionException(SQLException)} applies to it just as much
-   * -- more so, since a scan applies nothing at all.
+   * scanner would be the one CRUD path where a conflict is not reported as one.
    */
   private CrudException createCrudException(ExecutionException e) {
     if (e.getCause() instanceof SQLException) {
@@ -397,30 +395,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     return new CrudException(e.getMessage(), e, txId);
   }
 
-  /**
-   * Returns whether the exception is a connection exception (SQLState class "08"), which includes
-   * everything the AWS Advanced JDBC Wrapper reports on an Aurora failover.
-   *
-   * <p>Losing the connection here, before {@link #commit()} runs, means the transaction was never
-   * committed: the pool opens transactional connections with autoCommit disabled, so nothing has
-   * been applied, and the server discards the open transaction when the connection dies. The
-   * transaction is therefore safe to retry from the beginning.
-   *
-   * <p>This reasoning holds only in the CRUD phase. Do not reuse it for {@link #commit()}, where a
-   * lost connection leaves the outcome genuinely unknown, nor for {@code
-   * RdbEngineStrategy#isConflict}, which the storage layer uses without knowing which phase it is
-   * serving.
-   */
-  private static boolean isConnectionException(SQLException e) {
-    String sqlState = e.getSQLState();
-    return sqlState != null && sqlState.startsWith("08");
-  }
-
   private CommitException createCommitException(SQLException e) {
-    // Unlike createCrudException, connection exceptions (SQLState class "08") are deliberately not
-    // treated as conflicts here. A connection lost during commit leaves the outcome unknown, and a
-    // conflict tells the caller it is safe to retry. They normally never reach this method anyway:
-    // commit() turns them into UnknownTransactionStatusException when the rollback fails.
     if (rdbEngine.isConflict(e)) {
       return new CommitConflictException(
           CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED.buildMessage(e.getMessage()), e, txId);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/FailoverSimulatingDriver.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/FailoverSimulatingDriver.java
@@ -1,0 +1,115 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+/**
+ * A JDBC driver that simulates the exceptions the AWS Advanced JDBC Wrapper raises during an Aurora
+ * failover, so the resulting behavior can be pinned without a real database or AWS credentials.
+ *
+ * <p>The connection it hands out succeeds at connect time and during the setup calls HikariCP makes
+ * on a fresh connection. Only {@link Connection#commit()} fails, and only while a SQLState has been
+ * armed via {@link #failOnCommitWith(String)}. This is what makes the interesting path reachable:
+ * the connection must be established and pooled normally before the failure can be observed.
+ *
+ * <p>This class must be public with a public no-arg constructor. HikariCP resolves {@code
+ * driverClassName} by loading the class and calling {@code getDeclaredConstructor().newInstance()}.
+ */
+public class FailoverSimulatingDriver implements Driver {
+
+  public static final String URL_PREFIX = "jdbc:scalardb-failover-test:";
+
+  private static final AtomicReference<String> commitSqlState = new AtomicReference<>();
+
+  /** Arms the driver so the next {@code commit()} throws a {@link SQLException} with this state. */
+  public static void failOnCommitWith(String sqlState) {
+    commitSqlState.set(sqlState);
+  }
+
+  public static void reset() {
+    commitSqlState.set(null);
+  }
+
+  /** Builds a transactional pool backed by this driver, configured the way ScalarDB configures. */
+  public static HikariDataSource createDataSource() {
+    HikariConfig config = new HikariConfig();
+    config.setDriverClassName(FailoverSimulatingDriver.class.getName());
+    config.setJdbcUrl(URL_PREFIX + "//localhost/test");
+    config.setAutoCommit(false);
+    config.setMinimumIdle(0);
+    config.setMaximumPoolSize(1);
+    config.setConnectionTimeout(1000);
+    return new HikariDataSource(config);
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    if (!acceptsURL(url)) {
+      return null;
+    }
+
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(true);
+
+    DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+    when(metaData.getDriverName()).thenReturn(FailoverSimulatingDriver.class.getSimpleName());
+    when(metaData.getDriverVersion()).thenReturn("1.0");
+    when(connection.getMetaData()).thenReturn(metaData);
+
+    doAnswer(
+            invocation -> {
+              String sqlState = commitSqlState.get();
+              if (sqlState != null) {
+                throw new SQLException("Simulated failover", sqlState);
+              }
+              return null;
+            })
+        .when(connection)
+        .commit();
+
+    return connection;
+  }
+
+  @Override
+  public boolean acceptsURL(String url) {
+    return url != null && url.startsWith(URL_PREFIX);
+  }
+
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+    return new DriverPropertyInfo[0];
+  }
+
+  @Override
+  public int getMajorVersion() {
+    return 1;
+  }
+
+  @Override
+  public int getMinorVersion() {
+    return 0;
+  }
+
+  @Override
+  public boolean jdbcCompliant() {
+    return false;
+  }
+
+  @Override
+  public Logger getParentLogger() {
+    return Logger.getLogger(FailoverSimulatingDriver.class.getName());
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcFailoverExceptionBehaviorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcFailoverExceptionBehaviorTest.java
@@ -1,0 +1,105 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
+import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;
+import software.amazon.jdbc.plugin.failover.TransactionStateUnknownSQLException;
+
+/**
+ * Pins the connection-pool behavior that ScalarDB's JDBC failure handling depends on.
+ *
+ * <p>ScalarDB deliberately adds no classification for the AWS Advanced JDBC Wrapper's failover
+ * SQLStates. That is correct only because HikariCP evicts a connection whose SQLState starts with
+ * "08", which makes the subsequent {@code rollback()} fail. {@link
+ * com.scalar.db.transaction.jdbc.JdbcTransaction#commit()} infers "the outcome is unknown" from
+ * exactly that failure. If the eviction stops happening -- because HikariCP changes, or because
+ * someone sets {@code exceptionOverrideClassName} -- the rollback would quietly succeed as a no-op
+ * and an unknown outcome would be reported as a plain commit failure, which the caller is told is
+ * safe to retry.
+ *
+ * <p>These tests exist so that regression is caught in CI rather than in production. The companion
+ * defense for the storage layer lives in {@code RdbEnginePostgresqlTest} and {@code
+ * RdbEngineMysqlTest}, which pin that {@code isConflict} does not match failover SQLStates.
+ */
+class JdbcFailoverExceptionBehaviorTest {
+
+  private HikariDataSource dataSource;
+
+  @BeforeEach
+  void setUp() {
+    FailoverSimulatingDriver.reset();
+    dataSource = FailoverSimulatingDriver.createDataSource();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (dataSource != null) {
+      dataSource.close();
+    }
+    FailoverSimulatingDriver.reset();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"08001", "08S02", "08007"})
+  void commit_GivenFailoverSqlState_ShouldEvictConnectionFromPool(String sqlState)
+      throws SQLException {
+    // Arrange
+    Connection connection = dataSource.getConnection();
+    FailoverSimulatingDriver.failOnCommitWith(sqlState);
+
+    // Act
+    assertThatThrownBy(connection::commit).isInstanceOf(SQLException.class);
+
+    // Assert
+    // HikariCP marked the connection broken, so it is no longer usable. This is the behavior
+    // JdbcTransaction#commit() relies on to distinguish "unknown outcome" from "definitely failed".
+    assertThatThrownBy(connection::rollback)
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("Connection is closed");
+  }
+
+  @Test
+  void commit_GivenNonConnectionSqlState_ShouldKeepConnectionUsable() throws SQLException {
+    // Arrange
+    Connection connection = dataSource.getConnection();
+    // 40001 is a genuine serialization failure. The connection survives it.
+    FailoverSimulatingDriver.failOnCommitWith("40001");
+
+    // Act
+    assertThatThrownBy(connection::commit).isInstanceOf(SQLException.class);
+
+    // Assert
+    // The connection was not evicted, so rollback still works. JdbcTransaction#commit() therefore
+    // classifies this as a definite failure rather than an unknown outcome -- which is correct.
+    assertThat(connection.isClosed()).isFalse();
+    connection.rollback();
+    connection.close();
+  }
+
+  /**
+   * The whole design rests on the AWS Advanced JDBC Wrapper reporting failover with a SQLState that
+   * HikariCP recognizes as a connection exception, carried on the exception itself rather than on a
+   * cause -- HikariCP walks {@code getNextException()} but never {@code getCause()}.
+   *
+   * <p>Pin that contract against the bundled wrapper so a version bump that changes it fails here
+   * instead of silently removing the eviction the rest of this class depends on.
+   */
+  @Test
+  void wrapperFailoverExceptions_ShouldCarryConnectionSqlStateAtTopLevel() {
+    // Act
+    // Assert
+    assertThat(new FailoverSuccessSQLException().getSQLState()).startsWith("08");
+    assertThat(new TransactionStateUnknownSQLException().getSQLState()).startsWith("08");
+    assertThat(new FailoverFailedSQLException("failover failed").getSQLState()).startsWith("08");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
@@ -10,6 +11,9 @@ import com.google.common.collect.ImmutableMap;
 import com.scalar.db.config.DatabaseConfig;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
@@ -490,5 +494,39 @@ public class JdbcUtilsTest {
             JdbcUtils.removeAwsWrapperPrefix(
                 "jdbc:aws-wrapper:mysql://h:3306/db?permitMysqlScheme=true"))
         .isEqualTo("jdbc:mysql://h:3306/db?permitMysqlScheme=true");
+  }
+
+  /**
+   * HikariCP reads {@code hikaricp.configurationFile} in its constructor, so this setting can
+   * arrive without ScalarDB configuration being involved -- and AWS documentation recommends
+   * setting it when using their JDBC wrapper. It must be refused rather than silently breaking the
+   * inference {@link com.scalar.db.transaction.jdbc.JdbcTransaction#commit()} relies on.
+   */
+  @Test
+  public void initDataSource_GivenHikariExceptionOverrideConfigured_ShouldThrowException()
+      throws Exception {
+    // Arrange
+    Path configFile = Files.createTempFile("hikari", ".properties");
+    try {
+      Files.write(
+          configFile,
+          "exceptionOverrideClassName=software.amazon.jdbc.util.HikariCPSQLException"
+              .getBytes(StandardCharsets.UTF_8));
+      System.setProperty("hikaricp.configurationFile", configFile.toString());
+
+      Properties properties = new Properties();
+      properties.setProperty(
+          DatabaseConfig.CONTACT_POINTS, "jdbc:postgresql://localhost:5432/test");
+      properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+      JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+
+      // Act Assert
+      assertThatThrownBy(() -> JdbcUtils.initDataSource(config, rdbEngine))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("exceptionOverrideClassName");
+    } finally {
+      System.clearProperty("hikaricp.configurationFile");
+      Files.deleteIfExists(configFile);
+    }
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -390,4 +390,105 @@ public class JdbcUtilsTest {
     // Assert
     assertThat(result1).isNotEqualTo(result2);
   }
+
+  /**
+   * The AWS Advanced JDBC Wrapper supplies its own driver, and the URL must keep the
+   * "jdbc:aws-wrapper:" prefix because that is what routes the connection through it. The engine's
+   * own getDriverClassName() is left alone; only what reaches the pool changes.
+   */
+  @Test
+  public void initDataSource_GivenAwsWrapperUrl_ShouldUseWrapperDriverAndKeepPrefix() {
+    // Arrange
+    String jdbcUrl = "jdbc:aws-wrapper:postgresql://localhost:5432/test";
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.CONTACT_POINTS, jdbcUrl);
+    properties.setProperty(DatabaseConfig.USERNAME, "postgres");
+    properties.setProperty(DatabaseConfig.PASSWORD, "postgres");
+    properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+
+    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    when(rdbEngine.getDriverClassName()).thenReturn("org.postgresql.Driver");
+    when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl(jdbcUrl)).thenReturn(jdbcUrl);
+
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSource(config, rdbEngine);
+    }
+
+    // Assert
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("software.amazon.jdbc.Driver");
+    assertThat(hikariConfig.getJdbcUrl()).isEqualTo(jdbcUrl);
+  }
+
+  @Test
+  public void initDataSource_GivenNonAwsWrapperUrl_ShouldKeepEngineDriverClass() {
+    // Arrange
+    String jdbcUrl = "jdbc:postgresql://localhost:5432/test";
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.CONTACT_POINTS, jdbcUrl);
+    properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+
+    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    when(rdbEngine.getDriverClassName()).thenReturn("org.postgresql.Driver");
+    when(rdbEngine.getConnectionProperties(config)).thenReturn(Collections.emptyMap());
+    when(rdbEngine.adjustJdbcUrl(jdbcUrl)).thenReturn(jdbcUrl);
+
+    AtomicReference<HikariConfig> capturedConfig = new AtomicReference<>();
+
+    try (MockedStatic<JdbcUtils> jdbcUtils =
+        Mockito.mockStatic(
+            JdbcUtils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+      jdbcUtils
+          .when(() -> JdbcUtils.createDataSource(Mockito.any(HikariConfig.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedConfig.set(invocation.getArgument(0));
+                return Mockito.mock(HikariDataSource.class);
+              });
+
+      // Act
+      JdbcUtils.initDataSource(config, rdbEngine);
+    }
+
+    // Assert
+    HikariConfig hikariConfig = capturedConfig.get();
+    assertThat(hikariConfig).isNotNull();
+    assertThat(hikariConfig.getDriverClassName()).isEqualTo("org.postgresql.Driver");
+  }
+
+  @Test
+  public void isAwsWrapperUrl_ShouldMatchOnlyTheExactPrefix() {
+    // Act Assert
+    assertThat(JdbcUtils.isAwsWrapperUrl("jdbc:aws-wrapper:postgresql://h/db")).isTrue();
+    assertThat(JdbcUtils.isAwsWrapperUrl("jdbc:aws-wrapper:mysql://h/db")).isTrue();
+    assertThat(JdbcUtils.isAwsWrapperUrl("jdbc:postgresql://h/db")).isFalse();
+    assertThat(JdbcUtils.isAwsWrapperUrl("jdbc:aws-wrapperfoo:postgresql://h/db")).isFalse();
+    assertThat(JdbcUtils.isAwsWrapperUrl(null)).isFalse();
+  }
+
+  @Test
+  public void removeAwsWrapperPrefix_ShouldExposeUnderlyingUrl() {
+    // Act Assert
+    assertThat(JdbcUtils.removeAwsWrapperPrefix("jdbc:aws-wrapper:postgresql://h:5432/db"))
+        .isEqualTo("jdbc:postgresql://h:5432/db");
+    assertThat(
+            JdbcUtils.removeAwsWrapperPrefix(
+                "jdbc:aws-wrapper:mysql://h:3306/db?permitMysqlScheme=true"))
+        .isEqualTo("jdbc:mysql://h:3306/db?permitMysqlScheme=true");
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineFactoryTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineFactoryTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.jdbc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -210,5 +211,129 @@ class RdbEngineFactoryTest {
     assertThatThrownBy(() -> RdbEngineFactory.create(config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED.buildMessage(unsupportedUrl));
+  }
+
+  @Test
+  void create_GivenAwsWrapperPostgresqlUrl_ShouldReturnRdbEnginePostgresql() {
+    // Arrange
+    JdbcConfig config = configWithUrl("jdbc:aws-wrapper:postgresql://localhost:5432/test");
+
+    // Act
+    RdbEngineStrategy engine = RdbEngineFactory.create(config);
+
+    // Assert
+    assertThat(engine).isInstanceOf(RdbEnginePostgresql.class);
+  }
+
+  @Test
+  void create_GivenAwsWrapperMysqlUrlAndMysqlServer_ShouldReturnRdbEngineMysql()
+      throws SQLException {
+    // Arrange
+    JdbcConfig config = configWithUrl("jdbc:aws-wrapper:mysql://localhost:3306/test");
+    HikariDataSource dataSource = mock(HikariDataSource.class);
+    Connection connection = mock(Connection.class);
+    DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.getMetaData()).thenReturn(metaData);
+    when(metaData.getDatabaseProductVersion()).thenReturn("8.0.44");
+
+    // The wrapper-URL helpers must keep their real behavior, so only the data source is stubbed.
+    try (MockedStatic<JdbcUtils> mocked = mockStatic(JdbcUtils.class, CALLS_REAL_METHODS)) {
+      mocked
+          .when(() -> JdbcUtils.initDataSourceForAdmin(any(JdbcConfig.class), any()))
+          .thenReturn(dataSource);
+
+      // Act
+      RdbEngineStrategy engine = RdbEngineFactory.create(config);
+
+      // Assert
+      assertThat(engine).isInstanceOf(RdbEngineMysql.class);
+      assertThat(engine).isNotInstanceOf(RdbEngineTidb.class);
+    }
+  }
+
+  @Test
+  void create_GivenAwsWrapperMysqlUrlAndTidbServer_ShouldThrowIllegalArgumentException()
+      throws SQLException {
+    // Arrange
+    String jdbcUrl = "jdbc:aws-wrapper:mysql://localhost:4000/test";
+    JdbcConfig config = configWithUrl(jdbcUrl);
+    HikariDataSource dataSource = mock(HikariDataSource.class);
+    Connection connection = mock(Connection.class);
+    DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.getMetaData()).thenReturn(metaData);
+    when(metaData.getDatabaseProductVersion()).thenReturn("5.7.25-TiDB-v6.1.0");
+
+    try (MockedStatic<JdbcUtils> mocked = mockStatic(JdbcUtils.class, CALLS_REAL_METHODS)) {
+      mocked
+          .when(() -> JdbcUtils.initDataSourceForAdmin(any(JdbcConfig.class), any()))
+          .thenReturn(dataSource);
+
+      // Act Assert
+      // TiDB is untested through the wrapper, so it is rejected like MariaDB.
+      assertThatThrownBy(() -> RdbEngineFactory.create(config))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER.buildMessage(
+                  jdbcUrl));
+    }
+  }
+
+  @Test
+  void create_GivenAwsWrapperMariadbUrl_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String jdbcUrl = "jdbc:aws-wrapper:mariadb://localhost:3306/test";
+    JdbcConfig config = configWithUrl(jdbcUrl);
+
+    // Act Assert
+    // The wrapper supports MariaDB, but ScalarDB does not test that combination for Aurora.
+    assertThatThrownBy(() -> RdbEngineFactory.create(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        // The message must show the URL the user configured, not the prefix-stripped one.
+        .hasMessage(
+            CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER.buildMessage(
+                jdbcUrl));
+  }
+
+  @Test
+  void create_GivenAwsWrapperUnsupportedUrl_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String jdbcUrl = "jdbc:aws-wrapper:oracle:thin:@//localhost:1521/FREEPDB1";
+    JdbcConfig config = configWithUrl(jdbcUrl);
+
+    // Act Assert
+    assertThatThrownBy(() -> RdbEngineFactory.create(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER.buildMessage(
+                jdbcUrl));
+  }
+
+  @Test
+  void create_GivenAwsWrapperUrlWithoutUnderlyingScheme_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String jdbcUrl = "jdbc:aws-wrapper:";
+    JdbcConfig config = configWithUrl(jdbcUrl);
+
+    // Act Assert
+    assertThatThrownBy(() -> RdbEngineFactory.create(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED_WITH_AWS_ADVANCED_JDBC_WRAPPER.buildMessage(
+                jdbcUrl));
+  }
+
+  @Test
+  void create_GivenUrlOnlyResemblingAwsWrapperPrefix_ShouldNotBeTreatedAsWrapper() {
+    // Arrange
+    // "jdbc:aws-wrapperfoo:" must not be mistaken for the wrapper prefix.
+    String jdbcUrl = "jdbc:aws-wrapperfoo:postgresql://localhost:5432/test";
+    JdbcConfig config = configWithUrl(jdbcUrl);
+
+    // Act Assert
+    assertThatThrownBy(() -> RdbEngineFactory.create(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(CoreError.JDBC_RDB_ENGINE_NOT_SUPPORTED.buildMessage(jdbcUrl));
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
@@ -52,4 +52,98 @@ class RdbEngineMysqlTest {
 
     verify(connection, never()).setReadOnly(anyBoolean());
   }
+
+  /**
+   * The AWS Advanced JDBC Wrapper reports failover with SQLState 08001, 08S02, and 08007. These
+   * must never be treated as conflicts. {@link com.scalar.db.storage.jdbc.JdbcDatabase} converts a
+   * conflict into a {@code RetriableExecutionException}, which tells the caller the operation
+   * definitely did not apply and is safe to retry. That guarantee does not hold for a failover,
+   * where the outcome may be unknown or the write may already have been applied. Adding a failover
+   * error to this check would silently break the storage layer's safety.
+   */
+  @Test
+  void isConflict_GivenFailoverSqlStates_ShouldReturnFalse() {
+    // Act
+    // Assert
+    assertThat(rdbEngineMysql.isConflict(new SQLException("failover failed", "08001"))).isFalse();
+    assertThat(rdbEngineMysql.isConflict(new SQLException("communication link changed", "08S02")))
+        .isFalse();
+    assertThat(
+            rdbEngineMysql.isConflict(new SQLException("transaction resolution unknown", "08007")))
+        .isFalse();
+  }
+
+  @Test
+  void isConflict_GivenDeadlockOrLockWaitTimeout_ShouldReturnTrue() {
+    // Act
+    // Assert
+    assertThat(rdbEngineMysql.isConflict(new SQLException("deadlock found", "40001", 1213)))
+        .isTrue();
+    assertThat(rdbEngineMysql.isConflict(new SQLException("lock wait timeout", "HY000", 1205)))
+        .isTrue();
+  }
+
+  @Test
+  void isConflict_GivenNullSqlState_ShouldReturnFalse() {
+    // Act
+    // Assert
+    assertThat(rdbEngineMysql.isConflict(new SQLException("no sql state"))).isFalse();
+  }
+
+  /**
+   * ScalarDB reaches MySQL through MariaDB Connector/J and does not bundle MySQL Connector/J, but
+   * the AWS Advanced JDBC Wrapper defaults to the MySQL Connector/J dialect for a "jdbc:mysql://"
+   * URL. Without the dialect parameter the wrapper asks for a driver that is not on the classpath.
+   */
+  @Test
+  void adjustJdbcUrl_GivenAwsWrapperUrl_ShouldAppendSchemeAndDialectParameters() {
+    String result = rdbEngineMysql.adjustJdbcUrl("jdbc:aws-wrapper:mysql://localhost:3306/");
+    assertThat(result)
+        .isEqualTo(
+            "jdbc:aws-wrapper:mysql://localhost:3306/"
+                + "?permitMysqlScheme=true&wrapperTargetDriverDialect=mariadb-connector-j-3");
+  }
+
+  @Test
+  void adjustJdbcUrl_GivenAwsWrapperUrlWithExistingParams_ShouldAppendWithAmpersand() {
+    String result =
+        rdbEngineMysql.adjustJdbcUrl("jdbc:aws-wrapper:mysql://localhost:3306/?sslMode=REQUIRED");
+    assertThat(result)
+        .isEqualTo(
+            "jdbc:aws-wrapper:mysql://localhost:3306/?sslMode=REQUIRED"
+                + "&permitMysqlScheme=true&wrapperTargetDriverDialect=mariadb-connector-j-3");
+  }
+
+  @Test
+  void adjustJdbcUrl_GivenAwsWrapperUrlWithDialectAlreadySet_ShouldNotOverrideIt() {
+    String url =
+        "jdbc:aws-wrapper:mysql://localhost:3306/?wrapperTargetDriverDialect=mysql-connector-j";
+    String result = rdbEngineMysql.adjustJdbcUrl(url);
+    // The user's explicit choice survives; only the scheme parameter is added.
+    assertThat(result).isEqualTo(url + "&permitMysqlScheme=true");
+  }
+
+  @Test
+  void adjustJdbcUrl_GivenAwsWrapperUrlWithSchemeParameterAlreadySet_ShouldAppendDialectOnly() {
+    // What an existing MySQL user ends up with after prefixing their URL to adopt the wrapper.
+    String url = "jdbc:aws-wrapper:mysql://localhost:3306/?permitMysqlScheme=true";
+    String result = rdbEngineMysql.adjustJdbcUrl(url);
+    assertThat(result).isEqualTo(url + "&wrapperTargetDriverDialect=mariadb-connector-j-3");
+  }
+
+  @Test
+  void adjustJdbcUrl_GivenAwsWrapperUrlWithBothParametersSet_ShouldReturnAsIs() {
+    String url =
+        "jdbc:aws-wrapper:mysql://localhost:3306/"
+            + "?permitMysqlScheme=true&wrapperTargetDriverDialect=mariadb-connector-j-3";
+    String result = rdbEngineMysql.adjustJdbcUrl(url);
+    assertThat(result).isEqualTo(url);
+  }
+
+  @Test
+  void adjustJdbcUrl_GivenNonAwsWrapperUrl_ShouldNotAppendDialectParameter() {
+    String result = rdbEngineMysql.adjustJdbcUrl("jdbc:mysql://localhost:3306/");
+    assertThat(result).isEqualTo("jdbc:mysql://localhost:3306/?permitMysqlScheme=true");
+    assertThat(result).doesNotContain("wrapperTargetDriverDialect");
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
+import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 
 class RdbEnginePostgresqlTest {
@@ -54,5 +55,48 @@ class RdbEnginePostgresqlTest {
     // Assert
     assertThat(sqls).hasSize(1);
     assertThat(sqls[0]).startsWith("CREATE UNIQUE INDEX ");
+  }
+
+  /**
+   * The AWS Advanced JDBC Wrapper reports failover with SQLState 08001, 08S02, and 08007. These
+   * must never be treated as conflicts. {@link com.scalar.db.storage.jdbc.JdbcDatabase} converts a
+   * conflict into a {@code RetriableExecutionException}, which tells the caller the operation
+   * definitely did not apply and is safe to retry. That guarantee does not hold for a failover,
+   * where the outcome may be unknown or the write may already have been applied. Adding a failover
+   * SQLState here would silently break the storage layer's safety.
+   */
+  @Test
+  void isConflict_GivenFailoverSqlStates_ShouldReturnFalse() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+
+    // Act
+    // Assert
+    assertThat(rdbEngine.isConflict(new SQLException("failover failed", "08001"))).isFalse();
+    assertThat(rdbEngine.isConflict(new SQLException("communication link changed", "08S02")))
+        .isFalse();
+    assertThat(rdbEngine.isConflict(new SQLException("transaction resolution unknown", "08007")))
+        .isFalse();
+  }
+
+  @Test
+  void isConflict_GivenSerializationFailureOrDeadlock_ShouldReturnTrue() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+
+    // Act
+    // Assert
+    assertThat(rdbEngine.isConflict(new SQLException("serialization failure", "40001"))).isTrue();
+    assertThat(rdbEngine.isConflict(new SQLException("deadlock detected", "40P01"))).isTrue();
+  }
+
+  @Test
+  void isConflict_GivenNullSqlState_ShouldReturnFalse() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+
+    // Act
+    // Assert
+    assertThat(rdbEngine.isConflict(new SQLException("no sql state"))).isFalse();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
@@ -1177,59 +1177,13 @@ public class JdbcTransactionTest {
   }
 
   /**
-   * Losing the connection during the CRUD phase means the transaction was never committed: the pool
-   * opens transactional connections with autoCommit disabled, so nothing has been applied and the
-   * server discards the open transaction. Reporting this as a conflict lets an application's normal
-   * retry loop absorb an Aurora failover instead of surfacing it as a generic failure.
-   */
-  @ParameterizedTest
-  @ValueSource(strings = {"08001", "08S02", "08007", "08006"})
-  public void get_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException(String sqlState)
-      throws ExecutionException, SQLException {
-    // Arrange
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .build();
-    when(jdbcCrudService.get(any(Get.class), any(Connection.class)))
-        .thenThrow(new SQLException("Simulated failover", sqlState));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(CrudConflictException.class);
-  }
-
-  @Test
-  public void get_WhenNonConnectionExceptionThrown_ShouldThrowPlainCrudException()
-      throws ExecutionException, SQLException {
-    // Arrange
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .build();
-    // 42P01 is undefined_table -- an application error, not something a retry would fix.
-    when(jdbcCrudService.get(any(Get.class), any(Connection.class)))
-        .thenThrow(new SQLException("Undefined table", "42P01"));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.get(get))
-        .isInstanceOf(CrudException.class)
-        .isNotInstanceOf(CrudConflictException.class);
-  }
-
-  /**
    * The scanner reports a read failure as an {@link ExecutionException} carrying the {@link
-   * SQLException} as its cause, so iterating one would otherwise be the only CRUD path that misses
-   * the classification above and reports a failover as a non-retriable {@link CrudException}.
+   * SQLException} as its cause, so without unwrapping it, iterating one would be the only CRUD path
+   * that fails to recognize a conflict.
    */
-  @ParameterizedTest
-  @ValueSource(strings = {"08001", "08S02", "08007", "08006"})
-  public void
-      getScannerAndScannerOne_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException(
-          String sqlState) throws ExecutionException, SQLException, CrudException {
+  @Test
+  public void getScannerAndScannerOne_WhenConflictThrown_ShouldThrowCrudConflictException()
+      throws ExecutionException, SQLException, CrudException {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1242,8 +1196,9 @@ public class JdbcTransactionTest {
         .thenThrow(
             new ExecutionException(
                 "Fetching the next result failed",
-                new SQLException("Simulated failover", sqlState)));
+                new SQLException("Serialization failure", "40001")));
     when(jdbcCrudService.getScanner(scan, connection, false)).thenReturn(scanner);
+    when(rdbEngineStrategy.isConflict(any(SQLException.class))).thenReturn(true);
 
     // Act Assert
     TransactionCrudOperable.Scanner actual = transaction.getScanner(scan);
@@ -1251,9 +1206,8 @@ public class JdbcTransactionTest {
   }
 
   @Test
-  public void
-      getScannerAndScannerAll_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException()
-          throws ExecutionException, SQLException, CrudException {
+  public void getScannerAndScannerAll_WhenConflictThrown_ShouldThrowCrudConflictException()
+      throws ExecutionException, SQLException, CrudException {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1266,8 +1220,9 @@ public class JdbcTransactionTest {
         .thenThrow(
             new ExecutionException(
                 "Fetching the next result failed",
-                new SQLException("Simulated failover", "08S02")));
+                new SQLException("Serialization failure", "40001")));
     when(jdbcCrudService.getScanner(scan, connection, false)).thenReturn(scanner);
+    when(rdbEngineStrategy.isConflict(any(SQLException.class))).thenReturn(true);
 
     // Act Assert
     TransactionCrudOperable.Scanner actual = transaction.getScanner(scan);
@@ -1275,9 +1230,8 @@ public class JdbcTransactionTest {
   }
 
   @Test
-  public void
-      getScannerAndScannerOne_WhenNonConnectionExceptionThrown_ShouldThrowPlainCrudException()
-          throws ExecutionException, SQLException, CrudException {
+  public void getScannerAndScannerOne_WhenNonConflictThrown_ShouldThrowPlainCrudException()
+      throws ExecutionException, SQLException, CrudException {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1286,7 +1240,6 @@ public class JdbcTransactionTest {
             .partitionKey(Key.ofText("p1", "val"))
             .build();
     Scanner scanner = mock(Scanner.class);
-    // 42P01 is undefined_table -- an application error, not something a retry would fix.
     when(scanner.one())
         .thenThrow(
             new ExecutionException(

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.jdbc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -23,12 +24,17 @@ import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.io.Key;
+import com.scalar.db.storage.jdbc.FailoverSimulatingDriver;
 import com.scalar.db.storage.jdbc.JdbcCrudService;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
+import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -43,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -1093,5 +1100,228 @@ public class JdbcTransactionTest {
     // Act Assert
     assertThatThrownBy(() -> transaction.batch(Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * {@link JdbcTransaction#commit()} infers the transaction outcome from whether the follow-up
+   * {@code rollback()} succeeds. That inference is sound only because HikariCP evicts a connection
+   * whose SQLState starts with "08", which is exactly the range the AWS Advanced JDBC Wrapper uses
+   * to report a failover. Setting HikariCP's {@code exceptionOverrideClassName} -- which AWS
+   * recommends -- would keep the connection alive, let the rollback succeed as a no-op, and turn an
+   * unknown outcome into a {@link com.scalar.db.exception.transaction.CommitException} whose
+   * contract tells the caller it is safe to retry from the beginning.
+   *
+   * <p>These tests run against a real HikariCP pool so the eviction is genuinely exercised. See
+   * {@code JdbcFailoverExceptionBehaviorTest} for the pool-level counterpart.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"08001", "08S02", "08007"})
+  public void commit_WhenFailoverSqlStateThrown_ShouldThrowUnknownTransactionStatusException(
+      String sqlState) throws SQLException {
+    // Arrange
+    try (HikariDataSource dataSource = FailoverSimulatingDriver.createDataSource()) {
+      Connection pooledConnection = dataSource.getConnection();
+      JdbcTransaction target =
+          new JdbcTransaction(ANY_TX_ID, jdbcCrudService, pooledConnection, rdbEngineStrategy);
+      FailoverSimulatingDriver.failOnCommitWith(sqlState);
+
+      // Act Assert
+      assertThatThrownBy(target::commit).isInstanceOf(UnknownTransactionStatusException.class);
+    } finally {
+      FailoverSimulatingDriver.reset();
+    }
+  }
+
+  @Test
+  public void commit_WhenConflictThrownAndConnectionAlive_ShouldThrowCommitConflictException()
+      throws SQLException {
+    // Arrange
+    try (HikariDataSource dataSource = FailoverSimulatingDriver.createDataSource()) {
+      Connection pooledConnection = dataSource.getConnection();
+      JdbcTransaction target =
+          new JdbcTransaction(ANY_TX_ID, jdbcCrudService, pooledConnection, rdbEngineStrategy);
+      when(rdbEngineStrategy.isConflict(any(SQLException.class))).thenReturn(true);
+      // 40001 is a genuine serialization failure. HikariCP does not evict, so the rollback
+      // succeeds and the outcome is known to be a failure rather than unknown.
+      FailoverSimulatingDriver.failOnCommitWith("40001");
+
+      // Act Assert
+      assertThatThrownBy(target::commit).isInstanceOf(CommitConflictException.class);
+    } finally {
+      FailoverSimulatingDriver.reset();
+    }
+  }
+
+  @Test
+  public void commit_WhenNonConflictThrownAndConnectionAlive_ShouldThrowPlainCommitException()
+      throws SQLException {
+    // Arrange
+    try (HikariDataSource dataSource = FailoverSimulatingDriver.createDataSource()) {
+      Connection pooledConnection = dataSource.getConnection();
+      JdbcTransaction target =
+          new JdbcTransaction(ANY_TX_ID, jdbcCrudService, pooledConnection, rdbEngineStrategy);
+      when(rdbEngineStrategy.isConflict(any(SQLException.class))).thenReturn(false);
+      // 42000 is a syntax error or access rule violation: neither a conflict nor a connection
+      // exception. HikariCP does not evict, so the rollback succeeds and the transaction is known
+      // to have failed. Reporting it as unknown would send the caller reconciling a transaction
+      // that plainly did not commit.
+      FailoverSimulatingDriver.failOnCommitWith("42000");
+
+      // Act Assert
+      assertThatThrownBy(target::commit)
+          .isInstanceOf(CommitException.class)
+          .isNotInstanceOf(CommitConflictException.class);
+    } finally {
+      FailoverSimulatingDriver.reset();
+    }
+  }
+
+  /**
+   * Losing the connection during the CRUD phase means the transaction was never committed: the pool
+   * opens transactional connections with autoCommit disabled, so nothing has been applied and the
+   * server discards the open transaction. Reporting this as a conflict lets an application's normal
+   * retry loop absorb an Aurora failover instead of surfacing it as a generic failure.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"08001", "08S02", "08007", "08006"})
+  public void get_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException(String sqlState)
+      throws ExecutionException, SQLException {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .build();
+    when(jdbcCrudService.get(any(Get.class), any(Connection.class)))
+        .thenThrow(new SQLException("Simulated failover", sqlState));
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void get_WhenNonConnectionExceptionThrown_ShouldThrowPlainCrudException()
+      throws ExecutionException, SQLException {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .build();
+    // 42P01 is undefined_table -- an application error, not something a retry would fix.
+    when(jdbcCrudService.get(any(Get.class), any(Connection.class)))
+        .thenThrow(new SQLException("Undefined table", "42P01"));
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.get(get))
+        .isInstanceOf(CrudException.class)
+        .isNotInstanceOf(CrudConflictException.class);
+  }
+
+  /**
+   * The scanner reports a read failure as an {@link ExecutionException} carrying the {@link
+   * SQLException} as its cause, so iterating one would otherwise be the only CRUD path that misses
+   * the classification above and reports a failover as a non-retriable {@link CrudException}.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"08001", "08S02", "08007", "08006"})
+  public void
+      getScannerAndScannerOne_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException(
+          String sqlState) throws ExecutionException, SQLException, CrudException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.one())
+        .thenThrow(
+            new ExecutionException(
+                "Fetching the next result failed",
+                new SQLException("Simulated failover", sqlState)));
+    when(jdbcCrudService.getScanner(scan, connection, false)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner actual = transaction.getScanner(scan);
+    assertThatThrownBy(actual::one).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void
+      getScannerAndScannerAll_WhenConnectionExceptionThrown_ShouldThrowCrudConflictException()
+          throws ExecutionException, SQLException, CrudException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.all())
+        .thenThrow(
+            new ExecutionException(
+                "Fetching the next result failed",
+                new SQLException("Simulated failover", "08S02")));
+    when(jdbcCrudService.getScanner(scan, connection, false)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner actual = transaction.getScanner(scan);
+    assertThatThrownBy(actual::all).isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void
+      getScannerAndScannerOne_WhenNonConnectionExceptionThrown_ShouldThrowPlainCrudException()
+          throws ExecutionException, SQLException, CrudException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+    Scanner scanner = mock(Scanner.class);
+    // 42P01 is undefined_table -- an application error, not something a retry would fix.
+    when(scanner.one())
+        .thenThrow(
+            new ExecutionException(
+                "Fetching the next result failed", new SQLException("Undefined table", "42P01")));
+    when(jdbcCrudService.getScanner(scan, connection, false)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner actual = transaction.getScanner(scan);
+    assertThatThrownBy(actual::one)
+        .isInstanceOf(CrudException.class)
+        .isNotInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void commit_WhenFailoverSqlStateThrown_ShouldKeepOriginalFailureAsSuppressed()
+      throws SQLException {
+    // Arrange
+    try (HikariDataSource dataSource = FailoverSimulatingDriver.createDataSource()) {
+      Connection pooledConnection = dataSource.getConnection();
+      JdbcTransaction target =
+          new JdbcTransaction(ANY_TX_ID, jdbcCrudService, pooledConnection, rdbEngineStrategy);
+      FailoverSimulatingDriver.failOnCommitWith("08007");
+
+      // Act
+      Throwable thrown = catchThrowable(target::commit);
+
+      // Assert
+      assertThat(thrown).isInstanceOf(UnknownTransactionStatusException.class);
+      // Without this the caller only learns that a rollback failed, which says nothing about the
+      // failover that made the outcome unknown in the first place.
+      assertThat(thrown.getSuppressed()).hasSize(1);
+      assertThat(thrown.getSuppressed()[0]).isInstanceOf(SQLException.class);
+      assertThat(((SQLException) thrown.getSuppressed()[0]).getSQLState()).isEqualTo("08007");
+    } finally {
+      FailoverSimulatingDriver.reset();
+    }
   }
 }


### PR DESCRIPTION
## Description

Running ScalarDB on Aurora means that a writer failover stalls writes while the client waits for DNS to propagate. Measured against real Aurora clusters, that stall was about 26 seconds.

The AWS Advanced JDBC Wrapper avoids the wait by discovering the cluster topology and reconnecting to the new writer directly, but ScalarDB could not use it: `RdbEngineFactory` dispatches on the JDBC URL prefix and did not recognize `jdbc:aws-wrapper:`, so startup failed outright.

The interesting part turned out not to be the URL handling. ScalarDB already reports failover outcomes correctly, but for two different reasons on two different code paths, and neither was covered by a test. Most of this PR is about making those reasons explicit and keeping them from being broken.

## Related issues and/or PRs

N/A

## Changes made

**Accept the wrapper's URLs**

- `RdbEngineFactory` recognizes `jdbc:aws-wrapper:` and picks the engine from the URL underneath the prefix. Only Aurora PostgreSQL and Aurora MySQL are accepted; the wrapper also supports MariaDB, but allowing an untested combination would let it fail in subtler ways than an unsupported-engine error at startup.
- `JdbcUtils` hands the connection pool the wrapper's driver. Each engine's `getDriverClassName()` is left untouched.
- The URL given to HikariCP keeps the `jdbc:aws-wrapper:` prefix. Stripping it is only how the RDB dialect is identified; the prefix is what routes the connection through the wrapper at all. The unsupported-engine error also reports the URL the user configured rather than the stripped one.
- MySQL gets `wrapperTargetDriverDialect=mariadb-connector-j-3` added automatically. ScalarDB reaches MySQL through MariaDB Connector/J and does not bundle MySQL Connector/J, but the wrapper defaults to the MySQL Connector/J dialect for a `jdbc:mysql://` URL. A dialect the user set explicitly is left alone.

**Bundle the wrapper**

- Added to `core` as an `implementation` dependency, following how the AlloyDB connector is handled. All of the wrapper's declared dependencies are optional, so nothing is pulled in transitively — in particular, MySQL Connector/J is not among them and no MySQL code ships.

**Pin the failover exception handling**

No new classification code was needed, but the existing behavior was undocumented and untested:

- `JdbcTransaction#commit()` infers "outcome unknown" from the rollback failing. That only works because HikariCP evicts a connection whose SQLState starts with `08`. Setting HikariCP's `exceptionOverrideClassName`, which AWS recommends, would keep the connection alive, let the rollback succeed as a no-op, and report an unknown outcome as a `CommitException` — whose contract tells the caller it is safe to retry.
- `JdbcDatabase` relies on `isConflict` not matching failover SQLStates. Eviction is irrelevant there; adding `08*` to `isConflict` would turn an unknown outcome into a `RetriableExecutionException`.

Added a driver that simulates the failover exceptions so both paths can be exercised against a real HikariCP pool without a database or AWS credentials, plus a test that pins the wrapper's own exception contract so a version bump cannot silently change it.

**Refuse to start when HikariCP has an exception override configured**

The inference above only holds while HikariCP actually discards the connection. `HikariConfig`'s constructor reads `hikaricp.configurationFile`, so `exceptionOverrideClassName` can arrive without ScalarDB configuration being touched — and AWS documentation recommends setting it. Startup now fails instead, because the alternative is invisible: it surfaces only during a failover, looks like an ordinary retry, and gets found by noticing duplicated data.

**Classify what a scanner throws**

A scanner reports a read failure as an `ExecutionException` wrapping the `SQLException`, so iterating one was the only CRUD path that could not recognize a conflict. It now unwraps and classifies like a single operation.

**Stop discarding the commit failure**

When the follow-up rollback failed, the thrown `UnknownTransactionStatusException` described only the failed rollback, so a caller hitting a failover saw "Rolling back the transaction failed" with no trace of the SQLState that made the outcome unknown. The original failure is now kept as a suppressed exception.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

**One change reaches beyond Aurora.** Refusing to start when `exceptionOverrideClassName` is set applies to every JDBC deployment, not only wrapper users, because the inference it protects is not Aurora-specific either — a plain connection drop mid-commit reports the same SQLState class on any backend. An existing deployment that sets the override will now fail to start. That is intended: such a deployment is already exposed. Worth a look during review.

An earlier revision of this PR also reported a CRUD-phase connection failure as a conflict. That has been dropped after review: SQLState class 08 describes the cause rather than whether a retry helps, and it covers both a writer failover and a database that has gone away for good. `CrudException` already tells callers they may retry, so nothing changes for applications, and Consensus Commit reports the same event the same way.

**Verified against real Aurora clusters** (PostgreSQL 17.10 and MySQL 8.0.44, two instances each, since a managed failover promotes a reader). The clusters were deleted afterwards.

| | Write failures / attempts | Error window |
|---|---|---|
| With the wrapper | 1 / 560 | ~0 ms |
| Without | 90 / 617 | 26,159 ms |

Also confirmed there: Aurora MySQL connects through the existing MariaDB Connector/J, it is not mistaken for TiDB, and every failover exception carries its `08` SQLState on the exception itself rather than on a cause — which matters because HikariCP walks `getNextException()` but never `getCause()`.

**A note on `08S02`.** AWS documents it as "failover succeeded outside of a transaction", but that does not hold for how ScalarDB drives transactions. The wrapper decides between `08S02` and `08007` using `pluginService.isInTransaction()`, which tracks transaction state by parsing SQL text (`BEGIN` / `COMMIT`). ScalarDB uses the JDBC API instead, so the wrapper does not see a transaction in progress, and a commit that failed with uncommitted changes still reports `08S02`. Observed on a real cluster. It is handled correctly either way — both states start with `08`, so HikariCP evicts and the outcome is reported as unknown — but it is the reason no failover SQLState is treated as "nothing was applied".

**User-facing documentation is not in this repo.** A hand-off covering the configuration reference, the exception semantics, and why `exceptionOverrideClassName` must not be set has been prepared separately for the docs repository.

**Aurora is not needed to test this.** The wrapper works against any MySQL or PostgreSQL, so pointing the existing Docker-based integration tests at a `jdbc:aws-wrapper:` URL would put this on CI without AWS credentials. Worth a follow-up issue.

## Release notes

Added support for the AWS Advanced JDBC Wrapper, which enables fast Aurora failover for Aurora PostgreSQL and Aurora MySQL. Configuring HikariCP with an exception override is now rejected at startup, since it would cause a transaction with an unknown outcome to be reported as a definite failure.

