### PR TITLE
Backport to branch(3.16) : Upgrade the AWS SDK to avoid vulnerable Apache HttpComponents Core 5 versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         cassandraDriverVersion = '3.12.1'
         azureCosmosVersion = '4.81.0'
         jooqVersion = '3.14.16'
-        awssdkVersion = '2.31.3'
+        awssdkVersion = '2.49.3'
         commonsDbcp2Version = '2.13.0'
         postgresqlDriverVersion = '42.7.13'
         oracleDriverVersion = '23.8.0.25.04'


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/3838
- **Commit to backport:** bc7b6c749f54e6274e3d422a3eddd2b3ea17b4b2

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-3838 &&
git cherry-pick --no-rerere-autoupdate -m1 bc7b6c749f54e6274e3d422a3eddd2b3ea17b4b2
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!