### PR TITLE
Backport to branch(3.17) : Retry conflict errors on catalog statements in the JDBC admin path

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -196,7 +196,7 @@ public class JdbcAdminImportTestUtils {
         dataSource,
         requiresExplicitCommit,
         connection -> {
-          JdbcAdmin.execute(connection, sql, requiresExplicitCommit);
+          JdbcAdmin.execute(connection, rdbEngine, sql, requiresExplicitCommit);
         });
   }
 
@@ -205,7 +205,7 @@ public class JdbcAdminImportTestUtils {
         dataSource,
         requiresExplicitCommit,
         connection -> {
-          JdbcAdmin.execute(connection, sqls, requiresExplicitCommit);
+          JdbcAdmin.execute(connection, rdbEngine, sqls, requiresExplicitCommit);
         });
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -150,7 +150,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
         dataSource,
         requiresExplicitCommit,
         connection -> {
-          JdbcAdmin.execute(connection, sql, requiresExplicitCommit);
+          JdbcAdmin.execute(connection, rdbEngine, sql, requiresExplicitCommit);
         });
   }
 
@@ -181,6 +181,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
             connection ->
                 executeQuery(
                     connection,
+                    rdbEngine,
                     sql,
                     requiresExplicitCommit,
                     ps -> ps.setString(1, namespace),

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -22,6 +22,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.ThrowableConsumer;
 import com.scalar.db.util.ThrowableFunction;
+import com.scalar.db.util.ThrowableSupplier;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -57,6 +58,22 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   @VisibleForTesting static final String JDBC_COL_DECIMAL_DIGITS = "DECIMAL_DIGITS";
 
   private static final String INDEX_NAME_PREFIX = "index";
+
+  /**
+   * The maximum number of retries for a conflict error on a catalog statement. Conflict errors here
+   * are transient: one statement is one transaction on this path, so re-executing the statement
+   * after a rollback is safe.
+   *
+   * <p>Two consecutive retries is the worst case measured while reproducing the Oracle {@code
+   * ORA-08177} leaf split, which is the only engine this was measured on. It is not the bound that
+   * matters for the others: a deadlock or a serialization failure is settled by the server before
+   * the error is returned, so a retry either succeeds or meets a genuinely contended table. This
+   * bound therefore has ample headroom in both cases.
+   *
+   * <p>No backoff is applied. See {@link #executeWithConflictRetry} for why, and for why errors
+   * reported only after a lock wait are retried under the same bound.
+   */
+  @VisibleForTesting static final int MAX_CONFLICT_RETRY_COUNT = 10;
 
   private final RdbEngineStrategy rdbEngine;
   private final BasicDataSource dataSource;
@@ -168,7 +185,11 @@ public class JdbcAdmin implements DistributedStorageAdmin {
           dataSource,
           requiresExplicitCommit,
           connection -> {
-            execute(connection, rdbEngine.createSchemaSqls(namespace), requiresExplicitCommit);
+            execute(
+                connection,
+                rdbEngine,
+                rdbEngine.createSchemaSqls(namespace),
+                requiresExplicitCommit);
           });
     } catch (SQLException e) {
       throw new ExecutionException("Creating the " + namespace + " schema failed", e);
@@ -243,6 +264,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     try {
       execute(
           connection,
+          rdbEngine,
           stmts,
           requiresExplicitCommit,
           ifNotExists ? null : rdbEngine::throwIfDuplicatedIndexWarning);
@@ -314,7 +336,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   private void dropTableInternal(Connection connection, String schema, String table)
       throws SQLException {
     String dropTableStatement = "DROP TABLE " + encloseFullTableName(schema, table);
-    execute(connection, dropTableStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, dropTableStatement, requiresExplicitCommit);
   }
 
   @Override
@@ -330,7 +352,11 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                   CoreError.NAMESPACE_WITH_NON_SCALARDB_TABLES_CANNOT_BE_DROPPED.buildMessage(
                       namespace, remainingTables));
             }
-            execute(connection, rdbEngine.dropNamespaceSql(namespace), requiresExplicitCommit);
+            execute(
+                connection,
+                rdbEngine,
+                rdbEngine.dropNamespaceSql(namespace),
+                requiresExplicitCommit);
           });
     } catch (SQLException e) {
       throw new ExecutionException("Dropping the " + namespace + " schema failed", e);
@@ -345,6 +371,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
     return executeQuery(
         connection,
+        rdbEngine,
         sql,
         requiresExplicitCommit,
         ps -> ps.setString(1, namespace),
@@ -372,12 +399,14 @@ public class JdbcAdmin implements DistributedStorageAdmin {
               // truncate the source tables
               execute(
                   connection,
+                  rdbEngine,
                   rdbEngine.truncateTableSql(
                       virtualTableInfo.getLeftSourceNamespaceName(),
                       virtualTableInfo.getLeftSourceTableName()),
                   requiresExplicitCommit);
               execute(
                   connection,
+                  rdbEngine,
                   rdbEngine.truncateTableSql(
                       virtualTableInfo.getRightSourceNamespaceName(),
                       virtualTableInfo.getRightSourceTableName()),
@@ -387,7 +416,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
             // For a regular table
             String truncateTableStatement = rdbEngine.truncateTableSql(namespace, table);
-            execute(connection, truncateTableStatement, requiresExplicitCommit);
+            execute(connection, rdbEngine, truncateTableStatement, requiresExplicitCommit);
           });
     } catch (SQLException e) {
       throw new ExecutionException(
@@ -620,6 +649,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     String namespaceExistsStatement = rdbEngine.namespaceExistsStatement();
     return executeQuery(
         connection,
+        rdbEngine,
         namespaceExistsStatement,
         requiresExplicitCommit,
         ps -> ps.setString(1, rdbEngine.namespaceExistsPlaceholder(namespace)),
@@ -742,7 +772,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     String[] sqls = rdbEngine.alterColumnTypeSql(namespace, table, columnName, columnTypeForKey);
-    execute(connection, sqls, requiresExplicitCommit);
+    execute(connection, rdbEngine, sqls, requiresExplicitCommit);
   }
 
   private void alterToRegularColumnTypeIfNecessary(
@@ -757,7 +787,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
     String columnType = rdbEngine.getDataTypeForEngine(dataType);
     String[] sqls = rdbEngine.alterColumnTypeSql(namespace, table, columnName, columnType);
-    execute(connection, sqls, requiresExplicitCommit);
+    execute(connection, rdbEngine, sqls, requiresExplicitCommit);
   }
 
   @Override
@@ -902,7 +932,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                     + enclose(columnName)
                     + " "
                     + getVendorDbColumnType(updatedTableMetadata, columnName);
-            execute(connection, addNewColumnStatement, requiresExplicitCommit);
+            execute(connection, rdbEngine, addNewColumnStatement, requiresExplicitCommit);
             addTableMetadata(connection, namespace, table, updatedTableMetadata, false, true);
           });
     } catch (SQLException e) {
@@ -940,7 +970,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                     .build();
             String[] dropColumnStatements = rdbEngine.dropColumnSql(namespace, table, columnName);
 
-            execute(connection, dropColumnStatements, requiresExplicitCommit);
+            execute(connection, rdbEngine, dropColumnStatements, requiresExplicitCommit);
             addTableMetadata(connection, namespace, table, updatedTableMetadata, false, true);
           });
     } catch (SQLException e) {
@@ -988,7 +1018,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                     oldColumnName,
                     newColumnName,
                     getVendorDbColumnType(updatedTableMetadata, newColumnName));
-            execute(connection, renameColumnStatement, requiresExplicitCommit);
+            execute(connection, rdbEngine, renameColumnStatement, requiresExplicitCommit);
 
             if (currentTableMetadata.getSecondaryIndexNames().contains(oldColumnName)) {
               renameIndexInternal(
@@ -1032,7 +1062,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             String[] alterColumnTypeStatements =
                 rdbEngine.alterColumnTypeSql(namespace, table, columnName, newStorageColumnType);
 
-            execute(connection, alterColumnTypeStatements, requiresExplicitCommit);
+            execute(connection, rdbEngine, alterColumnTypeStatements, requiresExplicitCommit);
             addTableMetadata(connection, namespace, table, updatedTableMetadata, false, true);
           });
     } catch (SQLException e) {
@@ -1062,7 +1092,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
             String renameTableStatement =
                 rdbEngine.renameTableSql(namespace, oldTableName, newTableName);
-            execute(connection, renameTableStatement, requiresExplicitCommit);
+            execute(connection, rdbEngine, renameTableStatement, requiresExplicitCommit);
 
             tableMetadataService.deleteTableMetadata(connection, namespace, oldTableName, false);
 
@@ -1100,7 +1130,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     String[] sqls =
         rdbEngine.renameIndexSqls(schema, newTable, newColumn, oldIndexName, newIndexName);
     try {
-      execute(connection, sqls, requiresExplicitCommit);
+      execute(connection, rdbEngine, sqls, requiresExplicitCommit);
     } catch (SQLException e) {
       if (!rdbEngine.isUndefinedIndexError(e)) {
         throw e;
@@ -1114,7 +1144,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       }
       String[] fallbackSqls =
           rdbEngine.renameIndexSqls(schema, newTable, newColumn, originalIndexName, newIndexName);
-      execute(connection, fallbackSqls, requiresExplicitCommit);
+      execute(connection, rdbEngine, fallbackSqls, requiresExplicitCommit);
     }
   }
 
@@ -1130,6 +1160,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     try {
       execute(
           connection,
+          rdbEngine,
           createIndexStatement,
           requiresExplicitCommit,
           ifNotExists ? null : rdbEngine::throwIfDuplicatedIndexWarning);
@@ -1146,7 +1177,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     String indexName = getIndexName(schema, table, indexedColumn);
     String sql = rdbEngine.dropIndexSql(schema, table, indexName);
     try {
-      execute(connection, sql, requiresExplicitCommit);
+      execute(connection, rdbEngine, sql, requiresExplicitCommit);
     } catch (SQLException e) {
       if (!rdbEngine.isUndefinedIndexError(e)) {
         throw e;
@@ -1159,7 +1190,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
         throw e;
       }
       String fallbackSql = rdbEngine.dropIndexSql(schema, table, originalIndexName);
-      execute(connection, fallbackSql, requiresExplicitCommit);
+      execute(connection, rdbEngine, fallbackSql, requiresExplicitCommit);
     }
   }
 
@@ -1368,13 +1399,13 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       firstCondition = false;
     }
 
-    execute(connection, createViewSql.toString(), requiresExplicitCommit);
+    execute(connection, rdbEngine, createViewSql.toString(), requiresExplicitCommit);
   }
 
   private void dropVirtualTableView(Connection connection, String namespace, String table)
       throws SQLException {
     String dropViewStatement = "DROP VIEW " + encloseFullTableName(namespace, table);
-    execute(connection, dropViewStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, dropViewStatement, requiresExplicitCommit);
   }
 
   @Override
@@ -1445,7 +1476,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     String sql = rdbEngine.dropNamespaceSql(metadataSchema);
-    execute(connection, sql, requiresExplicitCommit);
+    execute(connection, rdbEngine, sql, requiresExplicitCommit);
   }
 
   private void createTable(Connection connection, String createTableStatement, boolean ifNotExists)
@@ -1455,7 +1486,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       stmt = rdbEngine.tryAddIfNotExistsToCreateTableSql(createTableStatement);
     }
     try {
-      execute(connection, stmt, requiresExplicitCommit);
+      execute(connection, rdbEngine, stmt, requiresExplicitCommit);
     } catch (SQLException e) {
       // Suppress the exception thrown when the table already exists
       if (!(ifNotExists && rdbEngine.isDuplicateTableError(e))) {
@@ -1478,6 +1509,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws SQLException {
     return executeQuery(
         connection,
+        rdbEngine,
         rdbEngine.internalTableExistsCheckSql(),
         requiresExplicitCommit,
         ps -> rdbEngine.bindInternalTableExistsCheckParams(ps, schema, table),
@@ -1487,7 +1519,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   private void createSchemaIfNotExists(Connection connection, String schema) throws SQLException {
     String[] sqls = rdbEngine.createSchemaIfNotExistsSqls(schema);
     try {
-      execute(connection, sqls, requiresExplicitCommit);
+      execute(connection, rdbEngine, sqls, requiresExplicitCommit);
     } catch (SQLException e) {
       // Suppress exceptions indicating the duplicate metadata schema
       if (!rdbEngine.isDuplicateSchemaError(e)) {
@@ -1542,13 +1574,18 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  static void execute(Connection connection, String sql, boolean requiresExplicitCommit)
+  static void execute(
+      Connection connection,
+      RdbEngineStrategy rdbEngine,
+      String sql,
+      boolean requiresExplicitCommit)
       throws SQLException {
-    execute(connection, sql, requiresExplicitCommit, null);
+    execute(connection, rdbEngine, sql, requiresExplicitCommit, null);
   }
 
   static void execute(
       Connection connection,
+      RdbEngineStrategy rdbEngine,
       String sql,
       boolean requiresExplicitCommit,
       @Nullable SqlWarningHandler handler)
@@ -1558,12 +1595,108 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Statement stmt = connection.createStatement()) {
-      stmt.execute(sql);
-      if (requiresExplicitCommit) {
-        connection.commit();
-      }
+      executeWithConflictRetry(
+          connection,
+          rdbEngine,
+          requiresExplicitCommit,
+          sql,
+          () -> {
+            stmt.execute(sql);
+            return null;
+          });
 
+      // Outside the retry region on purpose: the handler runs after the commit has succeeded, so an
+      // exception raised here must never trigger a re-execution of an already committed statement.
       throwSqlWarningIfNeeded(handler, stmt);
+    }
+  }
+
+  /**
+   * Executes a catalog statement, retrying it when the engine reports a conflict error.
+   *
+   * <p>The retried region covers the statement execution <em>and</em> the commit, because a
+   * conflict can surface at either point. The explicit {@code commit()} below runs only for engines
+   * that require one, which today means Oracle at SERIALIZABLE; on an autocommit connection the
+   * commit happens inside the statement call, so a conflict raised at commit time (PostgreSQL
+   * raises {@code 40001} there) falls in the same region. Conversely, once the commit succeeds the
+   * loop is left immediately, which guarantees that a committed statement is never re-executed.
+   *
+   * <p>These helpers do not run only under the admin operations. {@link JdbcDatabase} builds a
+   * {@link JdbcAdmin} over the table metadata pool and hands it to {@link
+   * com.scalar.db.common.TableMetadataManager}, whose cache loader calls {@code getTableMetadata()}
+   * on a miss and blocks the calling thread while it reloads. Retrying a single statement is safe
+   * on both paths because one statement is one transaction on either: the two pools are both
+   * created non-transactional and apply {@code requiresExplicitCommit} the same way, so with
+   * explicit commit the failed transaction is rolled back below, and with autocommit the driver has
+   * already ended it.
+   *
+   * <p>Of the two, the data path is the less exposed: the statement it runs is a non-locking read
+   * of the catalog, which takes no row locks to contend over, so the errors reported only after a
+   * lock wait, discussed below, are effectively out of reach there.
+   *
+   * <p>No backoff is applied. The conflicts this retry exists for consume no wait before they are
+   * reported: an index leaf block split has completed by the time the retry runs, and a deadlock
+   * victim is rolled back as soon as the server detects the cycle. Waiting therefore does not
+   * improve the odds.
+   *
+   * <p>{@link RdbEngineStrategy#isConflict(SQLException)} also matches errors that are reported
+   * only after a lock wait has already elapsed (MySQL 1205, SQLite 5 and 6, Db2 -911 raised on
+   * timeout), for which a retry re-enters the same wait. Those are deliberately not excluded here:
+   * with {@code innodb_deadlock_detect} disabled, MySQL never reports 1213 and a deadlock surfaces
+   * as 1205 instead, so excluding it would stop retrying the very case this helper exists for.
+   *
+   * <p>What would make those waits add up is sustained contention on the catalog tables, and that
+   * cannot originate from either path: catalog statements are committed one at a time, so no lock
+   * is held across statements. It indicates a leaked or external transaction, which is a bug to
+   * surface rather than a condition to absorb -- hence the per-attempt warning below and no
+   * elapsed-time bound on the loop.
+   */
+  private static <T> T executeWithConflictRetry(
+      Connection connection,
+      RdbEngineStrategy rdbEngine,
+      boolean requiresExplicitCommit,
+      String sql,
+      ThrowableSupplier<T, SQLException> action)
+      throws SQLException {
+    int attempt = 0;
+    while (true) {
+      try {
+        T result = action.get();
+        if (requiresExplicitCommit) {
+          connection.commit();
+        }
+        return result;
+      } catch (SQLException e) {
+        if (!rdbEngine.isConflict(e)) {
+          throw e;
+        }
+        if (attempt >= MAX_CONFLICT_RETRY_COUNT) {
+          logger.warn(
+              "Giving up on a conflicting statement after {} retries. SQL: {}, error code: {}",
+              attempt,
+              sql,
+              e.getErrorCode());
+          throw e;
+        }
+        if (requiresExplicitCommit) {
+          // Only engines that require an explicit commit reach this branch, which today means
+          // Oracle at SERIALIZABLE, where the transaction is already rolled back once the conflict
+          // error is returned. The call is kept for engines that keep the transaction alive after a
+          // conflict, and is harmless when it has already ended.
+          try {
+            connection.rollback();
+          } catch (SQLException rollbackEx) {
+            e.addSuppressed(rollbackEx);
+            throw e;
+          }
+        }
+        attempt++;
+        logger.warn(
+            "Retrying a conflicting statement (attempt {}). SQL: {}, error code: {}",
+            attempt,
+            sql,
+            e.getErrorCode());
+      }
     }
   }
 
@@ -1580,69 +1713,113 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  static void execute(Connection connection, String[] sqls, boolean requiresExplicitCommit)
+  static void execute(
+      Connection connection,
+      RdbEngineStrategy rdbEngine,
+      String[] sqls,
+      boolean requiresExplicitCommit)
       throws SQLException {
-    execute(connection, sqls, requiresExplicitCommit, null);
+    execute(connection, rdbEngine, sqls, requiresExplicitCommit, null);
   }
 
   static void execute(
       Connection connection,
+      RdbEngineStrategy rdbEngine,
       String[] sqls,
       boolean requiresExplicitCommit,
       @Nullable SqlWarningHandler warningHandler)
       throws SQLException {
     for (String sql : sqls) {
-      execute(connection, sql, requiresExplicitCommit, warningHandler);
+      execute(connection, rdbEngine, sql, requiresExplicitCommit, warningHandler);
     }
   }
 
+  /**
+   * Executes an update statement, retrying it when the engine reports a conflict error.
+   *
+   * <p>Because a conflict retry re-runs the whole action, {@code paramSetter} must be free of side
+   * effects and safe to run more than once. The retry re-applies it to the same {@link
+   * PreparedStatement}.
+   */
   static void executeUpdate(
       Connection connection,
+      RdbEngineStrategy rdbEngine,
       String sql,
       boolean requiresExplicitCommit,
       ThrowableConsumer<PreparedStatement, SQLException> paramSetter)
       throws SQLException {
     try (PreparedStatement ps = connection.prepareStatement(sql)) {
-      paramSetter.accept(ps);
-      ps.executeUpdate();
-      if (requiresExplicitCommit) {
-        connection.commit();
-      }
+      executeWithConflictRetry(
+          connection,
+          rdbEngine,
+          requiresExplicitCommit,
+          sql,
+          () -> {
+            paramSetter.accept(ps);
+            ps.executeUpdate();
+            return null;
+          });
     }
   }
 
+  /**
+   * Executes a query, retrying it when the engine reports a conflict error.
+   *
+   * <p>Because a conflict retry re-runs the whole action, {@code resultMapper} must be free of side
+   * effects and safe to run more than once. The retry re-runs it against a new {@link ResultSet}.
+   * Build any collection it returns inside the lambda rather than appending to one captured from
+   * the enclosing scope, which a retry would fill twice.
+   */
   static <T> T executeQuery(
       Connection connection,
+      RdbEngineStrategy rdbEngine,
       String sql,
       boolean requiresExplicitCommit,
       ThrowableFunction<ResultSet, T, SQLException> resultMapper)
       throws SQLException {
-    try (Statement stmt = connection.createStatement();
-        ResultSet rs = stmt.executeQuery(sql)) {
-      T result = resultMapper.apply(rs);
-      if (requiresExplicitCommit) {
-        connection.commit();
-      }
-      return result;
+    try (Statement stmt = connection.createStatement()) {
+      return executeWithConflictRetry(
+          connection,
+          rdbEngine,
+          requiresExplicitCommit,
+          sql,
+          () -> {
+            try (ResultSet rs = stmt.executeQuery(sql)) {
+              return resultMapper.apply(rs);
+            }
+          });
     }
   }
 
+  /**
+   * Executes a query with bound parameters, retrying it when the engine reports a conflict error.
+   *
+   * <p>Because a conflict retry re-runs the whole action, {@code paramSetter} and {@code
+   * resultMapper} must be free of side effects and safe to run more than once. The retry re-applies
+   * the former to the same {@link PreparedStatement} and re-runs the latter against a new {@link
+   * ResultSet}. Build any collection it returns inside the lambda rather than appending to one
+   * captured from the enclosing scope, which a retry would fill twice.
+   */
   static <T> T executeQuery(
       Connection connection,
+      RdbEngineStrategy rdbEngine,
       String sql,
       boolean requiresExplicitCommit,
       ThrowableConsumer<PreparedStatement, SQLException> paramSetter,
       ThrowableFunction<ResultSet, T, SQLException> resultMapper)
       throws SQLException {
     try (PreparedStatement ps = connection.prepareStatement(sql)) {
-      paramSetter.accept(ps);
-      try (ResultSet rs = ps.executeQuery()) {
-        T result = resultMapper.apply(rs);
-        if (requiresExplicitCommit) {
-          connection.commit();
-        }
-        return result;
-      }
+      return executeWithConflictRetry(
+          connection,
+          rdbEngine,
+          requiresExplicitCommit,
+          sql,
+          () -> {
+            paramSetter.accept(ps);
+            try (ResultSet rs = ps.executeQuery()) {
+              return resultMapper.apply(rs);
+            }
+          });
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/TableMetadataService.java
@@ -53,7 +53,10 @@ public class TableMetadataService {
     if (overwriteMetadata) {
       // Delete the metadata for the table before we add them
       execute(
-          connection, getDeleteTableMetadataStatement(namespace, table), requiresExplicitCommit);
+          connection,
+          rdbEngine,
+          getDeleteTableMetadataStatement(namespace, table),
+          requiresExplicitCommit);
     }
     LinkedHashSet<String> orderedColumns = new LinkedHashSet<>(metadata.getPartitionKeyNames());
     orderedColumns.addAll(metadata.getClusteringKeyNames());
@@ -131,7 +134,7 @@ public class TableMetadataService {
             metadata.getClusteringOrder(column),
             metadata.getSecondaryIndexNames().contains(column),
             ordinalPosition);
-    execute(connection, insertStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, insertStatement, requiresExplicitCommit);
   }
 
   private String getInsertStatement(
@@ -161,7 +164,10 @@ public class TableMetadataService {
       throws SQLException {
     try {
       execute(
-          connection, getDeleteTableMetadataStatement(namespace, table), requiresExplicitCommit);
+          connection,
+          rdbEngine,
+          getDeleteTableMetadataStatement(namespace, table),
+          requiresExplicitCommit);
       if (deleteMetadataTableIfEmpty) {
         deleteMetadataTableIfEmpty(connection);
       }
@@ -195,7 +201,8 @@ public class TableMetadataService {
             + enclose(COL_FULL_TABLE_NAME)
             + " FROM "
             + encloseFullTableName(metadataSchema, TABLE_NAME);
-    return executeQuery(connection, selectAllTables, requiresExplicitCommit, rs -> !rs.next());
+    return executeQuery(
+        connection, rdbEngine, selectAllTables, requiresExplicitCommit, rs -> !rs.next());
   }
 
   TableMetadata getTableMetadata(Connection connection, String namespace, String table)
@@ -206,6 +213,7 @@ public class TableMetadataService {
 
     return executeQuery(
         connection,
+        rdbEngine,
         getSelectColumnsStatement(),
         requiresExplicitCommit,
         ps -> ps.setString(1, getFullTableName(namespace, table)),
@@ -291,7 +299,7 @@ public class TableMetadataService {
             + "='"
             + columnName
             + "'";
-    execute(connection, updateStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, updateStatement, requiresExplicitCommit);
   }
 
   Set<String> getNamespaceTableNames(Connection connection, String namespace) throws SQLException {
@@ -310,6 +318,7 @@ public class TableMetadataService {
     String prefix = namespace + ".";
     return executeQuery(
         connection,
+        rdbEngine,
         selectTablesOfNamespaceStatement,
         requiresExplicitCommit,
         ps -> ps.setString(1, prefix + "%"),
@@ -336,6 +345,7 @@ public class TableMetadataService {
     Set<String> namespaceOfExistingTables =
         executeQuery(
             connection,
+            rdbEngine,
             selectAllTableNames,
             requiresExplicitCommit,
             rs -> {
@@ -370,7 +380,7 @@ public class TableMetadataService {
       stmt = rdbEngine.tryAddIfNotExistsToCreateTableSql(createTableStatement);
     }
     try {
-      execute(connection, stmt, requiresExplicitCommit);
+      execute(connection, rdbEngine, stmt, requiresExplicitCommit);
     } catch (SQLException e) {
       // Suppress the exception thrown when the table already exists
       if (!(ifNotExists && rdbEngine.isDuplicateTableError(e))) {
@@ -387,7 +397,7 @@ public class TableMetadataService {
 
   private void deleteTable(Connection connection, String fullTableName) throws SQLException {
     String dropTableStatement = "DROP TABLE " + fullTableName;
-    execute(connection, dropTableStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, dropTableStatement, requiresExplicitCommit);
   }
 
   private String enclose(String name) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/VirtualTableMetadataService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/VirtualTableMetadataService.java
@@ -80,7 +80,8 @@ public class VirtualTableMetadataService {
 
   private boolean isVirtualTablesTableEmpty(Connection connection) throws SQLException {
     String selectAllTables = "SELECT * FROM " + encloseFullTableName(metadataSchema, TABLE_NAME);
-    return executeQuery(connection, selectAllTables, requiresExplicitCommit, rs -> !rs.next());
+    return executeQuery(
+        connection, rdbEngine, selectAllTables, requiresExplicitCommit, rs -> !rs.next());
   }
 
   void insertIntoVirtualTablesTable(
@@ -98,6 +99,7 @@ public class VirtualTableMetadataService {
         "INSERT INTO " + encloseFullTableName(metadataSchema, TABLE_NAME) + " VALUES (?,?,?,?,?)";
     executeUpdate(
         connection,
+        rdbEngine,
         insertStatement,
         requiresExplicitCommit,
         ps -> {
@@ -119,6 +121,7 @@ public class VirtualTableMetadataService {
             + " = ?";
     executeUpdate(
         connection,
+        rdbEngine,
         deleteStatement,
         requiresExplicitCommit,
         ps -> ps.setString(1, getFullTableName(namespace, table)));
@@ -139,6 +142,7 @@ public class VirtualTableMetadataService {
             + " = ?";
     return executeQuery(
         connection,
+        rdbEngine,
         selectStatement,
         requiresExplicitCommit,
         ps -> ps.setString(1, getFullTableName(namespace, table)),
@@ -166,6 +170,7 @@ public class VirtualTableMetadataService {
             + " = ?";
     return executeQuery(
         connection,
+        rdbEngine,
         selectStatement,
         requiresExplicitCommit,
         ps -> {
@@ -255,6 +260,7 @@ public class VirtualTableMetadataService {
     String prefix = namespace + ".";
     return executeQuery(
         connection,
+        rdbEngine,
         selectTablesOfNamespaceStatement,
         requiresExplicitCommit,
         ps -> ps.setString(1, prefix + "%"),
@@ -280,6 +286,7 @@ public class VirtualTableMetadataService {
             + encloseFullTableName(metadataSchema, TABLE_NAME);
     return executeQuery(
         connection,
+        rdbEngine,
         selectAllTableNames,
         requiresExplicitCommit,
         rs -> {
@@ -304,7 +311,7 @@ public class VirtualTableMetadataService {
       stmt = rdbEngine.tryAddIfNotExistsToCreateTableSql(createTableStatement);
     }
     try {
-      execute(connection, stmt, requiresExplicitCommit);
+      execute(connection, rdbEngine, stmt, requiresExplicitCommit);
     } catch (SQLException e) {
       // Suppress the exception thrown when the table already exists
       if (!(ifNotExists && rdbEngine.isDuplicateTableError(e))) {
@@ -321,7 +328,7 @@ public class VirtualTableMetadataService {
 
   private void deleteTable(Connection connection, String fullTableName) throws SQLException {
     String dropTableStatement = "DROP TABLE " + fullTableName;
-    execute(connection, dropTableStatement, requiresExplicitCommit);
+    execute(connection, rdbEngine, dropTableStatement, requiresExplicitCommit);
   }
 
   private String enclose(String name) {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminConflictRetryTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminConflictRetryTest.java
@@ -1,0 +1,352 @@
+package com.scalar.db.storage.jdbc;
+
+import static com.scalar.db.storage.jdbc.JdbcAdmin.MAX_CONFLICT_RETRY_COUNT;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.execute;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.executeQuery;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.executeUpdate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for the conflict retry behavior of the {@link JdbcAdmin} statement helpers.
+ *
+ * <p>The retried region covers the statement execution and the commit, but not the SQL warning
+ * handling that follows a successful commit. See {@code JdbcAdmin#executeWithConflictRetry}.
+ */
+public class JdbcAdminConflictRetryTest {
+
+  private static final String SQL = "INSERT INTO \"scalardb\".\"metadata\" VALUES ('t','c')";
+  private static final String OTHER_SQL = "CREATE TABLE \"ns\".\"tbl\" (pk INT)";
+
+  @Mock private Connection connection;
+  @Mock private Statement statement;
+  @Mock private PreparedStatement preparedStatement;
+  @Mock private ResultSet resultSet;
+  @Mock private RdbEngineStrategy rdbEngine;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(connection.createStatement()).thenReturn(statement);
+    when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+  }
+
+  private static SQLException conflict(int errorCode) {
+    return new SQLException("conflict", "40001", errorCode);
+  }
+
+  private void treatAsConflict() {
+    when(rdbEngine.isConflict(any(SQLException.class))).thenReturn(true);
+  }
+
+  // --- execute -------------------------------------------------------------------------------
+
+  @Test
+  public void execute_WhenNoErrorOccurs_ShouldExecuteOnceAndCommitOnce() throws Exception {
+    // Act
+    execute(connection, rdbEngine, SQL, true);
+
+    // Assert
+    verify(statement).execute(SQL);
+    verify(connection).commit();
+    verify(connection, never()).rollback();
+  }
+
+  @Test
+  public void execute_WhenConflictOccursOnceThenSucceeds_ShouldRetryAndCommitOnce()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    doThrow(conflict(8177)).doReturn(false).when(statement).execute(SQL);
+
+    // Act
+    execute(connection, rdbEngine, SQL, true);
+
+    // Assert
+    verify(statement, times(2)).execute(SQL);
+    verify(connection).rollback();
+    verify(connection).commit();
+  }
+
+  @Test
+  public void execute_WhenConflictOccursUpToTheLimitThenSucceeds_ShouldNotThrow() throws Exception {
+    // Arrange
+    treatAsConflict();
+    SQLException[] failures = new SQLException[MAX_CONFLICT_RETRY_COUNT];
+    for (int i = 0; i < MAX_CONFLICT_RETRY_COUNT; i++) {
+      failures[i] = conflict(8177);
+    }
+    doThrow(failures).doReturn(false).when(statement).execute(SQL);
+
+    // Act
+    execute(connection, rdbEngine, SQL, true);
+
+    // Assert
+    verify(statement, times(MAX_CONFLICT_RETRY_COUNT + 1)).execute(SQL);
+    verify(connection, times(MAX_CONFLICT_RETRY_COUNT)).rollback();
+    verify(connection).commit();
+  }
+
+  @Test
+  public void execute_WhenConflictExceedsTheLimit_ShouldThrowTheOriginalException()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    SQLException original = conflict(8177);
+    doThrow(original).when(statement).execute(SQL);
+
+    // Act Assert
+    assertThatThrownBy(() -> execute(connection, rdbEngine, SQL, true))
+        .isSameAs(original)
+        .hasMessage("conflict");
+    assertThat(original.getErrorCode()).isEqualTo(8177);
+    verify(statement, times(MAX_CONFLICT_RETRY_COUNT + 1)).execute(SQL);
+    verify(connection, never()).commit();
+  }
+
+  @Test
+  public void execute_WhenErrorIsNotConflict_ShouldThrowImmediatelyWithoutRollback()
+      throws Exception {
+    // Arrange
+    when(rdbEngine.isConflict(any(SQLException.class))).thenReturn(false);
+    SQLException original = new SQLException("table or view does not exist", "42000", 942);
+    doThrow(original).when(statement).execute(SQL);
+
+    // Act Assert
+    assertThatThrownBy(() -> execute(connection, rdbEngine, SQL, true)).isSameAs(original);
+    verify(statement).execute(SQL);
+    verify(connection, never()).rollback();
+    verify(connection, never()).commit();
+  }
+
+  @Test
+  public void execute_WhenAutoCommit_ShouldRetryWithoutCallingRollbackOrCommit() throws Exception {
+    // Arrange
+    treatAsConflict();
+    doThrow(conflict(8177)).doReturn(false).when(statement).execute(SQL);
+
+    // Act
+    execute(connection, rdbEngine, SQL, false);
+
+    // Assert
+    verify(statement, times(2)).execute(SQL);
+    verify(connection, never()).rollback();
+    verify(connection, never()).commit();
+  }
+
+  @Test
+  public void execute_WhenRollbackFails_ShouldThrowOriginalExceptionWithSuppressed()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    SQLException original = conflict(8177);
+    SQLException rollbackFailure = new SQLException("rollback failed");
+    doThrow(original).when(statement).execute(SQL);
+    doThrow(rollbackFailure).when(connection).rollback();
+
+    // Act Assert
+    assertThatThrownBy(() -> execute(connection, rdbEngine, SQL, true)).isSameAs(original);
+    assertThat(original.getSuppressed()).containsExactly(rollbackFailure);
+    verify(statement).execute(SQL);
+  }
+
+  @Test
+  public void execute_WhenCommitReportsConflict_ShouldRetryStatementAndCommit() throws Exception {
+    // Arrange -- PostgreSQL surfaces serialization failures during the commit attempt
+    treatAsConflict();
+    doThrow(conflict(0)).doNothing().when(connection).commit();
+
+    // Act
+    execute(connection, rdbEngine, SQL, true);
+
+    // Assert
+    verify(statement, times(2)).execute(SQL);
+    verify(connection).rollback();
+    verify(connection, times(2)).commit();
+  }
+
+  @Test
+  public void execute_WhenWarningHandlerThrowsAfterCommit_ShouldNotReExecuteTheStatement()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    when(statement.getWarnings()).thenReturn(new SQLWarning("duplicated index"));
+    SQLException fromHandler = conflict(8177);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                execute(
+                    connection,
+                    rdbEngine,
+                    SQL,
+                    true,
+                    warning -> {
+                      throw fromHandler;
+                    }))
+        .isSameAs(fromHandler);
+    verify(statement).execute(SQL);
+    verify(connection).commit();
+    verify(connection, never()).rollback();
+  }
+
+  @Test
+  public void execute_WithSqls_WhenConflictOccursOnSecondSql_ShouldRetryOnlyThatSql()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    doReturn(false).when(statement).execute(OTHER_SQL);
+    doThrow(conflict(8177)).doReturn(false).when(statement).execute(SQL);
+
+    // Act
+    execute(connection, rdbEngine, new String[] {OTHER_SQL, SQL}, true);
+
+    // Assert
+    verify(statement, times(1)).execute(OTHER_SQL);
+    verify(statement, times(2)).execute(SQL);
+    // One statement is one transaction here: each SQL commits on its own, which is what makes
+    // re-executing only the conflicting statement safe.
+    verify(connection, times(2)).commit();
+  }
+
+  @Test
+  public void execute_WhenDeadlockOrConsistentReadFailureOccurs_ShouldRetry() throws Exception {
+    // Arrange -- isConflict() also covers ORA-00060 and ORA-08176
+    treatAsConflict();
+    doThrow(conflict(60)).doThrow(conflict(8176)).doReturn(false).when(statement).execute(SQL);
+
+    // Act
+    execute(connection, rdbEngine, SQL, true);
+
+    // Assert
+    verify(statement, times(3)).execute(SQL);
+    verify(connection, times(2)).rollback();
+  }
+
+  // --- executeUpdate -------------------------------------------------------------------------
+
+  @Test
+  public void executeUpdate_WhenConflictOccursOnceThenSucceeds_ShouldReapplyParamsAndRetry()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    doThrow(conflict(8177)).doReturn(1).when(preparedStatement).executeUpdate();
+    List<String> boundValues = new ArrayList<>();
+
+    // Act
+    executeUpdate(connection, rdbEngine, SQL, true, ps -> boundValues.add("bound"));
+
+    // Assert
+    verify(preparedStatement, times(2)).executeUpdate();
+    assertThat(boundValues).hasSize(2);
+    verify(connection).rollback();
+    verify(connection).commit();
+  }
+
+  // --- executeQuery --------------------------------------------------------------------------
+
+  @Test
+  public void
+      executeQuery_WhenConflictOccursOnceThenSucceeds_ShouldReturnMappedResultWithoutDuping()
+          throws Exception {
+    // Arrange
+    treatAsConflict();
+    when(resultSet.next()).thenReturn(true, false, true, false);
+    when(resultSet.getString(1)).thenReturn("a");
+    doThrow(conflict(8177)).doReturn(resultSet).when(statement).executeQuery(SQL);
+
+    // Act -- the mapper builds its collection inside the lambda, so a retry must not double-add
+    List<String> result =
+        executeQuery(
+            connection,
+            rdbEngine,
+            SQL,
+            true,
+            rs -> {
+              List<String> names = new ArrayList<>();
+              while (rs.next()) {
+                names.add(rs.getString(1));
+              }
+              return names;
+            });
+
+    // Assert
+    assertThat(result).containsExactly("a");
+    verify(statement, times(2)).executeQuery(SQL);
+    verify(connection).rollback();
+  }
+
+  @Test
+  public void executeQuery_WhenConflictOccursDuringResultIteration_ShouldNotDupeMappedResult()
+      throws Exception {
+    // Arrange -- ORA-08176 is a consistent read failure, so the conflict surfaces while the result
+    // set is being read, after the mapper has already consumed part of it
+    treatAsConflict();
+    when(statement.executeQuery(SQL)).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(true).thenThrow(conflict(8176)).thenReturn(true, false);
+    when(resultSet.getString(1)).thenReturn("a");
+
+    // Act -- the mapper is re-run from scratch against a new result set, so the partially built
+    // collection from the first attempt must not survive into the returned one
+    List<String> result =
+        executeQuery(
+            connection,
+            rdbEngine,
+            SQL,
+            true,
+            rs -> {
+              List<String> names = new ArrayList<>();
+              while (rs.next()) {
+                names.add(rs.getString(1));
+              }
+              return names;
+            });
+
+    // Assert
+    assertThat(result).containsExactly("a");
+    verify(statement, times(2)).executeQuery(SQL);
+    verify(connection).rollback();
+    verify(connection).commit();
+  }
+
+  @Test
+  public void executeQuery_WithParamSetter_WhenConflictOccurs_ShouldReapplyParamsAndRetry()
+      throws Exception {
+    // Arrange
+    treatAsConflict();
+    when(resultSet.next()).thenReturn(false);
+    doThrow(conflict(8177)).doReturn(resultSet).when(preparedStatement).executeQuery();
+    List<String> boundValues = new ArrayList<>();
+
+    // Act
+    Boolean result =
+        executeQuery(
+            connection, rdbEngine, SQL, true, ps -> boundValues.add("bound"), ResultSet::next);
+
+    // Assert
+    assertThat(result).isFalse();
+    assertThat(boundValues).hasSize(2);
+    verify(preparedStatement, times(2)).executeQuery();
+  }
+}


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3820
- **Commit to backport:** 96bdf6a81b7e30c101ea621fb3db71b67151619f

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.17-pull-3820 &&
git cherry-pick --no-rerere-autoupdate -m1 96bdf6a81b7e30c101ea621fb3db71b67151619f
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!