### PR TITLE
Fix get operation in Cloud Storage adapter to handle concurrent writes

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/objectstorage/MutateStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/MutateStatementHandler.java
@@ -108,6 +108,9 @@ public class MutateStatementHandler extends StatementHandler {
               () ->
                   new ObjectStoragePartitionSnapshot(
                       objectKey, new ObjectStoragePartition(null), null));
+    } catch (ConflictOccurredException e) {
+      throw new RetriableExecutionException(
+          CoreError.OBJECT_STORAGE_CONFLICT_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
     } catch (ObjectStorageWrapperException e) {
       throw new ExecutionException(
           CoreError.OBJECT_STORAGE_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);

--- a/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapper.java
+++ b/core/src/main/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapper.java
@@ -9,6 +9,7 @@ import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.storage.objectstorage.ConflictOccurredException;
 import com.scalar.db.storage.objectstorage.ObjectStorageWrapper;
 import com.scalar.db.storage.objectstorage.ObjectStorageWrapperException;
 import com.scalar.db.storage.objectstorage.ObjectStorageWrapperResponse;
@@ -28,6 +29,10 @@ import javax.annotation.concurrent.ThreadSafe;
 public class CloudStorageWrapper implements ObjectStorageWrapper {
   // Batch API has a limit of 100 operations per request
   public static final int BATCH_DELETE_SIZE_LIMIT = 100;
+
+  // The maximum number of retries for the get operation, which is performed when the object is
+  // updated between the metadata retrieval and the payload download
+  @VisibleForTesting static final int GET_MAX_RETRY_COUNT = 3;
 
   private final Storage storage;
   private final String bucket;
@@ -55,18 +60,48 @@ public class CloudStorageWrapper implements ObjectStorageWrapper {
   @Override
   public Optional<ObjectStorageWrapperResponse> get(String key)
       throws ObjectStorageWrapperException {
-    try {
-      Blob blob = storage.get(BlobId.of(bucket, key));
-      if (blob == null) {
-        return Optional.empty();
+    StorageException lastPreconditionFailure = null;
+    for (int retryCount = 0; retryCount <= GET_MAX_RETRY_COUNT; retryCount++) {
+      try {
+        Blob blob = storage.get(BlobId.of(bucket, key));
+        if (blob == null) {
+          return Optional.empty();
+        }
+        long generation = blob.getGeneration();
+        // Download the payload with the generation precondition instead of specifying the
+        // generation in the blob ID. With the precondition, a concurrent deletion results in
+        // NOT_FOUND while a concurrent update results in PRECONDITION_FAILED, which allows the two
+        // cases to be distinguished. If the generation were specified in the blob ID, both cases
+        // would result in NOT_FOUND since the specified generation no longer exists unless object
+        // versioning is enabled.
+        byte[] payload =
+            storage.readAllBytes(
+                BlobId.of(bucket, key), Storage.BlobSourceOption.generationMatch(generation));
+        return Optional.of(
+            new ObjectStorageWrapperResponse(
+                new String(payload, StandardCharsets.UTF_8), String.valueOf(generation)));
+      } catch (StorageException e) {
+        if (e.getCode() == CloudStorageErrorCode.NOT_FOUND.get()) {
+          // The object was deleted after the metadata was retrieved, so it is regarded as absent
+          return Optional.empty();
+        }
+        if (e.getCode() != CloudStorageErrorCode.PRECONDITION_FAILED.get()) {
+          throw new ObjectStorageWrapperException(
+              String.format("Failed to get the object with key '%s'", key), e);
+        }
+        // The object was updated after the metadata was retrieved. Retry from the metadata
+        // retrieval to get the payload and its generation consistently.
+        lastPreconditionFailure = e;
+      } catch (Exception e) {
+        throw new ObjectStorageWrapperException(
+            String.format("Failed to get the object with key '%s'", key), e);
       }
-      String payload = new String(blob.getContent(), StandardCharsets.UTF_8);
-      String generation = String.valueOf(blob.getGeneration());
-      return Optional.of(new ObjectStorageWrapperResponse(payload, generation));
-    } catch (Exception e) {
-      throw new ObjectStorageWrapperException(
-          String.format("Failed to get the object with key '%s'", key), e);
     }
+    throw new ConflictOccurredException(
+        String.format(
+            "Failed to get the object with key '%s' after retrying %d times due to conflicts",
+            key, GET_MAX_RETRY_COUNT),
+        lastPreconditionFailure);
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/MutateStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/MutateStatementHandlerTest.java
@@ -16,6 +16,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import java.util.Arrays;
@@ -239,6 +240,22 @@ public class MutateStatementHandlerTest {
     // Act & Assert
     assertThatThrownBy(() -> handler.handle(put))
         .isInstanceOf(ExecutionException.class)
+        .hasCause(exception);
+  }
+
+  @Test
+  public void
+      handle_PutGiven_WhenWrapperGetThrowsConflictOccurredException_ShouldThrowRetriableExecutionException()
+          throws Exception {
+    // Arrange
+    Put put = preparePut();
+    ConflictOccurredException exception =
+        new ConflictOccurredException("Test error", new RuntimeException());
+    when(wrapper.get(anyString())).thenThrow(exception);
+
+    // Act & Assert
+    assertThatThrownBy(() -> handler.handle(put))
+        .isInstanceOf(RetriableExecutionException.class)
         .hasCause(exception);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapperTest.java
+++ b/core/src/test/java/com/scalar/db/storage/objectstorage/cloudstorage/CloudStorageWrapperTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +22,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageException;
+import com.scalar.db.storage.objectstorage.ConflictOccurredException;
 import com.scalar.db.storage.objectstorage.ObjectStorageWrapperException;
 import com.scalar.db.storage.objectstorage.ObjectStorageWrapperResponse;
 import com.scalar.db.storage.objectstorage.PreconditionFailedException;
@@ -43,6 +45,8 @@ public class CloudStorageWrapperTest {
   private static final String ANY_PREFIX = "any_prefix/";
   private static final String ANY_DATA = "any_data";
   private static final long ANY_GENERATION = 12345L;
+  private static final long ANY_UPDATED_GENERATION = 12346L;
+  private static final String ANY_UPDATED_DATA = "any_updated_data";
 
   @Mock private CloudStorageConfig config;
   @Mock private Storage storage;
@@ -65,14 +69,16 @@ public class CloudStorageWrapperTest {
     BlobId blobId = BlobId.of(BUCKET, ANY_OBJECT_KEY);
     Blob blob = mock(Blob.class);
     when(storage.get(blobId)).thenReturn(blob);
-    when(blob.getContent()).thenReturn(ANY_DATA.getBytes(StandardCharsets.UTF_8));
     when(blob.getGeneration()).thenReturn(ANY_GENERATION);
+    when(storage.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION)))
+        .thenReturn(ANY_DATA.getBytes(StandardCharsets.UTF_8));
 
     // Act
     Optional<ObjectStorageWrapperResponse> result = wrapper.get(ANY_OBJECT_KEY);
 
     // Assert
     verify(storage).get(blobId);
+    verify(storage).readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION));
     assertThat(result).isPresent();
     assertThat(result.get().getPayload()).isEqualTo(ANY_DATA);
     assertThat(result.get().getVersion()).isEqualTo(String.valueOf(ANY_GENERATION));
@@ -100,6 +106,84 @@ public class CloudStorageWrapperTest {
     // Act Assert
     assertThatCode(() -> wrapper.get(ANY_OBJECT_KEY))
         .isInstanceOf(ObjectStorageWrapperException.class);
+  }
+
+  @Test
+  public void get_WhenObjectDeletedAfterMetadataRetrieved_ShouldReturnEmptyOptional()
+      throws Exception {
+    // Arrange
+    BlobId blobId = BlobId.of(BUCKET, ANY_OBJECT_KEY);
+    Blob blob = mock(Blob.class);
+    when(storage.get(blobId)).thenReturn(blob);
+    when(blob.getGeneration()).thenReturn(ANY_GENERATION);
+    when(storage.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION)))
+        .thenThrow(new StorageException(CloudStorageErrorCode.NOT_FOUND.get(), "Not Found"));
+
+    // Act
+    Optional<ObjectStorageWrapperResponse> result = wrapper.get(ANY_OBJECT_KEY);
+
+    // Assert
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void get_WhenObjectUpdatedAfterMetadataRetrieved_ShouldRetryAndReturnUpdatedObjectData()
+      throws Exception {
+    // Arrange
+    BlobId blobId = BlobId.of(BUCKET, ANY_OBJECT_KEY);
+    Blob blob = mock(Blob.class);
+    when(storage.get(blobId)).thenReturn(blob);
+    when(blob.getGeneration()).thenReturn(ANY_GENERATION, ANY_UPDATED_GENERATION);
+    when(storage.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION)))
+        .thenThrow(
+            new StorageException(
+                CloudStorageErrorCode.PRECONDITION_FAILED.get(), "Precondition Failed"));
+    when(storage.readAllBytes(
+            blobId, Storage.BlobSourceOption.generationMatch(ANY_UPDATED_GENERATION)))
+        .thenReturn(ANY_UPDATED_DATA.getBytes(StandardCharsets.UTF_8));
+
+    // Act
+    Optional<ObjectStorageWrapperResponse> result = wrapper.get(ANY_OBJECT_KEY);
+
+    // Assert
+    verify(storage, times(2)).get(blobId);
+    assertThat(result).isPresent();
+    assertThat(result.get().getPayload()).isEqualTo(ANY_UPDATED_DATA);
+    assertThat(result.get().getVersion()).isEqualTo(String.valueOf(ANY_UPDATED_GENERATION));
+  }
+
+  @Test
+  public void get_WhenObjectUpdatedRepeatedly_ShouldThrowConflictOccurredException() {
+    // Arrange
+    BlobId blobId = BlobId.of(BUCKET, ANY_OBJECT_KEY);
+    Blob blob = mock(Blob.class);
+    when(storage.get(blobId)).thenReturn(blob);
+    when(blob.getGeneration()).thenReturn(ANY_GENERATION);
+    when(storage.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION)))
+        .thenThrow(
+            new StorageException(
+                CloudStorageErrorCode.PRECONDITION_FAILED.get(), "Precondition Failed"));
+
+    // Act Assert
+    assertThatCode(() -> wrapper.get(ANY_OBJECT_KEY)).isInstanceOf(ConflictOccurredException.class);
+    verify(storage, times(CloudStorageWrapper.GET_MAX_RETRY_COUNT + 1)).get(blobId);
+  }
+
+  @Test
+  public void
+      get_WhenStorageExceptionThrownWhileDownloadingPayload_ShouldThrowObjectStorageWrapperException() {
+    // Arrange
+    BlobId blobId = BlobId.of(BUCKET, ANY_OBJECT_KEY);
+    Blob blob = mock(Blob.class);
+    when(storage.get(blobId)).thenReturn(blob);
+    when(blob.getGeneration()).thenReturn(ANY_GENERATION);
+    when(storage.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(ANY_GENERATION)))
+        .thenThrow(new StorageException(500, "Any Error"));
+
+    // Act Assert
+    assertThatCode(() -> wrapper.get(ANY_OBJECT_KEY))
+        .isInstanceOf(ObjectStorageWrapperException.class);
+    verify(storage).get(blobId);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes an issue reported by @jnmt where the get operation does not handle concurrent writes. 

The payload was downloaded with the _generation_ pinned in the blob ID, so a read that raced with a concurrent deletion or update failed with a 404 error instead of reporting the object as absent, because a non-current generation does not exist in a bucket without object versioning. The S3 and Blob Storage adapters don't have this window because they read the payload and its version in a single request.

## Related issues and/or PRs

N/A

## Changes made

- Update Cloud Storage adapter's get operation:
  - Download the payload with the precondition instead of pinning the generation in the blob ID, which distinguishes a concurrent deletion (`404`) from a concurrent update (`412`).
  - Return an empty optional when the object is deleted during the read.
  - Retry from the metadata retrieval when the object is updated during the read, up to `GET_MAX_RETRY_COUNT` times.
  - Throw `ConflictOccurredException` once the retries are exhausted.
- Update unit test for the get operation.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed the get operation in the Cloud Storage adapter to handle concurrent writes.