### PR TITLE
Make ConsensusCommitAdmin.tableExists() a single-table lookup

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -308,6 +308,23 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public boolean tableExists(String namespace, String table) throws ExecutionException {
+    // The default implementation checks the table against getNamespaceTableNames(), which loads the
+    // metadata of every table in the namespace. Answer the same question with a single table
+    // instead: the table is a transaction table when the storage has it and it has transaction
+    // metadata.
+    //
+    // The storage is asked first, in the same order as getNamespaceTableNames(), which only reaches
+    // for metadata once it knows the table is there. Reading metadata for a table the storage does
+    // not have is not always harmless: on DynamoDB it fails outright while the metadata table has
+    // yet to be created.
+    if (namespace.equals(coordinatorNamespace)) {
+      return false;
+    }
+    return admin.tableExists(namespace, table) && getTableMetadata(namespace, table) != null;
+  }
+
+  @Override
   public boolean namespaceExists(String namespace) throws ExecutionException {
     if (namespace.equals(coordinatorNamespace)) {
       return false;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -600,6 +600,93 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
+  public void tableExists_ForTransactionTable_ShouldReturnTrueWithoutListingTheNamespace()
+      throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.tableExists(NAMESPACE, TABLE)).thenReturn(true);
+    when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE))
+        .thenReturn(transactionTableMetadata());
+
+    // Act
+    boolean actual = admin.tableExists(NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual).isTrue();
+    verify(distributedStorageAdmin).tableExists(NAMESPACE, TABLE);
+    verify(distributedStorageAdmin).getTableMetadata(NAMESPACE, TABLE);
+    verify(distributedStorageAdmin, never()).getNamespaceTableNames(anyString());
+  }
+
+  @Test
+  public void tableExists_ForStorageTable_ShouldReturnFalse() throws ExecutionException {
+    // Arrange
+    TableMetadata storageTableMetadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("id")
+            .addColumn("id", DataType.TEXT)
+            .addColumn("created_at", DataType.BIGINT)
+            .build();
+    when(distributedStorageAdmin.tableExists(NAMESPACE, TABLE)).thenReturn(true);
+    when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE))
+        .thenReturn(storageTableMetadata);
+
+    // Act
+    boolean actual = admin.tableExists(NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual).isFalse();
+    verify(distributedStorageAdmin, never()).getNamespaceTableNames(anyString());
+  }
+
+  @Test
+  public void tableExists_WhenStorageDoesNotHaveTheTable_ShouldNotReadTheMetadata()
+      throws ExecutionException {
+    // Arrange
+    // Reading metadata for a table the storage does not have is not always harmless: on DynamoDB it
+    // fails while the metadata table has yet to be created.
+    when(distributedStorageAdmin.tableExists(NAMESPACE, TABLE)).thenReturn(false);
+
+    // Act
+    boolean actual = admin.tableExists(NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual).isFalse();
+    verify(distributedStorageAdmin, never()).getTableMetadata(anyString(), anyString());
+    verify(distributedStorageAdmin, never()).getNamespaceTableNames(anyString());
+  }
+
+  @Test
+  public void tableExists_ForCoordinatorNamespace_ShouldReturnFalseWithoutReachingTheStorage()
+      throws ExecutionException {
+    // Act
+    boolean actual = admin.tableExists(coordinatorNamespaceName, TABLE);
+
+    // Assert
+    assertThat(actual).isFalse();
+    verify(distributedStorageAdmin, never()).tableExists(anyString(), anyString());
+    verify(distributedStorageAdmin, never()).getTableMetadata(anyString(), anyString());
+  }
+
+  private static TableMetadata transactionTableMetadata() {
+    return TableMetadata.newBuilder()
+        .addPartitionKey("account_id")
+        .addColumn("account_id", DataType.INT)
+        .addColumn("balance", DataType.INT)
+        .addColumn(Attribute.ID, DataType.TEXT)
+        .addColumn(Attribute.STATE, DataType.INT)
+        .addColumn(Attribute.VERSION, DataType.INT)
+        .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+        .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+        .addColumn(Attribute.BEFORE_PREFIX + "balance", DataType.INT)
+        .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+        .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+        .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+        .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+        .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+        .build();
+  }
+
+  @Test
   public void
       getNamespaceTableNames_ForNamespaceContainingTransactionAndStorageTables_ShouldCallReturnOnlyTransactionTables()
           throws ExecutionException {
@@ -1083,6 +1170,7 @@ public abstract class ConsensusCommitAdminTestBase {
         .isInstanceOf(IllegalArgumentException.class);
     assertThat(admin.getTableMetadata(coordinatorNamespaceName, "tbl")).isNull();
     assertThat(admin.getNamespaceTableNames(coordinatorNamespaceName)).isEmpty();
+    assertThat(admin.tableExists(coordinatorNamespaceName, "tbl")).isFalse();
     assertThat(admin.namespaceExists(coordinatorNamespaceName)).isFalse();
     assertThatThrownBy(
             () -> admin.repairNamespace(coordinatorNamespaceName, Collections.emptyMap()))


### PR DESCRIPTION
## Description

`ConsensusCommitAdmin.tableExists()` is far more expensive than it looks.

It is not overridden, so it uses the default implementation in `Admin`:

```java
default boolean tableExists(String namespace, String table) throws ExecutionException {
  return getNamespaceTableNames(namespace).contains(table);
}
```

and `ConsensusCommitAdmin.getNamespaceTableNames()` loads the metadata of every table in the namespace in order to filter out non-transaction tables:

```java
for (String table : admin.getNamespaceTableNames(namespace)) {
  // Remove non transaction table
  if (getTableMetadata(namespace, table) != null) {
    tables.add(table);
  }
}
```

So a single existence check costs a number of storage queries proportional to the number of tables in the namespace, and nothing in the admin chain caches metadata. Measured against PostgreSQL with a namespace holding 18 tables, one `tableExists()` call issued **39 SQL statements** and took about **44 ms**. Callers that check existence before an operation pay this every time, and the cost grows as users add tables.

## Related issues and/or PRs

None.

## Changes made

Overrode `tableExists()` in `ConsensusCommitAdmin` so that it looks at one table rather than the whole namespace:

```java
return getTableMetadata(namespace, table) != null && admin.tableExists(namespace, table);
```

This is the same condition `getNamespaceTableNames()` filters on — the storage has the table, and it has transaction metadata — so the result is unchanged, including for tables that exist in the storage without transaction metadata.

The storage is asked first, in the same order as `getNamespaceTableNames()`, which only reaches for metadata once it knows the table is there. Reading metadata for a table the storage does not have is not always harmless: on DynamoDB, `getTableMetadata()` fails outright while the metadata table has yet to be created, so checking it first breaks creating the very first table. The coordinator namespace is short-circuited to false to match `getNamespaceTableNames()`, which returns an empty set for it.

Measured against the same PostgreSQL namespace, one `tableExists()` call now issues **5 SQL statements** and takes about **4.7 ms**.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

### Why the default in `Admin` is left alone

Answering a single-table question by listing the whole namespace is an odd shape, and resolving the default from `getTableMetadata(namespace, table) != null` is tempting: that is what every caller in this repository actually means by `tableExists()`, and it would fix the storage admins too, including DynamoDB's account-wide `ListTables`. It was tried and it does not work.

The listing the default uses reads only table names, while `getTableMetadata()` parses the stored metadata. Repairing a table whose metadata is corrupt depends on that difference. With the default changed, `ConsensusCommitAdminRepairIntegrationTest` fails: `repairTable_ForCorruptedMetadataTable_ShouldRepairProperly` writes a metadata row with an unparseable data type, and the subsequent `dropTable(..., ifExists)` throws `No enum constant DataType.corrupted` from inside `tableExists()` instead of reporting whether the table is there. Repair can no longer clean up after itself, the coordinator tables are left behind, and every following test fails on `Coordinator tables already exist`.

Measured on a clean database, changing the default fails 4 of the 11 repair tests, while this PR passes all 11. Making the default a single-table lookup has to wait until the repair paths stop depending on `tableExists()` tolerating unreadable metadata, and that is a separate change.

### Testing

Added unit tests covering a transaction table, a storage table without transaction metadata, a table the storage does not have, and the coordinator namespace, each asserting that the namespace is no longer listed. Two of them pin the ordering that DynamoDB depends on: the metadata is not read when the storage does not have the table, and the storage is not reached at all for the coordinator namespace. The existing coordinator namespace test was extended to cover `tableExists()` as well.

`:core:test` and `:core:spotlessCheck` pass. `integrationTestJdbc` against PostgreSQL 17 passes (6847 tests). One run of that suite hit `ConsensusCommitSpecificIntegrationTestWithJdbcDatabaseInHighestIsolation.get_GetWithIndexForTransientDeletedAndPreparedRecordsWhenWriterAborted_ShouldResolveToNoRecord`, which failed on a PostgreSQL serialization conflict during recovery (`could not serialize access due to read/write dependencies among transactions ... might succeed if retried`); a second run of the full suite passed, the class passes on its own, and `tableExists()` is not on that code path.

`:core:spotbugsMain` fails on `KeyBytesEncoder` both with and without this change, so that failure is pre-existing and unrelated.

`DistributedStorageAdmin` has the same default `tableExists()`, but its `getNamespaceTableNames()` implementations do not perform a per-table metadata lookup, so the storage-level check does not have this amplification. It was left alone.

## Release notes

Reduced the number of storage queries that `ConsensusCommitAdmin.tableExists()` issues, which previously scaled with the number of tables in the namespace.
