### PR TITLE
Throw RetriableExecutionException for conflict errors in single put and delete in JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -214,6 +214,13 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       } catch (SQLException ex) {
         e.addSuppressed(ex);
       }
+      if (rdbEngine.isConflict(e)) {
+        // A conflict, such as a row lock wait timeout or a serialization failure, can occur. Throw
+        // RetriableExecutionException in that case.
+        throw new RetriableExecutionException(
+            CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()),
+            e);
+      }
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
     } finally {
@@ -258,6 +265,13 @@ public class JdbcDatabase extends AbstractDistributedStorage {
         }
       } catch (SQLException ex) {
         e.addSuppressed(ex);
+      }
+      if (rdbEngine.isConflict(e)) {
+        // A conflict, such as a row lock wait timeout or a serialization failure, can occur. Throw
+        // RetriableExecutionException in that case.
+        throw new RetriableExecutionException(
+            CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()),
+            e);
       }
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
@@ -344,8 +358,8 @@ public class JdbcDatabase extends AbstractDistributedStorage {
             CoreError.JDBC_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
       }
       if (rdbEngine.isConflict(e)) {
-        // Since a mutate operation executes multiple put/delete operations in a transaction,
-        // conflicts can occur. Throw RetriableExecutionException in that case.
+        // A conflict, such as a row lock wait timeout or a serialization failure, can occur. Throw
+        // RetriableExecutionException in that case.
         throw new RetriableExecutionException(
             CoreError.JDBC_TRANSACTION_CONFLICT_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()),
             e);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -35,6 +35,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -276,6 +277,29 @@ public class JdbcDatabaseTest {
   }
 
   @Test
+  public void put_WithConflictError_ShouldThrowRetriableExecutionException() throws Exception {
+    // Arrange
+    when(jdbcCrudService.put(any(), any())).thenThrow(sqlException);
+    when(sqlException.getSQLState()).thenReturn("40001");
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Put put =
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
+              jdbcDatabase.put(put);
+            })
+        .isInstanceOf(RetriableExecutionException.class)
+        .hasCause(sqlException);
+    verify(connection).close();
+  }
+
+  @Test
   public void
       whenPutOperationExecutedAndJdbcCrudServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
@@ -338,6 +362,28 @@ public class JdbcDatabaseTest {
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(NoMutationException.class);
+    verify(connection).close();
+  }
+
+  @Test
+  public void delete_WithConflictError_ShouldThrowRetriableExecutionException() throws Exception {
+    // Arrange
+    when(jdbcCrudService.delete(any(), any())).thenThrow(sqlException);
+    when(sqlException.getSQLState()).thenReturn("40001");
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Delete delete =
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .build();
+              jdbcDatabase.delete(delete);
+            })
+        .isInstanceOf(RetriableExecutionException.class)
+        .hasCause(sqlException);
     verify(connection).close();
   }
 
@@ -489,6 +535,30 @@ public class JdbcDatabaseTest {
     verify(connection).setAutoCommit(false);
     verify(jdbcCrudService).mutate(any(), any());
     verify(connection).rollback();
+    verify(connection).close();
+  }
+
+  @Test
+  public void mutate_WithSingleMutationAndConflictError_ShouldThrowRetriableExecutionException()
+      throws Exception {
+    // Arrange
+    when(jdbcCrudService.put(any(), any())).thenThrow(sqlException);
+    when(sqlException.getSQLState()).thenReturn("40001");
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Put put =
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .textValue("v1", "val2")
+                      .build();
+              jdbcDatabase.mutate(Collections.singletonList(put));
+            })
+        .isInstanceOf(RetriableExecutionException.class)
+        .hasCause(sqlException);
     verify(connection).close();
   }
 


### PR DESCRIPTION
## Description

`JdbcDatabase` classifies conflict errors inconsistently depending on how many mutations an operation carries, which prevents callers from retrying conflicts that are safe to retry.

`mutateInternal` checks `RdbEngineStrategy#isConflict(SQLException)` and throws `RetriableExecutionException`, but `put(Put)` and `delete(Delete)` wrap every `SQLException` in a plain `ExecutionException`. Since `mutate(List)` delegates a single-element list back to `put(Put)` or `delete(Delete)`, a conflict on a single mutation is never classified regardless of the entry point. As a result, a transient conflict such as a row lock wait timeout, a deadlock, or a serialization failure reaches the caller as a permanent storage failure, and the opportunity to resolve it by retrying is lost.

The premise recorded in the `mutateInternal` comment — that conflicts occur because a mutate operation executes multiple put/delete operations in a transaction — does not hold. A single conditional mutation is executed as one `UPDATE` statement and can face a conflict on its own, and every `RdbEngineStrategy` implementation already defines the relevant error codes (MySQL 1213/1205, PostgreSQL 40001/40P01, Oracle ORA-08177/00060/08176, and so on).

This affects Consensus Commit on JDBC storage. `ParticipantCommitHandler` executes each mutation group with `DistributedStorage#mutate`, and a group that contains a single record takes the unclassified path. A transient conflict while preparing such a record is therefore reported by `ConsensusCommit#commit` as `CommitException` instead of `CommitConflictException`, and when one-phase commit is enabled, a conflict while committing a single record is reported as `UnknownTransactionStatusException` even though the write did not apply.

## Related issues and/or PRs

N/A

## Changes made

- `JdbcDatabase#put(Put)` and `JdbcDatabase#delete(Delete)` now check `rdbEngine.isConflict(e)` in their `SQLException` handlers and throw `RetriableExecutionException` for conflicts, matching `mutateInternal`. No new detection logic and no new error code are introduced; the existing `isConflict` check and the existing `JDBC_TRANSACTION_CONFLICT_OCCURRED_IN_MUTATION` error are reused.
- The rollback handling of the single-mutation paths is left as is, so the existing behavior of suppressing a rollback failure and continuing is unchanged.
- The comment explaining the conflict check is unified across the three sites and no longer attributes conflicts to executing multiple operations in a transaction.
- Added unit tests that pin `put`, `delete`, and `mutate` with a single mutation to `RetriableExecutionException` on a conflict error. Existing tests already cover that a non-conflict `SQLException` still produces `ExecutionException`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

`RetriableExecutionException` extends `ExecutionException`, so this is a source- and binary-compatible change for callers that catch `ExecutionException`. Callers that branch on the exception type now see conflicts on single mutations classified as retriable.

Lazy recovery is not changed by this PR. `CrudHandler#waitForRecoveryCompletion` wraps any storage exception from a recovery task in `CrudException`, so a conflict during recovery is still reported as `CommitException`. This is independent of the storage adapter and is not addressed here.

The read paths are left untouched. They do not use `RetriableExecutionException` in any storage, and deciding which read failures are transient is a larger question that deserves its own change.

Other storage adapters may have the same asymmetry between their single-mutation and multi-mutation paths. That is not addressed here.

## Release notes

Fixed an issue where a conflict error, such as a lock wait timeout or a serialization failure, in a single put or delete operation on JDBC databases was not classified as retriable. As a result, Consensus Commit can now report such a conflict during commit as `CommitConflictException` instead of `CommitException` or `UnknownTransactionStatusException`.

