### PR TITLE
Upgrade the AWS SDK to avoid vulnerable Apache HttpComponents Core 5 versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
         azureCosmosVersion = '4.81.0'
         azureBlobStorageVersion = '12.35.0'
         jooqVersion = '3.14.16'
-        awssdkVersion = '2.42.4'
+        awssdkVersion = '2.49.3'
         hikariCpVersion = '4.0.3'
         postgresqlDriverVersion = '42.7.13'
         oracleDriverVersion = '23.26.1.0.0'


### PR DESCRIPTION
## Description

Branch `3.18` pins the AWS SDK at 2.42.4, while `3.19` is on 2.49.3 (#3743) and `master` on 2.54.0. This bumps `3.18` to 2.49.3 to match `3.19`.

Beyond keeping the branches aligned, the bump changes what core contributes to a consumer's dependency graph. Verified with `./gradlew :core:dependencyInsight --configuration runtimeClasspath`:

| `awssdkVersion` | HttpComponents Core 5 on `:core:runtimeClasspath` |
| --- | --- |
| 2.42.4 (current) | absent — no `httpclient5`, no `httpcore5` |
| 2.49.3 | `httpcore5` 5.4.3, `httpcore5-h2` 5.4.3 |

From 2.49.3 the SDK brings in `software.amazon.awssdk:apache5-client` through `applicationautoscaling`, `dynamodb`, and `s3`. That module requires `httpclient5` 5.6.2, which puts HttpComponents Core 5 on the classpath at 5.4.3.

This matters because ScalarDB is published as a library, so whatever core resolves becomes the floor for every consumer. Today core sets no floor for HttpComponents Core 5, and a consumer that picks it up from its own dependencies can land on `httpcore5` 5.3.4, which has two known HIGH vulnerabilities:

| Library | Affected | CVE | Fixed in |
| --- | --- | --- | --- |
| `org.apache.httpcomponents.core5:httpcore5` | 5.3.4 | CVE-2026-54399 | 5.4.3 |
| `org.apache.httpcomponents.core5:httpcore5-h2` | 5.3.4 | CVE-2026-54428 | 5.4.3 |

Core on `3.18` is not itself affected — it carries no HttpComponents Core 5 at all — but shipping the 5.4.3 floor removes a way for consumers to resolve the vulnerable line, and it is what `3.19` and `master` already do.

## Related issues and/or PRs

- #3743 — the Dependabot bump that brought `master` and `3` to AWS SDK 2.49.3

## Changes made

- Bumped `awssdkVersion` from `2.42.4` to `2.49.3`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The same bump applies to `3.17` and `3.16`, whose AWS SDK versions are 2.39.2 and 2.31.3. The backport cherry-picks will fail because the version lines differ, so those need the bump applied by hand — the same situation as #3758. `3.16` crosses the largest range and warrants its own check.
- Do **not** target `3.19` or `master` with this change: they already run 2.49.3 and 2.54.0.
- The vulnerability check on this repository reports nothing for this today and will still report nothing after the merge, since `httpcore5` is absent from the images now and arrives at the already-fixed 5.4.3.

## Release notes

Upgraded the AWS SDK to fix security issues: CVE-2026-54399 and CVE-2026-54428
