### PR TITLE
Backport to branch(3) : Fix ReadOnly for MySQL family

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -497,6 +497,15 @@ class RdbEngineMysql extends AbstractRdbEngine {
   }
 
   @Override
+  public void setConnectionToReadOnly(Connection connection, boolean readOnly) {
+    // Do nothing. Setting a connection to read-only brings no benefit in MySQL: read-only is
+    // enforced at the ScalarDB layer (see ReadOnlyDistributedTransaction) and the read paths
+    // only issue SELECTs, while MariaDB Connector/J 3.5.10 and later issue SET SESSION
+    // TRANSACTION READ ONLY / READ WRITE, which adds two round trips per read since HikariCP
+    // restores the pool default on connection return. TiDB rejects the statement entirely.
+  }
+
+  @Override
   public String getTableNamesInNamespaceSql() {
     return "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ?";
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -117,6 +117,25 @@ public class JdbcAdminTest {
     }
   }
 
+  /**
+   * Verifies that the connection was set to read-only, unless the engine overrides {@link
+   * RdbEngineStrategy#setConnectionToReadOnly(Connection, boolean)} to do nothing. SQLite does not
+   * support read-only mode, and the MySQL family does not benefit from it, cf. {@link
+   * RdbEngineMysql#setConnectionToReadOnly(Connection, boolean)}.
+   */
+  private void verifyConnectionSetToReadOnly(Connection connection, RdbEngine rdbEngine)
+      throws SQLException {
+    switch (rdbEngine) {
+      case SQLITE:
+      case MYSQL:
+      case MARIADB:
+        verify(connection, never()).setReadOnly(anyBoolean());
+        break;
+      default:
+        verify(connection).setReadOnly(true);
+    }
+  }
+
   private JdbcAdmin createJdbcAdminFor(RdbEngineStrategy rdbEngineStrategy) {
     // Arrange
     try (MockedStatic<RdbEngineFactory> mocked = mockStatic(RdbEngineFactory.class)) {
@@ -295,11 +314,7 @@ public class JdbcAdminTest {
             .addSecondaryIndex("c4")
             .build();
     assertThat(actualMetadata).isEqualTo(expectedMetadata);
-    if (rdbEngine == RdbEngine.SQLITE) {
-      verify(connection, never()).setReadOnly(anyBoolean());
-    } else {
-      verify(connection).setReadOnly(true);
-    }
+    verifyConnectionSetToReadOnly(connection, rdbEngine);
     verify(connection).prepareStatement(expectedSelectStatements);
   }
 
@@ -2421,11 +2436,7 @@ public class JdbcAdminTest {
     Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
 
     // Assert
-    if (rdbEngine == RdbEngine.SQLITE) {
-      verify(connection, never()).setReadOnly(anyBoolean());
-    } else {
-      verify(connection).setReadOnly(true);
-    }
+    verifyConnectionSetToReadOnly(connection, rdbEngine);
     verify(connection).prepareStatement(expectedSelectStatement);
     assertThat(actualTableNames).containsExactly(table1, table2);
     verify(preparedStatement).setString(1, namespace + ".%");
@@ -2657,11 +2668,7 @@ public class JdbcAdminTest {
     // Assert
     assertThat(admin.namespaceExists(namespace)).isTrue();
 
-    if (rdbEngine == RdbEngine.SQLITE) {
-      verify(connection, never()).setReadOnly(anyBoolean());
-    } else {
-      verify(connection).setReadOnly(true);
-    }
+    verifyConnectionSetToReadOnly(connection, rdbEngine);
     verify(selectStatement).executeQuery();
     verify(connection).prepareStatement(expectedSelectStatement);
     verify(selectStatement).setString(1, namespace + namespacePlaceholderSuffix);
@@ -4766,11 +4773,7 @@ public class JdbcAdminTest {
     Set<String> actual = admin.getNamespaceNames();
 
     // Assert
-    if (rdbEngine == RdbEngine.SQLITE) {
-      verify(connection, never()).setReadOnly(anyBoolean());
-    } else {
-      verify(connection).setReadOnly(true);
-    }
+    verifyConnectionSetToReadOnly(connection, rdbEngine);
     verify(connection).createStatement();
     verify(getTableMetadataNamespacesStatementMock)
         .executeQuery(getTableMetadataNamespacesStatement);
@@ -4933,7 +4936,7 @@ public class JdbcAdminTest {
     verify(connection, description(description)).prepareStatement(expectedCheckTableExistStatement);
     assertThat(actual.getPartitionKeyNames()).hasSameElementsAs(ImmutableSet.of("pk1", "pk2"));
     assertThat(actual.getColumnDataTypes()).containsExactlyEntriesOf(expectedColumns);
-    verify(connection).setReadOnly(true);
+    verifyConnectionSetToReadOnly(connection, rdbEngine);
     verify(rdbEngineStrategy)
         .getDataTypeForScalarDb(
             any(JDBCType.class),

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineMysqlTest.java
@@ -1,7 +1,13 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,5 +38,18 @@ class RdbEngineMysqlTest {
     String url = "jdbc:mysql://localhost:3306/?permitMysqlScheme=true";
     String result = rdbEngineMysql.adjustJdbcUrl(url);
     assertThat(result).isEqualTo(url);
+  }
+
+  @Test
+  void setConnectionToReadOnly_ShouldDoNothing() throws SQLException {
+    // MariaDB Connector/J 3.5.10 and later issue SET SESSION TRANSACTION READ ONLY / READ WRITE
+    // from Connection#setReadOnly(), which adds two round trips per read and which TiDB rejects.
+    // This override was first added in #2801 and dropped in #3428; if this test starts failing,
+    // check whether the driver still propagates the read-only state before relaxing it.
+    Connection connection = mock(Connection.class);
+
+    rdbEngineMysql.setConnectionToReadOnly(connection, true);
+
+    verify(connection, never()).setReadOnly(anyBoolean());
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTidbTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTidbTest.java
@@ -1,0 +1,41 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RdbEngineTidbTest {
+
+  // TiDB is MySQL compatible and uses the same connection string, cf. RdbEngineFactory#create()
+  private static final String ANY_JDBC_URL = "jdbc:mysql://localhost:4000/";
+
+  private RdbEngineTidb rdbEngineTidb;
+
+  @BeforeEach
+  void setUp() {
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_JDBC_URL);
+    props.setProperty(DatabaseConfig.STORAGE, "jdbc");
+    rdbEngineTidb = new RdbEngineTidb(new JdbcConfig(new DatabaseConfig(props)));
+  }
+
+  @Test
+  void setConnectionToReadOnly_ShouldDoNothing() throws SQLException {
+    // TiDB rejects "SET SESSION TRANSACTION READ ONLY" with error 1235 unless
+    // tidb_enable_noop_functions is enabled, and MariaDB Connector/J 3.5.10 and later issue that
+    // statement from Connection#setReadOnly(). Inherited from RdbEngineMysql.
+    Connection connection = mock(Connection.class);
+
+    rdbEngineTidb.setConnectionToReadOnly(connection, true);
+
+    verify(connection, never()).setReadOnly(anyBoolean());
+  }
+}


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3799
- **Commit to backport:** cc7ce3d377349d764a1cce807b788a76f168a7d9

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-3799 &&
git cherry-pick --no-rerere-autoupdate -m1 cc7ce3d377349d764a1cce807b788a76f168a7d9
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!