### PR TITLE
Allow writes to records a scanner has already returned

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/CoreError.java
@@ -452,7 +452,8 @@ public enum CoreError implements ScalarDbError {
   CONSENSUS_COMMIT_SCANNING_ALREADY_WRITTEN_OR_DELETED_DATA_NOT_ALLOWED(
       Category.USER_ERROR,
       "0106",
-      "Scanning data already-written or already-deleted by the same transaction is not allowed",
+      "Scanning data already-written or already-deleted by the same transaction is not allowed."
+          + " Record: %s",
       "",
       ""),
   CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_SERIALIZABLE(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -29,11 +29,14 @@ import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -407,7 +410,9 @@ public class CrudHandler {
     TableMetadata metadata = txMetadata.getTableMetadata();
     LinkedHashMap<Snapshot.Key, TransactionResult> results =
         scanInternal(scan, context, txMetadata);
-    verifyNoOverlap(scan, results, context);
+    // The batch scan path exempts nothing: no write can be interleaved with it, so a key found in
+    // the write set here was necessarily written before the scan ran.
+    verifyNoOverlap(scan, results, Collections.emptySet(), context);
     return results.values().stream()
         .map(r -> new FilteredResult(r, scan.getProjections(), metadata, isIncludeMetadataEnabled))
         .collect(Collectors.toList());
@@ -561,10 +566,35 @@ public class CrudHandler {
   }
 
   private void verifyNoOverlap(
-      Scan scan, Map<Snapshot.Key, TransactionResult> results, TransactionContext context) {
+      Scan scan,
+      Map<Snapshot.Key, TransactionResult> results,
+      @Nullable Set<Snapshot.Key> exemptKeys,
+      TransactionContext context) {
     if (isOverlapVerificationRequired(context)) {
-      context.snapshot.verifyNoOverlap(scan, results);
+      // Reaching here guarantees exemptKeys was allocated: both scanners allocate it under exactly
+      // this condition, and the flags it reads are final on the context, so the condition cannot
+      // have differed at construction time. A scanner that skips the allocation therefore never
+      // gets here. The batch scan path passes an empty set explicitly.
+      assert exemptKeys != null;
+
+      context.snapshot.verifyNoOverlap(scan, results, exemptKeys);
     }
+  }
+
+  /**
+   * Returns whether this transaction has not yet written or deleted the given key.
+   *
+   * <p>A scanner calls this at the moment it produces a record. If the key is still absent from
+   * both the write set and the delete set, any later write to it necessarily happened after the
+   * caller had already seen the record, which is safe and makes the key exempt from the overlap
+   * check at close time. A key that is already written or deleted here is never exempt, so the scan
+   * is still rejected for it. Union membership is monotonic (see {@link Snapshot#putIntoWriteSet}),
+   * which is what makes this membership test equivalent to comparing the order of the two
+   * operations.
+   */
+  private boolean isNotYetWrittenOrDeleted(Snapshot.Key key, TransactionContext context) {
+    return !context.snapshot.containsKeyInWriteSet(key)
+        && !context.snapshot.containsKeyInDeleteSet(key);
   }
 
   private boolean isOverlapVerificationRequired(TransactionContext context) {
@@ -936,6 +966,12 @@ public class CrudHandler {
     private final Scanner scanner;
 
     @Nullable private final LinkedHashMap<Snapshot.Key, TransactionResult> results;
+
+    // The keys this scanner produced while they were still absent from the write set and the
+    // delete set. Writes to them happened after the caller saw the record, so they are exempt from
+    // the overlap check at close time.
+    @Nullable private final Set<Snapshot.Key> exemptKeys;
+
     private final AtomicInteger scanCount = new AtomicInteger();
     private final AtomicBoolean fullyScanned = new AtomicBoolean();
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -957,6 +993,11 @@ public class CrudHandler {
         // into the scan set
         results = null;
       }
+
+      // This gate is narrower than the one for `results` above, which also fires for validation and
+      // snapshot reads. Read-only and one-operation transactions never verify overlap, so they
+      // track nothing here.
+      exemptKeys = isOverlapVerificationRequired(context) ? new HashSet<>() : null;
     }
 
     @Override
@@ -981,6 +1022,13 @@ public class CrudHandler {
               processScanResult(key, scan, result, context, metadata);
           if (!processedScanResult.isPresent()) {
             continue;
+          }
+
+          // Recorded only for rows that are actually delivered. Rows dropped by the conjunction
+          // filter or by lazy recovery above never reach the caller, so exempting them would let a
+          // later write to such a key escape the overlap check.
+          if (exemptKeys != null && isNotYetWrittenOrDeleted(key, context)) {
+            exemptKeys.add(key);
           }
 
           if (results != null) {
@@ -1057,7 +1105,7 @@ public class CrudHandler {
         putIntoScannerSetInSnapshot(scan, results, context);
       }
 
-      verifyNoOverlap(scan, results, context);
+      verifyNoOverlap(scan, results, exemptKeys, context);
     }
 
     @Override
@@ -1085,6 +1133,10 @@ public class CrudHandler {
     private final Iterator<Map.Entry<Snapshot.Key, TransactionResult>> resultsIterator;
 
     private final LinkedHashMap<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
+
+    // See ConsensusCommitStorageScanner#exemptKeys
+    @Nullable private final Set<Snapshot.Key> exemptKeys;
+
     private boolean closed;
 
     public ConsensusCommitSnapshotScanner(
@@ -1096,6 +1148,7 @@ public class CrudHandler {
       this.context = context;
       this.metadata = metadata;
       resultsIterator = resultsInSnapshot.entrySet().iterator();
+      exemptKeys = isOverlapVerificationRequired(context) ? new HashSet<>() : null;
     }
 
     @Override
@@ -1105,6 +1158,11 @@ public class CrudHandler {
       }
 
       Map.Entry<Snapshot.Key, TransactionResult> entry = resultsIterator.next();
+
+      if (exemptKeys != null && isNotYetWrittenOrDeleted(entry.getKey(), context)) {
+        exemptKeys.add(entry.getKey());
+      }
+
       results.put(entry.getKey(), entry.getValue());
 
       return Optional.of(
@@ -1130,7 +1188,7 @@ public class CrudHandler {
     @Override
     public void close() {
       closed = true;
-      verifyNoOverlap(scan, results, context);
+      verifyNoOverlap(scan, results, exemptKeys, context);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -74,9 +74,17 @@ public class Snapshot {
   private final List<ScannerInfo> scannerSet;
 
   // The write set stores information about writes in this transaction.
+  //
+  // Invariant: a key must never leave writeSet ∪ deleteSet, not even transiently on an exception
+  // path. Scanners test membership of this union at the moment they produce a record to decide
+  // whether a write happened before or after the read, so a key that briefly belongs to neither set
+  // would be misread as never written. putIntoWriteSet and putIntoDeleteSet are currently the only
+  // mutators of these two maps and both preserve it; any new mutator must preserve it too. See
+  // putIntoWriteSet for the details.
   private final Map<Key, Put> writeSet;
 
-  // The delete set stores information about deletes in this transaction.
+  // The delete set stores information about deletes in this transaction. See the invariant
+  // documented on writeSet above.
   private final Map<Key, Delete> deleteSet;
 
   public Snapshot(
@@ -132,13 +140,25 @@ public class Snapshot {
     scanSet.put(scan, results);
   }
 
+  /**
+   * Adds the specified {@link Put} to the write set.
+   *
+   * <p>Invariant: a key must never leave {@code writeSet ∪ deleteSet}. Together with {@link
+   * #putIntoDeleteSet}, this method is the only mutator of those two sets, and both preserve the
+   * invariant even on their exception paths. Scanners rely on it: they decide whether a write
+   * happened before or after a record was read by testing membership of that union at the moment
+   * the record is produced, so a key that temporarily belongs to neither set would be misread as
+   * never written.
+   *
+   * @param key the key of the record to write
+   * @param put the put operation to add
+   * @throws CrudException if retrieving the table metadata fails
+   */
   public void putIntoWriteSet(Key key, Put put) throws CrudException {
     if (deleteSet.containsKey(key)) {
       // If a Put is performed on a previously deleted record within the same transaction, move it
       // from the delete set to the write set. Since Delete clears all column values, any columns
       // not explicitly specified in the Put must be set to null to ensure correct behavior.
-
-      deleteSet.remove(key);
 
       PutBuilder.BuildableFromExisting putBuilder = Put.newBuilder(put);
 
@@ -162,7 +182,12 @@ public class Snapshot {
       // preparation.
       putBuilder = putBuilder.enableImplicitPreRead();
 
-      writeSet.put(key, putBuilder.build());
+      // Build the merged Put before touching either set. Everything above can throw, and moving the
+      // key out of the delete set first would leave it in neither set, breaking the invariant
+      // documented on this method.
+      Put mergedPut = putBuilder.build();
+      deleteSet.remove(key);
+      writeSet.put(key, mergedPut);
     } else if (writeSet.containsKey(key)) {
       if (isInsertModeEnabled(put)) {
         throw new IllegalArgumentException(
@@ -190,6 +215,16 @@ public class Snapshot {
     }
   }
 
+  /**
+   * Adds the specified {@link Delete} to the delete set.
+   *
+   * <p>Preserves the {@code writeSet ∪ deleteSet} invariant documented on {@link #putIntoWriteSet}:
+   * the insert-mode rejection below throws before the key is removed from the write set, and
+   * nothing runs between that removal and the insertion into the delete set.
+   *
+   * @param key the key of the record to delete
+   * @param delete the delete operation to add
+   */
   public void putIntoDeleteSet(Key key, Delete delete) {
     Put put = writeSet.get(key);
     if (put != null) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -382,8 +382,9 @@ public class Snapshot {
   }
 
   /**
-   * Verifies that the scan does not overlap with the previous write or delete operations of the
-   * same transaction to prevent incorrect results.
+   * Verifies that the scan does not overlap with the write or delete operations of the same
+   * transaction, ignoring the keys that the scan is known to have produced before they were
+   * written, to prevent incorrect results.
    *
    * <p>For instance, consider the following records in the database, where X is the partition key
    * and Y is the clustering key: R1(X=1, Y=1), R2(X=1, Y=2), R3(X=1, Y=3), and R4(X=1, Y=4).
@@ -407,46 +408,82 @@ public class Snapshot {
    * impossible to determine whether the scanned results include any records that match the keys
    * from previous writes or deletes.
    *
+   * <p>The exempt keys carry the ordering information that plain overlap detection lacks. Both
+   * examples above are writes that happened <i>before</i> the scan, which is why the scan result is
+   * wrong. A write issued <i>after</i> the scan already returned the record is harmless: the caller
+   * has seen the value it would have seen under "run the whole scan, then apply the write". A
+   * scanner therefore records a key as exempt only when the key was absent from both the write set
+   * and the delete set at the moment the record was produced, and those keys are skipped here. A
+   * key written before the scan produced it is never recorded as exempt and is still rejected.
+   *
+   * <p>The exemption is per-scan. A different scan or scanner covering the same key does not
+   * inherit it, because that other read would return a stale record. Pass an empty set for a scan
+   * that carries no ordering information, such as the batch scan path, which reproduces the
+   * behaviour of rejecting every overlap.
+   *
    * @param scan the scan to be verified
    * @param results the results of the scan
+   * @param exemptKeys the keys that this scan produced before the transaction wrote them
    */
-  public void verifyNoOverlap(Scan scan, Map<Snapshot.Key, TransactionResult> results) {
-    if (isWriteSetOrDeleteSetOverlappedWith(scan, results)) {
+  public void verifyNoOverlap(
+      Scan scan, Map<Snapshot.Key, TransactionResult> results, Set<Snapshot.Key> exemptKeys) {
+    Key overlappedKey = getKeyOverlappedWithWriteSetOrDeleteSet(scan, results, exemptKeys);
+    if (overlappedKey != null) {
       throw new IllegalArgumentException(
           CoreError.CONSENSUS_COMMIT_SCANNING_ALREADY_WRITTEN_OR_DELETED_DATA_NOT_ALLOWED
-              .buildMessage());
+              .buildMessage(overlappedKey));
     }
   }
 
-  private boolean isWriteSetOrDeleteSetOverlappedWith(
-      Scan scan, Map<Snapshot.Key, TransactionResult> results) {
-    if (isDeleteSetOverlappedWith(results)) {
-      return true;
+  /**
+   * Returns a key that this transaction has written or deleted and that the given scan covers, or
+   * null if there is none. When several keys overlap, the returned one is whichever is found first
+   * while iterating the write set or the delete set, so it is not defined which one it is. It is
+   * intended as a pointer for the user, not as an exhaustive report.
+   */
+  @Nullable
+  private Key getKeyOverlappedWithWriteSetOrDeleteSet(
+      Scan scan, Map<Snapshot.Key, TransactionResult> results, Set<Snapshot.Key> exemptKeys) {
+    Key key = getKeyOverlappedWithDeleteSet(results, exemptKeys);
+    if (key != null) {
+      return key;
     }
 
     if (scan instanceof ScanWithIndex) {
-      return isWriteSetOverlappedWith((ScanWithIndex) scan, results);
+      return getKeyOverlappedWithWriteSet((ScanWithIndex) scan, results, exemptKeys);
     } else if (scan instanceof ScanAll) {
-      return isWriteSetOverlappedWith((ScanAll) scan, results);
+      return getKeyOverlappedWithWriteSet((ScanAll) scan, results, exemptKeys);
     } else {
-      return isWriteSetOverlappedWith(scan, results);
+      return getKeyOverlappedWithWriteSet(scan, results, exemptKeys);
     }
   }
 
-  private boolean isDeleteSetOverlappedWith(Map<Snapshot.Key, TransactionResult> results) {
+  @Nullable
+  private Key getKeyOverlappedWithDeleteSet(
+      Map<Snapshot.Key, TransactionResult> results, Set<Snapshot.Key> exemptKeys) {
     for (Map.Entry<Key, Delete> entry : deleteSet.entrySet()) {
+      if (exemptKeys.contains(entry.getKey())) {
+        continue;
+      }
       if (results.containsKey(entry.getKey())) {
-        return true;
+        return entry.getKey();
       }
     }
-    return false;
+    return null;
   }
 
-  private boolean isWriteSetOverlappedWith(
-      ScanWithIndex scanWithIndex, Map<Snapshot.Key, TransactionResult> results) {
+  @Nullable
+  private Key getKeyOverlappedWithWriteSet(
+      ScanWithIndex scanWithIndex,
+      Map<Snapshot.Key, TransactionResult> results,
+      Set<Snapshot.Key> exemptKeys) {
     for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
+      if (exemptKeys.contains(entry.getKey())) {
+        continue;
+      }
+
       if (results.containsKey(entry.getKey())) {
-        return true;
+        return entry.getKey();
       }
 
       Put put = entry.getValue();
@@ -464,14 +501,15 @@ public class Snapshot {
       String indexColumnName = indexColumn.getName();
       if (columns.containsKey(indexColumnName)
           && columns.get(indexColumnName).equals(indexColumn)) {
-        return true;
+        return entry.getKey();
       }
     }
-    return false;
+    return null;
   }
 
-  private boolean isWriteSetOverlappedWith(
-      ScanAll scanAll, Map<Snapshot.Key, TransactionResult> results) {
+  @Nullable
+  private Key getKeyOverlappedWithWriteSet(
+      ScanAll scanAll, Map<Snapshot.Key, TransactionResult> results, Set<Snapshot.Key> exemptKeys) {
     for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
       // We need to consider three cases here to prevent scan-after-write.
       //   1) A put operation overlaps the scan range regardless of the update (put) results.
@@ -486,9 +524,15 @@ public class Snapshot {
       // case, we cannot find the overlap using the scan results since the database is not updated
       // yet. Thus, we need to evaluate if the scan condition potentially matches put operations.
 
+      // An exempt key is excluded from all three cases. Case 3 in particular would otherwise fire
+      // on a record the scan already returned whose updated columns still match the conjunctions.
+      if (exemptKeys.contains(entry.getKey())) {
+        continue;
+      }
+
       // Check for cases 1 and 2
       if (results.containsKey(entry.getKey())) {
-        return true;
+        return entry.getKey();
       }
 
       // Check for case 3
@@ -499,17 +543,22 @@ public class Snapshot {
       }
 
       if (areConjunctionsOverlapped(put, scanAll)) {
-        return true;
+        return entry.getKey();
       }
     }
-    return false;
+    return null;
   }
 
-  private boolean isWriteSetOverlappedWith(
-      Scan scan, Map<Snapshot.Key, TransactionResult> results) {
+  @Nullable
+  private Key getKeyOverlappedWithWriteSet(
+      Scan scan, Map<Snapshot.Key, TransactionResult> results, Set<Snapshot.Key> exemptKeys) {
     for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
+      if (exemptKeys.contains(entry.getKey())) {
+        continue;
+      }
+
       if (results.containsKey(entry.getKey())) {
-        return true;
+        return entry.getKey();
       }
 
       Put put = entry.getValue();
@@ -525,7 +574,7 @@ public class Snapshot {
 
       // If partition keys match and a primary key does not have a clustering key
       if (!put.getClusteringKey().isPresent()) {
-        return true;
+        return entry.getKey();
       }
 
       com.scalar.db.io.Key writtenKey = put.getClusteringKey().get();
@@ -534,7 +583,7 @@ public class Snapshot {
 
       // If no range is specified, which means it scans the whole partition space
       if (!isStartGiven && !isEndGiven) {
-        return true;
+        return entry.getKey();
       }
 
       if (isStartGiven && isEndGiven) {
@@ -544,7 +593,7 @@ public class Snapshot {
         if ((scan.getStartInclusive() && writtenKey.equals(startKey))
             || (writtenKey.compareTo(startKey) > 0 && writtenKey.compareTo(endKey) < 0)
             || (scan.getEndInclusive() && writtenKey.equals(endKey))) {
-          return true;
+          return entry.getKey();
         }
       }
 
@@ -553,7 +602,7 @@ public class Snapshot {
         // If startKey <= writtenKey
         if ((scan.getStartInclusive() && startKey.equals(writtenKey))
             || writtenKey.compareTo(startKey) > 0) {
-          return true;
+          return entry.getKey();
         }
       }
 
@@ -562,11 +611,11 @@ public class Snapshot {
         // If writtenKey <= endKey
         if ((scan.getEndInclusive() && writtenKey.equals(endKey))
             || writtenKey.compareTo(endKey) < 0) {
-          return true;
+          return entry.getKey();
         }
       }
     }
-    return false;
+    return null;
   }
 
   private boolean areConjunctionsOverlapped(Put put, Scan scan) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
@@ -917,7 +918,7 @@ public class CrudHandlerTest {
     verify(scanner).close();
     verify(snapshot).putIntoReadSet(key, Optional.of(expected));
     verify(snapshot).putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, expected)));
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, expected));
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of(key, expected)), any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -949,7 +950,7 @@ public class CrudHandlerTest {
     verify(storage).scan(scanForStorage);
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot).putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, expected)));
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -981,7 +982,7 @@ public class CrudHandlerTest {
     verify(storage).scan(scanForStorage);
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot, never()).putIntoScanSet(any(), any());
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -1014,7 +1015,7 @@ public class CrudHandlerTest {
     verify(storage).scan(scanForStorage);
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot).putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, expected)));
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -1068,7 +1069,7 @@ public class CrudHandlerTest {
     verify(snapshot).putIntoReadSet(key, Optional.of(recoveredResult));
     verify(snapshot)
         .putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, recoveredResult)));
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, recoveredResult));
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of(key, recoveredResult)), any());
 
     assertThat(results)
         .containsExactly(
@@ -1122,7 +1123,7 @@ public class CrudHandlerTest {
     verify(scanner).close();
     verify(snapshot).putIntoReadSet(key, Optional.of(recoveredResult));
     verify(snapshot, never()).putIntoScanSet(any(), any());
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, recoveredResult));
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of(key, recoveredResult)), any());
 
     assertThat(results)
         .containsExactly(
@@ -1176,7 +1177,7 @@ public class CrudHandlerTest {
     verify(scanner).close();
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot, never()).putIntoScanSet(any(), any());
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
 
     assertThat(results)
         .containsExactly(
@@ -1436,7 +1437,7 @@ public class CrudHandlerTest {
     verify(snapshot).putIntoReadSet(key, Optional.of(transactionResult));
     verify(snapshot)
         .putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, transactionResult)));
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, transactionResult));
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of(key, transactionResult)), any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(
@@ -1499,7 +1500,7 @@ public class CrudHandlerTest {
     verify(snapshot).putIntoReadSet(key, Optional.of(recoveredResult));
     verify(snapshot)
         .putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, recoveredResult)));
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, recoveredResult));
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of(key, recoveredResult)), any());
 
     assertThat(results)
         .containsExactly(
@@ -1561,7 +1562,7 @@ public class CrudHandlerTest {
     verify(scanner).close();
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot).putIntoScanSet(scan, Maps.newLinkedHashMap());
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of());
+    verify(snapshot).verifyNoOverlap(eq(scan), eq(ImmutableMap.of()), any());
 
     assertThat(results).isEmpty();
   }
@@ -1747,7 +1748,9 @@ public class CrudHandlerTest {
             Maps.newLinkedHashMap(ImmutableMap.of(key2, recoveredResult1, key3, recoveredResult2)));
     verify(snapshot)
         .verifyNoOverlap(
-            scanWithLimit, ImmutableMap.of(key2, recoveredResult1, key3, recoveredResult2));
+            eq(scanWithLimit),
+            eq(ImmutableMap.of(key2, recoveredResult1, key3, recoveredResult2)),
+            any());
 
     assertThat(results)
         .containsExactly(
@@ -1879,10 +1882,139 @@ public class CrudHandlerTest {
     verify(snapshot).putIntoReadSet(key1, Optional.of(txResult1));
     verify(snapshot)
         .putIntoScannerSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key1, txResult1)));
-    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key1, txResult1));
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key1, txResult1), ImmutableSet.of(key1));
 
     assertThat(actualResult)
         .hasValue(new FilteredResult(txResult1, Collections.emptyList(), TABLE_METADATA, false));
+  }
+
+  @Test
+  public void getScanner_ScannerProducedKeyAlreadyInWriteSet_ShouldNotExemptTheKey()
+      throws ExecutionException, CrudException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    Result result = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
+    TransactionResult txResult = new TransactionResult(result);
+    when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    // The transaction wrote the record before the scanner produced it
+    when(snapshot.containsKeyInWriteSet(key)).thenReturn(true);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    try (TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan, context)) {
+      actualScanner.one();
+    }
+
+    // Assert
+    // The key must not be exempt, so the overlap check still rejects it
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, txResult), ImmutableSet.of());
+  }
+
+  @Test
+  public void getScanner_ScannerProducedKeyAlreadyInDeleteSet_ShouldNotExemptTheKey()
+      throws ExecutionException, CrudException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    Result result = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
+    TransactionResult txResult = new TransactionResult(result);
+    when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    when(snapshot.containsKeyInDeleteSet(key)).thenReturn(true);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    try (TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan, context)) {
+      actualScanner.one();
+    }
+
+    // Assert
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, txResult), ImmutableSet.of());
+  }
+
+  @Test
+  public void getScanner_ScannerProducedRowFilteredOutByConjunction_ShouldNotExemptTheKey()
+      throws ExecutionException, CrudException, IOException {
+    // Arrange: the storage row is committed but its current ANY_NAME_4 value (ANY_INT_1) does not
+    // satisfy the scan conjunction (ANY_NAME_4 = ANY_INT_2), so the conjunction filter drops it and
+    // the caller never sees it.
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .all()
+            .where(column(ANY_NAME_4).isEqualToInt(ANY_INT_2))
+            .build();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    Result result = prepareResult(TransactionState.COMMITTED);
+    when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    try (TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan, context)) {
+      actualScanner.one();
+    }
+
+    // Assert
+    // A row that is never delivered must not become exempt. Otherwise a later write to that key
+    // would skip the range and conjunction checks even though the scan did not return the record.
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(), ImmutableSet.of());
+    verify(snapshot, never()).putIntoReadSet(any(), any());
+  }
+
+  @Test
+  public void getScanner_SnapshotScannerProducedKeyAlreadyInWriteSet_ShouldNotExemptTheKey()
+      throws ExecutionException, CrudException, IOException {
+    // Arrange: the scan is already in the scan set, so the cached snapshot scanner serves it
+    Scan scan = prepareScan();
+    Result result = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
+    TransactionResult txResult = new TransactionResult(result);
+    when(snapshot.getResults(scan))
+        .thenReturn(Optional.of(Maps.newLinkedHashMap(ImmutableMap.of(key, txResult))));
+    when(snapshot.containsKeyInWriteSet(key)).thenReturn(true);
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    try (TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan, context)) {
+      actualScanner.one();
+    }
+
+    // Assert
+    // A repeated identical scan after a write must stay rejected
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, txResult), ImmutableSet.of());
+    verify(storage, never()).scan(any());
+  }
+
+  @Test
+  public void getScanner_SnapshotScannerProducedCleanKey_ShouldExemptTheKey()
+      throws ExecutionException, CrudException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Result result = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key = new Snapshot.Key(scan, result, TABLE_METADATA);
+    TransactionResult txResult = new TransactionResult(result);
+    when(snapshot.getResults(scan))
+        .thenReturn(Optional.of(Maps.newLinkedHashMap(ImmutableMap.of(key, txResult))));
+    TransactionContext context =
+        new TransactionContext(ANY_ID_1, snapshot, Isolation.SNAPSHOT, false, false);
+
+    // Act
+    try (TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan, context)) {
+      actualScanner.one();
+    }
+
+    // Assert
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, txResult), ImmutableSet.of(key));
   }
 
   @Test
@@ -1912,7 +2044,7 @@ public class CrudHandlerTest {
     verify(storage).scan(scanForStorage);
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot, never()).putIntoScannerSet(any(), any());
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
 
     assertThat(actualResult)
         .hasValue(new FilteredResult(txResult1, Collections.emptyList(), TABLE_METADATA, false));
@@ -1947,7 +2079,7 @@ public class CrudHandlerTest {
     verify(snapshot, never()).putIntoReadSet(any(), any());
     verify(snapshot)
         .putIntoScannerSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key1, txResult1)));
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
 
     assertThat(actualResult)
         .hasValue(new FilteredResult(txResult1, Collections.emptyList(), TABLE_METADATA, false));
@@ -3812,7 +3944,7 @@ public class CrudHandlerTest {
     // The old record rolled forward to deleted (empty), so it must not be cached as a result.
     verify(snapshot, never()).putIntoReadSet(eq(keyOld), any());
     // An index Get is resolved like read() (not scan()), so it must never run overlap verification.
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
   }
 
   @Test
@@ -3838,7 +3970,7 @@ public class CrudHandlerTest {
         .hasMessageContaining("Please use scan() for non-exact match selection");
     verify(recoveryExecutor, never()).execute(any(), any(), any(), any(), any());
     verify(snapshot, never()).putIntoReadSet(any(), any());
-    verify(snapshot, never()).verifyNoOverlap(any(), any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any(), any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -2063,7 +2063,10 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2084,7 +2087,10 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2102,7 +2108,9 @@ public class SnapshotTest {
     Scan scan = prepareScan();
 
     // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2127,7 +2135,9 @@ public class SnapshotTest {
             .build();
 
     // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2151,7 +2161,9 @@ public class SnapshotTest {
             .build();
 
     // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2200,15 +2212,20 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown1 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown2 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown3 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown4 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan4, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan4, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown5 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan5, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan5, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -2255,11 +2272,14 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown1 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown2 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown3 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -2304,11 +2324,14 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown1 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan1, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown2 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan2, Collections.emptyMap(), Collections.emptySet()));
     Throwable thrown3 =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap()));
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan3, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -2335,7 +2358,10 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2367,7 +2393,10 @@ public class SnapshotTest {
 
     // Act Assert
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2409,7 +2438,10 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2454,10 +2486,202 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void verifyNoOverlap_ScanGivenAndPutInWriteSetInExemptKeys_ShouldNotThrowException()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Put put = preparePut();
+    Snapshot.Key putKey = new Snapshot.Key(put);
+    snapshot.putIntoWriteSet(putKey, put);
+    Scan scan = prepareScan();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(putKey, result), Collections.singleton(putKey)));
+
+    // Assert
+    assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void verifyNoOverlap_ScanGivenAndDeleteInDeleteSetInExemptKeys_ShouldNotThrowException() {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Delete delete = prepareDelete();
+    Snapshot.Key deleteKey = new Snapshot.Key(delete);
+    snapshot.putIntoDeleteSet(deleteKey, delete);
+    Scan scan = prepareScan();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan,
+                    Collections.singletonMap(deleteKey, result),
+                    Collections.singleton(deleteKey)));
+
+    // Assert
+    assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      verifyNoOverlap_CrossPartitionScanGivenAndPutMatchingConditionsInExemptKeys_ShouldNotThrowException()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Put put = preparePutWithIntColumns();
+    Snapshot.Key putKey = new Snapshot.Key(put);
+    snapshot.putIntoWriteSet(putKey, put);
+    Scan scan =
+        Scan.newBuilder(prepareCrossPartitionScan())
+            .clearConditions()
+            .where(
+                ConditionSetBuilder.andConditionSet(
+                        ImmutableSet.of(
+                            ConditionBuilder.column(ANY_NAME_1).isEqualToInt(ANY_INT_1),
+                            ConditionBuilder.column(ANY_NAME_2).isNotEqualToInt(ANY_INT_2),
+                            ConditionBuilder.column(ANY_NAME_3).isGreaterThanInt(ANY_INT_0),
+                            ConditionBuilder.column(ANY_NAME_4)
+                                .isGreaterThanOrEqualToInt(ANY_INT_1),
+                            ConditionBuilder.column(ANY_NAME_5).isLessThanInt(ANY_INT_2),
+                            ConditionBuilder.column(ANY_NAME_6).isLessThanOrEqualToInt(ANY_INT_1),
+                            ConditionBuilder.column(ANY_NAME_7).isNotNullInt(),
+                            ConditionBuilder.column(ANY_NAME_8).isNullInt()))
+                    .build())
+            .build();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    // The put still matches all the scan conditions, so without the exemption guard in the
+    // conjunction check ("case 3"), this would be rejected even though the scan already returned
+    // the record before the write happened.
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(putKey, result), Collections.singleton(putKey)));
+
+    // Assert
+    assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      verifyNoOverlap_ScanWithIndexGivenAndPutWithSameIndexKeyInExemptKeys_ShouldNotThrowException()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_2))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_4, ANY_TEXT_4)
+            .build();
+    Snapshot.Key putKey = new Snapshot.Key(put);
+    snapshot.putIntoWriteSet(putKey, put);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .indexKey(Key.ofText(ANY_NAME_4, ANY_TEXT_4))
+            .build();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(putKey, result), Collections.singleton(putKey)));
+
+    // Assert
+    assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      verifyNoOverlap_ScanGivenAndPutInWriteSetNotInExemptKeys_ShouldThrowExceptionNamingTheRecord()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Put put = preparePut();
+    Snapshot.Key putKey = new Snapshot.Key(put);
+    snapshot.putIntoWriteSet(putKey, put);
+    Scan scan = prepareScan();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    // Only one overlapping write-set entry is seeded, so the reported record is deterministic. With
+    // several overlaps the reported one follows the iteration order of the write set.
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(putKey, result), Collections.emptySet()));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    assertThat(thrown.getMessage()).contains(ANY_NAMESPACE_NAME);
+    assertThat(thrown.getMessage()).contains(ANY_TABLE_NAME);
+  }
+
+  @Test
+  public void
+      verifyNoOverlap_ScanGivenAndPutNotInResultsWhileAnotherKeyIsExempt_ShouldThrowException()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+
+    // An already-scanned record that the transaction updated afterwards
+    Put scannedPut = preparePut();
+    Snapshot.Key scannedKey = new Snapshot.Key(scannedPut);
+    snapshot.putIntoWriteSet(scannedKey, scannedPut);
+
+    // A record inserted into the scan range that the scan never returned
+    Put insertedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_3))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Snapshot.Key insertedKey = new Snapshot.Key(insertedPut);
+    snapshot.putIntoWriteSet(insertedKey, insertedPut);
+
+    Scan scan = prepareScan();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan,
+                    Collections.singletonMap(scannedKey, result),
+                    Collections.singleton(scannedKey)));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -2477,7 +2701,9 @@ public class SnapshotTest {
     // Act Assert
     Throwable thrown =
         catchThrowable(
-            () -> snapshot.verifyNoOverlap(scanAll, Collections.singletonMap(key, result)));
+            () ->
+                snapshot.verifyNoOverlap(
+                    scanAll, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2501,7 +2727,9 @@ public class SnapshotTest {
     // Act Assert
     Throwable thrown =
         catchThrowable(
-            () -> snapshot.verifyNoOverlap(scanAll, Collections.singletonMap(key, result)));
+            () ->
+                snapshot.verifyNoOverlap(
+                    scanAll, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2521,7 +2749,10 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2542,7 +2773,10 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2563,7 +2797,10 @@ public class SnapshotTest {
 
     // Act
     Throwable thrown =
-        catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.singletonMap(key, result)));
+        catchThrowable(
+            () ->
+                snapshot.verifyNoOverlap(
+                    scan, Collections.singletonMap(key, result), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2597,7 +2834,9 @@ public class SnapshotTest {
             .build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2620,7 +2859,9 @@ public class SnapshotTest {
             .build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2643,7 +2884,9 @@ public class SnapshotTest {
             .build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -2666,7 +2909,9 @@ public class SnapshotTest {
             .build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
@@ -2684,7 +2929,9 @@ public class SnapshotTest {
     Scan scan = Scan.newBuilder(prepareCrossPartitionScan()).clearConditions().build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> snapshot.verifyNoOverlap(scan, Collections.emptyMap()));
+    Throwable thrown =
+        catchThrowable(
+            () -> snapshot.verifyNoOverlap(scan, Collections.emptyMap(), Collections.emptySet()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -600,6 +600,77 @@ public class SnapshotTest {
   }
 
   @Test
+  public void
+      putIntoWriteSet_PutGivenAfterDeleteButGettingTableMetadataFailed_ShouldKeepDeleteInDeleteSet()
+          throws Exception {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Delete delete = prepareDelete();
+    Snapshot.Key key = new Snapshot.Key(delete);
+    snapshot.putIntoDeleteSet(key, delete);
+
+    when(tableMetadataManager.getTransactionTableMetadata(any(), any()))
+        .thenThrow(new ExecutionException("error"));
+
+    Put put = preparePut();
+
+    // Act
+    Throwable thrown = catchThrowable(() -> snapshot.putIntoWriteSet(key, put));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(CrudException.class);
+
+    // The key must not disappear from both the write set and the delete set. Otherwise, the delete
+    // is silently lost, and the read-time membership test used by scanners would wrongly consider
+    // the key unwritten.
+    assertThat(deleteSet).containsKey(key);
+    assertThat(writeSet).doesNotContainKey(key);
+  }
+
+  @Test
+  public void putIntoDeleteSet_DeleteGivenAfterPutWithInsertModeEnabled_ShouldKeepPutInWriteSet()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Delete delete = prepareDelete();
+    Snapshot.Key key = new Snapshot.Key(delete);
+
+    Put putWithInsertModeEnabled = Put.newBuilder(preparePut()).enableInsertMode().build();
+    snapshot.putIntoWriteSet(key, putWithInsertModeEnabled);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> snapshot.putIntoDeleteSet(key, delete));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+
+    // The rejection must happen before the key is removed from the write set
+    assertThat(writeSet).containsKey(key);
+    assertThat(deleteSet).doesNotContainKey(key);
+  }
+
+  @Test
+  public void
+      putIntoWriteSetAndDeleteSet_PutDeletePutGiven_ShouldAlwaysKeepKeyInWriteSetOrDeleteSet()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot();
+    Put put = preparePut();
+    Snapshot.Key key = new Snapshot.Key(put);
+    Delete delete = prepareDelete();
+
+    // Act Assert
+    snapshot.putIntoWriteSet(key, put);
+    assertThat(writeSet.containsKey(key) || deleteSet.containsKey(key)).isTrue();
+
+    snapshot.putIntoDeleteSet(key, delete);
+    assertThat(writeSet.containsKey(key) || deleteSet.containsKey(key)).isTrue();
+
+    snapshot.putIntoWriteSet(key, put);
+    assertThat(writeSet.containsKey(key) || deleteSet.containsKey(key)).isTrue();
+  }
+
+  @Test
   public void putIntoScanSet_ScanGiven_ShouldHoldWhatsGivenInScanSet() {
     // Arrange
     snapshot = prepareSnapshot();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -1389,6 +1389,74 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
+  public void getScanner_WhenUpdatingEachReturnedRecord_ShouldUpdateAllOfThem()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    Scan scan = prepareScan(0, 0, NUM_TYPES - 1);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      Optional<Result> result;
+      while ((result = scanner.one()).isPresent()) {
+        transaction.update(
+            Update.newBuilder()
+                .namespace(namespace)
+                .table(TABLE)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.get().getInt(ACCOUNT_TYPE)))
+                .intValue(BALANCE, getBalance(result.get()) + 100)
+                .build());
+      }
+    }
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.start();
+    List<Result> results = another.scan(scan);
+    another.commit();
+
+    assertThat(results).hasSize(NUM_TYPES);
+    results.forEach(result -> assertThat(getBalance(result)).isEqualTo(INITIAL_BALANCE + 100));
+  }
+
+  @Test
+  public void getScanner_WhenDeletingEachReturnedRecord_ShouldDeleteAllOfThem()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    Scan scan = prepareScan(0, 0, NUM_TYPES - 1);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      Optional<Result> result;
+      while ((result = scanner.one()).isPresent()) {
+        transaction.delete(
+            Delete.newBuilder()
+                .namespace(namespace)
+                .table(TABLE)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.get().getInt(ACCOUNT_TYPE)))
+                .build());
+      }
+    }
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.start();
+    List<Result> results = another.scan(scan);
+    Optional<Result> untouched = another.get(prepareGet(1, 0));
+    another.commit();
+
+    assertThat(results).isEmpty();
+    assertThat(untouched).isPresent();
+  }
+
+  @Test
   public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -11309,6 +11309,277 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             .build());
   }
 
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void getScanner_WhenUpdatingEachRecordReturnedByScannerWithLimit_ShouldCommitProperly(
+      Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    Scan scan =
+        Scan.newBuilder(prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1)).limit(2).build();
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      Optional<Result> result;
+      while ((result = scanner.one()).isPresent()) {
+        transaction.update(
+            Update.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.get().getInt(ACCOUNT_TYPE)))
+                .intValue(BALANCE, NEW_BALANCE)
+                .build());
+      }
+    }
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.begin();
+    List<Result> results = another.scan(prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1));
+    another.commit();
+
+    assertThat(getBalance(results.get(0))).isEqualTo(NEW_BALANCE);
+    assertThat(getBalance(results.get(1))).isEqualTo(NEW_BALANCE);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void getScanner_WhenUpdatingRecordsOfPartiallyConsumedScanner_ShouldCommitProperly(
+      Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    Scan scan = prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    // Stop consuming after two records, so the scanner is never fully scanned
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      for (int i = 0; i < 2; i++) {
+        Result result = scanner.one().get();
+        transaction.update(
+            Update.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.getInt(ACCOUNT_TYPE)))
+                .intValue(BALANCE, NEW_BALANCE)
+                .build());
+      }
+    }
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.begin();
+    List<Result> results = another.scan(scan);
+    another.commit();
+
+    assertThat(getBalance(results.get(0))).isEqualTo(NEW_BALANCE);
+    assertThat(getBalance(results.get(1))).isEqualTo(NEW_BALANCE);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void getScanner_WhenUpdatingRecordMakingItStopMatchingScanCondition_ShouldCommitProperly(
+      Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    // A conjunction-bearing scan. Updating a returned record so that it stops matching exercises
+    // the branch of the validation that relies on the write set rather than on the transaction id.
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .all()
+            .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+            .build();
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      Result result = scanner.one().get();
+      transaction.update(
+          Update.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE_1)
+              .partitionKey(Key.ofInt(ACCOUNT_ID, result.getInt(ACCOUNT_ID)))
+              .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.getInt(ACCOUNT_TYPE)))
+              .intValue(BALANCE, NEW_BALANCE)
+              .build());
+    }
+
+    // Assert
+    transaction.commit();
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void getScanner_WhenInsertingRecordIntoScanRangeWhileScannerOpen_ShouldThrowException(
+      Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    // The scan covers a clustering-key range with a gap the populated records do not fill
+    Scan scan = prepareScan(NUM_ACCOUNTS, 0, NUM_TYPES - 1, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                scanner.all();
+                transaction.insert(
+                    prepareInsert(NUM_ACCOUNTS, 0, namespace1, TABLE_1, INITIAL_BALANCE));
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void getScanner_WhenScanningRecordWrittenBeforeTheScan_ShouldThrowException(
+      Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    Scan scan = prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+
+    // The write happens before the scan produces the record, so it is not exempt
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, NEW_BALANCE)
+            .build());
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+                scanner.all();
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void
+      getScanner_WhenAnotherScannerStillOpenCoversTheWrittenRecord_ShouldThrowExceptionAtItsClose(
+          Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    Scan scan1 = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    Scan scan2 = prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner1 = transaction.getScanner(scan1);
+    TransactionCrudOperable.Scanner scanner2 = transaction.getScanner(scan2);
+
+    Result result = scanner1.one().get();
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, result.getInt(ACCOUNT_TYPE)))
+            .intValue(BALANCE, NEW_BALANCE)
+            .build());
+
+    // The scanner that returned the record accepts the write
+    scanner1.close();
+
+    // The other scanner covers the record but never returned it, so it would hand its caller a
+    // stale row. The exemption is per-scanner while the rejection is transaction-wide.
+    assertThatThrownBy(scanner2::close).isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @ParameterizedTest
+  @EnumSource(Isolation.class)
+  public void
+      getScanner_WhenInsertingRecordAlreadyReturnedByScanner_ShouldThrowCommitConflictException(
+          Isolation isolation) throws TransactionException {
+    // Arrange
+    ConsensusCommitManager manager = createConsensusCommitManager(isolation);
+    populateRecords(manager, namespace1, TABLE_1);
+    Scan scan = prepareScan(0, 0, NUM_TYPES - 1, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      Result result = scanner.one().get();
+      transaction.insert(
+          prepareInsert(
+              result.getInt(ACCOUNT_ID),
+              result.getInt(ACCOUNT_TYPE),
+              namespace1,
+              TABLE_1,
+              NEW_BALANCE));
+    }
+
+    // Assert
+    // The scanner already returned the record, so the write cannot change what the scan should
+    // have returned and is not an overlap. The insert is simply invalid because the record exists,
+    // which is detected at prepare time — the same as the equivalent get-then-insert.
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      getScanner_WhenInsertingRecordReturnedAsBeforeImageOfDeletedRecord_ShouldCommitProperly()
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    // READ_COMMITTED only: it is the isolation that returns the committed before-image of a record
+    // whose delete has already committed. Under SNAPSHOT and SERIALIZABLE the scanner returns
+    // nothing for this record, so inserting it while the scanner is open is an insert into the
+    // scanned range and is rejected — a different case, covered separately.
+    ConsensusCommitManager manager = createConsensusCommitManager(Isolation.READ_COMMITTED);
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.COMMITTED,
+        CommitType.NORMAL_COMMIT);
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+    int expectedBalance = 100;
+
+    // Act
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      // The record is returned even though its delete is committed
+      assertThat(scanner.one()).isPresent();
+
+      // Inserting it is correct: the record does not actually exist
+      transaction.insert(prepareInsert(0, 0, namespace1, TABLE_1, expectedBalance));
+    }
+    transaction.commit();
+
+    // Assert
+    Optional<Result> actual = manager.get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(actual).isPresent();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+  }
+
   private void populateRecords(ConsensusCommitManager manager, String namespace, String table)
       throws TransactionException {
     DistributedTransaction transaction = manager.begin();

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -290,6 +290,16 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
   @Test
+  public void getScanner_WhenUpdatingEachReturnedRecord_ShouldUpdateAllOfThem() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void getScanner_WhenDeletingEachReturnedRecord_ShouldDeleteAllOfThem() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
   public void put_DefaultNamespaceGiven_ShouldWorkProperly() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")


### PR DESCRIPTION
## Description

Consensus Commit rejects Update and Delete on a record while a `Scanner` is still iterating. At `Scanner.close()`, `verifyNoOverlap` detects any overlap between the write/delete set and the scan results and throws `DB-CORE-USER-0106`.

The check only asks *whether* the write set and the scan results overlap, never *when* the write happened relative to the read. So it rejects the safe case — a write issued after the scan had already returned the record — along with the unsafe one. The same restriction does not apply to `scan()`, which returns every row at once and verifies once at completion, so scan-then-write already works there.

The practical cost is that mutating while iterating is simply not expressible: callers have to fall back to `scan()` and process the result in two passes.

This PR adds the missing ordering signal.

**Why it is safe.** Writes are not applied to storage until commit, so a write issued mid-iteration cannot affect any row the scanner reads afterwards. For the rows a scanner has already delivered, the values the caller saw are identical to those it would have seen under "finish the whole scan, then apply all writes" — which Consensus Commit already permits through `scan()`.

The claim is per-scanner and does not extend to later reads. Any other scan or scanner whose range covers a written key is still rejected, because that read would return a stale row.

**What is not changed.** Every rejection that happens today still happens, at the same call site (`close()` / scan completion). Inserts into the scanned range stay rejected. The `scan()` batch path is untouched.

## Related issues and/or PRs

N/A

## Changes made

Four commits, each of which leaves the tree green on its own.

**1. Make the delete-set-to-write-set transition in `Snapshot` atomic**

`putIntoWriteSet` removed the key from the delete set before building the merged `Put`, so a throw from `getTableMetadata` left the key in neither set. That silently lost the delete, and it breaks the invariant the new ordering rule depends on. Build the merged `Put` first and perform both map mutations last. The invariant is now documented on both mutators.

**2. Decide scan overlap by when the write happened**

Scanners build a **filtered exempt set** as they produce rows: a key is recorded only when it is still absent from `writeSet ∪ deleteSet` at that moment, which means any later write to it happened after the caller had already seen the record. `close()` passes the set to a new `verifyNoOverlap(Scan, Map, Set)` overload that skips those keys in all three overlap checks, including the conjunction check — which would otherwise fire on an exempt record whose updated columns still match the predicate.

A key written *before* the scanner produced it never enters the set, so it is rejected exactly as before. The set is recorded only for rows that are actually delivered: rows dropped by the conjunction filter or by lazy recovery never reach the caller, and exempting them would let a later write escape the range and conjunction checks. The set is allocated only when overlap verification is required, so read-only and one-operation transactions track nothing.

`verifyNoOverlap` takes the exempt keys as a third parameter rather than gaining an overload. The batch scan path passes an empty set, which is exactly the old behaviour of rejecting every overlap, so `scan()` is unchanged. Keeping a two-argument overload was considered and dropped: it would have had no caller, and it would not have protected a downstream override either, since the scanners call the three-argument form and would silently bypass it. Removing it turns that into a compile error instead. The overlap checks now return the offending key instead of a boolean, so `0106` can name the record.

**3. Integration coverage**

The positive pattern goes in `DistributedTransactionIntegrationTestBase`, so iterating a scanner and mutating each returned record is an API-level guarantee. The Consensus Commit specific rejection and isolation cases stay in `ConsensusCommitSpecificIntegrationTestBase` and run under all three isolation levels.

**4. Pin the exempt keys passed to `verifyNoOverlap` in the scan tests**

The `ScanType`-parameterized tests now assert the exact exempt set instead of `any()`: empty for `scan()`, and the delivered keys for the scanners.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

### User-facing rule

Within a transaction you may write to a record once a scan or scanner has returned it. A scan or scanner is rejected at `close()` / completion if it returns a record the transaction had already written or deleted, or if the transaction put a record that may fall within its range or conditions — judged from the key and the columns the put sets — without the scan having returned it first.

| Action | Result |
|---|---|
| Write a record the scan or scanner already returned | Allowed |
| Write or delete a record, then have a scan or scanner return it — including another scanner still open, or a later scan | Rejected at that scan's `close()` / completion |
| Put a record the scan has not returned but that may fall within its range or conditions — including an insert into the range | Rejected at `close()` / scan completion, even if a scanner never reaches the record |
| Delete a record a scanner covers but closes before returning | Not rejected; the caller never saw the record |
| `insert()` a record the scan already returned | Not an overlap; fails at commit because the record exists |
| Insert into the range after the scanner is closed | Allowed (pre-existing `scan()` behaviour) |

The exemption is per scanner; the rejection is transaction-wide. The sharp edge worth documenting: whether a write is allowed depends on whether the scanner has already reached that row, which for a scan with a `limit` or a partially consumed scanner is data-dependent.

### Behaviour changes reviewers should weigh

1. **`insert()` on a record a scanner already returned now fails later, and retriably.** Today it is
   caught at `close()` with `0106`. After this change the key is exempt — correctly, because the
   write cannot alter which rows the scan should have returned — so the invalid insert reaches
   prepare and surfaces as a retriable `CommitConflictException`. For a record that genuinely exists,
   retrying never converges. This matches the long-standing `get()`-then-`insert()` behaviour that
   `putAndCommit_PutWithInsertModeGivenForExistingAfterRead_ShouldThrowCommitConflictException`
   pins, but it does mean one path loses its fail-fast. Fixing it means reclassifying the
   prepare-time `CONSENSUS_COMMIT_PREPARING_RECORD_EXISTS` result, which affects the `get()` path too
   and belongs in its own change.

   An earlier revision of this PR added a CRUD-time rejection for it. It was withdrawn: under
   READ_COMMITTED a read returns the committed before-image of a record whose delete has already
   committed, so "present in the read set" does not imply the record exists, and the following insert
   is correct and must succeed — as
   `insert_InsertGivenForDeletedWhenCoordinatorStateCommitted_ShouldBehaveCorrectly` requires.

2. **A write can now be rejected at a different scanner's `close()`.** If a second scanner is still
   open, the write is accepted where it was made and rejected at the second scanner's `close()` when
   that scanner goes on to return the record or, for a put, when the put may fall within its range or
   conditions. Whether that happens depends on how far the second scanner gets and when it is closed
   relative to the write.

3. **The relaxation is unconditional.** No configuration restores the previous strict behaviour.
   Opt-in was considered and rejected: an opt-in caller carries the same data-dependent acceptance,
   and there is no precedent in this layer for a switch that toggles transaction semantics.

4. **`0106` message text changed** — it now names the record.

### Things checked, not assumed

- `JdbcTransaction` supports mutating while its scanner is open — verified on SQLite, PostgreSQL and MySQL. It has no overlap check at all, so nothing is relaxed there; the shared-base tests pin behaviour that had never been asserted. Oracle, SQL Server and YugabyteDB are left to CI.
- SERIALIZABLE validation tolerates exempted keys with a `limit`, with a partially consumed scanner, and with a conjunction that the update stops matching.

### Still open

- **Documentation**: scalardb-docs needs the user-facing rule above and the reworded `0106`. Not yet written.
- **Downstream check before merge**: confirm nothing in scalardb-cluster or scalardb-sql calls or overrides the public `Snapshot.verifyNoOverlap`. Its signature changed, so any such use is a compile error rather than a silent behaviour change or string-matches the `0106` message.
- **Separate task**: `close()` is not an unconditional verification point. `one()`'s catch blocks call `closeScanner()`, which sets `closed`, and `close()` returns early when it is set, so verification is skipped after a `one()` failure; both scanners also set `closed` before verifying, so a caller that swallows the rejection can still reach `commit()`. Pre-existing and untouched here, but this change makes `close()` the sole enforcement point for the new rule.

### Post-deploy monitoring and validation

No runtime rollout concerns — this is a library change with no background jobs, migrations, or external calls. What to watch after the first release that includes it:

- **Expected healthy signal**: `DB-CORE-USER-0106` occurrences drop, since the scan-then-write cases that used to trip it now pass.
- **Expected new signal**: a rise in `DB-CORE-CONCURRENCY-0013` (`The record being prepared already exists`). Inserts on records a scanner already returned now reach prepare instead of being stopped at `close()`. A large rise would mean applications are hitting the non-converging retry described above.
- **Rollback trigger**: unexpected `ValidationConflictException` under SERIALIZABLE on scan-heavy workloads, which would point at the exempt-key interaction with `validateScanResults`.

## Release notes

Allowed updating and deleting records that a scanner has already returned, so applications can mutate rows while iterating a scanner instead of buffering the whole result with `scan()`. Inserting into the scanned range remains disallowed.

