### PR TITLE
Deprecate join and resume in the distributed transaction manager API

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -415,7 +415,9 @@ public interface DistributedTransactionManager
    * @return {@link DistributedTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
    *     transaction ID is not found. You can retry the transaction from the beginning
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   default DistributedTransaction join(String txId) throws TransactionNotFoundException {
     return resume(txId);
   }
@@ -427,7 +429,9 @@ public interface DistributedTransactionManager
    * @return {@link DistributedTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
    *     transaction ID is not found. You can retry the transaction from the beginning
+   * @deprecated As of release 3.19.0. Will be removed in release 3.20.0
    */
+  @Deprecated
   DistributedTransaction resume(String txId) throws TransactionNotFoundException;
 
   /**

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -63,11 +63,15 @@ public abstract class AbstractDistributedTransactionManager
     return tableName;
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction join(String txId) throws TransactionNotFoundException {
     throw new UnsupportedOperationException("join is not supported in this implementation");
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     throw new UnsupportedOperationException("resume is not supported in this implementation");

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -71,11 +71,15 @@ public class ActiveTransactionManagedDistributedTransactionManager
     return new ActiveTransaction(transaction);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction join(String txId) throws TransactionNotFoundException {
     return resume(txId);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     return registry

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -206,11 +206,15 @@ public abstract class DecoratedDistributedTransactionManager
     return transaction;
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     return transactionManager.resume(txId);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction join(String txId) throws TransactionNotFoundException {
     return transactionManager.join(txId);

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -207,6 +207,8 @@ public class TransactionService implements DistributedTransactionManager {
     return manager.start(txId, isolation, strategy);
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     return manager.resume(txId);

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -143,6 +143,8 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
             .buildMessage());
   }
 
+  /** @deprecated As of release 3.19.0. Will be removed in release 3.20.0 */
+  @Deprecated
   @Override
   public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     throw new UnsupportedOperationException(


### PR DESCRIPTION
## Description

The two-phase commit transaction API was deprecated in 3.19.0 (#3742), targeting removal in 3.20.0. That PR deliberately left `DistributedTransactionManager.join()` and `resume()` alone, because they are not specific to two-phase commit — they also work in the normal transaction mode and would have survived the removal.

This PR retires that carve-out. `join` and `resume` are the session-resumption surface of the *normal* transaction mode, and they are now being retired on the same schedule and with the same treatment as the two-phase commit surface.

Affected users are those who begin a transaction in one call and re-acquire it by transaction ID in a later one. This change is advance notice only: it is annotation- and Javadoc-only, with no behavior change.

## Related issues and/or PRs

- #3742 — the deprecation of the two-phase commit transaction API, whose carve-out this PR retires. This PR follows its Javadoc convention (`As of release X. Will be removed in release Y`).

## Changes made

- Deprecate `DistributedTransactionManager.join(String)` and `DistributedTransactionManager.resume(String)` **as of release 3.19.0, for removal in release 3.20.0**.
- Deprecate every override reachable through a non-deprecated type:
  - `AbstractDistributedTransactionManager` (`join`, `resume`)
  - `ActiveTransactionManagedDistributedTransactionManager` (`join`, `resume`)
  - `DecoratedDistributedTransactionManager` (`join`, `resume`)
  - `SingleCrudOperationTransactionManager` (`resume`)
  - `TransactionService` (`resume`)
- Annotation- and Javadoc-only; no runtime behavior change. Internal callers of the deprecated methods are intentionally left untouched and will be migrated when the methods are removed.

## Checklist

The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

**On the version string.** `3.19.0` is used even though this branch reports `4.0.0-SNAPSHOT`, matching the surrounding two-phase commit / GlobalTransaction stack, which is uniformly stamped 3.19.0 on the mainline. The notice reaches users through the backports to branches `3` and `3.19`, which are handled separately.

**No successor is named.** The GlobalTransaction API was considered and rejected as a stated successor. In core, `DistributedTransactionBackedGlobalTransactionManager.beginBranch` is itself implemented as `manager.join(txId)`, that backing is in-process only, and `GlobalTransaction` offers no re-acquisition by transaction ID. It therefore replaces the multi-participant aspect of `join` but not the resume-across-requests aspect of `resume`. Naming it would be a promise this PR cannot keep; migration guidance belongs in the release notes and in the docs.

**Why `TransactionService.resume` gets a member-level marker even though the class is already `@Deprecated`.** The class-level tag announces removal in 4.0.0, but `resume` disappears in 3.20.0, so relying on the class-level marker alone would announce the wrong removal release. This also matches the file's own convention: `TransactionService` is deprecated as a class yet carries member-level markers on all eleven methods the interface deprecates, each with the interface's own version. #3742 solved the same mismatch on `TwoPhaseCommitTransactionService` by pulling the class tag forward to 3.20.0 and dropping the then-redundant member markers; that route is unavailable here because `TransactionService` is a normal-mode class that genuinely lives until 4.0.0.

**`ActiveTransactionManagedDistributedTransactionManager` is not deprecated at the class level**, and neither are the `scalar.db.active_transaction_management.*` configuration properties — only that class's `join` and `resume` overrides are. Its registry is what makes `resume` work at all (every other implementation throws `UnsupportedOperationException`), so deciding its fate belongs to the removal work, which needs a non-deprecated lookup entry point first.

**On warnings.** Because this deprecates public API that internal and test code still uses, the build reports `Note: Some input files use or override a deprecated API.` No `@SuppressWarnings("deprecation")` was added, following #3742: the build has no `-Werror` and Error Prone does not promote deprecation, so no new failures are introduced. `@SuppressWarnings("InlineMeSuggester")` also turned out to be unnecessary — it was tested empirically on the two bodies that are a bare `return resume(txId);`, and Error Prone raises nothing there, since `join` delegates to an overridable instance method rather than to an inlinable one.

**On tests.** No tests were added — the change is annotation- and Javadoc-only with no behavior change, and the existing unit and integration suites keep exercising these methods. `./gradlew build` and `:core:javadoc` pass.

## Release notes

Deprecated `DistributedTransactionManager.join()` and `DistributedTransactionManager.resume()`, along with their implementations, for removal in 3.20.0.
